### PR TITLE
CI: Only run C++ checks for Linux on PRs

### DIFF
--- a/.github/workflows/cpp_matrix_fast.json
+++ b/.github/workflows/cpp_matrix_fast.json
@@ -1,0 +1,11 @@
+{
+    "include": [
+        {
+            "name": "Linux x64, C++17",
+            "runs_on": "ubuntu-latest-16-cores",
+            "cache_key": "build-linux",
+            "extra_env_vars": "RERUN_USE_ASAN=1 RERUN_SET_CXX_VERSION=17",
+            "additional_commands": "pixi run cpp-docs"
+        }
+    ]
+}

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -51,9 +51,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+
       - name: Load C++ test matrix
         id: set-matrix
-        run: echo "matrix=$(jq -c . < ./.github/workflows/cpp_matrix_full.json)" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ github.event.inputs.CHANNEL }}" == "pr" ]]; then
+            echo "matrix=$(jq -c . < ./.github/workflows/cpp_matrix_fast.json)" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=$(jq -c . < ./.github/workflows/cpp_matrix_full.json)" >> $GITHUB_OUTPUT
+          fi
+
 
   cpp-tests:
     name: C++ build & test - ${{ matrix.name }}


### PR DESCRIPTION
On `main` and `nightly` we run all platforms.

The C++ checks are very slow, and we run them whenever we do any codegen, e.g. add/change blueprint properties.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
