### PR TITLE
Update the example in configure-viewer-through-code.md to use subclasses of `SpaceView`

### DIFF
--- a/docs/content/howto/configure-viewer-through-code.md
+++ b/docs/content/howto/configure-viewer-through-code.md
@@ -37,10 +37,10 @@ For example:
 ```python
 my_blueprint = rrb.Blueprint(
     rrb.Horizontal(
-        rrb.SpaceView(rrb.BarChartView()),
+        rrb.BarChartView(),
         rrb.Vertical(
-            rrb.SpaceView(rrb.Spatial2DView()),
-            rrb.SpaceView(rrb.Spatial3DView()),
+            rrb.Spatial2DView(),
+            rrb.Spatial3DView(),
         ),
     ),
 )


### PR DESCRIPTION
### What

Whereas the Python API docs say that we should use subclasses of `SpaceView` instead of `SpaceView` directly (see [here](https://ref.rerun.io/docs/python/0.15.1/common/blueprint_apis/#rerun.blueprint.SpaceView)), the [blueprint documentation](https://www.rerun.io/docs/howto/configure-viewer-through-code) uses `SpaceView` with a subclass as positional argument to the constructor of the `SpaceView`.

Not only is this contradictory, the example that is currently in the online docs does not run for me in version 0.15.1, see the error below.

```
Traceback (most recent call last):
  File "rerun_blueprint_test.py", line 6, in <module>
    rrb.SpaceView(rrb.BarChartView()),
TypeError: SpaceView.__init__() takes 1 positional argument but 2 were given
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6092?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6092?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6092)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.