### PR TITLE
Fix migration guide redirect link

### DIFF
--- a/docs/content/reference/migration-0-9.md
+++ b/docs/content/reference/migration-0-9.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from 0.8 to 0.9
 order: 13
-redirect: migration/migration-0-9
+redirect: reference/migration/migration-0-9
 hidden: true
 ---


### PR DESCRIPTION
### What

This link was never actually used anywhere except when navigating to it, in which case it was broken.

See https://rerun.io/docs/reference/migration-0-9 which briefly shows a page, then redirect you to https://rerun.io/docs/migration/migration-0-9 which is a 404. It should be `reference/migration/migration-0-9`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6229?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6229?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6229)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.