### PR TITLE
Add some static data to the store dump test suite

### DIFF
--- a/crates/re_data_store/tests/dump.rs
+++ b/crates/re_data_store/tests/dump.rs
@@ -8,7 +8,7 @@ use re_data_store::{
 };
 use re_log_types::{
     build_frame_nr, build_log_time, example_components::MyIndex, DataRow, DataTable, EntityPath,
-    RowId, TableId,
+    RowId, TableId, TimePoint,
 };
 use re_types::datagen::{build_some_colors, build_some_positions2d};
 
@@ -269,6 +269,7 @@ fn data_store_dump_filtered_impl(store1: &mut DataStore, store2: &mut DataStore)
 fn create_insert_table(entity_path: impl Into<EntityPath>) -> DataTable {
     let entity_path = entity_path.into();
 
+    let timeless = TimePoint::default();
     let frame1 = TimeInt::new_temporal(1);
     let frame2 = TimeInt::new_temporal(2);
     let frame3 = TimeInt::new_temporal(3);
@@ -282,7 +283,7 @@ fn create_insert_table(entity_path: impl Into<EntityPath>) -> DataTable {
     let positions2 = build_some_positions2d(3);
     let row2 = test_row!(entity_path @ [
             build_frame_nr(frame2),
-        ] => [instances1, positions2]);
+        ] => [instances1, positions2.clone()]);
 
     let positions3 = build_some_positions2d(10);
     let row3 = test_row!(entity_path @ [
@@ -292,9 +293,11 @@ fn create_insert_table(entity_path: impl Into<EntityPath>) -> DataTable {
     let colors4 = build_some_colors(5);
     let row4 = test_row!(entity_path @ [
             build_frame_nr(frame4),
-        ] => [colors4]);
+        ] => [colors4.clone()]);
 
-    let mut table = DataTable::from_rows(TableId::new(), [row1, row2, row3, row4]);
+    let row0 = test_row!(entity_path @ timeless => [positions2, colors4]);
+
+    let mut table = DataTable::from_rows(TableId::new(), [row0, row1, row2, row3, row4]);
     table.compute_all_size_bytes();
 
     table


### PR DESCRIPTION
I cannot reproduce https://github.com/rerun-io/rerun/issues/6094, see https://github.com/rerun-io/rerun/issues/6094#issuecomment-2084709242:
> I actually cannot repro this. I tried:
> - Saving entire timeline, `0.15.1`
> - Saving time selection, `0.15.1`
> - Saving entire timeline, `main`
> - Saving time selection, `main`

For now the best I can think of is to add some static data to the test suite and call it a day...

Marking as do not merge until the situation is clarified.

- Closes https://github.com/rerun-io/rerun/issues/6094

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
