### PR TITLE
Fix `pixi run fast-lint`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ fmt = { depends_on = ["format"] }
 # Assorted linting tasks
 fast-lint = "python scripts/fast_lint.py"
 lint-codegen = "cargo --quiet run --package re_types_builder -- --check"
-# TODO(jleibs): implement lint-cpp-all
+# TODO(jleibs): implement lint-cpp-files
 lint-rerun = "python scripts/lint.py"
 lint-rs-files = "rustfmt --edition 2021 --check"
 lint-rs-all = "cargo fmt --check"

--- a/scripts/fast_lint.py
+++ b/scripts/fast_lint.py
@@ -139,11 +139,12 @@ def main() -> None:
 
     jobs = [
         LintJob("lint-codegen", accepts_files=False),
-        LintJob(
-            "lint-cpp-files",
-            extensions=[".cpp", ".c", ".h", ".hpp"],
-            allow_no_filter=False,
-        ),
+        # TODO(jleibs): implement lint-cpp-files
+        # LintJob(
+        #     "lint-cpp-files",
+        #     extensions=[".cpp", ".c", ".h", ".hpp"],
+        #     allow_no_filter=False,
+        # ),
         LintJob("lint-rerun"),
         LintJob(
             "lint-rs-files",


### PR DESCRIPTION


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6119?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6119?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6119)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.