### PR TITLE
Add ROS 2 bridge example

### DIFF
--- a/examples/cpp/ros2_bridge/README.md
+++ b/examples/cpp/ros2_bridge/README.md
@@ -1,0 +1,27 @@
+<!--[metadata]
+title = "ROS 2 bridge"
+source = "https://github.com/rerun-io/cpp-example-ros2-bridge"
+tags = ["2D", "3D", "Pinhole camera", "ROS", "Time series", "C++"]
+thumbnail = "https://static.rerun.io/carla_thumbnail/8ec07c28f8eb901b8246afdd0b6d2b97ff75fb8d/480w.png"
+thumbnail_dimensions = [480, 480]
+-->
+
+A proof-of-concept Rerun bridge for ROS 2 that subscribes to all supported topics and visualizes the messages in Rerun.
+
+https://vimeo.com/940929187?autoplay=1&loop=1&autopause=0&background=1&muted=1&ratio=2696:1552
+
+## Background
+
+This is an example that shows how to use Rerun's C++ API to log and visualize [ROS 2](https://www.ros.org/) messages.
+
+It works by subscribing to all topics with supported types, converting the messages, and logging the data to Rerun. It further allows to remap topic names to specific entity paths, specify additional timeless transforms, and pinhole parameters via an external config file. See the [launch](https://github.com/rerun-io/cpp-example-ros2-bridge/tree/main/rerun_bridge/launch) directory for usage examples.
+
+## Run the code
+
+This is an external example, check the [repository](https://github.com/rerun-io/cpp-example-ros2-bridge) for more information.
+
+In a nutshell, clone the repo and run a demo with:
+
+```
+pixi run carla_example
+```

--- a/examples/cpp/ros_bridge/README.md
+++ b/examples/cpp/ros_bridge/README.md
@@ -6,6 +6,8 @@ thumbnail = "https://static.rerun.io/ros_bridge/121f72ebaea57a1b895196a5587fd1a4
 thumbnail_dimensions = [480, 480]
 -->
 
+A proof-of-concept Rerun bridge for ROS 1 that subscribes to all supported topics and visualizes the messages in Rerun.
+
 ## Background
 
 This is an example that shows how to use Rerun's C++ API to log and visualize [ROS](https://www.ros.org/) messages.
@@ -28,7 +30,7 @@ This is an external example, check the [repository](https://github.com/rerun-io/
 In a nutshell, clone the repo and run a demo with:
 
 ```
-pixi run example
+pixi run {spot_,drone_}example
 ```
 
 Note that this example currently supports Linux only.

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -34,6 +34,7 @@ examples = [
   # display order, most interesting first
   "ros_node",
   "nuscenes_dataset",
+  "ros2_bridge",
   "ros_bridge",
   "kiss-icp",
   "urdf_loader",
@@ -102,6 +103,7 @@ Integration with 3rd party tools, formats, libraries, and APIs.
 examples = [
   # display order, most interesting first
   "ros_node",
+  "ros2_bridge",
   "ros_bridge",
   "urdf_loader",
   "vrs",


### PR DESCRIPTION
### What
Add external [ROS 2 bridge](https://github.com/rerun-io/cpp-example-ros2-bridge) (with CARLA simulator example) to examples.

https://github.com/rerun-io/rerun/assets/9785832/39a026d8-d47b-4563-b0ea-0c8f53a4c575

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG