### PR TITLE
Improve new time_ranges property python api & add snippet for time series view, explaining all its options

### DIFF
--- a/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
@@ -20,7 +20,8 @@ namespace rerun.blueprint.archetypes;
 /// - For any other view, the default is to apply latest-at semantics.
 table VisibleTimeRanges (
     "attr.rerun.scope": "blueprint",
-    "attr.rust.derive": "Default"
+    "attr.rust.derive": "Default",
+    "attr.python.aliases": "blueprint_components.VisibleTimeRangeLike, Sequence[blueprint_components.VisibleTimeRangeLike]"
 ) {
     /// The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
     ///

--- a/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
@@ -21,7 +21,7 @@ namespace rerun.blueprint.archetypes;
 table VisibleTimeRanges (
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Default",
-    "attr.python.aliases": "blueprint_components.VisibleTimeRangeLike, Sequence[blueprint_components.VisibleTimeRangeLike]"
+    "attr.python.aliases": "datatypes.VisibleTimeRangeLike, Sequence[datatypes.VisibleTimeRangeLike]"
 ) {
     /// The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
     ///

--- a/crates/re_types/definitions/rerun/blueprint/views/time_series.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/views/time_series.fbs
@@ -3,6 +3,8 @@ include "rerun/attributes.fbs";
 namespace rerun.blueprint.views;
 
 /// A time series view.
+///
+/// \example timeseriesview title="Use a blueprint to customize a TimeSeriesView"
 table TimeSeriesView (
     "attr.rerun.view_identifier": "TimeSeries"
 ) {

--- a/docs/content/reference/types/views/time_series_view.md
+++ b/docs/content/reference/types/views/time_series_view.md
@@ -32,3 +32,9 @@ The default visual time range depends on the type of view this property applies 
 ## Links
  * 🐍 [Python API docs for `TimeSeriesView`](https://ref.rerun.io/docs/python/stable/common/blueprint_views#rerun.blueprint.views.TimeSeriesView)
 
+## Example
+
+### Use a blueprint to customize a TimeSeriesView
+
+snippet: timeseriesview
+

--- a/docs/snippets/all/timeseriesview.py
+++ b/docs/snippets/all/timeseriesview.py
@@ -31,18 +31,14 @@ blueprint = rrb.Blueprint(
             # Sliding window depending on the time cursor for the first timeline.
             rrb.VisibleTimeRange(
                 "timeline0",
-                rr.TimeRange(
-                    start=rr.TimeRangeBoundary.cursor_relative(-100),
-                    end=rr.TimeRangeBoundary.cursor_relative(),
-                ),
+                start=rr.TimeRangeBoundary.cursor_relative(-100),
+                end=rr.TimeRangeBoundary.cursor_relative(),
             ),
             # Time range from some point to the end of the timeline for the second timeline.
             rrb.VisibleTimeRange(
                 "timeline1",
-                rr.TimeRange(
-                    start=rr.TimeRangeBoundary.absolute(300),
-                    end=rr.TimeRangeBoundary.infinite(),
-                ),
+                start=rr.TimeRangeBoundary.absolute(300),
+                end=rr.TimeRangeBoundary.infinite(),
             ),
         ],
     )

--- a/docs/snippets/all/timeseriesview.py
+++ b/docs/snippets/all/timeseriesview.py
@@ -25,23 +25,23 @@ blueprint = rrb.Blueprint(
         # Set a custom Y axis.
         axis_y=rrb.ScalarAxis(range=(-1.0, 1.0), lock_range_during_zoom=True),
         # Configure the legend.
-        plot_legend=rrb.Corner2D.RightTop,
+        plot_legend=rrb.PlotLegend(visible=False),
         # Set time different time ranges for different timelines.
         time_ranges=[
-            # Sliding window depending on the time cursor
+            # Sliding window depending on the time cursor for the first timeline.
             rrb.VisibleTimeRange(
                 "timeline0",
-                range=rr.TimeRange(
-                    start=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.RelativeToTimeCursor, -100),
-                    end=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.RelativeToTimeCursor, 0),
+                rr.TimeRange(
+                    start=rr.TimeRangeBoundary.cursor_relative(-100),
+                    end=rr.TimeRangeBoundary.cursor_relative(),
                 ),
             ),
-            # Time range from some point to the end of the timeline.
+            # Time range from some point to the end of the timeline for the second timeline.
             rrb.VisibleTimeRange(
                 "timeline1",
-                range=rr.TimeRange(
-                    start=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Absolute, 100),
-                    end=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Infinite, 200),
+                rr.TimeRange(
+                    start=rr.TimeRangeBoundary.absolute(300),
+                    end=rr.TimeRangeBoundary.infinite(),
                 ),
             ),
         ],

--- a/docs/snippets/all/timeseriesview.py
+++ b/docs/snippets/all/timeseriesview.py
@@ -31,14 +31,14 @@ blueprint = rrb.Blueprint(
             # Sliding window depending on the time cursor for the first timeline.
             rrb.VisibleTimeRange(
                 "timeline0",
-                start=rr.TimeRangeBoundary.cursor_relative(-100),
-                end=rr.TimeRangeBoundary.cursor_relative(),
+                start=rrb.TimeRangeBoundary.cursor_relative(-100),
+                end=rrb.TimeRangeBoundary.cursor_relative(),
             ),
             # Time range from some point to the end of the timeline for the second timeline.
             rrb.VisibleTimeRange(
                 "timeline1",
-                start=rr.TimeRangeBoundary.absolute(300),
-                end=rr.TimeRangeBoundary.infinite(),
+                start=rrb.TimeRangeBoundary.absolute(300),
+                end=rrb.TimeRangeBoundary.infinite(),
             ),
         ],
     )

--- a/docs/snippets/all/timeseriesview.py
+++ b/docs/snippets/all/timeseriesview.py
@@ -1,0 +1,51 @@
+"""Use a blueprint to customize a TimeSeriesVieew."""
+
+import math
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+rr.init("rerun_example_timeseries", spawn=True)
+
+# Log some trigonometric functions
+rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)
+rr.log("trig/cos", rr.SeriesLine(color=[0, 0, 255], name="cos(0.01t) scaled"), static=True)
+for t in range(0, int(math.pi * 4 * 100.0)):
+    rr.set_time_sequence("timeline0", t)
+    rr.set_time_sequence("timeline1", t)
+    rr.log("trig/sin", rr.Scalar(math.sin(float(t) / 100.0)))
+    rr.log("trig/cos", rr.Scalar(math.cos(float(t) / 100.0)))
+    rr.log("trig/cos_scaled", rr.Scalar(math.cos(float(t) / 100.0) * 2.0))
+
+# Create a TimeSeries View
+blueprint = rrb.Blueprint(
+    rrb.TimeSeriesView(
+        origin="/trig",
+        # Set a custom Y axis.
+        axis_y=rrb.ScalarAxis(range=(-1.0, 1.0), lock_range_during_zoom=True),
+        # Configure the legend.
+        plot_legend=rrb.Corner2D.RightTop,
+        # Set time different time ranges for different timelines.
+        time_ranges=[
+            # Sliding window depending on the time cursor
+            rrb.VisibleTimeRange(
+                "timeline0",
+                range=rr.TimeRange(
+                    start=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.RelativeToTimeCursor, -100),
+                    end=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.RelativeToTimeCursor, 0),
+                ),
+            ),
+            # Time range from some point to the end of the timeline.
+            rrb.VisibleTimeRange(
+                "timeline1",
+                range=rr.TimeRange(
+                    start=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Absolute, 100),
+                    end=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Infinite, 200),
+                ),
+            ),
+        ],
+    )
+)
+
+rr.send_blueprint(blueprint)

