### PR TITLE
Fix auto properties no longer being applied for legacy properties (`EntityProperties`)

### DIFF
--- a/crates/re_space_view/src/data_query.rs
+++ b/crates/re_space_view/src/data_query.rs
@@ -1,12 +1,17 @@
-use re_entity_db::{external::re_data_store::LatestAtQuery, EntityDb, EntityProperties};
+use re_entity_db::{
+    external::re_data_store::LatestAtQuery, EntityDb, EntityProperties, EntityPropertyMap,
+};
 use re_log_types::Timeline;
 use re_viewer_context::{
     DataQueryResult, PerVisualizer, QueryRange, SpaceViewClassRegistry, StoreContext,
     VisualizableEntities,
 };
 
-pub struct EntityOverrideContext {
+pub struct EntityOverrideContext<'a> {
     pub legacy_space_view_properties: EntityProperties,
+
+    /// Provides auto properties for each entity.
+    pub legacy_auto_properties: &'a EntityPropertyMap,
 
     /// Query range that data results should fall back to if they don't specify their own.
     pub default_query_range: QueryRange,
@@ -23,6 +28,7 @@ pub trait PropertyResolver {
         blueprint_query: &LatestAtQuery,
         active_timeline: &Timeline,
         space_view_class_registry: &SpaceViewClassRegistry,
+        legacy_auto_properties: &EntityPropertyMap,
         query_result: &mut DataQueryResult,
     );
 }
