### PR TITLE
Introduce a snippet for Spatial3DView and fix issues related to _RERUN_TEST_FORCE_SAVE

### DIFF
--- a/crates/re_data_source/src/load_file.rs
+++ b/crates/re_data_source/src/load_file.rs
@@ -123,7 +123,6 @@ pub(crate) fn prepare_store_info(
                 is_official_example: false,
                 started: re_log_types::Time::now(),
                 store_source,
-                store_kind: re_log_types::StoreKind::Recording,
             },
         })
     })

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -39,12 +39,11 @@ impl crate::DataUi for EntityDb {
             if let Some(store_info) = self.store_info() {
                 let re_log_types::StoreInfo {
                     application_id,
-                    store_id: _,
+                    store_id,
                     cloned_from,
                     is_official_example: _,
                     started,
                     store_source,
-                    store_kind,
                 } = store_info;
 
                 if let Some(cloned_from) =  cloned_from {
@@ -62,7 +61,7 @@ impl crate::DataUi for EntityDb {
                 ui.end_row();
 
                 re_ui.grid_left_hand_label(ui, "Kind");
-                ui.label(store_kind.to_string());
+                ui.label(store_id.kind.to_string());
                 ui.end_row();
 
                 re_ui.grid_left_hand_label(ui, "Created");

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -48,7 +48,6 @@ impl DataUi for SetStoreInfo {
             started,
             store_source,
             is_official_example,
-            store_kind,
         } = info;
 
         let re_ui = &ctx.re_ui;
@@ -83,7 +82,7 @@ impl DataUi for SetStoreInfo {
             ui.end_row();
 
             re_ui.grid_left_hand_label(ui, "store_kind:");
-            ui.label(format!("{store_kind}"));
+            ui.label(format!("{}", store_id.kind));
             ui.end_row();
         });
     }

--- a/crates/re_entity_db/src/store_bundle.rs
+++ b/crates/re_entity_db/src/store_bundle.rs
@@ -107,7 +107,6 @@ impl StoreBundle {
                     is_official_example: false,
                     started: re_log_types::Time::now(),
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
-                    store_kind: StoreKind::Blueprint,
                 },
             });
 

--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -239,7 +239,6 @@ fn test_encode_decode() {
                 rustc_version: String::new(),
                 llvm_version: String::new(),
             },
-            store_kind: re_log_types::StoreKind::Recording,
         },
     })];
 

--- a/crates/re_log_encoding/src/decoder/stream.rs
+++ b/crates/re_log_encoding/src/decoder/stream.rs
@@ -239,7 +239,6 @@ mod tests {
                 is_official_example: false,
                 started: Time::from_ns_since_epoch(0),
                 store_source: StoreSource::Unknown,
-                store_kind: StoreKind::Recording,
             },
         })
     }

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -360,8 +360,6 @@ pub struct StoreInfo {
     pub started: Time,
 
     pub store_source: StoreSource,
-
-    pub store_kind: StoreKind,
 }
 
 impl StoreInfo {

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -182,7 +182,6 @@ pub fn new_store_info(
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },
-        store_kind: re_log_types::StoreKind::Recording,
     }
 }
 

--- a/docs/snippets/all/spatial3dview.py
+++ b/docs/snippets/all/spatial3dview.py
@@ -1,3 +1,5 @@
+"""Use a blueprint to customize a Spatial3DView."""
+
 import rerun as rr
 import rerun.blueprint as rrb
 from numpy.random import default_rng

--- a/docs/snippets/all/spatial3dview.py
+++ b/docs/snippets/all/spatial3dview.py
@@ -1,0 +1,23 @@
+import rerun as rr
+import rerun.blueprint as rrb
+from numpy.random import default_rng
+
+rr.init("rerun_example_spatial_3d", spawn=True)
+
+# Create some random points
+rng = default_rng(12345)
+positions = rng.uniform(-5, 5, size=[10, 3])
+colors = rng.uniform(0, 255, size=[10, 3])
+radii = rng.uniform(0, 1, size=[10])
+
+rr.log("points", rr.Points3D(positions, colors=colors, radii=radii))
+
+# Create a Spatial3D View
+blueprint = rrb.Blueprint(
+    rrb.Spatial3DView(
+        origin="/points",
+        background=[80, 80, 80],
+    )
+)
+
+rr.send_blueprint(blueprint)

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -13,6 +13,7 @@ log_line = [ # Not a complete example -- just a single log line
   "rust",
   "py",
 ]
+spatial3dview = ["cpp", "rust"] # Missing examples
 timelines_example = [ # TODO(ab): incomplete code, need hideable stubs, see https://github.com/rerun-io/landing/issues/515
   "py",
   "cpp",

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1062,7 +1062,7 @@ fn send_blueprint(
 
         recording.send_blueprint(blueprint.inner.take(), activation_cmd);
     } else {
-        re_log::warn!("Provided `default_blueprint` has no store info, cannot send it.");
+        re_log::warn!("Provided `blueprint` has no store info, cannot send it.");
     }
 }
 


### PR DESCRIPTION
### What
- Introduce a new snippet that also sends a blueprint

It turned out that _RERUN_TEST_FORCE_SAVE is totally broken when using blueprints since the blueprint stream stomps on the recording.
- Make it so _RERUN_TEST_FORCE_SAVE works with blueprints
- Remove redundant store_kind since this led to bugs opting out blueprint memory recordings from the force-save path.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6120?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6120?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6120)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.