### PR TITLE
Don't fail CI workflow when link checks fail

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -165,6 +165,8 @@ jobs:
   link-checker:
     name: Check links
     runs-on: ubuntu-latest
+    # do not fail entire workflow (e.g. nightly) if this is the only failing check
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What

Links check have proven flaky given it relies on remote servers to cooperate. It's pretty annoying when entire workflow fails (e.g. `nightly`) just because of a 500 error. This PR marks the link check step with `continue-on-error: true`.

- Fixes https://github.com/rerun-io/rerun/issues/6055

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