@@ -33,8 +39,6 @@ pub trait PropertyResolver {
 /// to be added to a `SpaceView` including both the [`re_log_types::EntityPath`] and context for any overrides.
 pub trait DataQuery {
     /// Execute a full query, returning a `DataResultTree` containing all results.
-    ///
-    /// `auto_properties` is a map containing any heuristic-derived auto properties for the given `SpaceView`.
     ///
     /// This is used when building up the contents for a `SpaceView`.
     fn execute_query(

--- a/crates/re_space_view/src/space_view.rs
+++ b/crates/re_space_view/src/space_view.rs
@@ -330,7 +330,7 @@ impl SpaceViewBlueprint {
         &self,
         ctx: &ViewerContext<'_>,
         view_state: &mut dyn SpaceViewState,
-        view_props: &mut EntityPropertyMap,
+        auto_properties: &mut EntityPropertyMap,
     ) {
         let query_result = ctx.lookup_query_result(self.id).clone();
 
@@ -353,7 +353,7 @@ impl SpaceViewBlueprint {
             ctx,
             view_state,
             &per_system_entities,
-            view_props,
+            auto_properties,
         );
     }
 
@@ -490,6 +490,7 @@ mod tests {
         let timeline = Timeline::new("time", re_log_types::TimeType::Time);
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut blueprint = EntityDb::new(StoreId::random(re_log_types::StoreKind::Blueprint));
+        let legacy_auto_properties = EntityPropertyMap::default();
 
         let points = Points3D::new(vec![[1.0, 2.0, 3.0]]);
 
@@ -559,6 +560,7 @@ mod tests {
                 &blueprint_query,
                 &timeline,
                 &space_view_class_registry,
+                &legacy_auto_properties,
                 &mut query_result,
             );
 
@@ -610,6 +612,7 @@ mod tests {
                 &blueprint_query,
                 &timeline,
                 &space_view_class_registry,
+                &legacy_auto_properties,
                 &mut query_result,
             );
 
@@ -667,6 +670,7 @@ mod tests {
                 &blueprint_query,
                 &timeline,
                 &space_view_class_registry,
+                &legacy_auto_properties,
                 &mut query_result,
             );
 
@@ -693,6 +697,7 @@ mod tests {
     fn test_component_overrides() {
         let space_view_class_registry = SpaceViewClassRegistry::default();
         let timeline = Timeline::new("time", re_log_types::TimeType::Time);
+        let legacy_auto_properties = EntityPropertyMap::default();
         let mut recording = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
         let mut visualizable_entities_per_visualizer =
             PerVisualizer::<VisualizableEntities>::default();
@@ -948,6 +953,7 @@ mod tests {
                 &blueprint_query,
                 &timeline,
                 &space_view_class_registry,
+                &legacy_auto_properties,
                 &mut query_result,
             );
 

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -18,7 +18,7 @@ use re_viewer_context::{
 use crate::{
     contexts::{register_spatial_contexts, PrimitiveCounter},
     heuristics::{
-        default_visualized_entities_for_visualizer_kind, update_object_property_heuristics,
+        default_visualized_entities_for_visualizer_kind, generate_auto_legacy_properties,
     },
     max_image_dimension_subscriber::{ImageDimensions, MaxImageDimensions},
     spatial_topology::{SpatialTopology, SubSpaceConnectionFlags},
@@ -156,15 +156,14 @@ impl SpaceViewClass for SpatialSpaceView2D {
         ctx: &ViewerContext<'_>,
         state: &mut dyn SpaceViewState,
         ent_paths: &PerSystemEntities,
-        entity_properties: &mut re_entity_db::EntityPropertyMap,
+        auto_properties: &mut re_entity_db::EntityPropertyMap,
     ) {
         let Ok(state) = state.downcast_mut::<SpatialSpaceViewState>() else {
             return;
         };
-        update_object_property_heuristics(
+        *auto_properties = generate_auto_legacy_properties(
             ctx,
             ent_paths,
-            entity_properties,
             &state.bounding_boxes.accumulated,
             SpatialSpaceViewKind::TwoD,
         );

--- a/crates/re_space_view_spatial/src/space_view_3d.rs
+++ b/crates/re_space_view_spatial/src/space_view_3d.rs
@@ -13,7 +13,7 @@ use re_viewer_context::{
 use crate::{
     contexts::{register_spatial_contexts, PrimitiveCounter},
     heuristics::{
-        default_visualized_entities_for_visualizer_kind, update_object_property_heuristics,
+        default_visualized_entities_for_visualizer_kind, generate_auto_legacy_properties,
     },
     spatial_topology::{HeuristicHints, SpatialTopology, SubSpaceConnectionFlags},
     ui::{format_vector, SpatialSpaceViewState},
@@ -278,15 +278,14 @@ impl SpaceViewClass for SpatialSpaceView3D {
         ctx: &ViewerContext<'_>,
         state: &mut dyn SpaceViewState,
         ent_paths: &PerSystemEntities,
-        entity_properties: &mut re_entity_db::EntityPropertyMap,
+        auto_properties: &mut re_entity_db::EntityPropertyMap,
     ) {
         let Ok(state) = state.downcast_mut::<SpatialSpaceViewState>() else {
             return;
         };
-        update_object_property_heuristics(
+        *auto_properties = generate_auto_legacy_properties(
             ctx,
             ent_paths,
-            entity_properties,
             &state.bounding_boxes.accumulated,
             SpatialSpaceViewKind::ThreeD,
         );

--- a/crates/re_space_view_spatial/src/visualizers/results_ext.rs
+++ b/crates/re_space_view_spatial/src/visualizers/results_ext.rs
@@ -120,7 +120,8 @@ impl RangeResultsExt for LatestAtResults {
         // In particular, it is pretty common to have a secondary component be more recent than the
         // associated primary component in latest-at contexts, e.g. colors in an otherwise fixed
         // point cloud being changed each frame.
-        let data = RangeData::from_latest_at(resolver, results, Some((TimeInt::MIN, RowId::ZERO)));
+        let data =
+            RangeData::from_latest_at(resolver, results, Some((TimeInt::STATIC, RowId::ZERO)));
 
         // TODO(#5607): what should happen if the promise is still pending?
         let (front_status, back_status) = data.status();

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -267,11 +267,13 @@ impl AppState {
                         &visualizable_entities,
                         &indicated_entities_per_visualizer,
                     );
+
                     resolver.update_overrides(
                         store_context.blueprint,
                         &blueprint_query,
                         rec_cfg.time_ctrl.read().timeline(),
                         space_view_class_registry,
+                        viewport.state.legacy_auto_properties(space_view.id),
                         query_result,
                     );
                 }

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -951,19 +951,20 @@ fn blueprint_ui_for_data_result(
                 .lookup_result_by_path(entity_path)
                 .cloned()
             {
-                let mut props = data_result
-                    .individual_properties()
-                    .cloned()
-                    .unwrap_or_default();
+                let mut accumulated_legacy_props = data_result.accumulated_properties().clone();
+                let accumulated_legacy_props_before = accumulated_legacy_props.clone();
 
                 entity_props_ui(
                     ctx,
                     ui,
                     ctx.lookup_query_result(space_view_id),
                     entity_path,
-                    &mut props,
+                    &mut accumulated_legacy_props,
                 );
-                data_result.save_individual_override_properties(ctx, Some(props));
+                if accumulated_legacy_props != accumulated_legacy_props_before {
+                    data_result
+                        .save_individual_override_properties(ctx, Some(accumulated_legacy_props));
+                }
             }
         }
     }

--- a/crates/re_viewport/src/viewport.rs
+++ b/crates/re_viewport/src/viewport.rs
@@ -75,7 +75,7 @@ impl ViewportState {
             })
     }
 
-    pub fn space_view_props(&self, space_view_id: SpaceViewId) -> &EntityPropertyMap {
+    pub fn legacy_auto_properties(&self, space_view_id: SpaceViewId) -> &EntityPropertyMap {
         self.space_view_states
             .get(&space_view_id)
             .map_or(&DEFAULT_PROPS, |state| &state.auto_properties)


### PR DESCRIPTION
### What

* Fixes #6175

This regressed in #6164. Decided not to roll back things (which would have been hard) but instead reimplement how these properties are passed through and make their role more obvious.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6190?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6190?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6190)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.