### PR TITLE
`pixi run format` now supports rust too

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -101,8 +101,16 @@ rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/c
   "rerun-build-web", # The checks require the web viewer wasm to be around.
 ] }
 
+rs-fmt = "cargo fmt"
+
 # Code formatting for all languages.
-format = { depends_on = ["py-fmt", "cpp-fmt", "toml-fmt", "misc-fmt"] }
+format = { depends_on = [
+  "py-fmt",
+  "cpp-fmt",
+  "rs-fmt",
+  "toml-fmt",
+  "misc-fmt",
+] }
 fmt = { depends_on = ["format"] }
 
 # Assorted linting tasks


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
