### PR TITLE
Fix out-of-bounds crash in origin selection popup

### DIFF
--- a/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
+++ b/crates/re_viewer/src/ui/space_view_space_origin_ui.rs
@@ -144,9 +144,11 @@ fn space_view_space_origin_widget_editing_ui(
 
     if let Some(selected_suggestion) = state.selected_suggestion {
         if enter_key_hit {
-            let origin = &filtered_space_view_suggestions[selected_suggestion].space_origin;
-            state.origin_string = origin.to_string();
-            control_flow = ControlFlow::Break(Some(origin.clone()));
+            if let Some(suggestion) = filtered_space_view_suggestions.get(selected_suggestion) {
+                let origin = &suggestion.space_origin;
+                state.origin_string = origin.to_string();
+                control_flow = ControlFlow::Break(Some(origin.clone()));
+            }
         }
     }
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6142

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6202?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6202?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6202)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.