### PR TITLE
Add button to equalize the size of the children of a container

### DIFF
--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -741,7 +741,7 @@ fn container_top_level_properties(
                 && ui
                     .add_enabled(
                         !all_shares_are_equal,
-                        egui::Button::new("Equalize children"),
+                        egui::Button::new("Distribute content equally"),
                     )
                     .on_hover_text("Make all children the same size")
                     .clicked()

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -720,6 +720,35 @@ fn container_top_level_properties(
                     },
                 );
             }
+            ui.end_row();
+
+            // ---
+
+            fn equal_shares(shares: &[f32]) -> bool {
+                shares.iter().all(|&share| share == shares[0])
+            }
+
+            let all_shares_are_equal =
+                equal_shares(&container.col_shares) && equal_shares(&container.row_shares);
+
+            if container.contents.len() > 1
+                && match container.container_kind {
+                    egui_tiles::ContainerKind::Tabs => false,
+                    egui_tiles::ContainerKind::Horizontal
+                    | egui_tiles::ContainerKind::Vertical
+                    | egui_tiles::ContainerKind::Grid => true,
+                }
+                && ui
+                    .add_enabled(
+                        !all_shares_are_equal,
+                        egui::Button::new("Equalize children"),
+                    )
+                    .on_hover_text("Make all children the same size")
+                    .clicked()
+            {
+                viewport.blueprint.make_all_children_same_size(container_id);
+            }
+            ui.end_row();
         });
 }
 

--- a/crates/re_viewport/src/viewport_blueprint.rs
+++ b/crates/re_viewport/src/viewport_blueprint.rs
@@ -673,6 +673,11 @@ impl ViewportBlueprint {
         ));
     }
 
+    /// Make all children of the given container the same size.
+    pub fn make_all_children_same_size(&self, container_id: &ContainerId) {
+        self.send_tree_action(TreeAction::MakeAllChildrenSameSize(*container_id));
+    }
+
     /// Set the container that is currently identified as the drop target of an ongoing drag.
     ///
     /// This is used for highlighting the drop target in the UI. Note that the drop target container is reset at every


### PR DESCRIPTION
### What

When drag-dropping tiles it's easy for the tiles to get very unevenly sized. This helps.

https://github.com/rerun-io/rerun/assets/1148717/efc9f152-a724-4f9a-b505-40d5a22ecd4a

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6194?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6194?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6194)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.