### PR TITLE
Add space view icons to various context menus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,6 +5035,7 @@ dependencies = [
  "ron",
  "serde",
  "serde_json",
+ "static_assertions",
  "thiserror",
  "time",
  "wasm-bindgen",
@@ -5113,6 +5114,7 @@ dependencies = [
  "re_ui",
  "re_viewer_context",
  "smallvec",
+ "static_assertions",
 ]
 
 [[package]]

--- a/crates/re_space_view_spatial/src/space_view_2d.rs
+++ b/crates/re_space_view_spatial/src/space_view_2d.rs
@@ -286,22 +286,24 @@ fn visual_bounds_ui(ctx: &ViewerContext<'_>, space_view_id: SpaceViewId, ui: &mu
     re_space_view::edit_blueprint_component::<VisualBounds, re_types::components::Range2D, ()>(
         ctx,
         space_view_id,
-        |range2d: &mut Option<re_types::components::Range2D>| {
+        |range2d_opt: &mut Option<re_types::components::Range2D>| {
             ctx.re_ui
                 .grid_left_hand_label(ui, "Visible bounds")
                 .on_hover_text(tooltip);
             ui.vertical(|ui| {
                 ui.style_mut().wrap = Some(false);
 
-                if let Some(range2d) = range2d {
+                if let Some(range2d) = range2d_opt {
                     let rect = egui::Rect::from(*range2d);
                     let (min, max) = (rect.min, rect.max);
                     ui.label(format!("x [{} - {}]", format_f32(min.x), format_f32(max.x),));
                     ui.label(format!("y [{} - {}]", format_f32(min.y), format_f32(max.y),));
-                }
 
-                if ui.button("Reset visible bounds").clicked() {
-                    *range2d = None;
+                    if ui.button("Reset visible bounds").clicked() {
+                        *range2d_opt = None;
+                    }
+                } else {
+                    ui.weak("Default");
                 }
             });
             ui.end_row();

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -118,8 +118,13 @@ impl SpatialSpaceViewState {
             auto_size_world_heuristic(&self.bounding_boxes.accumulated, self.scene_num_primitives);
 
         ctx.re_ui.grid_left_hand_label(ui, "Default size");
-        ui.vertical(|ui| {
-            ui.horizontal(|ui| {
+
+        egui::Grid::new("default_sizes")
+            .num_columns(2)
+            .show(ui, |ui| {
+                ctx.re_ui
+                    .grid_left_hand_label(ui, "Point radius")
+                    .on_hover_text("Point radius used whenever not explicitly specified");
                 ui.push_id("points", |ui| {
                     size_ui(
                         ui,
@@ -128,22 +133,20 @@ impl SpatialSpaceViewState {
                         &mut self.auto_size_config.point_radius,
                     );
                 });
-                ui.label("Point radius")
-                    .on_hover_text("Point radius used whenever not explicitly specified");
+                ui.end_row();
+
+                ctx.re_ui
+                    .grid_left_hand_label(ui, "Line radius")
+                    .on_hover_text("Line radius used whenever not explicitly specified");
+                size_ui(
+                    ui,
+                    1.5,
+                    auto_size_world,
+                    &mut self.auto_size_config.line_radius,
+                );
+                ui.end_row();
             });
-            ui.horizontal(|ui| {
-                ui.push_id("lines", |ui| {
-                    size_ui(
-                        ui,
-                        1.5,
-                        auto_size_world,
-                        &mut self.auto_size_config.line_radius,
-                    );
-                    ui.label("Line radius")
-                        .on_hover_text("Line radius used whenever not explicitly specified");
-                });
-            });
-        });
+
         ui.end_row();
     }
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -1227,3 +1227,35 @@ pub fn markdown_ui(ui: &mut egui::Ui, id: egui::Id, markdown: &str) {
 
     egui_commonmark::CommonMarkViewer::new(id).show(ui, &mut commonmark_cache.lock(), markdown);
 }
+
+/// A drop-down menu with a list of options.
+///
+/// Designed for use with [`list_item2`] content.
+///
+/// Use this instead of using [`egui::ComboBox`] directly.
+pub fn drop_down_menu(
+    ui: &mut egui::Ui,
+    id_source: impl std::hash::Hash,
+    min_width: f32,
+    selected_text: String,
+    content: impl FnOnce(&mut egui::Ui),
+) {
+    // TODO(emilk): make the button itself a `ListItem2`
+    egui::ComboBox::from_id_source(id_source)
+        .selected_text(selected_text)
+        .show_ui(ui, |ui| {
+            ui.set_min_width(min_width);
+
+            let background_x_range = ui
+                .spacing()
+                .menu_margin
+                .expand_rect(ui.max_rect())
+                .x_range();
+
+            list_item2::list_item_scope(ui, "inner_scope", |ui| {
+                full_span::full_span_scope(ui, background_x_range, |ui| {
+                    content(ui);
+                });
+            });
+        });
+}

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -104,6 +104,7 @@ rfd.workspace = true
 ron.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+static_assertions.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting"] }
 web-time.workspace = true

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -1,4 +1,5 @@
 use egui::{NumExt as _, Ui};
+use egui_tiles::ContainerKind;
 
 use re_data_ui::{
     image_meaning_for_entity, item_ui,
@@ -211,11 +212,7 @@ fn container_children(
         ui.strong("Contents");
 
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-            if ctx
-                .re_ui
-                .small_icon_button(ui, &re_ui::icons::ADD)
-                .clicked()
-            {
+            if ctx.re_ui.small_icon_button(ui, &icons::ADD).clicked() {
                 viewport.show_add_space_view_or_container_modal(*container_id);
             }
         });
@@ -375,9 +372,9 @@ fn what_is_selected_ui(
                 ui,
                 component_name.short_name(),
                 Some(if is_static {
-                    &re_ui::icons::COMPONENT_STATIC
+                    &icons::COMPONENT_STATIC
                 } else {
-                    &re_ui::icons::COMPONENT
+                    &icons::COMPONENT
                 }),
                 &format!(
                     "Component {} of entity '{}'",
@@ -669,7 +666,7 @@ fn container_top_level_properties(
 
             ui.end_row();
 
-            if container.container_kind == egui_tiles::ContainerKind::Grid {
+            if container.container_kind == ContainerKind::Grid {
                 ui.label("Columns");
 
                 fn columns_to_string(columns: &Option<u32>) -> String {
@@ -735,10 +732,10 @@ fn container_top_level_properties(
 
             if container.contents.len() > 1
                 && match container.container_kind {
-                    egui_tiles::ContainerKind::Tabs => false,
-                    egui_tiles::ContainerKind::Horizontal
-                    | egui_tiles::ContainerKind::Vertical
-                    | egui_tiles::ContainerKind::Grid => true,
+                    ContainerKind::Tabs => false,
+                    ContainerKind::Horizontal | ContainerKind::Vertical | ContainerKind::Grid => {
+                        true
+                    }
                 }
                 && ui
                     .add_enabled(
@@ -780,7 +777,7 @@ fn show_list_item_for_container_child(
                     .with_icon(space_view.class(ctx.space_view_class_registry).icon())
                     .with_buttons(|re_ui, ui| {
                         let response = re_ui
-                            .small_icon_button(ui, &re_ui::icons::REMOVE)
+                            .small_icon_button(ui, &icons::REMOVE)
                             .on_hover_text("Remove this space view");
 
                         if response.clicked() {
@@ -806,7 +803,7 @@ fn show_list_item_for_container_child(
                     .with_icon(icon_for_container_kind(&container.container_kind))
                     .with_buttons(|re_ui, ui| {
                         let response = re_ui
-                            .small_icon_button(ui, &re_ui::icons::REMOVE)
+                            .small_icon_button(ui, &icons::REMOVE)
                             .on_hover_text("Remove this container");
 
                         if response.clicked() {

--- a/crates/re_viewer/src/ui/selection_panel.rs
+++ b/crates/re_viewer/src/ui/selection_panel.rs
@@ -632,33 +632,7 @@ fn container_top_level_properties(
             ui.label("Kind");
 
             let mut container_kind = container.container_kind;
-            egui::ComboBox::from_id_source("container_kind")
-                .selected_text(format!("{container_kind:?}"))
-                .show_ui(ui, |ui| {
-                    ui.style_mut().wrap = Some(false);
-                    ui.set_min_width(64.0);
-
-                    ui.selectable_value(
-                        &mut container_kind,
-                        egui_tiles::ContainerKind::Tabs,
-                        format!("{:?}", egui_tiles::ContainerKind::Tabs),
-                    );
-                    ui.selectable_value(
-                        &mut container_kind,
-                        egui_tiles::ContainerKind::Horizontal,
-                        format!("{:?}", egui_tiles::ContainerKind::Horizontal),
-                    );
-                    ui.selectable_value(
-                        &mut container_kind,
-                        egui_tiles::ContainerKind::Vertical,
-                        format!("{:?}", egui_tiles::ContainerKind::Vertical),
-                    );
-                    ui.selectable_value(
-                        &mut container_kind,
-                        egui_tiles::ContainerKind::Grid,
-                        format!("{:?}", egui_tiles::ContainerKind::Grid),
-                    );
-                });
+            container_kind_selection_ui(ctx, ui, &mut container_kind);
 
             viewport
                 .blueprint
@@ -749,6 +723,40 @@ fn container_top_level_properties(
             }
             ui.end_row();
         });
+}
+
+fn container_kind_selection_ui(
+    ctx: &ViewerContext<'_>,
+    ui: &mut Ui,
+    in_out_kind: &mut ContainerKind,
+) {
+    let min_width = 90.0;
+    let selected_text = format!("{in_out_kind:?}");
+
+    re_ui::drop_down_menu(ui, "container_kind", min_width, selected_text, |ui| {
+        ui.style_mut().wrap = Some(false);
+
+        static_assertions::const_assert_eq!(ContainerKind::ALL.len(), 4);
+        for (kind, icon) in [
+            (ContainerKind::Tabs, &icons::CONTAINER_TABS),
+            (ContainerKind::Grid, &icons::CONTAINER_GRID),
+            (ContainerKind::Horizontal, &icons::CONTAINER_HORIZONTAL),
+            (ContainerKind::Vertical, &icons::CONTAINER_VERTICAL),
+        ] {
+            let response = ctx
+                .re_ui
+                .list_item2()
+                .selected(*in_out_kind == kind)
+                .show_flat(
+                    ui,
+                    re_ui::list_item2::LabelContent::new(format!("{kind:?}")).with_icon(icon),
+                );
+
+            if response.clicked() {
+                *in_out_kind = kind;
+            }
+        }
+    });
 }
 
 // TODO(#4560): this code should be generic and part of re_data_ui

--- a/crates/re_viewport/Cargo.toml
+++ b/crates/re_viewport/Cargo.toml
@@ -49,3 +49,4 @@ nohash-hasher.workspace = true
 once_cell.workspace = true
 rayon.workspace = true
 smallvec.workspace = true
+static_assertions.workspace = true

--- a/crates/re_viewport/src/context_menu/actions/add_container.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_container.rs
@@ -1,24 +1,38 @@
+use egui_tiles::ContainerKind;
+
+use re_ui::icons;
 use re_viewer_context::{ContainerId, Item};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
 
 /// Add a container of a specific type
-pub(crate) struct AddContainerAction(pub egui_tiles::ContainerKind);
+pub(crate) struct AddContainerAction(pub ContainerKind);
 
 impl ContextMenuAction for AddContainerAction {
     fn supports_selection(&self, ctx: &ContextMenuContext<'_>) -> bool {
         if let Some(Item::Container(container_id)) = ctx.selection.single_item() {
             if let Some(container) = ctx.viewport_blueprint.container(container_id) {
+                let is_linear = matches!(
+                    container.container_kind,
+                    ContainerKind::Horizontal | ContainerKind::Vertical
+                );
                 // same-kind linear containers cannot be nested
-                (container.container_kind != egui_tiles::ContainerKind::Vertical
-                    && container.container_kind != egui_tiles::ContainerKind::Horizontal)
-                    || container.container_kind != self.0
+                !is_linear || container.container_kind != self.0
             } else {
                 // unknown container
                 false
             }
         } else {
             false
+        }
+    }
+
+    fn icon(&self) -> Option<&'static re_ui::Icon> {
+        match self.0 {
+            ContainerKind::Tabs => Some(&icons::CONTAINER_TABS),
+            ContainerKind::Horizontal => Some(&icons::CONTAINER_HORIZONTAL),
+            ContainerKind::Vertical => Some(&icons::CONTAINER_VERTICAL),
+            ContainerKind::Grid => Some(&icons::CONTAINER_GRID),
         }
     }
 

--- a/crates/re_viewport/src/context_menu/actions/add_space_view.rs
+++ b/crates/re_viewport/src/context_menu/actions/add_space_view.rs
@@ -1,27 +1,35 @@
 use re_space_view::SpaceViewBlueprint;
 use re_types::SpaceViewClassIdentifier;
+use re_ui::Icon;
 use re_viewer_context::{ContainerId, Item, RecommendedSpaceView};
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
 
 /// Add a space view of the specific class
-pub(crate) struct AddSpaceViewAction(pub SpaceViewClassIdentifier);
+pub(crate) struct AddSpaceViewAction {
+    pub icon: &'static Icon,
+    pub id: SpaceViewClassIdentifier,
+}
 
 impl ContextMenuAction for AddSpaceViewAction {
     fn supports_item(&self, _ctx: &ContextMenuContext<'_>, item: &Item) -> bool {
         matches!(item, Item::Container(_))
     }
 
+    fn icon(&self) -> Option<&'static re_ui::Icon> {
+        Some(self.icon)
+    }
+
     fn label(&self, ctx: &ContextMenuContext<'_>) -> String {
         ctx.viewer_context
             .space_view_class_registry
-            .get_class_or_log_error(&self.0)
+            .get_class_or_log_error(&self.id)
             .display_name()
             .to_owned()
     }
 
     fn process_container(&self, ctx: &ContextMenuContext<'_>, container_id: &ContainerId) {
-        let space_view = SpaceViewBlueprint::new(self.0, RecommendedSpaceView::root());
+        let space_view = SpaceViewBlueprint::new(self.id, RecommendedSpaceView::root());
 
         ctx.viewport_blueprint.add_space_views(
             std::iter::once(space_view),

--- a/crates/re_viewport/src/context_menu/actions/move_contents_to_new_container.rs
+++ b/crates/re_viewport/src/context_menu/actions/move_contents_to_new_container.rs
@@ -1,16 +1,20 @@
+use egui_tiles::ContainerKind;
+
+use re_ui::icons;
 use re_viewer_context::Item;
 
 use crate::context_menu::{ContextMenuAction, ContextMenuContext};
 
 /// Move the selected contents to a newly created container of the given kind
-pub(crate) struct MoveContentsToNewContainerAction(pub egui_tiles::ContainerKind);
+pub(crate) struct MoveContentsToNewContainerAction(pub ContainerKind);
 
 impl ContextMenuAction for MoveContentsToNewContainerAction {
     fn supports_selection(&self, ctx: &ContextMenuContext<'_>) -> bool {
         if let Some((parent_container, _)) = ctx.clicked_item_enclosing_container_and_position() {
-            if (parent_container.container_kind == egui_tiles::ContainerKind::Vertical
-                || parent_container.container_kind == egui_tiles::ContainerKind::Horizontal)
-                && parent_container.container_kind == self.0
+            if matches!(
+                parent_container.container_kind,
+                ContainerKind::Vertical | ContainerKind::Horizontal
+            ) && parent_container.container_kind == self.0
             {
                 return false;
             }
@@ -36,6 +40,15 @@ impl ContextMenuAction for MoveContentsToNewContainerAction {
                 ctx.viewport_blueprint.root_container != Some(*container_id)
             }
             _ => false,
+        }
+    }
+
+    fn icon(&self) -> Option<&'static re_ui::Icon> {
+        match self.0 {
+            ContainerKind::Tabs => Some(&icons::CONTAINER_TABS),
+            ContainerKind::Horizontal => Some(&icons::CONTAINER_HORIZONTAL),
+            ContainerKind::Vertical => Some(&icons::CONTAINER_VERTICAL),
+            ContainerKind::Grid => Some(&icons::CONTAINER_GRID),
         }
     }
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -123,7 +123,7 @@ def print_section(title: str, items: list[str]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a changelog.")
-    parser.add_argument("--commit-range", help="e.g. 0.11.0..HEAD")
+    parser.add_argument("--commit-range", required=True, help="e.g. 0.11.0..HEAD")
     args = parser.parse_args()
 
     # Because how we branch, we sometimes get duplicate commits in the changelog unless we check for it


### PR DESCRIPTION
### What
Misc improvements to out UI, mostly adding more icons to it.

![image](https://github.com/rerun-io/rerun/assets/1148717/38d77ffb-c81a-4678-86cd-2cd7f8ff67d3)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6235?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6235?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6235)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.