### PR TITLE
Fix ui showing the wrong default solid color when switching from gradient

### DIFF
--- a/crates/re_space_view_spatial/src/lib.rs
+++ b/crates/re_space_view_spatial/src/lib.rs
@@ -20,7 +20,7 @@ mod ui_2d;
 mod ui_3d;
 mod visualizers;
 
-use re_types::blueprint::archetypes::Background;
+use re_types::blueprint::components::BackgroundKind;
 use re_types::components::{Resolution, TensorData};
 
 pub use space_view_2d::SpatialSpaceView2D;
@@ -76,12 +76,10 @@ fn query_pinhole(
 
 pub(crate) fn configure_background(
     ctx: &re_viewer_context::ViewerContext<'_>,
-    background: re_types::blueprint::archetypes::Background,
+    kind: BackgroundKind,
+    color: re_types::components::Color,
 ) -> (Option<re_renderer::QueueableDrawData>, re_renderer::Rgba) {
     use re_renderer::renderer;
-    use re_types::blueprint::components::BackgroundKind;
-
-    let Background { kind, color } = background;
 
     match kind {
         BackgroundKind::GradientDark => (
@@ -106,12 +104,6 @@ pub(crate) fn configure_background(
             re_renderer::Rgba::TRANSPARENT, // All zero is slightly faster to clear usually.
         ),
 
-        BackgroundKind::SolidColor => (
-            None,
-            // If the user has told us to use a solid color, but hasn't picked a specific color,
-            // we need to fall back to something. For dark mode, black makes sense.
-            // TODO(#3058): support light mode
-            color.unwrap_or(re_types::components::Color::BLACK).into(),
-        ),
+        BackgroundKind::SolidColor => (None, color.into()),
     }
 }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -2,9 +2,7 @@ use egui::{emath::RectTransform, pos2, vec2, Align2, Color32, Pos2, Rect, Shape,
 use macaw::IsoTransform;
 
 use re_entity_db::EntityPath;
-use re_renderer::{
-    view_builder::{TargetConfiguration, ViewBuilder},
-};
+use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
 use re_space_view::controls::{DRAG_PAN2D_BUTTON, RESET_VIEW_BUTTON_TEXT, ZOOM_SCROLL_MODIFIER};
 use re_types::{
     archetypes::Pinhole, blueprint::archetypes::Background, blueprint::archetypes::VisualBounds,

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -2,7 +2,9 @@ use egui::{emath::RectTransform, pos2, vec2, Align2, Color32, Pos2, Rect, Shape,
 use macaw::IsoTransform;
 
 use re_entity_db::EntityPath;
-use re_renderer::view_builder::{TargetConfiguration, ViewBuilder};
+use re_renderer::{
+    view_builder::{TargetConfiguration, ViewBuilder},
+};
 use re_space_view::controls::{DRAG_PAN2D_BUTTON, RESET_VIEW_BUTTON_TEXT, ZOOM_SCROLL_MODIFIER};
 use re_types::{
     archetypes::Pinhole, blueprint::archetypes::Background, blueprint::archetypes::VisualBounds,
@@ -277,7 +279,11 @@ pub fn view_2d(
 
     let background = re_space_view::view_property::<Background>(ctx, query.space_view_id)
         .unwrap_or(Background::DEFAULT_2D);
-    let (background_drawable, clear_color) = crate::configure_background(ctx, background);
+    let (background_drawable, clear_color) = crate::configure_background(
+        ctx,
+        background.kind,
+        background.color.unwrap_or(Background::DEFAULT_COLOR_2D),
+    );
     if let Some(background_drawable) = background_drawable {
         view_builder.queue_draw(background_drawable);
     }

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -667,7 +667,11 @@ pub fn view_3d(
 
     let background = re_space_view::view_property::<Background>(ctx, query.space_view_id)
         .unwrap_or(Background::DEFAULT_3D);
-    let (background_drawable, clear_color) = crate::configure_background(ctx, background);
+    let (background_drawable, clear_color) = crate::configure_background(
+        ctx,
+        background.kind,
+        background.color.unwrap_or(Background::DEFAULT_COLOR_3D),
+    );
 
     if let Some(background_drawable) = background_drawable {
         view_builder.queue_draw(background_drawable);


### PR DESCRIPTION
### What

Previously, when switching from gradient to "Solid Color" for the background color, we'd show the wrong color in the color picker.
This happened because a `Background` archetype already exists at that point in time but its color component is still None.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6196?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6196?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6196)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.