### PR TITLE
Allow any pan/zoom in 2D spatial views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6256,6 +6256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_pinhole_projection"
+version = "0.16.0-alpha.2"
+dependencies = [
+ "anyhow",
+ "clap",
+ "image",
+ "re_log",
+ "rerun",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_renderer/src/global_bindings.rs
+++ b/crates/re_renderer/src/global_bindings.rs
@@ -33,7 +33,7 @@ pub struct FrameUniformBuffer {
 
     /// How many pixels there are per point.
     /// I.e. the UI zoom factor
-    pub pixels_from_point: f32,
+    pub pixels_per_point: f32,
 
     /// (tan(fov_y / 2) * aspect_ratio, tan(fov_y /2)), i.e. half ratio of screen dimension to screen distance in x & y.
     /// Both values are set to f32max for orthographic projection

--- a/crates/re_renderer/src/transform.rs
+++ b/crates/re_renderer/src/transform.rs
@@ -36,10 +36,15 @@ pub fn ndc_from_pixel(pixel_coord: glam::Vec2, screen_extent: glam::UVec2) -> gl
 
 /// Defines a transformation from a rectangular region of interest into a rectangular target region.
 ///
+/// This is "pan and scan".
+///
 /// Transforms the range of `region_of_interest` to the range of `region`.
 #[derive(Clone, Debug)]
 pub struct RectTransform {
+    /// The region of the scene that should be visible.
     pub region_of_interest: RectF32,
+
+    /// The full scene.
     pub region: RectF32,
 }
 

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -243,7 +243,7 @@ pub struct TargetConfiguration {
     /// I.e. the UI zoom factor.
     /// Note that this does not affect any of the camera & projection properties and is only used
     /// whenever point sizes were explicitly specified.
-    pub pixels_from_point: f32,
+    pub pixels_per_point: f32,
 
     /// How [`Size::AUTO`] is interpreted.
     pub auto_size_config: AutoSizeConfig,
@@ -263,7 +263,7 @@ impl Default for TargetConfiguration {
                 aspect_ratio: 1.0,
             },
             viewport_transformation: RectTransform::IDENTITY,
-            pixels_from_point: 1.0,
+            pixels_per_point: 1.0,
             auto_size_config: Default::default(),
             outline_config: None,
         }
@@ -457,7 +457,7 @@ impl ViewBuilder {
             camera_forward,
             tan_half_fov: tan_half_fov.into(),
             pixel_world_size_from_camera_distance,
-            pixels_from_point: config.pixels_from_point,
+            pixels_per_point: config.pixels_per_point,
 
             auto_size_points: auto_size_points.0,
             auto_size_lines: auto_size_lines.0,

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -69,7 +69,7 @@ pub type SharedViewBuilder = Arc<RwLock<Option<ViewBuilder>>>;
 
 /// Configures the camera placement in the orthographic frustum,
 /// as well as the coordinate system convention.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum OrthographicCameraMode {
     /// Puts the view space origin into the middle of the screen.
     ///
@@ -94,7 +94,7 @@ pub enum OrthographicCameraMode {
 }
 
 /// How we project from 3D to 2D.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Projection {
     /// Perspective camera looking along the negative z view space axis.
     Perspective {
@@ -122,6 +122,73 @@ pub enum Projection {
         /// Distance of the far plane to the camera.
         far_plane_distance: f32,
     },
+}
+
+impl Projection {
+    fn projection_from_view(self, aspect_ratio: f32) -> glam::Mat4 {
+        match self {
+            Projection::Perspective {
+                vertical_fov,
+                near_plane_distance,
+                aspect_ratio,
+            } => {
+                // We use infinite reverse-z projection matrix
+                // * great precision both with floating point and integer: https://developer.nvidia.com/content/depth-precision-visualized
+                // * no need to worry about far plane
+                glam::Mat4::perspective_infinite_reverse_rh(
+                    vertical_fov,
+                    aspect_ratio,
+                    near_plane_distance,
+                )
+            }
+            Projection::Orthographic {
+                camera_mode,
+                vertical_world_size,
+                far_plane_distance,
+            } => {
+                let horizontal_world_size = vertical_world_size * aspect_ratio;
+
+                // Note that we inverse z (by swapping near and far plane) to be consistent with our perspective projection.
+                match camera_mode {
+                    OrthographicCameraMode::NearPlaneCenter => glam::Mat4::orthographic_rh(
+                        -0.5 * horizontal_world_size,
+                        0.5 * horizontal_world_size,
+                        -0.5 * vertical_world_size,
+                        0.5 * vertical_world_size,
+                        far_plane_distance,
+                        0.0,
+                    ),
+                    OrthographicCameraMode::TopLeftCornerAndExtendZ => glam::Mat4::orthographic_rh(
+                        0.0,
+                        horizontal_world_size,
+                        vertical_world_size,
+                        0.0,
+                        far_plane_distance,
+                        -far_plane_distance,
+                    ),
+                }
+            }
+        }
+    }
+
+    fn tan_half_fov(&self) -> glam::Vec2 {
+        match self {
+            Projection::Perspective {
+                vertical_fov,
+                aspect_ratio,
+                ..
+            } => {
+                // Calculate ratio between screen size and screen distance.
+                // Great for getting directions from normalized device coordinates.
+                // (btw. this is the same as [1.0 / projection_from_view[0].x, 1.0 / projection_from_view[1].y])
+                glam::vec2(
+                    (vertical_fov * 0.5).tan() * aspect_ratio,
+                    (vertical_fov * 0.5).tan(),
+                )
+            }
+            Projection::Orthographic { .. } => glam::vec2(f32::MAX, f32::MAX), // Can't use infinity in shaders
+        }
+    }
 }
 
 /// How [`Size::AUTO`] is interpreted.
@@ -314,89 +381,36 @@ impl ViewBuilder {
             },
         );
 
-        let (projection_from_view, tan_half_fov, pixel_world_size_from_camera_distance) =
-            match config.projection_from_view.clone() {
-                Projection::Perspective {
-                    vertical_fov,
-                    near_plane_distance,
-                    aspect_ratio,
-                } => {
-                    // We use infinite reverse-z projection matrix
-                    // * great precision both with floating point and integer: https://developer.nvidia.com/content/depth-precision-visualized
-                    // * no need to worry about far plane
-                    let projection_from_view = glam::Mat4::perspective_infinite_reverse_rh(
-                        vertical_fov,
-                        aspect_ratio,
-                        near_plane_distance,
-                    );
+        let aspect_ratio =
+            config.resolution_in_pixel[0] as f32 / config.resolution_in_pixel[1] as f32;
 
-                    // Calculate ratio between screen size and screen distance.
-                    // Great for getting directions from normalized device coordinates.
-                    // (btw. this is the same as [1.0 / projection_from_view[0].x, 1.0 / projection_from_view[1].y])
-                    let tan_half_fov = glam::vec2(
-                        (vertical_fov * 0.5).tan() * aspect_ratio,
-                        (vertical_fov * 0.5).tan(),
-                    );
+        let projection_from_view = config
+            .projection_from_view
+            .projection_from_view(aspect_ratio);
 
-                    // Determine how wide a pixel is in world space at unit distance from the camera.
-                    //
-                    // derivation:
-                    // tan(FOV / 2) = (screen_in_world / 2) / distance
-                    // screen_in_world = tan(FOV / 2) * distance * 2
-                    //
-                    // want: pixels in world per distance, i.e (screen_in_world / resolution / distance)
-                    // => (resolution / screen_in_world / distance) = tan(FOV / 2) * distance * 2 / resolution / distance =
-                    //                                              = tan(FOV / 2) * 2.0 / resolution
-                    let pixel_world_size_from_camera_distance =
-                        tan_half_fov.y * 2.0 / config.resolution_in_pixel[1] as f32;
+        let tan_half_fov = config.projection_from_view.tan_half_fov();
 
-                    (
-                        projection_from_view,
-                        tan_half_fov,
-                        pixel_world_size_from_camera_distance,
-                    )
-                }
-                Projection::Orthographic {
-                    camera_mode,
-                    vertical_world_size,
-                    far_plane_distance,
-                } => {
-                    let aspect_ratio =
-                        config.resolution_in_pixel[0] as f32 / config.resolution_in_pixel[1] as f32;
-                    let horizontal_world_size = vertical_world_size * aspect_ratio;
-                    // Note that we inverse z (by swapping near and far plane) to be consistent with our perspective projection.
-                    let projection_from_view = match camera_mode {
-                        OrthographicCameraMode::NearPlaneCenter => glam::Mat4::orthographic_rh(
-                            -0.5 * horizontal_world_size,
-                            0.5 * horizontal_world_size,
-                            -0.5 * vertical_world_size,
-                            0.5 * vertical_world_size,
-                            far_plane_distance,
-                            0.0,
-                        ),
-                        OrthographicCameraMode::TopLeftCornerAndExtendZ => {
-                            glam::Mat4::orthographic_rh(
-                                0.0,
-                                horizontal_world_size,
-                                vertical_world_size,
-                                0.0,
-                                far_plane_distance,
-                                -far_plane_distance,
-                            )
-                        }
-                    };
-
-                    let tan_half_fov = glam::vec2(f32::MAX, f32::MAX);
-                    let pixel_world_size_from_camera_distance = vertical_world_size
-                        / config.resolution_in_pixel[0].max(config.resolution_in_pixel[1]) as f32;
-
-                    (
-                        projection_from_view,
-                        tan_half_fov,
-                        pixel_world_size_from_camera_distance,
-                    )
-                }
-            };
+        let pixel_world_size_from_camera_distance = match config.projection_from_view {
+            Projection::Perspective { .. } => {
+                // Determine how wide a pixel is in world space at unit distance from the camera.
+                //
+                // derivation:
+                // tan(FOV / 2) = (screen_in_world / 2) / distance
+                // screen_in_world = tan(FOV / 2) * distance * 2
+                //
+                // want: pixels in world per distance, i.e (screen_in_world / resolution / distance)
+                // => (resolution / screen_in_world / distance) = tan(FOV / 2) * distance * 2 / resolution / distance =
+                //                                              = tan(FOV / 2) * 2.0 / resolution
+                tan_half_fov.y * 2.0 / config.resolution_in_pixel[1] as f32
+            }
+            Projection::Orthographic {
+                vertical_world_size,
+                ..
+            } => {
+                vertical_world_size
+                    / config.resolution_in_pixel[0].max(config.resolution_in_pixel[1]) as f32
+            }
+        };
 
         // Finally, apply a viewport transformation to the projection.
         let ndc_scale_and_translation = config

--- a/crates/re_renderer/src/view_builder.rs
+++ b/crates/re_renderer/src/view_builder.rs
@@ -125,7 +125,7 @@ pub enum Projection {
 }
 
 impl Projection {
-    fn projection_from_view(self, aspect_ratio: f32) -> glam::Mat4 {
+    fn projection_from_view(self, resolution_in_pixel: [u32; 2]) -> glam::Mat4 {
         match self {
             Projection::Perspective {
                 vertical_fov,
@@ -146,6 +146,7 @@ impl Projection {
                 vertical_world_size,
                 far_plane_distance,
             } => {
+                let aspect_ratio = resolution_in_pixel[0] as f32 / resolution_in_pixel[1] as f32;
                 let horizontal_world_size = vertical_world_size * aspect_ratio;
 
                 // Note that we inverse z (by swapping near and far plane) to be consistent with our perspective projection.
@@ -381,12 +382,9 @@ impl ViewBuilder {
             },
         );
 
-        let aspect_ratio =
-            config.resolution_in_pixel[0] as f32 / config.resolution_in_pixel[1] as f32;
-
         let projection_from_view = config
             .projection_from_view
-            .projection_from_view(aspect_ratio);
+            .projection_from_view(config.resolution_in_pixel);
 
         let tan_half_fov = config.projection_from_view.tan_half_fov();
 

--- a/crates/re_renderer_examples/2d.rs
+++ b/crates/re_renderer_examples/2d.rs
@@ -60,7 +60,7 @@ impl framework::Example for Render2D {
         re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         let splits = framework::split_resolution(resolution, 1, 2).collect::<Vec<_>>();
 
@@ -302,7 +302,7 @@ impl framework::Example for Render2D {
                             vertical_world_size: splits[0].resolution_in_pixel[1] as f32,
                             far_plane_distance: 1000.0,
                         },
-                        pixels_from_point,
+                        pixels_per_point,
                         ..Default::default()
                     },
                 );
@@ -344,7 +344,7 @@ impl framework::Example for Render2D {
                             near_plane_distance: 0.01,
                             aspect_ratio: resolution[0] as f32 / resolution[1] as f32,
                         },
-                        pixels_from_point,
+                        pixels_per_point,
                         ..Default::default()
                     },
                 );

--- a/crates/re_renderer_examples/depth_cloud.rs
+++ b/crates/re_renderer_examples/depth_cloud.rs
@@ -61,7 +61,7 @@ impl RenderDepthClouds {
     fn draw_backprojected_point_cloud<FD, ID>(
         &mut self,
         re_ctx: &re_renderer::RenderContext,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
         resolution_in_pixel: [u32; 2],
         target_location: glam::Vec2,
         frame_draw_data: FD,
@@ -122,7 +122,7 @@ impl RenderDepthClouds {
                     near_plane_distance: 0.01,
                     aspect_ratio: resolution_in_pixel[0] as f32 / resolution_in_pixel[1] as f32,
                 },
-                pixels_from_point,
+                pixels_per_point,
                 ..Default::default()
             },
         );
@@ -146,7 +146,7 @@ impl RenderDepthClouds {
     fn draw_depth_cloud<FD, ID>(
         &mut self,
         re_ctx: &re_renderer::RenderContext,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
         resolution_in_pixel: [u32; 2],
         target_location: glam::Vec2,
         frame_draw_data: FD,
@@ -202,7 +202,7 @@ impl RenderDepthClouds {
                     near_plane_distance: 0.01,
                     aspect_ratio: resolution_in_pixel[0] as f32 / resolution_in_pixel[1] as f32,
                 },
-                pixels_from_point,
+                pixels_per_point,
                 ..Default::default()
             },
         );
@@ -265,7 +265,7 @@ impl framework::Example for RenderDepthClouds {
         re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         let Self {
             albedo,
@@ -329,7 +329,7 @@ impl framework::Example for RenderDepthClouds {
         vec![
             self.draw_backprojected_point_cloud(
                 re_ctx,
-                pixels_from_point,
+                pixels_per_point,
                 splits[0].resolution_in_pixel,
                 splits[0].target_location,
                 frame_draw_data.clone(),
@@ -337,7 +337,7 @@ impl framework::Example for RenderDepthClouds {
             ),
             self.draw_depth_cloud(
                 re_ctx,
-                pixels_from_point,
+                pixels_per_point,
                 splits[1].resolution_in_pixel,
                 splits[1].target_location,
                 frame_draw_data,

--- a/crates/re_renderer_examples/depth_offset.rs
+++ b/crates/re_renderer_examples/depth_offset.rs
@@ -38,7 +38,7 @@ impl framework::Example for Render2D {
         re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         _time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         let mut rectangles = Vec::new();
 
@@ -110,7 +110,7 @@ impl framework::Example for Render2D {
                     near_plane_distance: self.near_plane,
                     aspect_ratio: resolution[0] as f32 / resolution[1] as f32,
                 },
-                pixels_from_point,
+                pixels_per_point,
                 ..Default::default()
             },
         );

--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -33,7 +33,7 @@ pub trait Example {
         re_ctx: &RenderContext,
         resolution: [u32; 2],
         time: &Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<ViewDrawResult>;
 
     fn on_key_event(&mut self, _event: winit::event::KeyEvent) {}

--- a/crates/re_renderer_examples/multiview.rs
+++ b/crates/re_renderer_examples/multiview.rs
@@ -306,7 +306,7 @@ impl Example for Multiview {
         re_ctx: &RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         if matches!(self.camera_control, CameraControl::RotateAroundCenter) {
             let seconds_since_startup = time.seconds_since_startup();
@@ -373,7 +373,7 @@ impl Example for Multiview {
                         resolution_in_pixel: splits[$n].resolution_in_pixel,
                         view_from_world,
                         projection_from_view: projection_from_view.clone(),
-                        pixels_from_point,
+                        pixels_per_point,
                         ..Default::default()
                     },
                     skybox.clone(),

--- a/crates/re_renderer_examples/outlines.rs
+++ b/crates/re_renderer_examples/outlines.rs
@@ -40,7 +40,7 @@ impl framework::Example for Outlines {
         re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         if !self.is_paused {
             self.seconds_since_startup += time.last_frame_duration.as_secs_f32();
@@ -65,7 +65,7 @@ impl framework::Example for Outlines {
                     near_plane_distance: 0.01,
                     aspect_ratio: resolution[0] as f32 / resolution[1] as f32,
                 },
-                pixels_from_point,
+                pixels_per_point,
                 outline_config: Some(OutlineConfig {
                     outline_radius_pixel: (seconds_since_startup * 2.0).sin().abs() * 10.0 + 2.0,
                     color_layer_a: re_renderer::Rgba::from_rgb(1.0, 0.6, 0.0),

--- a/crates/re_renderer_examples/picking.rs
+++ b/crates/re_renderer_examples/picking.rs
@@ -98,7 +98,7 @@ impl framework::Example for Picking {
         re_ctx: &re_renderer::RenderContext,
         resolution: [u32; 2],
         _time: &framework::Time,
-        pixels_from_point: f32,
+        pixels_per_point: f32,
     ) -> Vec<framework::ViewDrawResult> {
         while let Some(picking_result) =
             PickingLayerProcessor::next_readback_result::<()>(re_ctx, READBACK_IDENTIFIER)
@@ -136,7 +136,7 @@ impl framework::Example for Picking {
                     near_plane_distance: 0.01,
                     aspect_ratio: resolution[0] as f32 / resolution[1] as f32,
                 },
-                pixels_from_point,
+                pixels_per_point,
                 outline_config: None,
                 ..Default::default()
             },

--- a/crates/re_space_view_spatial/src/picking.rs
+++ b/crates/re_space_view_spatial/src/picking.rs
@@ -86,12 +86,12 @@ impl PickingContext {
         pointer_in_ui: egui::Pos2,
         space2d_from_ui: egui::emath::RectTransform,
         ui_clip_rect: egui::Rect,
-        pixels_from_points: f32,
+        pixels_per_point: f32,
         eye: &Eye,
     ) -> PickingContext {
         let pointer_in_space2d = space2d_from_ui.transform_pos(pointer_in_ui);
         let pointer_in_space2d = glam::vec2(pointer_in_space2d.x, pointer_in_space2d.y);
-        let pointer_in_pixel = (pointer_in_ui - ui_clip_rect.left_top()) * pixels_from_points;
+        let pointer_in_pixel = (pointer_in_ui - ui_clip_rect.left_top()) * pixels_per_point;
 
         PickingContext {
             pointer_in_space2d,

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -250,17 +250,18 @@ impl SpaceViewClass for SpatialSpaceView2D {
                 state.default_size_ui(ctx, ui);
                 state.bounding_box_ui(ctx, ui, SpatialSpaceViewKind::TwoD);
 
-                if let Some(bounds) = state.state_2d.bounds {
+                {
+                    let visual_bounds = &mut state.state_2d.visual_bounds;
                     ctx.re_ui
                         .grid_left_hand_label(ui, "Bounds")
                         .on_hover_text("The area guaranteed to be visible.\nDepending on the view's current aspect ratio the actually visible area might be larger either horizontally or vertically.");
                     ui.vertical(|ui| {
                         ui.style_mut().wrap = Some(false);
-                        let (min, max) = (bounds.min, bounds.max);
+                        let (min, max) = (visual_bounds.min, visual_bounds.max);
                         ui.label(format!("x [{} - {}]", format_f32(min.x), format_f32(max.x),));
                         ui.label(format!("y [{} - {}]", format_f32(min.y), format_f32(max.y),));
                         if ui.button("Reset bounds").clicked() {
-                            state.state_2d.bounds = None;
+                            *visual_bounds = egui::Rect::NAN;
                         }
                     });
                     ui.end_row();

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -2,6 +2,7 @@ use ahash::HashSet;
 use nohash_hasher::{IntMap, IntSet};
 
 use re_entity_db::{EntityDb, EntityProperties, EntityTree};
+use re_format::format_f32;
 use re_log_types::EntityPath;
 use re_types::{
     archetypes::{DepthImage, Image},
@@ -248,7 +249,22 @@ impl SpaceViewClass for SpatialSpaceView2D {
             .show(ui, |ui| {
                 state.default_size_ui(ctx, ui);
                 state.bounding_box_ui(ctx, ui, SpatialSpaceViewKind::TwoD);
-                ui.end_row();
+
+                if let Some(bounds) = state.state_2d.bounds {
+                    ctx.re_ui
+                        .grid_left_hand_label(ui, "Bounds")
+                        .on_hover_text("The currently visible area.");
+                    ui.vertical(|ui| {
+                        ui.style_mut().wrap = Some(false);
+                        let (min, max) = (bounds.min, bounds.max);
+                        ui.label(format!("x [{} - {}]", format_f32(min.x), format_f32(max.x),));
+                        ui.label(format!("y [{} - {}]", format_f32(min.y), format_f32(max.y),));
+                        if ui.button("Reset bounds").clicked() {
+                            state.state_2d.bounds = None;
+                        }
+                    });
+                    ui.end_row();
+                }
             });
         Ok(())
     }

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -253,7 +253,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
                 if let Some(bounds) = state.state_2d.bounds {
                     ctx.re_ui
                         .grid_left_hand_label(ui, "Bounds")
-                        .on_hover_text("The currently visible area.");
+                        .on_hover_text("The area guaranteed to be visible.\nDepending on the view's current aspect ratio the actually visible area might be larger either horizontally or vertically.");
                     ui.vertical(|ui| {
                         ui.style_mut().wrap = Some(false);
                         let (min, max) = (bounds.min, bounds.max);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -248,7 +248,7 @@ fn size_ui(
 
 pub fn create_labels(
     mut labels: Vec<UiLabel>,
-    ui_from_canvas: egui::emath::RectTransform,
+    ui_from_scene: egui::emath::RectTransform,
     eye3d: &Eye,
     parent_ui: &egui::Ui,
     highlights: &SpaceViewHighlights,
@@ -256,7 +256,7 @@ pub fn create_labels(
 ) -> (Vec<egui::Shape>, Vec<PickableUiRect>) {
     re_tracing::profile_function!();
 
-    let ui_from_world_3d = eye3d.ui_from_world(*ui_from_canvas.to());
+    let ui_from_world_3d = eye3d.ui_from_world(*ui_from_scene.to());
 
     // Closest last (painters algorithm)
     labels.sort_by_key(|label| {
@@ -277,7 +277,7 @@ pub fn create_labels(
                 if spatial_kind == SpatialSpaceViewKind::ThreeD {
                     continue;
                 }
-                let rect_in_ui = ui_from_canvas.transform_rect(rect);
+                let rect_in_ui = ui_from_scene.transform_rect(rect);
                 (
                     // Place the text centered below the rect
                     (rect_in_ui.width() - 4.0).at_least(60.0),
@@ -289,7 +289,7 @@ pub fn create_labels(
                 if spatial_kind == SpatialSpaceViewKind::ThreeD {
                     continue;
                 }
-                let pos_in_ui = ui_from_canvas.transform_pos(pos);
+                let pos_in_ui = ui_from_scene.transform_pos(pos);
                 (f32::INFINITY, pos_in_ui + egui::vec2(0.0, 3.0))
             }
             UiLabelTarget::Position3D(pos) => {
@@ -353,7 +353,7 @@ pub fn create_labels(
         ));
 
         ui_rects.push(PickableUiRect {
-            rect: ui_from_canvas.inverse().transform_rect(bg_rect),
+            rect: ui_from_scene.inverse().transform_rect(bg_rect),
             instance_hash: label.labeled_instance,
         });
     }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -105,6 +105,7 @@ impl SpatialSpaceViewState {
                 ui.label(format!("z [{} - {}]", format_f32(min.z), format_f32(max.z),));
             }
         });
+        ui.end_row();
     }
 
     pub fn default_size_ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -31,7 +31,7 @@ pub struct View2DState {
 }
 
 impl View2DState {
-    /// Pan and and zoom, and return the current transform.
+    /// Pan and zoom, and return the current transform.
     fn ui_from_scene(
         &mut self,
         response: &egui::Response,

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -294,6 +294,8 @@ fn setup_target_config(
     any_outlines: bool,
     scene_pinhole: Option<Pinhole>,
 ) -> anyhow::Result<TargetConfiguration> {
+    // ⚠️ When changing this code, make sure to run `tests/rust/test_pinhole_projection`.
+
     // TODO(#1025):
     // The camera setup is done in a way that works well with the way we inverse pinhole camera transformations right now.
     // This has a lot of issues though, mainly because we pretend that the 2D plane has a defined depth.

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -82,6 +82,11 @@ impl View2DState {
 
         let mut pan_delta_in_ui = response.drag_delta();
         if response.hovered() {
+            // NOTE: we use `raw_scroll` instead of `smooth_scroll_delta` to avoid the
+            // added latency of smoothing, which is really annoying on Mac trackpads.
+            // The smoothing is only useful for users with discreet scroll wheels,
+            // and they are likely to pan with dragging instead.
+            // TODO(egui#4401): https://github.com/emilk/egui/issues/4401
             pan_delta_in_ui += response.ctx.input(|i| i.raw_scroll_delta);
         }
         if pan_delta_in_ui != Vec2::ZERO {

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -381,9 +381,9 @@ fn setup_target_config(
 
     // ----------------------
 
-    let pixels_from_point = egui_painter.ctx().pixels_per_point();
+    let pixels_per_point = egui_painter.ctx().pixels_per_point();
     let resolution_in_pixel =
-        gpu_bridge::viewport_resolution_in_pixels(egui_painter.clip_rect(), pixels_from_point);
+        gpu_bridge::viewport_resolution_in_pixels(egui_painter.clip_rect(), pixels_per_point);
     anyhow::ensure!(0 < resolution_in_pixel[0] && 0 < resolution_in_pixel[1]);
 
     Ok({
@@ -394,7 +394,7 @@ fn setup_target_config(
             view_from_world,
             projection_from_view,
             viewport_transformation,
-            pixels_from_point,
+            pixels_per_point,
             auto_size_config,
             outline_config: any_outlines.then(|| outline_config(egui_painter.ctx())),
         }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -318,13 +318,18 @@ fn setup_target_config(
         // The user has a pinhole, and we may want to project 3D stuff into this 2D space,
         // and we want to use that pinhole projection to do so.
         pinhole = scene_pinhole;
-        canvas_rect = pinhole_resolution_rect(&pinhole).unwrap(); // TODO
+        canvas_rect = pinhole_resolution_rect(&pinhole).unwrap_or_else(|| {
+            // This is weird - we have a projection with an unknown scale.
+            // Let's just pick something plausible and hope for the best 😬.
+            Rect::from_min_size(Pos2::ZERO, egui::Vec2::splat(1000.0))
+        });
     } else {
         // The user didn't pick a pinhole, but we still set up a 3D projection.
-        // So we just pick any pinhole.
-        let focal_length = 1.0; // Whatever
-        let principal_point = glam::vec2(0.5, 0.5); // Whatever
-        let resolution = egui::vec2(1.0, 1.0); // Whatever
+        // So we just pick _any_ pinhole camera, but we pick a "plausible" one so that
+        // it is similar to real-life pinhole cameras, so that we get similar scales and precision.
+        let focal_length = 1000.0; // Whatever, but small values can cause precision issues, noticable on rectangle corners.
+        let principal_point = glam::Vec2::splat(500.0); // Whatever
+        let resolution = egui::Vec2::splat(1000.0); // Whatever
         pinhole = Pinhole {
             image_from_camera: glam::Mat3::from_cols(
                 glam::vec3(focal_length, 0.0, 0.0),

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -32,7 +32,7 @@ pub struct View2DState {
     /// Some thing outside of these bounds may also be visible due to letterboxing.
     ///
     /// Default: [`Rect::NAN`] (invalid).
-    /// Invlaid bound will be set to the default on the next frame.
+    /// Invalid bound will be set to the default on the next frame.
     /// The default is usually the scene bounding box.
     pub visual_bounds: Rect,
 }
@@ -187,6 +187,8 @@ pub fn view_2d(
     if ui.available_size().min_elem() <= 0.0 {
         return Ok(());
     }
+
+    // TODO(emilk): some way to visualize the resolution rectangle of the pinhole camera (in case there is no image logged).
 
     // Note that we can't rely on the camera being part of scene.space_cameras since that requires
     // the camera to be added to the scene!

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -1,7 +1,4 @@
-use egui::{
-    emath::RectTransform, pos2, vec2, Align2, Color32, NumExt as _, Pos2, Rect, ScrollArea, Shape,
-    Vec2,
-};
+use egui::{emath::RectTransform, pos2, vec2, Align2, Color32, Pos2, Rect, Shape, Vec2};
 use macaw::IsoTransform;
 
 use re_entity_db::EntityPath;
@@ -26,184 +23,101 @@ use crate::{
 
 // ---
 
-#[derive(Clone, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
 pub struct View2DState {
-    /// The zoom and pan state, which is either a zoom/center or `Auto` which will fill the screen
-    zoom: ZoomState2D,
-}
-
-#[derive(Clone, Copy, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-/// Sub-state specific to the Zoom/Scale/Pan engine
-pub enum ZoomState2D {
-    #[default]
-    Auto,
-
-    Scaled {
-        /// Number of ui points per scene unit
-        scale: f32,
-
-        /// Which scene coordinate will be at the center of the zoomed region.
-        center: Pos2,
-
-        /// Whether to allow the state to be updated by the current `ScrollArea` offsets
-        accepting_scroll: bool,
-    },
+    /// The visible parts of the scene, in the coordinate space of the scene.
+    pub bounds: Option<Rect>,
 }
 
 impl View2DState {
-    /// Determine the optimal sub-region and size based on the `ZoomState` and
-    /// available size. This will generally be used to construct the painter and
-    /// subsequent transforms
-    ///
-    /// Returns `(desired_size, scroll_offset)` where:
-    ///   - `desired_size` is the size of the painter necessary to capture the zoomed view in ui points
-    ///   - `scroll_offset` is the position of the `ScrollArea` offset in ui points
-    fn desired_size_and_offset(&self, available_size: Vec2, canvas_rect: Rect) -> (Vec2, Vec2) {
-        match self.zoom {
-            ZoomState2D::Scaled { scale, center, .. } => {
-                let desired_size = canvas_rect.size() * scale;
-
-                // Try to keep the center of the scene in the middle of the available size
-                let scroll_offset = (center.to_vec2() - canvas_rect.left_top().to_vec2()) * scale
-                    - available_size / 2.0;
-
-                (desired_size, scroll_offset)
-            }
-            ZoomState2D::Auto => {
-                // Otherwise, we autoscale the space to fit available area while maintaining aspect ratio
-                let scene_bbox = if canvas_rect.is_positive() {
-                    canvas_rect
-                } else {
-                    Rect::from_min_max(Pos2::ZERO, Pos2::new(1.0, 1.0))
-                };
-                let mut desired_size = scene_bbox.size();
-                desired_size *= available_size.x / desired_size.x; // fill full width
-                desired_size *= (available_size.y / desired_size.y).at_most(1.0); // shrink so we don't fill more than full height
-
-                if desired_size.is_finite() {
-                    (desired_size, Vec2::ZERO)
-                } else {
-                    (available_size, Vec2::ZERO)
-                }
-            }
-        }
-    }
-
-    /// Update our zoom state based on response
-    /// If nothing else happens this will reset `accepting_scroll` to true when appropriate
-    fn update(
+    /// Pan and and zoom, and return the current transform.
+    fn ui_from_scene(
         &mut self,
         response: &egui::Response,
-        ui_to_space: egui::emath::RectTransform,
-        canvas_rect: Rect,
-        available_size: Vec2,
-    ) {
-        // Determine if we are zooming
-        let zoom_delta = response.ctx.input(|i| i.zoom_delta());
-        let hovered_zoom = if response.hovered() && zoom_delta != 1.0 {
-            Some(zoom_delta)
+        default_scene_rect: Rect,
+    ) -> RectTransform {
+        if response.double_clicked() {
+            self.bounds = None; // double-click to reset
+        }
+
+        let bounds = self.bounds.get_or_insert(default_scene_rect);
+        if !bounds.is_positive() {
+            *bounds = default_scene_rect;
+        }
+        if !bounds.is_positive() {
+            // Nothing in scene, probably.
+            // Just return something that isn't NaN.
+            let fake_bounds = Rect::from_min_size(Pos2::ZERO, Vec2::splat(1.0));
+            return RectTransform::from_to(fake_bounds, response.rect);
+        }
+
+        // --------------------------------------------------------------------------
+        // Expand bounds for uniform scaling (letterboxing):
+
+        let mut letterboxed_bounds = *bounds;
+
+        // Temporary before applying letterboxing:
+        let ui_from_scene = RectTransform::from_to(*bounds, response.rect);
+
+        let scale_aspect = ui_from_scene.scale().x / ui_from_scene.scale().y;
+        if scale_aspect < 1.0 {
+            // Letterbox top/bottom:
+            let add = bounds.height() * (1.0 / scale_aspect - 1.0);
+            letterboxed_bounds.min.y -= 0.5 * add;
+            letterboxed_bounds.max.y += 0.5 * add;
         } else {
-            None
-        };
+            // Letterbox sides:
+            let add = bounds.width() * (scale_aspect - 1.0);
+            letterboxed_bounds.min.x -= 0.5 * add;
+            letterboxed_bounds.max.x += 0.5 * add;
+        }
 
-        match self.zoom {
-            ZoomState2D::Auto => {
-                if let Some(input_zoom) = hovered_zoom {
-                    if input_zoom > 1.0 {
-                        let scale = response.rect.height() / ui_to_space.to().height();
-                        let center = canvas_rect.center();
-                        self.zoom = ZoomState2D::Scaled {
-                            scale,
-                            center,
-                            accepting_scroll: false,
-                        };
-                        // Recursively update now that we have initialized `ZoomState` to `Scaled`
-                        self.update(response, ui_to_space, canvas_rect, available_size);
-                    }
-                }
-            }
-            ZoomState2D::Scaled {
-                mut scale,
-                mut center,
-                ..
-            } => {
-                let mut accepting_scroll = true;
+        // --------------------------------------------------------------------------
 
-                // If we are zooming, adjust the scale and center
-                if let Some(input_zoom) = hovered_zoom {
-                    let new_scale = scale * input_zoom;
+        // Temporary before applying panning/zooming delta:
+        let ui_from_scene = RectTransform::from_to(letterboxed_bounds, response.rect);
 
-                    // Adjust for mouse location while executing zoom
-                    if let Some(hover_pos) = response.ctx.input(|i| i.pointer.hover_pos()) {
-                        let zoom_loc = ui_to_space.transform_pos(hover_pos);
+        // --------------------------------------------------------------------------
 
-                        // Space-units under the cursor will shift based on distance from center
-                        let dist_from_center = zoom_loc - center;
-                        // In UI points this happens based on the difference in scale;
-                        let shift_in_ui = dist_from_center * (new_scale - scale);
-                        // But we will compensate for it by a shift in space units
-                        let shift_in_space = shift_in_ui / new_scale;
+        let mut pan_delta_in_ui = response.drag_delta();
+        if response.hovered() {
+            pan_delta_in_ui += response.ctx.input(|i| i.raw_scroll_delta);
+        }
+        if pan_delta_in_ui != Vec2::ZERO {
+            *bounds = bounds.translate(-pan_delta_in_ui / ui_from_scene.scale());
+        }
 
-                        // Moving the center in the direction of the desired shift
-                        center += shift_in_space;
-                    }
-                    // Don't show less than one horizontal scene unit in the entire screen.
-                    scale = new_scale.at_most(available_size.x);
-                    accepting_scroll = false;
-                }
+        if response.hovered() {
+            let zoom_delta = response.ctx.input(|i| i.zoom_delta_2d());
 
-                // If we are dragging, adjust the center accordingly
-                if response.dragged_by(DRAG_PAN2D_BUTTON) {
-                    // Adjust center based on drag
-                    center -= response.drag_delta() / scale;
-                    accepting_scroll = false;
-                }
-
-                // Save the zoom state
-                self.zoom = ZoomState2D::Scaled {
-                    scale,
-                    center,
-                    accepting_scroll,
-                };
+            if zoom_delta != Vec2::splat(1.0) {
+                let zoom_center_in_ui = response
+                    .hover_pos()
+                    .unwrap_or_else(|| response.rect.center());
+                let zoom_center_in_scene = ui_from_scene
+                    .inverse()
+                    .transform_pos(zoom_center_in_ui)
+                    .to_vec2();
+                *bounds = scale_rect(
+                    bounds.translate(-zoom_center_in_scene),
+                    Vec2::splat(1.0) / zoom_delta,
+                )
+                .translate(zoom_center_in_scene);
             }
         }
 
-        // Process things that might reset ZoomState to Auto
-        if let ZoomState2D::Scaled { scale, .. } = self.zoom {
-            // If the user double-clicks
-            if response.double_clicked() {
-                self.zoom = ZoomState2D::Auto;
-            }
+        // --------------------------------------------------------------------------
 
-            // If our zoomed region is smaller than the available size
-            if canvas_rect.size().x * scale < available_size.x
-                && canvas_rect.size().y * scale < available_size.y
-            {
-                self.zoom = ZoomState2D::Auto;
-            }
-        }
+        RectTransform::from_to(letterboxed_bounds, response.rect)
     }
+}
 
-    /// Take the offset from the `ScrollArea` and apply it back to center so that other
-    /// scroll interfaces work as expected.
-    fn capture_scroll(&mut self, offset: Vec2, available_size: Vec2, canvas_rect: Rect) {
-        if let ZoomState2D::Scaled {
-            scale,
-            accepting_scroll,
-            ..
-        } = self.zoom
-        {
-            if accepting_scroll {
-                let center = canvas_rect.left_top() + (available_size / 2.0 + offset) / scale;
-                self.zoom = ZoomState2D::Scaled {
-                    scale,
-                    center,
-                    accepting_scroll,
-                };
-            }
-        }
-    }
+fn scale_rect(rect: Rect, factor: Vec2) -> Rect {
+    Rect::from_min_max(
+        (factor * rect.min.to_vec2()).to_pos2(),
+        (factor * rect.max.to_vec2()).to_pos2(),
+    )
 }
 
 pub fn help_text(re_ui: &re_ui::ReUi) -> egui::WidgetText {
@@ -238,168 +152,127 @@ pub fn view_2d(
         draw_data,
     } = system_output;
 
-    // Save off the available_size since this is used for some of the layout updates later
-    let available_size = ui.available_size();
+    if ui.available_size().min_elem() <= 0.0 {
+        return Ok(());
+    }
 
-    let scene_rect_accum = state.bounding_boxes.accumulated;
-    let scene_rect_accum = egui::Rect::from_min_max(
-        scene_rect_accum.min.truncate().to_array().into(),
-        scene_rect_accum.max.truncate().to_array().into(),
+    let pinhole = query_pinhole(ctx.recording(), &ctx.current_query(), query.space_origin);
+
+    let default_scene_rect = if let Some(res) = pinhole.as_ref().and_then(|p| p.resolution()) {
+        // Note that we can't rely on the camera being part of scene.space_cameras since that requires
+        // the camera to be added to the scene!
+        Rect::from_min_max(Pos2::ZERO, pos2(res.x, res.y))
+    } else {
+        let scene_rect_accum = state.bounding_boxes.accumulated;
+        egui::Rect::from_min_max(
+            scene_rect_accum.min.truncate().to_array().into(),
+            scene_rect_accum.max.truncate().to_array().into(),
+        )
+    };
+
+    let (mut response, painter) =
+        ui.allocate_painter(ui.available_size(), egui::Sense::click_and_drag());
+
+    // Convert ui coordinates to/from scene coordinates.
+    let ui_from_scene = state.state_2d.ui_from_scene(&response, default_scene_rect);
+    let scene_from_ui = ui_from_scene.inverse();
+
+    // TODO(andreas): Use the same eye & transformations as in `setup_target_config`.
+    let eye = Eye {
+        world_from_rub_view: IsoTransform::IDENTITY,
+        fov_y: None,
+    };
+
+    let Ok(target_config) = setup_target_config(
+        &painter,
+        scene_from_ui,
+        &query.space_origin.to_string(),
+        state.auto_size_config(),
+        query.highlights.any_outlines(),
+        pinhole,
+    ) else {
+        return Ok(());
+    };
+
+    let mut view_builder = ViewBuilder::new(ctx.render_ctx, target_config);
+
+    // Create labels now since their shapes participate are added to scene.ui for picking.
+    let (label_shapes, ui_rects) = create_labels(
+        collect_ui_labels(&parts),
+        ui_from_scene,
+        &eye,
+        ui,
+        &query.highlights,
+        SpatialSpaceViewKind::TwoD,
     );
 
-    // Determine the canvas which determines the extent of the explorable scene coordinates,
-    // and thus the size of the scroll area.
-    //
-    // TODO(andreas): We want to move away from the scroll area and instead work with open ended 2D scene coordinates!
-    // The term canvas might then refer to the area in scene coordinates visible at a given moment.
-    // Orthogonally, we'll want to visualize the resolution rectangle of the pinhole camera.
-    //
-    // For that we need to check if this is defined by a pinhole camera.
-    // Note that we can't rely on the camera being part of scene.space_cameras since that requires
-    // the camera to be added to the scene!
-    let pinhole = query_pinhole(ctx.recording(), &ctx.current_query(), query.space_origin);
-    let canvas_rect = pinhole
-        .as_ref()
-        .and_then(|p| p.resolution())
-        .map_or(scene_rect_accum, |res| {
-            Rect::from_min_max(egui::Pos2::ZERO, egui::pos2(res.x, res.y))
-        });
-
-    let (desired_size, offset) = state
-        .state_2d
-        .desired_size_and_offset(available_size, canvas_rect);
-
-    // Bound the offset based on sizes
-    // TODO(jleibs): can we derive this from the ScrollArea shape?
-    let offset = offset.at_most(desired_size - available_size);
-    let offset = offset.at_least(Vec2::ZERO);
-
-    let scroll_area = ScrollArea::both()
-        .scroll_offset(offset)
-        .auto_shrink([false, false]);
-
-    let scroll_out = scroll_area.show(ui, |ui| -> Result<(), SpaceViewSystemExecutionError> {
-        let desired_size = desired_size.at_least(Vec2::ZERO);
-        let (mut response, painter) =
-            ui.allocate_painter(desired_size, egui::Sense::click_and_drag());
-
-        if !response.rect.is_positive() {
-            return Ok(());
-        }
-
-        let ui_from_canvas = egui::emath::RectTransform::from_to(canvas_rect, response.rect);
-        let canvas_from_ui = ui_from_canvas.inverse();
-
-        state
-            .state_2d
-            .update(&response, canvas_from_ui, canvas_rect, available_size);
-
-        // TODO(andreas): Use the same eye & transformations as in `setup_target_config`.
-        let eye = Eye {
-            world_from_rub_view: IsoTransform::IDENTITY,
-            fov_y: None,
-        };
-
-        let Ok(target_config) = setup_target_config(
-            &painter,
-            canvas_from_ui,
-            &query.space_origin.to_string(),
-            state.auto_size_config(),
-            query.highlights.any_outlines(),
-            pinhole,
-        ) else {
-            return Ok(());
-        };
-
-        let mut view_builder = ViewBuilder::new(ctx.render_ctx, target_config);
-
-        // Create labels now since their shapes participate are added to scene.ui for picking.
-        let (label_shapes, ui_rects) = create_labels(
-            collect_ui_labels(&parts),
-            ui_from_canvas,
-            &eye,
-            ui,
-            &query.highlights,
-            SpatialSpaceViewKind::TwoD,
-        );
-
-        if ui.ctx().dragged_id().is_none() {
-            response = picking(
-                ctx,
-                response,
-                canvas_from_ui,
-                painter.clip_rect(),
-                ui,
-                eye,
-                &mut view_builder,
-                state,
-                &view_ctx,
-                &parts,
-                &ui_rects,
-                query,
-                SpatialSpaceViewKind::TwoD,
-            )?;
-        }
-
-        for draw_data in draw_data {
-            view_builder.queue_draw(draw_data);
-        }
-
-        // ------------------------------------------------------------------------
-
-        // Screenshot context menu.
-        if let Some(mode) = screenshot_context_menu(ctx, &response) {
-            view_builder
-                .schedule_screenshot(ctx.render_ctx, query.space_view_id.gpu_readback_id(), mode)
-                .ok();
-        }
-
-        // Draw a re_renderer driven view.
-        // Camera & projection are configured to ingest space coordinates directly.
-        painter.add(gpu_bridge::new_renderer_callback(
-            view_builder,
+    if ui.ctx().dragged_id().is_none() {
+        response = picking(
+            ctx,
+            response,
+            scene_from_ui,
             painter.clip_rect(),
-            ui.visuals().extreme_bg_color.into(),
+            ui,
+            eye,
+            &mut view_builder,
+            state,
+            &view_ctx,
+            &parts,
+            &ui_rects,
+            query,
+            SpatialSpaceViewKind::TwoD,
+        )?;
+    }
+
+    for draw_data in draw_data {
+        view_builder.queue_draw(draw_data);
+    }
+
+    // ------------------------------------------------------------------------
+
+    if let Some(mode) = screenshot_context_menu(ctx, &response) {
+        view_builder
+            .schedule_screenshot(ctx.render_ctx, query.space_view_id.gpu_readback_id(), mode)
+            .ok();
+    }
+
+    // Draw a re_renderer driven view.
+    // Camera & projection are configured to ingest space coordinates directly.
+    painter.add(gpu_bridge::new_renderer_callback(
+        view_builder,
+        painter.clip_rect(),
+        ui.visuals().extreme_bg_color.into(),
+    ));
+
+    // Make sure to _first_ draw the selected, and *then* the hovered context on top!
+    for selected_context in ctx.selection_state().selection_space_contexts() {
+        painter.extend(show_projections_from_3d_space(
+            ui,
+            query.space_origin,
+            &ui_from_scene,
+            selected_context,
+            ui.style().visuals.selection.bg_fill,
         ));
+    }
+    if let Some(hovered_context) = ctx.selection_state().hovered_space_context() {
+        painter.extend(show_projections_from_3d_space(
+            ui,
+            query.space_origin,
+            &ui_from_scene,
+            hovered_context,
+            egui::Color32::WHITE,
+        ));
+    }
 
-        // Make sure to _first_ draw the selected, and *then* the hovered context on top!
-        for selected_context in ctx.selection_state().selection_space_contexts() {
-            painter.extend(show_projections_from_3d_space(
-                ui,
-                query.space_origin,
-                &ui_from_canvas,
-                selected_context,
-                ui.style().visuals.selection.bg_fill,
-            ));
-        }
-        if let Some(hovered_context) = ctx.selection_state().hovered_space_context() {
-            painter.extend(show_projections_from_3d_space(
-                ui,
-                query.space_origin,
-                &ui_from_canvas,
-                hovered_context,
-                egui::Color32::WHITE,
-            ));
-        }
+    // Add egui driven labels on top of re_renderer content.
+    painter.extend(label_shapes);
 
-        // Add egui driven labels on top of re_renderer content.
-        painter.extend(label_shapes);
-
-        Ok(())
-    });
-    scroll_out.inner?;
-
-    // Update the scroll area based on the computed offset
-    // This handles cases of dragging/zooming the space
-    state
-        .state_2d
-        .capture_scroll(scroll_out.state.offset, available_size, scene_rect_accum);
     Ok(())
 }
 
 fn setup_target_config(
     egui_painter: &egui::Painter,
-    canvas_from_ui: RectTransform,
+    scene_from_ui: RectTransform,
     space_name: &str,
     auto_size_config: re_renderer::AutoSizeConfig,
     any_outlines: bool,
@@ -426,11 +299,11 @@ fn setup_target_config(
 
     // For simplicity (and to reduce surprises!) we always render with a pinhole camera.
     // Make up a default pinhole camera if we don't have one placing it in a way to look at the entire space.
-    let canvas_size = glam::vec2(canvas_from_ui.to().width(), canvas_from_ui.to().height());
-    let default_principal_point = canvas_from_ui.to().center();
+    let scene_bounds_size = glam::vec2(scene_from_ui.to().width(), scene_from_ui.to().height());
+    let default_principal_point = scene_from_ui.to().center();
     let default_principal_point = glam::vec2(default_principal_point.x, default_principal_point.y);
     let pinhole = pinhole.unwrap_or_else(|| {
-        let focal_length_in_pixels = canvas_size.x;
+        let focal_length_in_pixels = scene_bounds_size.x;
 
         Pinhole {
             image_from_camera: glam::Mat3::from_cols(
@@ -439,7 +312,7 @@ fn setup_target_config(
                 default_principal_point.extend(1.0),
             )
             .into(),
-            resolution: Some(canvas_size.into()),
+            resolution: Some(scene_bounds_size.into()),
             camera_xyz: Some(ViewCoordinates::RDF),
         }
     });
@@ -449,7 +322,7 @@ fn setup_target_config(
         near_plane_distance: 0.1,
         aspect_ratio: pinhole
             .aspect_ratio()
-            .unwrap_or(canvas_size.x / canvas_size.y),
+            .unwrap_or(scene_bounds_size.x / scene_bounds_size.y),
     };
 
     // Put the camera at the position where it sees the entire image plane as defined
@@ -468,15 +341,15 @@ fn setup_target_config(
     // Cut to the portion of the currently visible ui area.
     let mut viewport_transformation = re_renderer::RectTransform {
         region_of_interest: re_render_rect_from_egui_rect(egui_painter.clip_rect()),
-        region: re_render_rect_from_egui_rect(*canvas_from_ui.from()),
+        region: re_render_rect_from_egui_rect(*scene_from_ui.from()),
     };
 
     // The principal point might not be quite centered.
     // We need to account for this translation in the viewport transformation.
     let principal_point_offset = default_principal_point - pinhole.principal_point();
-    let ui_from_canvas_scale = canvas_from_ui.inverse().scale();
+    let ui_from_scene_scale = scene_from_ui.inverse().scale();
     viewport_transformation.region_of_interest.min +=
-        principal_point_offset * glam::vec2(ui_from_canvas_scale.x, ui_from_canvas_scale.y);
+        principal_point_offset * glam::vec2(ui_from_scene_scale.x, ui_from_scene_scale.y);
 
     Ok({
         let name = space_name.into();
@@ -505,7 +378,7 @@ fn re_render_rect_from_egui_rect(rect: egui::Rect) -> re_renderer::RectF32 {
 fn show_projections_from_3d_space(
     ui: &egui::Ui,
     space: &EntityPath,
-    ui_from_canvas: &RectTransform,
+    ui_from_scene: &RectTransform,
     space_context: &ItemSpaceContext,
     color: egui::Color32,
 ) -> Vec<Shape> {
@@ -519,7 +392,7 @@ fn show_projections_from_3d_space(
             if space_2d == space {
                 if let Some(pos_2d) = pos_2d {
                     // User is hovering a 2D point inside a 3D view.
-                    let pos_in_ui = ui_from_canvas.transform_pos(pos2(pos_2d.x, pos_2d.y));
+                    let pos_in_ui = ui_from_scene.transform_pos(pos2(pos_2d.x, pos_2d.y));
                     let radius = 4.0;
                     shapes.push(Shape::circle_filled(
                         pos_in_ui,

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -511,7 +511,7 @@ pub fn view_3d(
         },
         viewport_transformation: re_renderer::RectTransform::IDENTITY,
 
-        pixels_from_point: ui.ctx().pixels_per_point(),
+        pixels_per_point: ui.ctx().pixels_per_point(),
         auto_size_config: state.auto_size_config(),
 
         outline_config: query

--- a/crates/re_types/src/archetypes/pinhole_ext.rs
+++ b/crates/re_types/src/archetypes/pinhole_ext.rs
@@ -37,6 +37,17 @@ impl Pinhole {
         Self::from_focal_length_and_resolution(focal_length, [aspect_ratio, 1.0])
     }
 
+    /// Principal point of the pinhole camera,
+    /// i.e. the intersection of the optical axis and the image plane.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn with_principal_point(mut self, principal_point: impl Into<Vec2D>) -> Self {
+        self.image_from_camera = self.image_from_camera.with_principal_point(principal_point);
+        self
+    }
+
     /// Field of View on the Y axis, i.e. the angle between top and bottom (in radians).
     #[inline]
     pub fn fov_y(&self) -> Option<f32> {

--- a/crates/re_types/src/components/pinhole_projection_ext.rs
+++ b/crates/re_types/src/components/pinhole_projection_ext.rs
@@ -17,6 +17,20 @@ impl PinholeProjection {
         ])
     }
 
+    /// Principal point of the pinhole camera,
+    /// i.e. the intersection of the optical axis and the image plane.
+    ///
+    /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)
+    #[cfg(feature = "glam")]
+    #[inline]
+    pub fn with_principal_point(mut self, principal_point: impl Into<Vec2D>) -> Self {
+        let pp = principal_point.into();
+        let col = 2;
+        self.0.set(0, col, pp.x());
+        self.0.set(1, col, pp.y());
+        self
+    }
+
     /// X & Y focal length in pixels.
     ///
     /// [see definition of intrinsic matrix](https://en.wikipedia.org/wiki/Camera_resectioning#Intrinsic_parameters)

--- a/crates/re_types/src/datatypes/mat3x3_ext.rs
+++ b/crates/re_types/src/datatypes/mat3x3_ext.rs
@@ -24,6 +24,28 @@ impl Mat3x3 {
             _ => panic!("index out of bounds"),
         }
     }
+
+    /// Get a specific element.
+    // NOTE: row-col is the normal index order for matrices in mathematics.
+    #[inline]
+    pub fn get(&self, row: usize, col: usize) -> f32 {
+        assert!(
+            row < 3 && col < 3,
+            "Mat3x3 index out of bounds (row: {row}, col: {col})"
+        );
+        self.0[row + col * 3]
+    }
+
+    /// Set a specific element.
+    // NOTE: row-col is the normal index order for matrices in mathematics.
+    #[inline]
+    pub fn set(&mut self, row: usize, col: usize, value: f32) {
+        assert!(
+            row < 3 && col < 3,
+            "Mat3x3 index out of bounds (row: {row}, col: {col})"
+        );
+        self.0[row + col * 3] = value;
+    }
 }
 
 impl<Idx> std::ops::Index<Idx> for Mat3x3
@@ -32,6 +54,7 @@ where
 {
     type Output = Idx::Output;
 
+    /// Column-major order matrix coefficients.
     #[inline]
     fn index(&self, index: Idx) -> &Self::Output {
         &self.0[index]

--- a/crates/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/mod.rs
@@ -86,9 +86,9 @@ pub fn tensor_decode_srgb_gamma_heuristic(
 
 // ----------------------------------------------------------------------------
 
-pub fn viewport_resolution_in_pixels(clip_rect: egui::Rect, pixels_from_point: f32) -> [u32; 2] {
-    let min = (clip_rect.min.to_vec2() * pixels_from_point).round();
-    let max = (clip_rect.max.to_vec2() * pixels_from_point).round();
+pub fn viewport_resolution_in_pixels(clip_rect: egui::Rect, pixels_per_point: f32) -> [u32; 2] {
+    let min = (clip_rect.min.to_vec2() * pixels_per_point).round();
+    let max = (clip_rect.max.to_vec2() * pixels_per_point).round();
     let resolution = max - min;
     [resolution.x as u32, resolution.y as u32]
 }
@@ -160,14 +160,14 @@ pub fn render_image(
 
     // ------------------------------------------------------------------------
 
-    let pixels_from_points = egui_painter.ctx().pixels_per_point();
+    let pixels_per_point = egui_painter.ctx().pixels_per_point();
     let ui_from_space = egui::emath::RectTransform::from_to(space_rect, image_rect_on_screen);
     let space_from_ui = ui_from_space.inverse();
     let space_from_points = space_from_ui.scale().y;
     let points_from_pixels = 1.0 / egui_painter.ctx().pixels_per_point();
     let space_from_pixel = space_from_points * points_from_pixels;
 
-    let resolution_in_pixel = viewport_resolution_in_pixels(viewport, pixels_from_points);
+    let resolution_in_pixel = viewport_resolution_in_pixels(viewport, pixels_per_point);
     anyhow::ensure!(resolution_in_pixel[0] > 0 && resolution_in_pixel[1] > 0);
 
     let camera_position_space = space_from_ui.transform_pos(viewport.min);
@@ -184,7 +184,7 @@ pub fn render_image(
             far_plane_distance: 1000.0,
         },
         viewport_transformation: re_renderer::RectTransform::IDENTITY,
-        pixels_from_point: pixels_from_points,
+        pixels_per_point,
         auto_size_config: Default::default(),
         outline_config: None,
     };

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -98,6 +98,8 @@ def log_nyud_data(recording_path: Path, subset_idx: int, frames: int) -> None:
                     rr.Pinhole(
                         resolution=[img_depth.shape[1], img_depth.shape[0]],
                         focal_length=0.7 * img_depth.shape[1],
+                        # Intentionally off-center to demonstrate that we support it
+                        principal_point=[0.45 * img_depth.shape[1], 0.55 * img_depth.shape[0]],
                     ),
                 )
 

--- a/tests/rust/test_pinhole_projection/Cargo.toml
+++ b/tests/rust/test_pinhole_projection/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_api"
+name = "test_pinhole_projection"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -11,12 +11,8 @@ workspace = true
 
 [dependencies]
 re_log = { workspace = true, features = ["setup"] }
-rerun = { path = "../../../crates/rerun", features = ["clap", "web_viewer"] }
+rerun = { path = "../../../crates/rerun", features = ["clap"] }
 
 anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
-glam.workspace = true
-itertools.workspace = true
-ndarray.workspace = true
-ndarray-rand.workspace = true
-rand.workspace = true
+image = { workspace = true, default-features = false }

--- a/tests/rust/test_pinhole_projection/src/main.rs
+++ b/tests/rust/test_pinhole_projection/src/main.rs
@@ -1,0 +1,83 @@
+//! Visual test for how we project 3D into 2D using Pinhole.
+//!
+//! ```
+//! cargo run -p test_pinhole_projection
+//! ```
+
+use rerun::{external::re_log, MediaType, RecordingStream};
+
+#[derive(Debug, clap::Parser)]
+#[clap(author, version, about)]
+struct Args {
+    #[command(flatten)]
+    rerun: rerun::clap::RerunArgs,
+}
+
+fn main() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    use clap::Parser as _;
+    let args = Args::parse();
+
+    let (rec, _serve_guard) = args.rerun.init("rerun_example_test_pinhole_projection")?;
+    run(&rec)
+}
+
+fn run(rec: &RecordingStream) -> anyhow::Result<()> {
+    const DESCRIPTION: &str = "\
+    Add `/world/points` to the 2D image space (projected).\n\nn\
+    The five points should project onto the corners and center of the image.\n\n\
+    Only the top-right point should be undistorted (circular).
+    ";
+    rec.log_static(
+        "description",
+        &rerun::TextDocument::new(DESCRIPTION).with_media_type(MediaType::markdown()),
+    )?;
+
+    rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Y_DOWN)?;
+
+    const W: u32 = 2000;
+    const H: u32 = 1000;
+
+    let focal_length = [H as f32, H as f32];
+
+    rec.log(
+        "world/camera/image",
+        &rerun::Pinhole::from_focal_length_and_resolution(focal_length, [W as f32, H as f32])
+            // We put the principal point in the unusual top-right corner
+            .with_principal_point([W as f32, 0.0]),
+    )?;
+
+    let mut depth_image: image::ImageBuffer<image::Luma<u16>, Vec<u16>> =
+        image::ImageBuffer::new(W, H);
+    for y in 0..H {
+        for x in 0..W {
+            let depth = 2000; // TODO(emilk): we could parameterize this over x/y to make it more interesting.
+            depth_image.put_pixel(x, y, image::Luma([depth]));
+        }
+    }
+
+    rec.log(
+        "world/camera/image/depth",
+        &rerun::DepthImage::try_from(depth_image)?.with_meter(1000.0),
+    )?;
+
+    rec.log(
+        "world/camera/image/bottom_right",
+        &rerun::Points2D::new([[W as f32, H as f32]]),
+    )?;
+
+    rec.log(
+        "world/points",
+        &rerun::Points3D::new([
+            [0.0, 0.0, 1.0],
+            [-2.0, 0.0, 1.0],
+            [0.0, 1.0, 1.0],
+            [-2.0, 1.0, 1.0],
+            [-1.0, 0.5, 1.0],
+        ])
+        .with_radii([0.05]),
+    )?;
+
+    Ok(())
+}


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/2531
* Closes https://github.com/rerun-io/rerun/issues/2490

By default the bounds are centered:

Before:
<img width="2023" alt="Screenshot 2024-04-24 at 11 46 47" src="https://github.com/rerun-io/rerun/assets/1148717/0b8678ac-e427-4a5a-a633-011eee239fc8">

After:
<img width="2023" alt="Screenshot 2024-04-24 at 11 45 41" src="https://github.com/rerun-io/rerun/assets/1148717/fbf6fd94-79a8-4ed2-b324-4f34672f0cb9">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6089?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6089?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6089)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.