### PR TITLE
Fix mesh flicker

### DIFF
--- a/crates/re_query/src/range/results.rs
+++ b/crates/re_query/src/range/results.rs
@@ -226,10 +226,13 @@ pub struct RangeData<'a, T> {
 
 impl<'a, C: Component> RangeData<'a, C> {
     /// Useful to abstract over latest-at and ranged results.
+    ///
+    /// Use `reindexed` override the index of the data, if needed.
     #[inline]
     pub fn from_latest_at(
         resolver: &PromiseResolver,
         results: &'a LatestAtComponentResults,
+        reindexed: Option<(TimeInt, RowId)>,
     ) -> Self {
         let LatestAtComponentResults {
             index,
@@ -238,9 +241,10 @@ impl<'a, C: Component> RangeData<'a, C> {
         } = results;
 
         let status = results.to_dense::<C>(resolver).map(|_| ());
+        let index = reindexed.unwrap_or(*index);
 
         Self {
-            indices: Some(Indices::Owned(vec![*index].into())),
+            indices: Some(Indices::Owned(vec![index].into())),
             data: cached_dense.get().map(|data| Data::Owned(Arc::clone(data))),
             time_range: TimeRange::new(index.0, index.0),
             front_status: status.clone(),


### PR DESCRIPTION
Funnily enough, the reason this was flickering on `0.15` was completely unrelated to the reason why it flickers on `main`.

Long story short: it had to with how explicit client-side splats were splitting the data across different timestamps and in some cases this was incorrectly handled.

In the new APIs it's just an issue in the entity_iterator machinery which lowers everything to range semantics, which leads to problems when the query expects latest-at semantics.

- Fixes #6072

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