--- a/docs/snippets/all/timeseriesview.py
+++ b/docs/snippets/all/timeseriesview.py
@@ -1,4 +1,4 @@
-"""Use a blueprint to customize a TimeSeriesVieew."""
+"""Use a blueprint to customize a TimeSeriesView."""
 
 import math
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+# Re-export time range types for better discoverability.
+from ..datatypes import (
+    TimeRange,
+    TimeRangeBoundary,
+    VisibleTimeRange,
+)
 from . import archetypes, components
 from .api import (
     Blueprint,
@@ -23,7 +29,6 @@ from .components import (
     BackgroundKind,
     Corner2D,
     LockRangeDuringZoom,
-    VisibleTimeRange,
 )
 from .containers import Grid, Horizontal, Tabs, Vertical
 from .views import (

--- a/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from ..datatypes import (
     TimeRange,
     TimeRangeBoundary,
-    VisibleTimeRange,
 )
 from . import archetypes, components
 from .api import (
@@ -29,6 +28,7 @@ from .components import (
     BackgroundKind,
     Corner2D,
     LockRangeDuringZoom,
+    VisibleTimeRange,
 )
 from .containers import Grid, Horizontal, Tabs, Vertical
 from .views import (

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 __all__ = ["Spatial2DView"]
 
 
@@ -29,7 +31,10 @@ class Spatial2DView(SpaceView):
         | blueprint_components.BackgroundKindLike
         | None = None,
         visual_bounds: blueprint_archetypes.VisualBounds | None = None,
-        time_ranges: blueprint_archetypes.VisibleTimeRanges | None = None,
+        time_ranges: blueprint_archetypes.VisibleTimeRanges
+        | blueprint_components.VisibleTimeRangeLike
+        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | None = None,
     ) -> None:
         """
         Construct a blueprint for a new Spatial2DView view.

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -32,8 +32,8 @@ class Spatial2DView(SpaceView):
         | None = None,
         visual_bounds: blueprint_archetypes.VisualBounds | None = None,
         time_ranges: blueprint_archetypes.VisibleTimeRanges
-        | blueprint_components.VisibleTimeRangeLike
-        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | datatypes.VisibleTimeRangeLike
+        | Sequence[datatypes.VisibleTimeRangeLike]
         | None = None,
     ) -> None:
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -63,8 +63,8 @@ class Spatial3DView(SpaceView):
         | blueprint_components.BackgroundKindLike
         | None = None,
         time_ranges: blueprint_archetypes.VisibleTimeRanges
-        | blueprint_components.VisibleTimeRangeLike
-        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | datatypes.VisibleTimeRangeLike
+        | Sequence[datatypes.VisibleTimeRangeLike]
         | None = None,
     ) -> None:
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 __all__ = ["Spatial3DView"]
 
 
@@ -60,7 +62,10 @@ class Spatial3DView(SpaceView):
         | datatypes.Rgba32Like
         | blueprint_components.BackgroundKindLike
         | None = None,
-        time_ranges: blueprint_archetypes.VisibleTimeRanges | None = None,
+        time_ranges: blueprint_archetypes.VisibleTimeRanges
+        | blueprint_components.VisibleTimeRangeLike
+        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | None = None,
     ) -> None:
         """
         Construct a blueprint for a new Spatial3DView view.

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 __all__ = ["TimeSeriesView"]
 
 
@@ -25,7 +27,10 @@ class TimeSeriesView(SpaceView):
         visible: blueprint_components.VisibleLike | None = None,
         axis_y: blueprint_archetypes.ScalarAxis | None = None,
         plot_legend: blueprint_archetypes.PlotLegend | blueprint_components.Corner2D | None = None,
-        time_ranges: blueprint_archetypes.VisibleTimeRanges | None = None,
+        time_ranges: blueprint_archetypes.VisibleTimeRanges
+        | blueprint_components.VisibleTimeRangeLike
+        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | None = None,
     ) -> None:
         """
         Construct a blueprint for a new TimeSeriesView view.

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -8,6 +8,7 @@ from typing import Sequence
 __all__ = ["TimeSeriesView"]
 
 
+from ... import datatypes
 from ..._baseclasses import AsComponents
 from ...datatypes import EntityPathLike, Utf8Like
 from .. import archetypes as blueprint_archetypes
@@ -82,8 +83,8 @@ class TimeSeriesView(SpaceView):
         axis_y: blueprint_archetypes.ScalarAxis | None = None,
         plot_legend: blueprint_archetypes.PlotLegend | blueprint_components.Corner2D | None = None,
         time_ranges: blueprint_archetypes.VisibleTimeRanges
-        | blueprint_components.VisibleTimeRangeLike
-        | Sequence[blueprint_components.VisibleTimeRangeLike]
+        | datatypes.VisibleTimeRangeLike
+        | Sequence[datatypes.VisibleTimeRangeLike]
         | None = None,
     ) -> None:
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -16,7 +16,61 @@ from ..api import SpaceView, SpaceViewContentsLike
 
 
 class TimeSeriesView(SpaceView):
-    """**View**: A time series view."""
+    """
+    **View**: A time series view.
+
+    Example
+    -------
+    ### Use a blueprint to customize a TimeSeriesView:
+    ```python
+    import math
+
+    import rerun as rr
+    import rerun.blueprint as rrb
+
+    rr.init("rerun_example_timeseries", spawn=True)
+
+    # Log some trigonometric functions
+    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)
+    rr.log("trig/cos", rr.SeriesLine(color=[0, 0, 255], name="cos(0.01t) scaled"), static=True)
+    for t in range(0, int(math.pi * 4 * 100.0)):
+        rr.set_time_sequence("timeline0", t)
+        rr.set_time_sequence("timeline1", t)
+        rr.log("trig/sin", rr.Scalar(math.sin(float(t) / 100.0)))
+        rr.log("trig/cos", rr.Scalar(math.cos(float(t) / 100.0)))
+        rr.log("trig/cos_scaled", rr.Scalar(math.cos(float(t) / 100.0) * 2.0))
+
+    # Create a TimeSeries View
+    blueprint = rrb.Blueprint(
+        rrb.TimeSeriesView(
+            origin="/trig",
+            # Set a custom Y axis.
+            axis_y=rrb.ScalarAxis(range=(-1.0, 1.0), lock_range_during_zoom=True),
+            # Configure the legend.
+            plot_legend=rrb.PlotLegend(visible=False),
+            # Set time different time ranges for different timelines.
+            time_ranges=[
+                # Sliding window depending on the time cursor for the first timeline.
+                rrb.VisibleTimeRange(
+                    "timeline0",
+                    start=rrb.TimeRangeBoundary.cursor_relative(-100),
+                    end=rrb.TimeRangeBoundary.cursor_relative(),
+                ),
+                # Time range from some point to the end of the timeline for the second timeline.
+                rrb.VisibleTimeRange(
+                    "timeline1",
+                    start=rrb.TimeRangeBoundary.absolute(300),
+                    end=rrb.TimeRangeBoundary.infinite(),
+                ),
+            ],
+        )
+    )
+
+    rr.send_blueprint(blueprint)
+    ```
+
+    """
 
     def __init__(
         self,

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
@@ -12,6 +12,7 @@ from attrs import define, field
 
 from .. import datatypes
 from .._baseclasses import BaseBatch, BaseExtensionType
+from .time_range_boundary_ext import TimeRangeBoundaryExt
 
 __all__ = [
     "TimeRangeBoundary",
@@ -23,7 +24,7 @@ __all__ = [
 
 
 @define
-class TimeRangeBoundary:
+class TimeRangeBoundary(TimeRangeBoundaryExt):
     """**Datatype**: Left or right boundary of a time range."""
 
     # You can define your own __init__ function as a member of TimeRangeBoundaryExt in time_range_boundary_ext.py

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -18,7 +18,7 @@ class TimeRangeBoundaryExt:
         return TimeRangeBoundary(inner=time, kind="cursor_relative")
 
     @staticmethod
-    def infinite(time: datatypes.TimeIntLike = 0) -> TimeRangeBoundary:
+    def infinite() -> TimeRangeBoundary:
         from .time_range_boundary import TimeRangeBoundary
 
         return TimeRangeBoundary(inner=None, kind="infinite")

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .. import datatypes
+from datatypes import TimeInt, TimeIntLike
 
 if TYPE_CHECKING:
     from .time_range_boundary import TimeRangeBoundary
@@ -12,7 +12,7 @@ class TimeRangeBoundaryExt:
     """Extension for [TimeRangeBoundary][rerun.datatypes.TimeRangeBoundary]."""
 
     @staticmethod
-    def cursor_relative(time: datatypes.TimeIntLike = 0) -> TimeRangeBoundary:
+    def cursor_relative(time: TimeIntLike = 0) -> TimeRangeBoundary:
         """
         Boundary that is relative to the timeline cursor.
 
@@ -24,6 +24,9 @@ class TimeRangeBoundaryExt:
         """
 
         from .time_range_boundary import TimeRangeBoundary
+
+        if not isinstance(time, TimeInt):
+            time = TimeInt(time)
 
         return TimeRangeBoundary(inner=time, kind="cursor_relative")
 
@@ -40,7 +43,7 @@ class TimeRangeBoundaryExt:
         return TimeRangeBoundary(inner=None, kind="infinite")
 
     @staticmethod
-    def absolute(time: datatypes.TimeIntLike) -> TimeRangeBoundary:
+    def absolute(time: TimeIntLike) -> TimeRangeBoundary:
         """
         Boundary that is at an absolute time.
 
@@ -52,5 +55,8 @@ class TimeRangeBoundaryExt:
         """
 
         from .time_range_boundary import TimeRangeBoundary
+
+        if not isinstance(time, TimeInt):
+            time = TimeInt(time)
 
         return TimeRangeBoundary(inner=time, kind="absolute")

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from .. import datatypes
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -13,18 +13,44 @@ class TimeRangeBoundaryExt:
 
     @staticmethod
     def cursor_relative(time: datatypes.TimeIntLike = 0) -> TimeRangeBoundary:
+        """
+        Boundary that is relative to the timeline cursor.
+
+        Parameters
+        ----------
+        time:
+            Offset from the cursor time, can be positive or negative.
+
+        """
+
         from .time_range_boundary import TimeRangeBoundary
 
         return TimeRangeBoundary(inner=time, kind="cursor_relative")
 
     @staticmethod
     def infinite() -> TimeRangeBoundary:
+        """
+        Boundary that extends to infinity.
+
+        Depending on the context, this can mean the beginning or the end of the timeline.
+        """
+
         from .time_range_boundary import TimeRangeBoundary
 
         return TimeRangeBoundary(inner=None, kind="infinite")
 
     @staticmethod
     def absolute(time: datatypes.TimeIntLike) -> TimeRangeBoundary:
+        """
+        Boundary that is at an absolute time.
+
+        Parameters
+        ----------
+        time:
+            Absolute time value.
+
+        """
+
         from .time_range_boundary import TimeRangeBoundary
 
         return TimeRangeBoundary(inner=time, kind="absolute")

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .. import datatypes
+
+if TYPE_CHECKING:
+    from .time_range_boundary import TimeRangeBoundary
+
+
+class TimeRangeBoundaryExt:
+    """Extension for [TimeRangeBoundary][rerun.datatypes.TimeRangeBoundary]."""
+
+    @staticmethod
+    def cursor_relative(time: datatypes.TimeIntLike = 0) -> TimeRangeBoundary:
+        from .time_range_boundary import TimeRangeBoundary
+
+        return TimeRangeBoundary(inner=time, kind="cursor_relative")
+
+    @staticmethod
+    def infinite(time: datatypes.TimeIntLike = 0) -> TimeRangeBoundary:
+        from .time_range_boundary import TimeRangeBoundary
+
+        return TimeRangeBoundary(inner=None, kind="infinite")
+
+    @staticmethod
+    def absolute(time: datatypes.TimeIntLike) -> TimeRangeBoundary:
+        from .time_range_boundary import TimeRangeBoundary
+
+        return TimeRangeBoundary(inner=time, kind="absolute")

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from datatypes import TimeInt, TimeIntLike
+from . import TimeInt, TimeIntLike
 
 if TYPE_CHECKING:
     from .time_range_boundary import TimeRangeBoundary

--- a/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
@@ -5,13 +5,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Sequence, Union
+from typing import Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
 from .._baseclasses import BaseBatch, BaseExtensionType
+from .visible_time_range_ext import VisibleTimeRangeExt
 
 __all__ = [
     "VisibleTimeRange",
@@ -30,24 +31,10 @@ def _visible_time_range__timeline__special_field_converter_override(x: datatypes
 
 
 @define(init=False)
-class VisibleTimeRange:
+class VisibleTimeRange(VisibleTimeRangeExt):
     """**Datatype**: Visible time range bounds for a specific timeline."""
 
-    def __init__(self: Any, timeline: datatypes.Utf8Like, range: datatypes.TimeRangeLike):
-        """
-        Create a new instance of the VisibleTimeRange datatype.
-
-        Parameters
-        ----------
-        timeline:
-            Name of the timeline this applies to.
-        range:
-            Time range to use for this timeline.
-
-        """
-
-        # You can define your own __init__ function as a member of VisibleTimeRangeExt in visible_time_range_ext.py
-        self.__attrs_init__(timeline=timeline, range=range)
+    # __init__ can be found in visible_time_range_ext.py
 
     timeline: datatypes.Utf8 = field(converter=_visible_time_range__timeline__special_field_converter_override)
     # Name of the timeline this applies to.

--- a/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range_ext.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from . import datatypes
+
+
+class VisibleTimeRangeExt:
+    """Extension for [VisibleTimeRange][rerun.datatypes.VisibleTimeRange]."""
+
+    def __init__(
+        self: Any,
+        timeline: datatypes.Utf8Like,
+        range: datatypes.TimeRangeLike | None = None,
+        *,
+        start: datatypes.TimeRangeBoundary | None = None,
+        end: datatypes.TimeRangeBoundary | None = None,
+    ):
+        """
+        Create a new instance of the VisibleTimeRange datatype.
+
+        Parameters
+        ----------
+        timeline:
+            Name of the timeline this applies to.
+        range:
+            Time range to use for this timeline.
+        start:
+            Low time boundary for sequence timeline. Specify this instead of `range`.
+        end:
+            High time boundary for sequence timeline. Specify this instead of `range`.
+
+        """
+        from . import TimeRange
+
+        if range is None:
+            if start is None or end is None:
+                raise ValueError("Specify either start_and_end or both start & end")
+            range = TimeRange(start=start, end=end)
+        else:
+            if start is not None or end is not None:
+                raise ValueError("Specify either start_and_end or both start & end, not both")
+
+        self.__attrs_init__(timeline=timeline, range=range)

--- a/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range_ext.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from . import datatypes
+from .. import datatypes
 
 
 class VisibleTimeRangeExt:

--- a/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
+++ b/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
@@ -32,10 +32,8 @@ def blueprint() -> rrb.BlueprintLike:
                 origin="/plots",
                 time_ranges=rrb.VisibleTimeRange(
                     "frame_nr",
-                    rr.TimeRange(
-                        start=rr.TimeRangeBoundary(rr.TimeRangeBoundary.CursorRelative, 50 - i * 10),
-                        end=rr.TimeRangeBoundary(rr.TimeRangeBoundary.CursorRelative, 50 - i * 10 + 10),
-                    ),
+                    start=rrb.TimeRangeBoundary.cursor_relative(50 - i * 10),
+                    end=rrb.TimeRangeBoundary.cursor_relative(50 - i * 10 + 10),
                 ),
             )
             for i in range(0, 10)
@@ -48,10 +46,8 @@ def blueprint() -> rrb.BlueprintLike:
                 origin="/2D",
                 time_ranges=rrb.VisibleTimeRange(
                     "frame_nr",
-                    rr.TimeRange(
-                        start=rr.TimeRangeBoundary(rr.TimeRangeBoundary.Infinite, 0),
-                        end=rr.TimeRangeBoundary(rr.TimeRangeBoundary.CursorRelative, 0),
-                    ),
+                    start=rrb.TimeRangeBoundary.infinite(),
+                    end=rrb.TimeRangeBoundary.cursor_relative(),
                 ),
             )
             for _ in range(0, 3)
@@ -63,10 +59,8 @@ def blueprint() -> rrb.BlueprintLike:
                 origin="/3D",
                 time_ranges=rrb.VisibleTimeRange(
                     "frame_nr",
-                    rr.TimeRange(
-                        start=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Infinite, 0),
-                        end=rr.TimeRangeBoundary(rr.TimeRangeBoundaryKind.Infinite, 0),
-                    ),
+                    start=rrb.TimeRangeBoundary.infinite(),
+                    end=rrb.TimeRangeBoundary.infinite(),
                 ),
             )
             for _ in range(0, 3)

--- a/tests/python/roundtrips/visible_time_ranges/main.py
+++ b/tests/python/roundtrips/visible_time_ranges/main.py
@@ -21,16 +21,16 @@ def main() -> None:
     rr.log(
         "visible_time_ranges",
         rrb.archetypes.VisibleTimeRanges([
-            rr.VisibleTimeRange(
+            rrb.VisibleTimeRange(
                 "timeline0",
-                rr.TimeRange(rr.TimeRangeBoundary(None, "infinite"), rr.TimeRangeBoundary(-10, "cursor_relative")),
+                start=rr.TimeRangeBoundary.infinite(),
+                end=rr.TimeRangeBoundary.cursor_relative(-10),
             ),
-            rr.VisibleTimeRange(
-                "timeline1",
-                rr.TimeRange(rr.TimeRangeBoundary(20, "cursor_relative"), rr.TimeRangeBoundary(None, "infinite")),
+            rrb.VisibleTimeRange(
+                "timeline1", start=rrb.TimeRangeBoundary.cursor_relative(20), end=rrb.TimeRangeBoundary.infinite()
             ),
-            rr.VisibleTimeRange(
-                "timeline2", rr.TimeRange(rr.TimeRangeBoundary(20, "absolute"), rr.TimeRangeBoundary(40, "absolute"))
+            rrb.VisibleTimeRange(
+                "timeline2", start=rrb.TimeRangeBoundary.absolute(20), end=rrb.TimeRangeBoundary.absolute(40)
             ),
         ]),
     )


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Improve `VisibleTimeRange` python api and add a snippet for time series view which is the primary (but not sole!) user of this feature.

```
# Create a TimeSeries View
blueprint = rrb.Blueprint(
    rrb.TimeSeriesView(
        origin="/trig",
        # Set a custom Y axis.
        axis_y=rrb.ScalarAxis(range=(-1.0, 1.0), lock_range_during_zoom=True),
        # Configure the legend.
        plot_legend=rrb.PlotLegend(visible=False),
        # Set time different time ranges for different timelines.
        time_ranges=[
            # Sliding window depending on the time cursor for the first timeline.
            rrb.VisibleTimeRange(
                "timeline0",
                start=rrb.TimeRangeBoundary.cursor_relative(-100),
                end=rrb.TimeRangeBoundary.cursor_relative(),
            ),
            # Time range from some point to the end of the timeline for the second timeline.
            rrb.VisibleTimeRange(
                "timeline1",
                start=rrb.TimeRangeBoundary.absolute(300),
                end=rrb.TimeRangeBoundary.infinite(),
            ),
        ],
    )
)
```


TODO:
* [x] update usage on checklist test!
* [x] integrate with snippet reorg pr 
* [x] put the snippet on to timeseries view
* [x] check again whether we can't make `TimeRangeBoundary` a union and if we can't or don't want note it down into the fbs file why

~*  think about how to document time range on other places and how to document usage of `VisibleTimeRange` type itself~
    * consider providing several snippets
~*  update docs on visible time range in the manual with some code examples while we're on it?~


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6221?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6221?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6221)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.