### PR TITLE
Avoid using re_types in re_query when to_archetypes feature is not enabled

### DIFF
--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -124,21 +124,25 @@ impl From<(RangeQuery, RangeResults)> for Results {
 ///
 /// Used internally to avoid unnecessarily caching components that are already cached in other
 /// places, for historical reasons.
-pub fn cacheable(component_name: re_types::ComponentName) -> bool {
+pub fn cacheable(component_name: re_types_core::ComponentName) -> bool {
     use std::sync::OnceLock;
-    static NOT_CACHEABLE: OnceLock<re_types::ComponentNameSet> = OnceLock::new();
+    static NOT_CACHEABLE: OnceLock<re_types_core::ComponentNameSet> = OnceLock::new();
 
+    #[cfg(feature = "to_archetype")]
     use re_types_core::Loggable as _;
     let not_cacheable = NOT_CACHEABLE.get_or_init(|| {
         [
             // TODO(#5974): tensors might already be cached in the ad-hoc JPEG cache, we don't
             // want yet another copy.
+            #[cfg(feature = "to_archetype")]
             re_types::components::TensorData::name(),
             // TODO(#5974): meshes are already cached in the ad-hoc mesh cache, we don't
             // want yet another copy.
+            #[cfg(feature = "to_archetype")]
             re_types::components::MeshProperties::name(),
             // TODO(#5974): blobs are used for assets, which are themselves already cached in
             // the ad-hoc mesh cache -- we don't want yet another copy.
+            #[cfg(feature = "to_archetype")]
             re_types::components::Blob::name(),
         ]
         .into()

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -130,6 +130,20 @@ pub fn cacheable(component_name: re_types_core::ComponentName) -> bool {
 
     #[cfg(feature = "to_archetype")]
     let component_names = {
+        // Make sure to break if these names change, so people know to update the fallback path below.
+        #[cfg(debug_assertions)]
+        {
+            assert_eq!(
+                re_types::components::TensorData::name(),
+                "rerun.components.TensorData"
+            );
+            assert_eq!(
+                re_types::components::MeshProperties::name(),
+                "rerun.components.MeshProperties"
+            );
+            assert_eq!(re_types::components::Blob::name(), "rerun.components.Blob");
+        }
+
         use re_types_core::Loggable as _;
         [
             // TODO(#5974): tensors might already be cached in the ad-hoc JPEG cache, we don't


### PR DESCRIPTION
### What
Without these changes `cargo check --quiet --no-default-features -p re_query` was failing nightly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6162?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6162?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6162)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.