### PR TITLE
Make visible time range ui aware of latest-at & `QueryRange`

### DIFF
--- a/crates/re_types_core/src/datatypes/visible_time_range_ext.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range_ext.rs
@@ -9,4 +9,13 @@ impl VisibleTimeRange {
         // This means +∞
         end: VisibleTimeRangeBoundary::INFINITE,
     };
+
+    /// A range of zero length exactly at the time cursor.
+    ///
+    /// This is *not* the same as latest-at queries and queries the state that was logged exactly at the cursor.
+    /// In contrast, latest-at queries each component's latest known state.
+    pub const AT_CURSOR: Self = Self {
+        start: VisibleTimeRangeBoundary::AT_CURSOR,
+        end: VisibleTimeRangeBoundary::AT_CURSOR,
+    };
 }

--- a/crates/re_viewer/src/ui/mod.rs
+++ b/crates/re_viewer/src/ui/mod.rs
@@ -8,9 +8,9 @@ mod top_panel;
 mod welcome_screen;
 
 pub(crate) mod memory_panel;
+pub(crate) mod query_range_ui;
 pub(crate) mod selection_panel;
 pub(crate) mod space_view_space_origin_ui;
-pub(crate) mod visual_time_range;
 
 pub use blueprint_panel::blueprint_panel_ui;
 pub use recordings_panel::recordings_panel_ui;

--- a/crates/re_viewer/src/ui/query_range_ui.rs
+++ b/crates/re_viewer/src/ui/query_range_ui.rs
@@ -372,7 +372,7 @@ fn show_visual_time_range(
             TimeType::Sequence => {
                 ui.label(format!("At current frame: {current_time}"))
             }
-        }.on_hover_text("Does not perform a latest-at query, only data shown logged at the current time cursor position is shown.");
+        }.on_hover_text("Does not perform a latest-at query, shows only data logged at exactly the current time cursor position.");
     } else {
         egui::Grid::new("from_to_labels").show(ui, |ui| {
             ctx.re_ui.grid_left_hand_label(ui, "From");

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -29,8 +29,8 @@ use crate::ui::override_ui::override_visualizer_ui;
 use crate::{app_state::default_selection_panel_width, ui::override_ui::override_ui};
 
 use super::{
-    selection_history_ui::SelectionHistoryUi, visual_time_range::visual_time_range_ui_data_result,
-    visual_time_range::visual_time_range_ui_space_view,
+    query_range_ui::query_range_ui_data_result, query_range_ui::query_range_ui_space_view,
+    selection_history_ui::SelectionHistoryUi,
 };
 
 // ---
@@ -904,7 +904,7 @@ fn blueprint_ui_for_space_view(
             &class_identifier,
         );
 
-        visual_time_range_ui_space_view(ctx, ui, space_view);
+        query_range_ui_space_view(ctx, ui, space_view);
 
         // Space View don't inherit (legacy) properties.
         let mut props =
@@ -1174,7 +1174,7 @@ fn entity_props_ui(
         .checkbox(ui, &mut entity_props.interactive, "Interactive")
         .on_hover_text("If disabled, the entity will not react to any mouse interaction");
 
-    visual_time_range_ui_data_result(ctx, ui, &query_result.tree, data_result);
+    query_range_ui_data_result(ctx, ui, &query_result.tree, data_result);
 
     egui::Grid::new("entity_properties")
         .num_columns(2)


### PR DESCRIPTION
### What

Under the hood this is now actually a "query range" ui since it operates directly on `QueryRange`, but I opted to not call it that in the viewer yet.

The user facing changes are rather subtle

Before:
Defaulting to latest-at:
![image](https://github.com/rerun-io/rerun/assets/1220815/d8d0bfe2-a797-4abf-8a2b-7aaaa3721610)
Defaulting to single timestamp:
![image](https://github.com/rerun-io/rerun/assets/1220815/20637666-e5b8-4f72-b938-00049a9bbd7d)

After:
Defaulting to latest-at:
![image](https://github.com/rerun-io/rerun/assets/1220815/d5a0e77f-ddcb-4207-9e22-35830555534a)
Defaulting to single timestamp:
![image](https://github.com/rerun-io/rerun/assets/1220815/f26517b9-b6fe-460e-b3f9-79dee3bb846a)


Note that today latest-at can only be inherited (via default). You can't actually set it as an override yet (we decided to delay that a bit since it needs even more restructuring and imho we may want to constrain that depending on the view type).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6176?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6176?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6176)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.