### PR TITLE
Fix formatting of relative times

### DIFF
--- a/crates/re_log_types/src/time.rs
+++ b/crates/re_log_types/src/time.rs
@@ -134,7 +134,9 @@ impl Time {
             let is_whole_second = nanos_since_epoch % 1_000_000_000 == 0;
 
             let secs = re_format::FloatFormatOptions::DEFAULT_f64
+                .with_always_sign(true)
                 .with_decimals(if is_whole_second { 0 } else { 3 })
+                .with_strip_trailing_zeros(false)
                 .format(secs);
             format!("{secs}s")
         }
@@ -307,6 +309,10 @@ mod tests {
         assert_eq!(
             &Time::from_us_since_epoch(42_000_000).format(TimeZone::Local),
             "+42s"
+        );
+        assert_eq!(
+            &Time::from_us_since_epoch(42_123_000_000).format(TimeZone::Local),
+            "+42 123s"
         );
         assert_eq!(
             &Time::from_us_since_epoch(69_000).format(TimeZone::Local),


### PR DESCRIPTION
I broke this test recently (we don't run tests on PRs anymore).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6217?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6217?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6217)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.