### PR TITLE
Allow setting view visibility from blueprint api

### DIFF
--- a/crates/re_types_builder/src/codegen/python/views.rs
+++ b/crates/re_types_builder/src/codegen/python/views.rs
@@ -39,6 +39,7 @@ fn init_method(reporter: &Reporter, objects: &Objects, obj: &Object) -> String {
     origin: EntityPathLike = "/",
     contents: SpaceViewContentsLike = "$origin/**",
     name: Utf8Like | None = None,
+    visible: blueprint_components.VisibilityLike | None = None,
     "#
     .to_owned();
 
@@ -100,6 +101,13 @@ See [rerun.blueprint.archetypes.SpaceViewContents][]."
                 .to_owned(),
         ),
         ("name", "The display name of the view.".to_owned()),
+        (
+            "visible",
+            "Whether this space view is visible.
+
+Defaults to true if not specified."
+                .to_owned(),
+        ),
     ];
     for field in &obj.fields {
         let doc_content = field.docs.doc_lines_for_untagged_and("py");
@@ -165,7 +173,7 @@ See [rerun.blueprint.archetypes.SpaceViewContents][]."
     }
     code.push_indented(
         1,
-        &format!(r#"super().__init__(class_identifier="{identifier}", origin=origin, contents=contents, name=name, properties=properties)"#),
+        &format!(r#"super().__init__(class_identifier="{identifier}", origin=origin, contents=contents, name=name, visible=visible, properties=properties)"#),
         1,
     );
 

--- a/crates/re_types_builder/src/codegen/python/views.rs
+++ b/crates/re_types_builder/src/codegen/python/views.rs
@@ -17,6 +17,7 @@ pub fn code_for_view(reporter: &Reporter, objects: &Objects, obj: &Object) -> St
 from .. import archetypes as blueprint_archetypes
 from .. import components as blueprint_components
 from ... import datatypes
+from ... import components
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
 from ..api import SpaceView, SpaceViewContentsLike
@@ -39,7 +40,7 @@ fn init_method(reporter: &Reporter, objects: &Objects, obj: &Object) -> String {
     origin: EntityPathLike = "/",
     contents: SpaceViewContentsLike = "$origin/**",
     name: Utf8Like | None = None,
-    visible: blueprint_components.VisibilityLike | None = None,
+    visible: blueprint_components.VisibleLike | None = None,
     "#
     .to_owned();
 

--- a/crates/re_types_builder/src/codegen/python/views.rs
+++ b/crates/re_types_builder/src/codegen/python/views.rs
@@ -103,7 +103,7 @@ See [rerun.blueprint.archetypes.SpaceViewContents][]."
         ("name", "The display name of the view.".to_owned()),
         (
             "visible",
-            "Whether this space view is visible.
+            "Whether this view is visible.
 
 Defaults to true if not specified."
                 .to_owned(),

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -12,7 +12,7 @@ from ..memory import MemoryRecording
 from ..notebook import as_html
 from ..recording_stream import RecordingStream
 from .archetypes import ContainerBlueprint, PanelBlueprint, SpaceViewBlueprint, SpaceViewContents, ViewportBlueprint
-from .components import ColumnShareArrayLike, RowShareArrayLike
+from .components import ColumnShareArrayLike, RowShareArrayLike, VisibleLike
 from .components.container_kind import ContainerKindLike
 
 SpaceViewContentsLike = Union[Utf8ArrayLike, SpaceViewContents]
@@ -42,6 +42,7 @@ class SpaceView:
         origin: EntityPathLike,
         contents: SpaceViewContentsLike,
         name: Utf8Like | None,
+        visible: VisibleLike | None = None,
         properties: dict[str, AsComponents] = {},
     ):
         """
@@ -60,6 +61,10 @@ class SpaceView:
         contents
             The contents of the space view specified as a query expression. This is either a single expression,
             or a list of multiple expressions. See [rerun.blueprint.archetypes.SpaceViewContents][].
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
         properties
             Dictionary of property archetypes to add to space view's internal hierarchy.
 
@@ -69,6 +74,7 @@ class SpaceView:
         self.name = name
         self.origin = origin
         self.contents = contents
+        self.visible = visible
         self.properties = properties
 
     def blueprint_path(self) -> str:
@@ -105,6 +111,7 @@ class SpaceView:
             class_identifier=self.class_identifier,
             display_name=self.name,
             space_origin=self.origin,
+            visible=self.visible,
         )
 
         stream.log(self.blueprint_path(), arch, recording=stream)  # type: ignore[attr-defined]

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
@@ -21,7 +21,7 @@ class BarChartView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new BarChartView view.
@@ -38,7 +38,7 @@ class BarChartView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
@@ -8,6 +8,7 @@ __all__ = ["BarChartView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class BarChartView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new BarChartView view.
@@ -35,10 +37,19 @@ class BarChartView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
         super().__init__(
-            class_identifier="BarChart", origin=origin, contents=contents, name=name, properties=properties
+            class_identifier="BarChart",
+            origin=origin,
+            contents=contents,
+            name=name,
+            visible=visible,
+            properties=properties,
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -21,7 +21,7 @@ class Spatial2DView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new Spatial2DView view.
@@ -38,7 +38,7 @@ class Spatial2DView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -8,6 +8,7 @@ __all__ = ["Spatial2DView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class Spatial2DView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new Spatial2DView view.
@@ -35,8 +37,14 @@ class Spatial2DView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
-        super().__init__(class_identifier="2D", origin=origin, contents=contents, name=name, properties=properties)
+        super().__init__(
+            class_identifier="2D", origin=origin, contents=contents, name=name, visible=visible, properties=properties
+        )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -23,7 +23,7 @@ class Spatial3DView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
         background: blueprint_archetypes.Background3D
         | datatypes.Rgba32Like
         | blueprint_components.Background3DKindLike
@@ -44,7 +44,7 @@ class Spatial3DView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
         background:

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -23,6 +23,7 @@ class Spatial3DView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
         background: blueprint_archetypes.Background3D
         | datatypes.Rgba32Like
         | blueprint_components.Background3DKindLike
@@ -42,6 +43,10 @@ class Spatial3DView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
         background:
             Configuration for the background of the 3D space view.
 
@@ -53,4 +58,6 @@ class Spatial3DView(SpaceView):
                 background = blueprint_archetypes.Background3D(background)
             properties["Background3D"] = background
 
-        super().__init__(class_identifier="3D", origin=origin, contents=contents, name=name, properties=properties)
+        super().__init__(
+            class_identifier="3D", origin=origin, contents=contents, name=name, visible=visible, properties=properties
+        )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
@@ -21,7 +21,7 @@ class TensorView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TensorView view.
@@ -38,7 +38,7 @@ class TensorView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
@@ -8,6 +8,7 @@ __all__ = ["TensorView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class TensorView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TensorView view.
@@ -35,8 +37,19 @@ class TensorView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
-        super().__init__(class_identifier="Tensor", origin=origin, contents=contents, name=name, properties=properties)
+        super().__init__(
+            class_identifier="Tensor",
+            origin=origin,
+            contents=contents,
+            name=name,
+            visible=visible,
+            properties=properties,
+        )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
@@ -21,7 +21,7 @@ class TextDocumentView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TextDocumentView view.
@@ -38,7 +38,7 @@ class TextDocumentView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
@@ -8,6 +8,7 @@ __all__ = ["TextDocumentView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class TextDocumentView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TextDocumentView view.
@@ -35,10 +37,19 @@ class TextDocumentView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
         super().__init__(
-            class_identifier="TextDocument", origin=origin, contents=contents, name=name, properties=properties
+            class_identifier="TextDocument",
+            origin=origin,
+            contents=contents,
+            name=name,
+            visible=visible,
+            properties=properties,
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
@@ -8,6 +8,7 @@ __all__ = ["TextLogView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class TextLogView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TextLogView view.
@@ -35,8 +37,19 @@ class TextLogView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
-        super().__init__(class_identifier="TextLog", origin=origin, contents=contents, name=name, properties=properties)
+        super().__init__(
+            class_identifier="TextLog",
+            origin=origin,
+            contents=contents,
+            name=name,
+            visible=visible,
+            properties=properties,
+        )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
@@ -21,7 +21,7 @@ class TextLogView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TextLogView view.
@@ -38,7 +38,7 @@ class TextLogView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -8,6 +8,7 @@ __all__ = ["TimeSeriesView"]
 
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
+from .. import components as blueprint_components
 from ..api import SpaceView, SpaceViewContentsLike
 
 
@@ -20,6 +21,7 @@ class TimeSeriesView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
+        visible: blueprint_components.VisibilityLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TimeSeriesView view.
@@ -35,10 +37,19 @@ class TimeSeriesView(SpaceView):
             See [rerun.blueprint.archetypes.SpaceViewContents][].
         name:
             The display name of the view.
+        visible:
+            Whether this space view is visible.
+
+            Defaults to true if not specified.
 
         """
 
         properties: dict[str, AsComponents] = {}
         super().__init__(
-            class_identifier="TimeSeries", origin=origin, contents=contents, name=name, properties=properties
+            class_identifier="TimeSeries",
+            origin=origin,
+            contents=contents,
+            name=name,
+            visible=visible,
+            properties=properties,
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -21,7 +21,7 @@ class TimeSeriesView(SpaceView):
         origin: EntityPathLike = "/",
         contents: SpaceViewContentsLike = "$origin/**",
         name: Utf8Like | None = None,
-        visible: blueprint_components.VisibilityLike | None = None,
+        visible: blueprint_components.VisibleLike | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TimeSeriesView view.
@@ -38,7 +38,7 @@ class TimeSeriesView(SpaceView):
         name:
             The display name of the view.
         visible:
-            Whether this space view is visible.
+            Whether this view is visible.
 
             Defaults to true if not specified.
 


### PR DESCRIPTION
### What

* Fixes #6107

Testing this from repl:
![image](https://github.com/rerun-io/rerun/assets/1220815/accd1f31-3226-4731-ab18-556104be9c36)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6108?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6108?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6108)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.