### PR TITLE
Fix broken `log_timeless` on C++

### DIFF
--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -346,7 +346,7 @@ namespace rerun {
         [[deprecated("Use `log_static` instead")]] void log_timeless(
             std::string_view entity_path, const Ts&... archetypes_or_collections
         ) const {
-            return log_static(entity_path, true, archetypes_or_collections...);
+            return log_static(entity_path, archetypes_or_collections...);
         }
 
         /// Logs one or more archetype and/or component batches as static data.


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/cpp-example-opencv-eigen/issues/25
    * Huge thanks once more to @traversaro who saved us from doing a patch release on this after the next release, very unlikely we would have noticed in time!

`log_timeless` broke when it got deprecated: this didn't get caught since the error only shows up when the template is instantiated - added a regression test to address this. (think Python ;-) T_T)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
