### PR TITLE
Don't bench the re_query binaries

### DIFF
--- a/crates/re_query/Cargo.toml
+++ b/crates/re_query/Cargo.toml
@@ -85,11 +85,13 @@ required-features = ["to_archetype"]
 [[bin]]
 name = "clamped_zip"
 required-features = ["codegen"]
+bench = false
 
 
 [[bin]]
 name = "range_zip"
 required-features = ["codegen"]
+bench = false
 
 
 [[bench]]


### PR DESCRIPTION
### What
This was causing nightly to fail with:
```
error: Unrecognized option: 'output-format'
error: bench failed, to rerun pass `-p re_query --bin clamped_zip`
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6160?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6160?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6160)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.