### PR TITLE
Fix multi-tenant cache concurrency edge-case

### DIFF
--- a/crates/re_query/src/range/query.rs
+++ b/crates/re_query/src/range/query.rs
@@ -292,26 +292,32 @@ impl RangeComponentResultsInner {
         // timestamp. All entries for a given timestamp are loaded and invalidated atomically,
         // whether it's promises or already resolved entries.
 
+        // We check the back promises too just because I'm feeling overly cautious.
+        // See `Concurrency edge-case` section below.
+
         let pending_front_min = self
             .promises_front
             .first()
             .map_or(TimeInt::MAX.as_i64(), |((t, _), _)| {
                 t.as_i64().saturating_sub(1)
             });
+        let pending_back_min = self
+            .promises_back
+            .first()
+            .map_or(TimeInt::MAX.as_i64(), |((t, _), _)| {
+                t.as_i64().saturating_sub(1)
+            });
+        let pending_min = i64::min(pending_front_min, pending_back_min);
 
         if let Some(time_range) = self.time_range() {
-            let time_range_min = i64::min(
-                time_range.min().as_i64().saturating_sub(1),
-                pending_front_min,
-            );
+            let time_range_min = i64::min(time_range.min().as_i64().saturating_sub(1), pending_min);
             reduced_query
                 .range
                 .set_max(i64::min(reduced_query.range.max().as_i64(), time_range_min));
         } else {
-            reduced_query.range.set_max(i64::min(
-                reduced_query.range.max().as_i64(),
-                pending_front_min,
-            ));
+            reduced_query
+                .range
+                .set_max(i64::min(reduced_query.range.max().as_i64(), pending_min));
         }
 
         if reduced_query.range.max() < reduced_query.range.min() {
@@ -357,26 +363,42 @@ impl RangeComponentResultsInner {
         // timestamp. All entries for a given timestamp are loaded and invalidated atomically,
         // whether it's promises or already resolved entries.
 
+        // # Concurrency edge-case
+        //
+        // We need to make sure to check for both front _and_ back promises here.
+        // If two or more threads are querying for the same entity path concurrently, it is possible
+        // that the first thread queues a bunch of promises to the front queue, but then relinquishes
+        // control to the second thread before ever resolving those promises.
+        //
+        // If that happens, the second thread would end up queuing the same exact promises in the
+        // back queue, yielding duplicated data.
+        // In most cases, duplicated data isn't noticeable (except for a performance drop), but if
+        // the duplication is only partial this can sometimes lead to visual glitches, depending on
+        // the visualizer used.
+
         let pending_back_max = self
             .promises_back
             .last()
             .map_or(TimeInt::MIN.as_i64(), |((t, _), _)| {
                 t.as_i64().saturating_add(1)
             });
+        let pending_front_max = self
+            .promises_front
+            .last()
+            .map_or(TimeInt::MIN.as_i64(), |((t, _), _)| {
+                t.as_i64().saturating_add(1)
+            });
+        let pending_max = i64::max(pending_back_max, pending_front_max);
 
         if let Some(time_range) = self.time_range() {
-            let time_range_max = i64::max(
-                time_range.max().as_i64().saturating_add(1),
-                pending_back_max,
-            );
+            let time_range_max = i64::max(time_range.max().as_i64().saturating_add(1), pending_max);
             reduced_query
                 .range
                 .set_min(i64::max(reduced_query.range.min().as_i64(), time_range_max));
         } else {
-            reduced_query.range.set_min(i64::max(
-                reduced_query.range.min().as_i64(),
-                pending_back_max,
-            ));
+            reduced_query
+                .range
+                .set_min(i64::max(reduced_query.range.min().as_i64(), pending_max));
         }
 
         // Back query should never overlap with the front query.

--- a/crates/re_query/tests/range.rs
+++ b/crates/re_query/tests/range.rs
@@ -756,6 +756,87 @@ fn invalidation_static() {
     );
 }
 
+// See <https://github.com/rerun-io/rerun/pull/6214>.
+#[test]
+fn concurrent_multitenant_edge_case() -> anyhow::Result<()> {
+    let mut store = DataStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        Default::default(),
+    );
+    let mut caches = Caches::new(&store);
+
+    let entity_path: EntityPath = "point".into();
+
+    let timepoint1 = [build_frame_nr(123)];
+    let points1 = vec![MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)];
+    let row1 = DataRow::from_cells1_sized(
+        RowId::new(),
+        entity_path.clone(),
+        timepoint1,
+        points1.clone(),
+    )?;
+    insert_and_react(&mut store, &mut caches, &row1);
+
+    let timepoint2 = [build_frame_nr(223)];
+    let points2 = vec![MyPoint::new(10.0, 20.0), MyPoint::new(30.0, 40.0)];
+    let row2 = DataRow::from_cells1_sized(
+        RowId::new(),
+        entity_path.clone(),
+        timepoint2,
+        points2.clone(),
+    )?;
+    insert_and_react(&mut store, &mut caches, &row2);
+
+    let timepoint3 = [build_frame_nr(323)];
+    let points3 = vec![MyPoint::new(100.0, 200.0), MyPoint::new(300.0, 400.0)];
+    let row3 = DataRow::from_cells1_sized(
+        RowId::new(),
+        entity_path.clone(),
+        timepoint3,
+        points3.clone(),
+    )?;
+    insert_and_react(&mut store, &mut caches, &row3);
+
+    // --- Tenant #1 queries the data, but doesn't cache the result in the deserialization cache ---
+
+    let query = re_data_store::RangeQuery::new(timepoint1[0].0, ResolvedTimeRange::EVERYTHING);
+
+    eprintln!("{}", store.to_data_table().unwrap());
+
+    {
+        let cached = caches.range(
+            &store,
+            &query,
+            &entity_path,
+            MyPoints::all_components().iter().copied(),
+        );
+
+        let _cached_all_points = cached.get_required(MyPoint::name()).unwrap();
+    }
+
+    // --- Meanwhile, tenant #2 queries and deserializes the data ---
+
+    let query = re_data_store::RangeQuery::new(timepoint1[0].0, ResolvedTimeRange::EVERYTHING);
+
+    let expected_points = &[
+        (
+            (TimeInt::new_temporal(123), row1.row_id()),
+            points1.as_slice(),
+        ), //
+        (
+            (TimeInt::new_temporal(223), row2.row_id()),
+            points2.as_slice(),
+        ), //
+        (
+            (TimeInt::new_temporal(323), row3.row_id()),
+            points3.as_slice(),
+        ), //
+    ];
+    query_and_compare(&caches, &store, &query, &entity_path, expected_points, &[]);
+
+    Ok(())
+}
+
 // ---
 
 fn insert_and_react(store: &mut DataStore, caches: &mut Caches, row: &DataRow) {

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -222,6 +222,17 @@ fn load_series(
             })
             .collect_vec();
 
