### PR TITLE
Add `TextDocument::from_markdown` constructor

### DIFF
--- a/crates/re_types/src/archetypes/text_document.rs
+++ b/crates/re_types/src/archetypes/text_document.rs
@@ -40,7 +40,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     rec.log(
 ///         "markdown",
-///         &rerun::TextDocument::new(
+///         &rerun::TextDocument::from_markdown(
 ///             r#"
 /// # Hello Markdown!
 /// [Click here to see the raw text](recording://markdown:Text).
@@ -77,7 +77,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ![A random image](https://picsum.photos/640/480)
 /// "#.trim(),
 ///         )
-///         .with_media_type(rerun::MediaType::markdown()),
 ///     )?;
 ///
 ///     Ok(())

--- a/crates/re_types/src/archetypes/text_document_ext.rs
+++ b/crates/re_types/src/archetypes/text_document_ext.rs
@@ -32,4 +32,12 @@ impl TextDocument {
             media_type,
         })
     }
+
+    /// Creates a new [`TextDocument`] containing Markdown.
+    ///
+    /// Equivalent to `TextDocument::new(markdown).with_media_type(MediaType::markdown())`.
+    #[inline]
+    pub fn from_markdown(markdown: impl Into<crate::components::Text>) -> Self {
+        Self::new(markdown).with_media_type(MediaType::markdown())
+    }
 }

--- a/docs/snippets/all/text_document.rs
+++ b/docs/snippets/all/text_document.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "markdown",
-        &rerun::TextDocument::new(
+        &rerun::TextDocument::from_markdown(
             r#"
 # Hello Markdown!
 [Click here to see the raw text](recording://markdown:Text).
@@ -47,7 +47,6 @@ Of course you can also have [normal https links](https://github.com/rerun-io/rer
 ![A random image](https://picsum.photos/640/480)
 "#.trim(),
         )
-        .with_media_type(rerun::MediaType::markdown()),
     )?;
 
     Ok(())

--- a/examples/rust/external_data_loader/src/main.rs
+++ b/examples/rust/external_data_loader/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
     rec.log_with_static(
         entity_path_prefix.join(&rerun::EntityPath::from_file_path(&args.filepath)),
         args.statically || args.timeless,
-        &rerun::TextDocument::new(text).with_media_type(MediaType::MARKDOWN),
+        &rerun::TextDocument::from_markdown(text),
     )?;
 
     Ok::<_, anyhow::Error>(())

--- a/examples/rust/incremental_logging/src/main.rs
+++ b/examples/rust/incremental_logging/src/main.rs
@@ -56,10 +56,7 @@ Move the time cursor around, and notice how the colors and radii from frame 0 ar
 "#;
 
 fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
-    rec.log_static(
-        "readme",
-        &rerun::TextDocument::new(README).with_media_type(rerun::MediaType::MARKDOWN),
-    )?;
+    rec.log_static("readme", &rerun::TextDocument::from_markdown(README))?;
 
     // TODO(#5264): just log one once clamp-to-edge semantics land.
     let colors = [rerun::Color::from_rgb(255, 0, 0); 10];

--- a/tests/rust/roundtrips/text_document/src/main.rs
+++ b/tests/rust/roundtrips/text_document/src/main.rs
@@ -17,15 +17,14 @@ fn run(rec: &RecordingStream, _args: &Args) -> anyhow::Result<()> {
     rec.log("text_document", &TextDocument::new("Hello, TextDocument!"))?;
     rec.log(
         "markdown",
-        &TextDocument::new(
+        &TextDocument::from_markdown(
             "# Hello\n\
              Markdown with `code`!\n\
              \n\
              A random image:\n\
              \n\
              ![A random image](https://picsum.photos/640/480)",
-        )
-        .with_media_type(MediaType::markdown()),
+        ),
     )?;
     Ok(())
 }

--- a/tests/rust/test_pinhole_projection/src/main.rs
+++ b/tests/rust/test_pinhole_projection/src/main.rs
@@ -31,7 +31,7 @@ fn run(rec: &RecordingStream) -> anyhow::Result<()> {
     ";
     rec.log_static(
         "description",
-        &rerun::TextDocument::new(DESCRIPTION).with_media_type(MediaType::markdown()),
+        &rerun::TextDocument::from_markdown(DESCRIPTION),
     )?;
 
     rec.log_static("world", &rerun::ViewCoordinates::RIGHT_HAND_Y_DOWN)?;


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