+        if cfg!(debug_assertions) {
+            for ps in points.windows(2) {
+                assert!(
+                    ps[0].time <= ps[1].time,
+                    "scalars should be sorted already when extracted from the cache, got p0 at {} and p1 at {}\n{:?}",
+                    ps[0].time, ps[1].time,
+                    points.iter().map(|p| p.time).collect_vec(),
+                );
+            }
+        }
+
         // Fill in values.
         for (i, scalars) in all_scalars
             .range_data(all_scalars_entry_range.clone())

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -181,6 +181,17 @@ impl SeriesPointSystem {
                     })
                     .collect_vec();
 
+                if cfg!(debug_assertions) {
+                    for ps in points.windows(2) {
+                        assert!(
+                            ps[0].time <= ps[1].time,
+                            "scalars should be sorted already when extracted from the cache, got p0 at {} and p1 at {}\n{:?}",
+                            ps[0].time, ps[1].time,
+                            points.iter().map(|p| p.time).collect_vec(),
+                        );
+                    }
+                }
+
                 // Fill in values.
                 for (i, scalars) in all_scalars
                     .range_data(all_scalars_entry_range.clone())


### PR DESCRIPTION
See commits.

Uncovered by vehemently stressing things thanks to the new `TimeRange` blueprint.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6214?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6214?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6214)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.