### PR TITLE
Stop using validity bitmaps in Rust union serialization

### DIFF
--- a/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
+++ b/crates/re_types/definitions/rerun/testing/datatypes/fuzzy.fbs
@@ -58,7 +58,7 @@ union AffixFuzzer3 (
   "attr.rust.derive": "PartialEq"
 ) {
   degrees: FlattenedScalar (transparent),
-  radians: FlattenedScalar (transparent, nullable),
+  //radians: FlattenedScalar (transparent, nullable), // Nullable fields on unions are not supported.
   craziness: __AffixFuzzer1Vec (transparent),
   fixed_size_shenanigans: ArrayOfFloats (transparent),
 }
@@ -76,7 +76,7 @@ union AffixFuzzer4 (
 ) {
   single_required: __AffixFuzzer3 (transparent),
   many_required: __AffixFuzzer3Vec (transparent),
-  many_optional: __AffixFuzzer3Vec (transparent, nullable),
+  //many_optional: __AffixFuzzer3Vec (transparent, nullable), // Nullable fields on unions are not supported.
 }
 
 table AffixFuzzer5 (

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -103,13 +103,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -123,7 +117,9 @@ impl ::re_types_core::Loggable for AnnotationContext {
                     offsets,
                     {
                         _ = data0_inner_bitmap;
-                        crate::datatypes::ClassDescriptionMapElem::to_arrow_opt(data0_inner_data)?
+                        crate::datatypes::ClassDescriptionMapElem::to_arrow_opt(
+                            data0_inner_data.into_iter().map(Some),
+                        )?
                     },
                     data0_bitmap,
                 )

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -121,7 +121,6 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -136,10 +135,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -121,7 +121,6 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -136,10 +135,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -103,13 +103,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -126,25 +120,12 @@ impl ::re_types_core::Loggable for LineStrip2D {
                         let data0_inner_data_inner_data: Vec<_> = data0_inner_data
                             .iter()
                             .map(|datum| {
-                                datum
-                                    .map(|datum| {
-                                        let crate::datatypes::Vec2D(data0) = datum;
-                                        data0
-                                    })
-                                    .unwrap_or_default()
+                                let crate::datatypes::Vec2D(data0) = datum.clone();
+                                data0
                             })
                             .flatten()
-                            .map(Some)
                             .collect();
-                        let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                            data0_inner_bitmap.as_ref().map(|bitmap| {
-                                bitmap
-                                    .iter()
-                                    .map(|i| std::iter::repeat(i).take(2usize))
-                                    .flatten()
-                                    .collect::<Vec<_>>()
-                                    .into()
-                            });
+                        let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -152,10 +133,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                             ),
                             PrimitiveArray::new(
                                 DataType::Float32,
-                                data0_inner_data_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
+                                data0_inner_data_inner_data.into_iter().collect(),
                                 data0_inner_data_inner_bitmap,
                             )
                             .boxed(),

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -103,13 +103,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -126,25 +120,12 @@ impl ::re_types_core::Loggable for LineStrip3D {
                         let data0_inner_data_inner_data: Vec<_> = data0_inner_data
                             .iter()
                             .map(|datum| {
-                                datum
-                                    .map(|datum| {
-                                        let crate::datatypes::Vec3D(data0) = datum;
-                                        data0
-                                    })
-                                    .unwrap_or_default()
+                                let crate::datatypes::Vec3D(data0) = datum.clone();
+                                data0
                             })
                             .flatten()
-                            .map(Some)
                             .collect();
-                        let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                            data0_inner_bitmap.as_ref().map(|bitmap| {
-                                bitmap
-                                    .iter()
-                                    .map(|i| std::iter::repeat(i).take(3usize))
-                                    .flatten()
-                                    .collect::<Vec<_>>()
-                                    .into()
-                            });
+                        let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -152,10 +133,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                             ),
                             PrimitiveArray::new(
                                 DataType::Float32,
-                                data0_inner_data_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
+                                data0_inner_data_inner_data.into_iter().collect(),
                                 data0_inner_data_inner_bitmap,
                             )
                             .boxed(),

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -128,7 +128,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -143,10 +142,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Position2D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Position2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Position3D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Position3D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Range1D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Range1D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float64,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -120,7 +120,6 @@ impl ::re_types_core::Loggable for Resolution {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -135,10 +134,7 @@ impl ::re_types_core::Loggable for Resolution {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -134,7 +134,6 @@ impl ::re_types_core::Loggable for Texcoord2D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -149,10 +148,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for TriangleIndices {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Vector2D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Vector2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Vector3D {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Vector3D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -126,7 +126,6 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                             std::iter::repeat(Default::default()).take(3usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -141,10 +140,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt8,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -108,8 +108,13 @@ impl ::re_types_core::Loggable for Angle {
                             _ => None,
                         })
                         .collect();
-                    PrimitiveArray::new(DataType::Float32, radians.into_iter().collect(), None)
-                        .boxed()
+                    let radians_bitmap: Option<arrow2::bitmap::Bitmap> = None;
+                    PrimitiveArray::new(
+                        DataType::Float32,
+                        radians.into_iter().collect(),
+                        radians_bitmap,
+                    )
+                    .boxed()
                 },
                 {
                     let degrees: Vec<_> = data
@@ -119,8 +124,13 @@ impl ::re_types_core::Loggable for Angle {
                             _ => None,
                         })
                         .collect();
-                    PrimitiveArray::new(DataType::Float32, degrees.into_iter().collect(), None)
-                        .boxed()
+                    let degrees_bitmap: Option<arrow2::bitmap::Bitmap> = None;
+                    PrimitiveArray::new(
+                        DataType::Float32,
+                        degrees.into_iter().collect(),
+                        degrees_bitmap,
+                    )
+                    .boxed()
                 },
             ];
             let offsets = Some({

--- a/crates/re_types/src/datatypes/angle.rs
+++ b/crates/re_types/src/datatypes/angle.rs
@@ -101,50 +101,26 @@ impl ::re_types_core::Loggable for Angle {
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, radians): (Vec<_>, Vec<_>) = data
+                    let radians: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Angle::Radians(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Angle::Radians(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Angle::Radians(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let radians_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
-                        radians_bitmap,
-                    )
-                    .boxed()
+                        .collect();
+                    PrimitiveArray::new(DataType::Float32, radians.into_iter().collect(), None)
+                        .boxed()
                 },
                 {
-                    let (somes, degrees): (Vec<_>, Vec<_>) = data
+                    let degrees: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Angle::Degrees(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Angle::Degrees(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Angle::Degrees(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let degrees_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
-                        degrees_bitmap,
-                    )
-                    .boxed()
+                        .collect();
+                    PrimitiveArray::new(DataType::Float32, degrees.into_iter().collect(), None)
+                        .boxed()
                 },
             ];
             let offsets = Some({

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -174,7 +174,6 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 .flatten()
                                 .flatten()
                                 .cloned()
-                                .map(Some)
                                 .collect();
                             let keypoint_annotations_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
@@ -195,7 +194,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 {
                                     _ = keypoint_annotations_inner_bitmap;
                                     crate::datatypes::AnnotationInfo::to_arrow_opt(
-                                        keypoint_annotations_inner_data,
+                                        keypoint_annotations_inner_data.into_iter().map(Some),
                                     )?
                                 },
                                 keypoint_annotations_bitmap,
@@ -228,7 +227,6 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 .flatten()
                                 .flatten()
                                 .cloned()
-                                .map(Some)
                                 .collect();
                             let keypoint_connections_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
@@ -249,7 +247,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 {
                                     _ = keypoint_connections_inner_bitmap;
                                     crate::datatypes::KeypointPair::to_arrow_opt(
-                                        keypoint_connections_inner_data,
+                                        keypoint_connections_inner_data.into_iter().map(Some),
                                     )?
                                 },
                                 keypoint_connections_bitmap,

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for Mat3x3 {
                             std::iter::repeat(Default::default()).take(9usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -120,7 +120,6 @@ impl ::re_types_core::Loggable for Mat4x4 {
                             std::iter::repeat(Default::default()).take(16usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -135,10 +134,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -110,7 +110,6 @@ impl ::re_types_core::Loggable for Quaternion {
                             std::iter::repeat(Default::default()).take(4usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -125,10 +124,7 @@ impl ::re_types_core::Loggable for Quaternion {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for Range1D {
                             std::iter::repeat(Default::default()).take(2usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for Range1D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float64,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -125,7 +125,6 @@ impl ::re_types_core::Loggable for Range2D {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let x_range_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 x_range_bitmap.as_ref().map(|bitmap| {
@@ -147,10 +146,7 @@ impl ::re_types_core::Loggable for Range2D {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float64,
-                                    x_range_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    x_range_inner_data.into_iter().collect(),
                                     x_range_inner_bitmap,
                                 )
                                 .boxed(),
@@ -187,7 +183,6 @@ impl ::re_types_core::Loggable for Range2D {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let y_range_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 y_range_bitmap.as_ref().map(|bitmap| {
@@ -209,10 +204,7 @@ impl ::re_types_core::Loggable for Range2D {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float64,
-                                    y_range_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    y_range_inner_data.into_iter().collect(),
                                     y_range_inner_bitmap,
                                 )
                                 .boxed(),

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -109,45 +109,23 @@ impl ::re_types_core::Loggable for Rotation3D {
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, quaternion): (Vec<_>, Vec<_>) = data
+                    let quaternion: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Rotation3D::Quaternion(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Rotation3D::Quaternion(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Rotation3D::Quaternion(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let quaternion_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let quaternion_inner_data: Vec<_> = quaternion
                             .iter()
                             .map(|datum| {
-                                datum
-                                    .map(|datum| {
-                                        let crate::datatypes::Quaternion(data0) = datum;
-                                        data0
-                                    })
-                                    .unwrap_or_default()
+                                let crate::datatypes::Quaternion(data0) = datum.clone();
+                                data0
                             })
                             .flatten()
-                            .map(Some)
                             .collect();
-                        let quaternion_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                            quaternion_bitmap.as_ref().map(|bitmap| {
-                                bitmap
-                                    .iter()
-                                    .map(|i| std::iter::repeat(i).take(4usize))
-                                    .flatten()
-                                    .collect::<Vec<_>>()
-                                    .into()
-                            });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -155,37 +133,27 @@ impl ::re_types_core::Loggable for Rotation3D {
                             ),
                             PrimitiveArray::new(
                                 DataType::Float32,
-                                quaternion_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
-                                quaternion_inner_bitmap,
+                                quaternion_inner_data.into_iter().collect(),
+                                None,
                             )
                             .boxed(),
-                            quaternion_bitmap,
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, axis_angle): (Vec<_>, Vec<_>) = data
+                    let axis_angle: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Rotation3D::AxisAngle(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Rotation3D::AxisAngle(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Rotation3D::AxisAngle(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let axis_angle_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
-                        _ = axis_angle_bitmap;
-                        crate::datatypes::RotationAxisAngle::to_arrow_opt(axis_angle)?
+                        crate::datatypes::RotationAxisAngle::to_arrow_opt(
+                            axis_angle.into_iter().map(Some),
+                        )?
                     }
                 },
             ];

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -116,6 +116,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                             _ => None,
                         })
                         .collect();
+                    let quaternion_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let quaternion_inner_data: Vec<_> = quaternion
@@ -126,6 +127,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                             })
                             .flatten()
                             .collect();
+                        let quaternion_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -134,10 +136,10 @@ impl ::re_types_core::Loggable for Rotation3D {
                             PrimitiveArray::new(
                                 DataType::Float32,
                                 quaternion_inner_data.into_iter().collect(),
-                                None,
+                                quaternion_inner_bitmap,
                             )
                             .boxed(),
-                            None,
+                            quaternion_bitmap,
                         )
                         .boxed()
                     }
@@ -150,7 +152,9 @@ impl ::re_types_core::Loggable for Rotation3D {
                             _ => None,
                         })
                         .collect();
+                    let axis_angle_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
+                        _ = axis_angle_bitmap;
                         crate::datatypes::RotationAxisAngle::to_arrow_opt(
                             axis_angle.into_iter().map(Some),
                         )?

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -120,7 +120,6 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let axis_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 axis_bitmap.as_ref().map(|bitmap| {
@@ -142,10 +141,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float32,
-                                    axis_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    axis_inner_data.into_iter().collect(),
                                     axis_inner_bitmap,
                                 )
                                 .boxed(),

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -101,45 +101,23 @@ impl ::re_types_core::Loggable for Scale3D {
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, three_d): (Vec<_>, Vec<_>) = data
+                    let three_d: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Scale3D::ThreeD(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Scale3D::ThreeD(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Scale3D::ThreeD(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let three_d_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let three_d_inner_data: Vec<_> = three_d
                             .iter()
                             .map(|datum| {
-                                datum
-                                    .map(|datum| {
-                                        let crate::datatypes::Vec3D(data0) = datum;
-                                        data0
-                                    })
-                                    .unwrap_or_default()
+                                let crate::datatypes::Vec3D(data0) = datum.clone();
+                                data0
                             })
                             .flatten()
-                            .map(Some)
                             .collect();
-                        let three_d_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                            three_d_bitmap.as_ref().map(|bitmap| {
-                                bitmap
-                                    .iter()
-                                    .map(|i| std::iter::repeat(i).take(3usize))
-                                    .flatten()
-                                    .collect::<Vec<_>>()
-                                    .into()
-                            });
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -147,40 +125,25 @@ impl ::re_types_core::Loggable for Scale3D {
                             ),
                             PrimitiveArray::new(
                                 DataType::Float32,
-                                three_d_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
-                                three_d_inner_bitmap,
+                                three_d_inner_data.into_iter().collect(),
+                                None,
                             )
                             .boxed(),
-                            three_d_bitmap,
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, uniform): (Vec<_>, Vec<_>) = data
+                    let uniform: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(Scale3D::Uniform(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Scale3D::Uniform(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Scale3D::Uniform(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let uniform_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        uniform.into_iter().map(|v| v.unwrap_or_default()).collect(),
-                        uniform_bitmap,
-                    )
-                    .boxed()
+                        .collect();
+                    PrimitiveArray::new(DataType::Float32, uniform.into_iter().collect(), None)
+                        .boxed()
                 },
             ];
             let offsets = Some({

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -108,6 +108,7 @@ impl ::re_types_core::Loggable for Scale3D {
                             _ => None,
                         })
                         .collect();
+                    let three_d_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let three_d_inner_data: Vec<_> = three_d
@@ -118,6 +119,7 @@ impl ::re_types_core::Loggable for Scale3D {
                             })
                             .flatten()
                             .collect();
+                        let three_d_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -126,10 +128,10 @@ impl ::re_types_core::Loggable for Scale3D {
                             PrimitiveArray::new(
                                 DataType::Float32,
                                 three_d_inner_data.into_iter().collect(),
-                                None,
+                                three_d_inner_bitmap,
                             )
                             .boxed(),
-                            None,
+                            three_d_bitmap,
                         )
                         .boxed()
                     }
@@ -142,8 +144,13 @@ impl ::re_types_core::Loggable for Scale3D {
                             _ => None,
                         })
                         .collect();
-                    PrimitiveArray::new(DataType::Float32, uniform.into_iter().collect(), None)
-                        .boxed()
+                    let uniform_bitmap: Option<arrow2::bitmap::Bitmap> = None;
+                    PrimitiveArray::new(
+                        DataType::Float32,
+                        uniform.into_iter().collect(),
+                        uniform_bitmap,
+                    )
+                    .boxed()
                 },
             ];
             let offsets = Some({

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -307,37 +307,23 @@ impl ::re_types_core::Loggable for TensorBuffer {
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, u8): (Vec<_>, Vec<_>) = data
+                    let u8: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::U8(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::U8(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::U8(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let u8_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u8_inner_data: Buffer<_> = u8
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let u8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            u8.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            u8.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -348,45 +334,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt8, u8_inner_data, u8_inner_bitmap)
-                                .boxed(),
-                            u8_bitmap,
+                            PrimitiveArray::new(DataType::UInt8, u8_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, u16): (Vec<_>, Vec<_>) = data
+                    let u16: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::U16(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::U16(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::U16(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let u16_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u16_inner_data: Buffer<_> = u16
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let u16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            u16.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            u16.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -397,45 +368,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt16, u16_inner_data, u16_inner_bitmap)
-                                .boxed(),
-                            u16_bitmap,
+                            PrimitiveArray::new(DataType::UInt16, u16_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, u32): (Vec<_>, Vec<_>) = data
+                    let u32: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::U32(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::U32(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::U32(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let u32_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u32_inner_data: Buffer<_> = u32
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let u32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            u32.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            u32.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -446,45 +402,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt32, u32_inner_data, u32_inner_bitmap)
-                                .boxed(),
-                            u32_bitmap,
+                            PrimitiveArray::new(DataType::UInt32, u32_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, u64): (Vec<_>, Vec<_>) = data
+                    let u64: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::U64(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::U64(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::U64(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let u64_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u64_inner_data: Buffer<_> = u64
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let u64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            u64.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            u64.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -495,45 +436,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt64, u64_inner_data, u64_inner_bitmap)
-                                .boxed(),
-                            u64_bitmap,
+                            PrimitiveArray::new(DataType::UInt64, u64_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, i8): (Vec<_>, Vec<_>) = data
+                    let i8: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::I8(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::I8(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::I8(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let i8_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i8_inner_data: Buffer<_> = i8
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let i8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            i8.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            i8.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -544,45 +470,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int8, i8_inner_data, i8_inner_bitmap)
-                                .boxed(),
-                            i8_bitmap,
+                            PrimitiveArray::new(DataType::Int8, i8_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, i16): (Vec<_>, Vec<_>) = data
+                    let i16: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::I16(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::I16(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::I16(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let i16_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i16_inner_data: Buffer<_> = i16
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let i16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            i16.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            i16.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -593,45 +504,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int16, i16_inner_data, i16_inner_bitmap)
-                                .boxed(),
-                            i16_bitmap,
+                            PrimitiveArray::new(DataType::Int16, i16_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, i32): (Vec<_>, Vec<_>) = data
+                    let i32: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::I32(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::I32(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::I32(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let i32_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i32_inner_data: Buffer<_> = i32
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let i32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            i32.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            i32.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -642,45 +538,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int32, i32_inner_data, i32_inner_bitmap)
-                                .boxed(),
-                            i32_bitmap,
+                            PrimitiveArray::new(DataType::Int32, i32_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, i64): (Vec<_>, Vec<_>) = data
+                    let i64: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::I64(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::I64(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::I64(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let i64_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i64_inner_data: Buffer<_> = i64
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let i64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            i64.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            i64.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -691,45 +572,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int64, i64_inner_data, i64_inner_bitmap)
-                                .boxed(),
-                            i64_bitmap,
+                            PrimitiveArray::new(DataType::Int64, i64_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, f16): (Vec<_>, Vec<_>) = data
+                    let f16: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::F16(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::F16(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::F16(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let f16_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f16_inner_data: Buffer<_> = f16
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let f16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            f16.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            f16.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -740,49 +606,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::Float16,
-                                f16_inner_data,
-                                f16_inner_bitmap,
-                            )
-                            .boxed(),
-                            f16_bitmap,
+                            PrimitiveArray::new(DataType::Float16, f16_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, f32): (Vec<_>, Vec<_>) = data
+                    let f32: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::F32(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::F32(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::F32(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let f32_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f32_inner_data: Buffer<_> = f32
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let f32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            f32.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            f32.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -793,49 +640,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::Float32,
-                                f32_inner_data,
-                                f32_inner_bitmap,
-                            )
-                            .boxed(),
-                            f32_bitmap,
+                            PrimitiveArray::new(DataType::Float32, f32_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, f64): (Vec<_>, Vec<_>) = data
+                    let f64: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::F64(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::F64(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::F64(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let f64_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f64_inner_data: Buffer<_> = f64
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let f64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            f64.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            f64.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -846,49 +674,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::Float64,
-                                f64_inner_data,
-                                f64_inner_bitmap,
-                            )
-                            .boxed(),
-                            f64_bitmap,
+                            PrimitiveArray::new(DataType::Float64, f64_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, jpeg): (Vec<_>, Vec<_>) = data
+                    let jpeg: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::Jpeg(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::Jpeg(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::Jpeg(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let jpeg_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let jpeg_inner_data: Buffer<_> = jpeg
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let jpeg_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            jpeg.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            jpeg.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -899,49 +708,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::UInt8,
-                                jpeg_inner_data,
-                                jpeg_inner_bitmap,
-                            )
-                            .boxed(),
-                            jpeg_bitmap,
+                            PrimitiveArray::new(DataType::UInt8, jpeg_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, nv12): (Vec<_>, Vec<_>) = data
+                    let nv12: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::Nv12(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::Nv12(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::Nv12(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let nv12_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let nv12_inner_data: Buffer<_> = nv12
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let nv12_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            nv12.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            nv12.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -952,49 +742,30 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::UInt8,
-                                nv12_inner_data,
-                                nv12_inner_bitmap,
-                            )
-                            .boxed(),
-                            nv12_bitmap,
+                            PrimitiveArray::new(DataType::UInt8, nv12_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, yuy2): (Vec<_>, Vec<_>) = data
+                    let yuy2: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(TensorBuffer::Yuy2(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(TensorBuffer::Yuy2(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(TensorBuffer::Yuy2(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let yuy2_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let yuy2_inner_data: Buffer<_> = yuy2
                             .iter()
-                            .flatten()
                             .map(|b| b.as_slice())
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
-                        let yuy2_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            yuy2.iter().map(|opt| {
-                                opt.as_ref()
-                                    .map(|datum| datum.num_instances())
-                                    .unwrap_or_default()
-                            }),
+                            yuy2.iter().map(|datum| datum.num_instances()),
                         )
                         .unwrap()
                         .into();
@@ -1005,13 +776,8 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(
-                                DataType::UInt8,
-                                yuy2_inner_data,
-                                yuy2_inner_bitmap,
-                            )
-                            .boxed(),
-                            yuy2_bitmap,
+                            PrimitiveArray::new(DataType::UInt8, yuy2_inner_data, None).boxed(),
+                            None,
                         )
                         .boxed()
                     }

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -314,6 +314,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let u8_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u8_inner_data: Buffer<_> = u8
@@ -322,6 +323,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let u8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u8.iter().map(|datum| datum.num_instances()),
                         )
@@ -334,8 +336,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt8, u8_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::UInt8, u8_inner_data, u8_inner_bitmap)
+                                .boxed(),
+                            u8_bitmap,
                         )
                         .boxed()
                     }
@@ -348,6 +351,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let u16_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u16_inner_data: Buffer<_> = u16
@@ -356,6 +360,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let u16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u16.iter().map(|datum| datum.num_instances()),
                         )
@@ -368,8 +373,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt16, u16_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::UInt16, u16_inner_data, u16_inner_bitmap)
+                                .boxed(),
+                            u16_bitmap,
                         )
                         .boxed()
                     }
@@ -382,6 +388,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let u32_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u32_inner_data: Buffer<_> = u32
@@ -390,6 +397,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let u32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u32.iter().map(|datum| datum.num_instances()),
                         )
@@ -402,8 +410,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt32, u32_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::UInt32, u32_inner_data, u32_inner_bitmap)
+                                .boxed(),
+                            u32_bitmap,
                         )
                         .boxed()
                     }
@@ -416,6 +425,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let u64_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let u64_inner_data: Buffer<_> = u64
@@ -424,6 +434,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let u64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u64.iter().map(|datum| datum.num_instances()),
                         )
@@ -436,8 +447,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt64, u64_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::UInt64, u64_inner_data, u64_inner_bitmap)
+                                .boxed(),
+                            u64_bitmap,
                         )
                         .boxed()
                     }
@@ -450,6 +462,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let i8_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i8_inner_data: Buffer<_> = i8
@@ -458,6 +471,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let i8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i8.iter().map(|datum| datum.num_instances()),
                         )
@@ -470,8 +484,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int8, i8_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::Int8, i8_inner_data, i8_inner_bitmap)
+                                .boxed(),
+                            i8_bitmap,
                         )
                         .boxed()
                     }
@@ -484,6 +499,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let i16_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i16_inner_data: Buffer<_> = i16
@@ -492,6 +508,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let i16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i16.iter().map(|datum| datum.num_instances()),
                         )
@@ -504,8 +521,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int16, i16_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::Int16, i16_inner_data, i16_inner_bitmap)
+                                .boxed(),
+                            i16_bitmap,
                         )
                         .boxed()
                     }
@@ -518,6 +536,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let i32_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i32_inner_data: Buffer<_> = i32
@@ -526,6 +545,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let i32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i32.iter().map(|datum| datum.num_instances()),
                         )
@@ -538,8 +558,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int32, i32_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::Int32, i32_inner_data, i32_inner_bitmap)
+                                .boxed(),
+                            i32_bitmap,
                         )
                         .boxed()
                     }
@@ -552,6 +573,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let i64_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let i64_inner_data: Buffer<_> = i64
@@ -560,6 +582,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let i64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i64.iter().map(|datum| datum.num_instances()),
                         )
@@ -572,8 +595,9 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Int64, i64_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(DataType::Int64, i64_inner_data, i64_inner_bitmap)
+                                .boxed(),
+                            i64_bitmap,
                         )
                         .boxed()
                     }
@@ -586,6 +610,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let f16_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f16_inner_data: Buffer<_> = f16
@@ -594,6 +619,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let f16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f16.iter().map(|datum| datum.num_instances()),
                         )
@@ -606,8 +632,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Float16, f16_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::Float16,
+                                f16_inner_data,
+                                f16_inner_bitmap,
+                            )
+                            .boxed(),
+                            f16_bitmap,
                         )
                         .boxed()
                     }
@@ -620,6 +651,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let f32_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f32_inner_data: Buffer<_> = f32
@@ -628,6 +660,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let f32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f32.iter().map(|datum| datum.num_instances()),
                         )
@@ -640,8 +673,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Float32, f32_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::Float32,
+                                f32_inner_data,
+                                f32_inner_bitmap,
+                            )
+                            .boxed(),
+                            f32_bitmap,
                         )
                         .boxed()
                     }
@@ -654,6 +692,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let f64_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let f64_inner_data: Buffer<_> = f64
@@ -662,6 +701,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let f64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f64.iter().map(|datum| datum.num_instances()),
                         )
@@ -674,8 +714,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::Float64, f64_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::Float64,
+                                f64_inner_data,
+                                f64_inner_bitmap,
+                            )
+                            .boxed(),
+                            f64_bitmap,
                         )
                         .boxed()
                     }
@@ -688,6 +733,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let jpeg_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let jpeg_inner_data: Buffer<_> = jpeg
@@ -696,6 +742,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let jpeg_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             jpeg.iter().map(|datum| datum.num_instances()),
                         )
@@ -708,8 +755,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt8, jpeg_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::UInt8,
+                                jpeg_inner_data,
+                                jpeg_inner_bitmap,
+                            )
+                            .boxed(),
+                            jpeg_bitmap,
                         )
                         .boxed()
                     }
@@ -722,6 +774,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let nv12_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let nv12_inner_data: Buffer<_> = nv12
@@ -730,6 +783,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let nv12_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             nv12.iter().map(|datum| datum.num_instances()),
                         )
@@ -742,8 +796,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt8, nv12_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::UInt8,
+                                nv12_inner_data,
+                                nv12_inner_bitmap,
+                            )
+                            .boxed(),
+                            nv12_bitmap,
                         )
                         .boxed()
                     }
@@ -756,6 +815,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             _ => None,
                         })
                         .collect();
+                    let yuy2_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let yuy2_inner_data: Buffer<_> = yuy2
@@ -764,6 +824,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .collect::<Vec<_>>()
                             .concat()
                             .into();
+                        let yuy2_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             yuy2.iter().map(|datum| datum.num_instances()),
                         )
@@ -776,8 +837,13 @@ impl ::re_types_core::Loggable for TensorBuffer {
                                 false,
                             ))),
                             offsets,
-                            PrimitiveArray::new(DataType::UInt8, yuy2_inner_data, None).boxed(),
-                            None,
+                            PrimitiveArray::new(
+                                DataType::UInt8,
+                                yuy2_inner_data,
+                                yuy2_inner_bitmap,
+                            )
+                            .boxed(),
+                            yuy2_bitmap,
                         )
                         .boxed()
                     }

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -130,13 +130,8 @@ impl ::re_types_core::Loggable for TensorData {
                         };
                         {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                            let shape_inner_data: Vec<_> = shape
-                                .iter()
-                                .flatten()
-                                .flatten()
-                                .cloned()
-                                .map(Some)
-                                .collect();
+                            let shape_inner_data: Vec<_> =
+                                shape.iter().flatten().flatten().cloned().collect();
                             let shape_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                             let offsets =
                                 arrow2::offset::Offsets::<i32>::try_from_lengths(shape.iter().map(
@@ -154,7 +149,7 @@ impl ::re_types_core::Loggable for TensorData {
                                 {
                                     _ = shape_inner_bitmap;
                                     crate::datatypes::TensorDimension::to_arrow_opt(
-                                        shape_inner_data,
+                                        shape_inner_data.into_iter().map(Some),
                                     )?
                                 },
                                 shape_bitmap,

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -113,55 +113,30 @@ impl ::re_types_core::Loggable for Transform3D {
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, translation_and_mat3x3): (Vec<_>, Vec<_>) = data
+                    let translation_and_mat3x3: Vec<_> = data
                         .iter()
-                        .filter(|datum| {
-                            matches!(datum.as_deref(), Some(Transform3D::TranslationAndMat3x3(_)))
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Transform3D::TranslationAndMat3x3(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Transform3D::TranslationAndMat3x3(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let translation_and_mat3x3_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
-                        _ = translation_and_mat3x3_bitmap;
                         crate::datatypes::TranslationAndMat3x3::to_arrow_opt(
-                            translation_and_mat3x3,
+                            translation_and_mat3x3.into_iter().map(Some),
                         )?
                     }
                 },
                 {
-                    let (somes, translation_rotation_scale): (Vec<_>, Vec<_>) = data
+                    let translation_rotation_scale: Vec<_> = data
                         .iter()
-                        .filter(|datum| {
-                            matches!(
-                                datum.as_deref(),
-                                Some(Transform3D::TranslationRotationScale(_))
-                            )
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(Transform3D::TranslationRotationScale(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(Transform3D::TranslationRotationScale(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let translation_rotation_scale_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
-                        _ = translation_rotation_scale_bitmap;
                         crate::datatypes::TranslationRotationScale3D::to_arrow_opt(
-                            translation_rotation_scale,
+                            translation_rotation_scale.into_iter().map(Some),
                         )?
                     }
                 },

--- a/crates/re_types/src/datatypes/transform3d.rs
+++ b/crates/re_types/src/datatypes/transform3d.rs
@@ -120,7 +120,9 @@ impl ::re_types_core::Loggable for Transform3D {
                             _ => None,
                         })
                         .collect();
+                    let translation_and_mat3x3_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
+                        _ = translation_and_mat3x3_bitmap;
                         crate::datatypes::TranslationAndMat3x3::to_arrow_opt(
                             translation_and_mat3x3.into_iter().map(Some),
                         )?
@@ -134,7 +136,9 @@ impl ::re_types_core::Loggable for Transform3D {
                             _ => None,
                         })
                         .collect();
+                    let translation_rotation_scale_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
+                        _ = translation_rotation_scale_bitmap;
                         crate::datatypes::TranslationRotationScale3D::to_arrow_opt(
                             translation_rotation_scale.into_iter().map(Some),
                         )?

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -136,7 +136,6 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let translation_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 translation_bitmap.as_ref().map(|bitmap| {
@@ -158,10 +157,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float32,
-                                    translation_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    translation_inner_data.into_iter().collect(),
                                     translation_inner_bitmap,
                                 )
                                 .boxed(),
@@ -201,7 +197,6 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let mat3x3_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 mat3x3_bitmap.as_ref().map(|bitmap| {
@@ -223,10 +218,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float32,
-                                    mat3x3_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    mat3x3_inner_data.into_iter().collect(),
                                     mat3x3_inner_bitmap,
                                 )
                                 .boxed(),

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -144,7 +144,6 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                         .unwrap_or_default()
                                 })
                                 .flatten()
-                                .map(Some)
                                 .collect();
                             let translation_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 translation_bitmap.as_ref().map(|bitmap| {
@@ -166,10 +165,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                 ),
                                 PrimitiveArray::new(
                                     DataType::Float32,
-                                    translation_inner_data
-                                        .into_iter()
-                                        .map(|v| v.unwrap_or_default())
-                                        .collect(),
+                                    translation_inner_data.into_iter().collect(),
                                     translation_inner_bitmap,
                                 )
                                 .boxed(),

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -111,7 +111,6 @@ impl ::re_types_core::Loggable for Uuid {
                             std::iter::repeat(Default::default()).take(16usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let bytes_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     bytes_bitmap.as_ref().map(|bitmap| {
@@ -126,10 +125,7 @@ impl ::re_types_core::Loggable for Uuid {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt8,
-                        bytes_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        bytes_inner_data.into_iter().collect(),
                         bytes_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for UVec2D {
                             std::iter::repeat(Default::default()).take(2usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for UVec2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for UVec3D {
                             std::iter::repeat(Default::default()).take(3usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for UVec3D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for UVec4D {
                             std::iter::repeat(Default::default()).take(4usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for UVec4D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for Vec2D {
                             std::iter::repeat(Default::default()).take(2usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for Vec2D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for Vec3D {
                             std::iter::repeat(Default::default()).take(3usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for Vec3D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -108,7 +108,6 @@ impl ::re_types_core::Loggable for Vec4D {
                             std::iter::repeat(Default::default()).take(4usize),
                         ),
                     })
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -123,10 +122,7 @@ impl ::re_types_core::Loggable for Vec4D {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::Float32,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -99,13 +99,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -118,15 +112,10 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                     Self::arrow_datatype(),
                     offsets,
                     {
-                        let inner_data: arrow2::buffer::Buffer<u8> = data0_inner_data
-                            .iter()
-                            .flatten()
-                            .flat_map(|s| s.0.clone())
-                            .collect();
+                        let inner_data: arrow2::buffer::Buffer<u8> =
+                            data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|opt| {
-                                opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
-                            }),
+                            data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
                         .unwrap()
                         .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -101,13 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -120,15 +114,10 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                     Self::arrow_datatype(),
                     offsets,
                     {
-                        let inner_data: arrow2::buffer::Buffer<u8> = data0_inner_data
-                            .iter()
-                            .flatten()
-                            .flat_map(|s| s.0.clone())
-                            .collect();
+                        let inner_data: arrow2::buffer::Buffer<u8> =
+                            data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|opt| {
-                                opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
-                            }),
+                            data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
                         .unwrap()
                         .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -77,7 +77,6 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
             std::sync::Arc::new(vec![
                 Field::new("_null_markers", DataType::Null, true),
                 Field::new("degrees", DataType::Float32, false),
-                Field::new("radians", DataType::Float32, false),
                 Field::new(
                     "craziness",
                     DataType::List(std::sync::Arc::new(Field::new(
@@ -96,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
                     false,
                 ),
             ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer15.rs
@@ -77,7 +77,6 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
             std::sync::Arc::new(vec![
                 Field::new("_null_markers", DataType::Null, true),
                 Field::new("degrees", DataType::Float32, false),
-                Field::new("radians", DataType::Float32, false),
                 Field::new(
                     "craziness",
                     DataType::List(std::sync::Arc::new(Field::new(
@@ -96,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                     false,
                 ),
             ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
             UnionMode::Dense,
         )
     }

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -93,13 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -113,7 +107,9 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                     offsets,
                     {
                         _ = data0_inner_bitmap;
-                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(data0_inner_data)?
+                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
+                            data0_inner_data.into_iter().map(Some),
+                        )?
                     },
                     data0_bitmap,
                 )

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -95,13 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -115,7 +109,9 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                     offsets,
                     {
                         _ = data0_inner_bitmap;
-                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(data0_inner_data)?
+                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
+                            data0_inner_data.into_iter().map(Some),
+                        )?
                     },
                     data0_bitmap,
                 )

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -95,13 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -115,7 +109,9 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                     offsets,
                     {
                         _ = data0_inner_bitmap;
-                        crate::testing::datatypes::AffixFuzzer4::to_arrow_opt(data0_inner_data)?
+                        crate::testing::datatypes::AffixFuzzer4::to_arrow_opt(
+                            data0_inner_data.into_iter().map(Some),
+                        )?
                     },
                     data0_bitmap,
                 )

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -95,13 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -115,7 +109,9 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                     offsets,
                     {
                         _ = data0_inner_bitmap;
-                        crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data0_inner_data)?
+                        crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(
+                            data0_inner_data.into_iter().map(Some),
+                        )?
                     },
                     data0_bitmap,
                 )

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -346,7 +346,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .flatten()
                                 .flatten()
                                 .cloned()
-                                .map(Some)
                                 .collect();
                             let many_strings_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
@@ -368,15 +367,12 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let inner_data: arrow2::buffer::Buffer<u8> =
                                         many_strings_required_inner_data
                                             .iter()
-                                            .flatten()
                                             .flat_map(|s| s.0.clone())
                                             .collect();
                                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                        many_strings_required_inner_data.iter().map(|opt| {
-                                            opt.as_ref()
-                                                .map(|datum| datum.0.len())
-                                                .unwrap_or_default()
-                                        }),
+                                        many_strings_required_inner_data
+                                            .iter()
+                                            .map(|datum| datum.0.len()),
                                     )
                                     .unwrap()
                                     .into();
@@ -424,7 +420,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .flatten()
                                 .flatten()
                                 .cloned()
-                                .map(Some)
                                 .collect();
                             let many_strings_optional_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
@@ -446,15 +441,12 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let inner_data: arrow2::buffer::Buffer<u8> =
                                         many_strings_optional_inner_data
                                             .iter()
-                                            .flatten()
                                             .flat_map(|s| s.0.clone())
                                             .collect();
                                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                        many_strings_optional_inner_data.iter().map(|opt| {
-                                            opt.as_ref()
-                                                .map(|datum| datum.0.len())
-                                                .unwrap_or_default()
-                                        }),
+                                        many_strings_optional_inner_data
+                                            .iter()
+                                            .map(|datum| datum.0.len()),
                                     )
                                     .unwrap()
                                     .into();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -127,7 +127,6 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                                     std::iter::repeat(Default::default()).take(4usize),
                                 ),
                             })
-                            .map(Some)
                             .collect();
                         let fixed_sized_native_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                             fixed_sized_native_bitmap.as_ref().map(|bitmap| {
@@ -145,10 +144,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                             ),
                             PrimitiveArray::new(
                                 DataType::UInt8,
-                                fixed_sized_native_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
+                                fixed_sized_native_inner_data.into_iter().collect(),
                                 fixed_sized_native_inner_bitmap,
                             )
                             .boxed(),

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -125,8 +125,13 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             _ => None,
                         })
                         .collect();
-                    PrimitiveArray::new(DataType::Float32, degrees.into_iter().collect(), None)
-                        .boxed()
+                    let degrees_bitmap: Option<arrow2::bitmap::Bitmap> = None;
+                    PrimitiveArray::new(
+                        DataType::Float32,
+                        degrees.into_iter().collect(),
+                        degrees_bitmap,
+                    )
+                    .boxed()
                 },
                 {
                     let craziness: Vec<_> = data
@@ -136,10 +141,12 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             _ => None,
                         })
                         .collect();
+                    let craziness_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let craziness_inner_data: Vec<_> =
                             craziness.iter().flatten().cloned().collect();
+                        let craziness_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             craziness.iter().map(|datum| datum.len()),
                         )
@@ -153,11 +160,12 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             ))),
                             offsets,
                             {
+                                _ = craziness_inner_bitmap;
                                 crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(
                                     craziness_inner_data.into_iter().map(Some),
                                 )?
                             },
-                            None,
+                            craziness_bitmap,
                         )
                         .boxed()
                     }
@@ -170,10 +178,13 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             _ => None,
                         })
                         .collect();
+                    let fixed_size_shenanigans_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let fixed_size_shenanigans_inner_data: Vec<_> =
                             fixed_size_shenanigans.iter().flatten().cloned().collect();
+                        let fixed_size_shenanigans_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
+                            None;
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -182,10 +193,10 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             PrimitiveArray::new(
                                 DataType::Float32,
                                 fixed_size_shenanigans_inner_data.into_iter().collect(),
-                                None,
+                                fixed_size_shenanigans_inner_bitmap,
                             )
                             .boxed(),
-                            None,
+                            fixed_size_shenanigans_bitmap,
                         )
                         .boxed()
                     }

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -25,7 +25,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, PartialEq)]
 pub enum AffixFuzzer3 {
     Degrees(f32),
-    Radians(Option<f32>),
     Craziness(Vec<crate::testing::datatypes::AffixFuzzer1>),
     FixedSizeShenanigans([f32; 3usize]),
 }
@@ -36,7 +35,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer3 {
     fn heap_size_bytes(&self) -> u64 {
         match self {
             Self::Degrees(v) => v.heap_size_bytes(),
-            Self::Radians(v) => v.heap_size_bytes(),
             Self::Craziness(v) => v.heap_size_bytes(),
             Self::FixedSizeShenanigans(v) => v.heap_size_bytes(),
         }
@@ -45,7 +43,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer3 {
     #[inline]
     fn is_pod() -> bool {
         <f32>::is_pod()
-            && <Option<f32>>::is_pod()
             && <Vec<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
             && <[f32; 3usize]>::is_pod()
     }
@@ -69,7 +66,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
             std::sync::Arc::new(vec![
                 Field::new("_null_markers", DataType::Null, true),
                 Field::new("degrees", DataType::Float32, false),
-                Field::new("radians", DataType::Float32, false),
                 Field::new(
                     "craziness",
                     DataType::List(std::sync::Arc::new(Field::new(
@@ -88,7 +84,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     false,
                 ),
             ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
             UnionMode::Dense,
         )
     }
@@ -115,94 +111,40 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 .map(|a| match a.as_deref() {
                     None => 0,
                     Some(AffixFuzzer3::Degrees(_)) => 1i8,
-                    Some(AffixFuzzer3::Radians(_)) => 2i8,
-                    Some(AffixFuzzer3::Craziness(_)) => 3i8,
-                    Some(AffixFuzzer3::FixedSizeShenanigans(_)) => 4i8,
+                    Some(AffixFuzzer3::Craziness(_)) => 2i8,
+                    Some(AffixFuzzer3::FixedSizeShenanigans(_)) => 3i8,
                 })
                 .collect();
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, degrees): (Vec<_>, Vec<_>) = data
+                    let degrees: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(AffixFuzzer3::Degrees(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer3::Degrees(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(AffixFuzzer3::Degrees(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let degrees_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        degrees.into_iter().map(|v| v.unwrap_or_default()).collect(),
-                        degrees_bitmap,
-                    )
-                    .boxed()
+                        .collect();
+                    PrimitiveArray::new(DataType::Float32, degrees.into_iter().collect(), None)
+                        .boxed()
                 },
                 {
-                    let (somes, radians): (Vec<_>, Vec<_>) = data
+                    let craziness: Vec<_> = data
                         .iter()
-                        .filter(|datum| matches!(datum.as_deref(), Some(AffixFuzzer3::Radians(_))))
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer3::Radians(v)) => Some(v.clone()),
-                                _ => None,
-                            }
-                            .flatten();
-                            (datum.is_some(), datum)
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(AffixFuzzer3::Craziness(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .unzip();
-                    let radians_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        radians.into_iter().map(|v| v.unwrap_or_default()).collect(),
-                        radians_bitmap,
-                    )
-                    .boxed()
-                },
-                {
-                    let (somes, craziness): (Vec<_>, Vec<_>) = data
-                        .iter()
-                        .filter(|datum| {
-                            matches!(datum.as_deref(), Some(AffixFuzzer3::Craziness(_)))
-                        })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer3::Craziness(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let craziness_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                        let craziness_inner_data: Vec<_> = craziness
-                            .iter()
-                            .flatten()
-                            .flatten()
-                            .cloned()
-                            .map(Some)
-                            .collect();
-                        let craziness_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        let offsets =
-                            arrow2::offset::Offsets::<i32>::try_from_lengths(craziness.iter().map(
-                                |opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default(),
-                            ))
-                            .unwrap()
-                            .into();
+                        let craziness_inner_data: Vec<_> =
+                            craziness.iter().flatten().cloned().collect();
+                        let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                            craziness.iter().map(|datum| datum.len()),
+                        )
+                        .unwrap()
+                        .into();
                         ListArray::new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
@@ -211,58 +153,27 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             ))),
                             offsets,
                             {
-                                _ = craziness_inner_bitmap;
                                 crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(
-                                    craziness_inner_data,
+                                    craziness_inner_data.into_iter().map(Some),
                                 )?
                             },
-                            craziness_bitmap,
+                            None,
                         )
                         .boxed()
                     }
                 },
                 {
-                    let (somes, fixed_size_shenanigans): (Vec<_>, Vec<_>) = data
+                    let fixed_size_shenanigans: Vec<_> = data
                         .iter()
-                        .filter(|datum| {
-                            matches!(
-                                datum.as_deref(),
-                                Some(AffixFuzzer3::FixedSizeShenanigans(_))
-                            )
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(AffixFuzzer3::FixedSizeShenanigans(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer3::FixedSizeShenanigans(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let fixed_size_shenanigans_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                        let fixed_size_shenanigans_inner_data: Vec<_> = fixed_size_shenanigans
-                            .iter()
-                            .flat_map(|v| match v {
-                                Some(v) => itertools::Either::Left(v.iter().cloned()),
-                                None => itertools::Either::Right(
-                                    std::iter::repeat(Default::default()).take(3usize),
-                                ),
-                            })
-                            .map(Some)
-                            .collect();
-                        let fixed_size_shenanigans_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                            fixed_size_shenanigans_bitmap.as_ref().map(|bitmap| {
-                                bitmap
-                                    .iter()
-                                    .map(|i| std::iter::repeat(i).take(3usize))
-                                    .flatten()
-                                    .collect::<Vec<_>>()
-                                    .into()
-                            });
+                        let fixed_size_shenanigans_inner_data: Vec<_> =
+                            fixed_size_shenanigans.iter().flatten().cloned().collect();
                         FixedSizeListArray::new(
                             DataType::FixedSizeList(
                                 std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
@@ -270,14 +181,11 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             ),
                             PrimitiveArray::new(
                                 DataType::Float32,
-                                fixed_size_shenanigans_inner_data
-                                    .into_iter()
-                                    .map(|v| v.unwrap_or_default())
-                                    .collect(),
-                                fixed_size_shenanigans_inner_bitmap,
+                                fixed_size_shenanigans_inner_data.into_iter().collect(),
+                                None,
                             )
                             .boxed(),
-                            fixed_size_shenanigans_bitmap,
+                            None,
                         )
                         .boxed()
                     }
@@ -285,7 +193,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
             ];
             let offsets = Some({
                 let mut degrees_offset = 0;
-                let mut radians_offset = 0;
                 let mut craziness_offset = 0;
                 let mut fixed_size_shenanigans_offset = 0;
                 let mut nulls_offset = 0;
@@ -299,11 +206,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                         Some(AffixFuzzer3::Degrees(_)) => {
                             let offset = degrees_offset;
                             degrees_offset += 1;
-                            offset
-                        }
-                        Some(AffixFuzzer3::Radians(_)) => {
-                            let offset = radians_offset;
-                            radians_offset += 1;
                             offset
                         }
                         Some(AffixFuzzer3::Craziness(_)) => {
@@ -386,29 +288,11 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                         .map(|opt| opt.copied())
                         .collect::<Vec<_>>()
                 };
-                let radians = {
+                let craziness = {
                     if 2usize >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[2usize];
-                    arrow_data
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.testing.datatypes.AffixFuzzer3#radians")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                let craziness = {
-                    if 3usize >= arrow_data_arrays.len() {
-                        return Ok(Vec::new());
-                    }
-                    let arrow_data = &*arrow_data_arrays[3usize];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -471,10 +355,10 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .collect::<Vec<_>>()
                 };
                 let fixed_size_shenanigans = {
-                    if 4usize >= arrow_data_arrays.len() {
+                    if 3usize >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[4usize];
+                    let arrow_data = &*arrow_data_arrays[3usize];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -583,21 +467,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                             })
                                         }
                                         2i8 => {
-                                            AffixFuzzer3::Radians({
-                                                if offset as usize >= radians.len() {
-                                                    return Err(
-                                                            DeserializationError::offset_oob(offset as _, radians.len()),
-                                                        )
-                                                        .with_context(
-                                                            "rerun.testing.datatypes.AffixFuzzer3#radians",
-                                                        );
-                                                }
-
-                                                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                                unsafe { radians.get_unchecked(offset as usize) }.clone()
-                                            })
-                                        }
-                                        3i8 => {
                                             AffixFuzzer3::Craziness({
                                                 if offset as usize >= craziness.len() {
                                                     return Err(
@@ -620,7 +489,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                                     )?
                                             })
                                         }
-                                        4i8 => {
+                                        3i8 => {
                                             AffixFuzzer3::FixedSizeShenanigans({
                                                 if offset as usize >= fixed_size_shenanigans.len() {
                                                     return Err(

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3_ext.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3_ext.rs
@@ -1,5 +1,5 @@
 impl Default for super::AffixFuzzer3 {
     fn default() -> Self {
-        Self::Radians(Some(0.0))
+        Self::Degrees(0.0)
     }
 }

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -117,7 +117,9 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             _ => None,
                         })
                         .collect();
+                    let single_required_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
+                        _ = single_required_bitmap;
                         crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
                             single_required.into_iter().map(Some),
                         )?
@@ -131,10 +133,12 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             _ => None,
                         })
                         .collect();
+                    let many_required_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let many_required_inner_data: Vec<_> =
                             many_required.iter().flatten().cloned().collect();
+                        let many_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             many_required.iter().map(|datum| datum.len()),
                         )
@@ -148,11 +152,12 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             ))),
                             offsets,
                             {
+                                _ = many_required_inner_bitmap;
                                 crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
                                     many_required_inner_data.into_iter().map(Some),
                                 )?
                             },
-                            None,
+                            many_required_bitmap,
                         )
                         .boxed()
                     }

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -26,7 +26,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum AffixFuzzer4 {
     SingleRequired(crate::testing::datatypes::AffixFuzzer3),
     ManyRequired(Vec<crate::testing::datatypes::AffixFuzzer3>),
-    ManyOptional(Option<Vec<crate::testing::datatypes::AffixFuzzer3>>),
 }
 
 impl ::re_types_core::SizeBytes for AffixFuzzer4 {
@@ -36,7 +35,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer4 {
         match self {
             Self::SingleRequired(v) => v.heap_size_bytes(),
             Self::ManyRequired(v) => v.heap_size_bytes(),
-            Self::ManyOptional(v) => v.heap_size_bytes(),
         }
     }
 
@@ -44,7 +42,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer4 {
     fn is_pod() -> bool {
         <crate::testing::datatypes::AffixFuzzer3>::is_pod()
             && <Vec<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
-            && <Option<Vec<crate::testing::datatypes::AffixFuzzer3>>>::is_pod()
     }
 }
 
@@ -79,17 +76,8 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     ))),
                     false,
                 ),
-                Field::new(
-                    "many_optional",
-                    DataType::List(std::sync::Arc::new(Field::new(
-                        "item",
-                        <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                        false,
-                    ))),
-                    false,
-                ),
             ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32])),
+            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
             UnionMode::Dense,
         )
     }
@@ -117,66 +105,38 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     None => 0,
                     Some(AffixFuzzer4::SingleRequired(_)) => 1i8,
                     Some(AffixFuzzer4::ManyRequired(_)) => 2i8,
-                    Some(AffixFuzzer4::ManyOptional(_)) => 3i8,
                 })
                 .collect();
             let fields = vec![
                 NullArray::new(DataType::Null, data.iter().filter(|v| v.is_none()).count()).boxed(),
                 {
-                    let (somes, single_required): (Vec<_>, Vec<_>) = data
+                    let single_required: Vec<_> = data
                         .iter()
-                        .filter(|datum| {
-                            matches!(datum.as_deref(), Some(AffixFuzzer4::SingleRequired(_)))
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(AffixFuzzer4::SingleRequired(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer4::SingleRequired(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let single_required_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
-                        _ = single_required_bitmap;
-                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(single_required)?
+                        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
+                            single_required.into_iter().map(Some),
+                        )?
                     }
                 },
                 {
-                    let (somes, many_required): (Vec<_>, Vec<_>) = data
+                    let many_required: Vec<_> = data
                         .iter()
-                        .filter(|datum| {
-                            matches!(datum.as_deref(), Some(AffixFuzzer4::ManyRequired(_)))
+                        .filter_map(|datum| match datum.as_deref() {
+                            Some(AffixFuzzer4::ManyRequired(v)) => Some(v.clone()),
+                            _ => None,
                         })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer4::ManyRequired(v)) => Some(v.clone()),
-                                _ => None,
-                            };
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let many_required_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
+                        .collect();
                     {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                        let many_required_inner_data: Vec<_> = many_required
-                            .iter()
-                            .flatten()
-                            .flatten()
-                            .cloned()
-                            .map(Some)
-                            .collect();
-                        let many_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
+                        let many_required_inner_data: Vec<_> =
+                            many_required.iter().flatten().cloned().collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            many_required.iter().map(|opt| {
-                                opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                            }),
+                            many_required.iter().map(|datum| datum.len()),
                         )
                         .unwrap()
                         .into();
@@ -188,66 +148,11 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             ))),
                             offsets,
                             {
-                                _ = many_required_inner_bitmap;
                                 crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
-                                    many_required_inner_data,
+                                    many_required_inner_data.into_iter().map(Some),
                                 )?
                             },
-                            many_required_bitmap,
-                        )
-                        .boxed()
-                    }
-                },
-                {
-                    let (somes, many_optional): (Vec<_>, Vec<_>) = data
-                        .iter()
-                        .filter(|datum| {
-                            matches!(datum.as_deref(), Some(AffixFuzzer4::ManyOptional(_)))
-                        })
-                        .map(|datum| {
-                            let datum = match datum.as_deref() {
-                                Some(AffixFuzzer4::ManyOptional(v)) => Some(v.clone()),
-                                _ => None,
-                            }
-                            .flatten();
-                            (datum.is_some(), datum)
-                        })
-                        .unzip();
-                    let many_optional_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                        let any_nones = somes.iter().any(|some| !*some);
-                        any_nones.then(|| somes.into())
-                    };
-                    {
-                        use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                        let many_optional_inner_data: Vec<_> = many_optional
-                            .iter()
-                            .flatten()
-                            .flatten()
-                            .cloned()
-                            .map(Some)
-                            .collect();
-                        let many_optional_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            many_optional.iter().map(|opt| {
-                                opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                            }),
-                        )
-                        .unwrap()
-                        .into();
-                        ListArray::new(
-                            DataType::List(std::sync::Arc::new(Field::new(
-                                "item",
-                                <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                                false,
-                            ))),
-                            offsets,
-                            {
-                                _ = many_optional_inner_bitmap;
-                                crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(
-                                    many_optional_inner_data,
-                                )?
-                            },
-                            many_optional_bitmap,
+                            None,
                         )
                         .boxed()
                     }
@@ -256,7 +161,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
             let offsets = Some({
                 let mut single_required_offset = 0;
                 let mut many_required_offset = 0;
-                let mut many_optional_offset = 0;
                 let mut nulls_offset = 0;
                 data.iter()
                     .map(|v| match v.as_deref() {
@@ -273,11 +177,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                         Some(AffixFuzzer4::ManyRequired(_)) => {
                             let offset = many_required_offset;
                             many_required_offset += 1;
-                            offset
-                        }
-                        Some(AffixFuzzer4::ManyOptional(_)) => {
-                            let offset = many_optional_offset;
-                            many_optional_offset += 1;
                             offset
                         }
                     })
@@ -408,72 +307,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     }
                     .collect::<Vec<_>>()
                 };
-                let many_optional = {
-                    if 3usize >= arrow_data_arrays.len() {
-                        return Ok(Vec::new());
-                    }
-                    let arrow_data = &*arrow_data_arrays[3usize];
-                    {
-                        let arrow_data = arrow_data
-                            .as_any()
-                            .downcast_ref::<arrow2::array::ListArray<i32>>()
-                            .ok_or_else(|| {
-                                let expected = DataType::List(std::sync::Arc::new(Field::new(
-                                    "item",
-                                    <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
-                                    false,
-                                )));
-                                let actual = arrow_data.data_type().clone();
-                                DeserializationError::datatype_mismatch(expected, actual)
-                            })
-                            .with_context("rerun.testing.datatypes.AffixFuzzer4#many_optional")?;
-                        if arrow_data.is_empty() {
-                            Vec::new()
-                        } else {
-                            let arrow_data_inner = {
-                                let arrow_data_inner = &**arrow_data.values();
-                                crate::testing::datatypes::AffixFuzzer3::from_arrow_opt(
-                                    arrow_data_inner,
-                                )
-                                .with_context("rerun.testing.datatypes.AffixFuzzer4#many_optional")?
-                                .into_iter()
-                                .collect::<Vec<_>>()
-                            };
-                            let offsets = arrow_data.offsets();
-                            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
-                                arrow_data.validity(),
-                            )
-                            .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end as usize > arrow_data_inner.len() {
-                                        return Err(DeserializationError::offset_slice_oob(
-                                            (start, end),
-                                            arrow_data_inner.len(),
-                                        ));
-                                    }
-
-                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                    let data = unsafe {
-                                        arrow_data_inner.get_unchecked(start as usize..end as usize)
-                                    };
-                                    let data = data
-                                        .iter()
-                                        .cloned()
-                                        .map(Option::unwrap_or_default)
-                                        .collect();
-                                    Ok(data)
-                                })
-                                .transpose()
-                            })
-                            .collect::<DeserializationResult<Vec<Option<_>>>>()?
-                        }
-                        .into_iter()
-                    }
-                    .collect::<Vec<_>>()
-                };
                 arrow_data_types
                     .iter()
                     .enumerate()
@@ -520,20 +353,6 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                                         .with_context(
                                             "rerun.testing.datatypes.AffixFuzzer4#many_required",
                                         )?
-                                }),
-                                3i8 => AffixFuzzer4::ManyOptional({
-                                    if offset as usize >= many_optional.len() {
-                                        return Err(DeserializationError::offset_oob(
-                                            offset as _,
-                                            many_optional.len(),
-                                        ))
-                                        .with_context(
-                                            "rerun.testing.datatypes.AffixFuzzer4#many_optional",
-                                        );
-                                    }
-
-                                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                                    unsafe { many_optional.get_unchecked(offset as usize) }.clone()
                                 }),
                                 _ => {
                                     return Err(DeserializationError::missing_union_arm(

--- a/crates/re_types/tests/fuzzy.rs
+++ b/crates/re_types/tests/fuzzy.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 
-use std::{collections::HashMap, f32::consts::TAU};
+use std::collections::HashMap;
 
 use arrow2::types::f16;
 use re_types::{
@@ -120,29 +120,22 @@ fn roundtrip() {
     ]));
 
     let fuzzy14_1 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Degrees(90.0));
-    let fuzzy14_2 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Radians(Some(TAU / 2.0)));
-    let fuzzy14_3 = components::AffixFuzzer14(datatypes::AffixFuzzer3::Radians(None));
 
     let fuzzy15_1 = components::AffixFuzzer15(None);
-    let fuzzy15_2 =
-        components::AffixFuzzer15(Some(datatypes::AffixFuzzer3::Radians(Some(TAU / 8.0))));
+    let fuzzy15_2 = components::AffixFuzzer15(Some(datatypes::AffixFuzzer3::Degrees(90.0)));
 
     let fuzzy16_1 = components::AffixFuzzer16(vec![
-        datatypes::AffixFuzzer3::Radians(None),      //
-        datatypes::AffixFuzzer3::Degrees(45.0),      //
-        datatypes::AffixFuzzer3::Radians(Some(TAU)), //
+        datatypes::AffixFuzzer3::Degrees(45.0), //
     ]);
     let fuzzy16_2 = components::AffixFuzzer16(vec![
-        datatypes::AffixFuzzer3::Degrees(20.0),           //
-        datatypes::AffixFuzzer3::Degrees(30.0),           //
-        datatypes::AffixFuzzer3::Radians(Some(0.424242)), //
+        datatypes::AffixFuzzer3::Degrees(20.0), //
+        datatypes::AffixFuzzer3::Degrees(30.0), //
     ]);
 
     let fuzzy17_1 = components::AffixFuzzer17(None);
     let fuzzy17_2 = components::AffixFuzzer17(Some(vec![
         datatypes::AffixFuzzer3::Degrees(20.0), //
         datatypes::AffixFuzzer3::Degrees(30.0), //
-        datatypes::AffixFuzzer3::Radians(None), //
     ]));
 
     let fuzzy18_1 = components::AffixFuzzer18(None);
@@ -161,13 +154,10 @@ fn roundtrip() {
             },
         ])), //
         datatypes::AffixFuzzer4::SingleRequired(datatypes::AffixFuzzer3::Degrees(30.0)), //
-        datatypes::AffixFuzzer4::SingleRequired(datatypes::AffixFuzzer3::Radians(None)), //
     ]));
     let fuzzy18_3 = components::AffixFuzzer18(Some(vec![
         datatypes::AffixFuzzer4::ManyRequired(vec![
-            datatypes::AffixFuzzer3::Radians(None),      //
-            datatypes::AffixFuzzer3::Degrees(45.0),      //
-            datatypes::AffixFuzzer3::Radians(Some(TAU)), //
+            datatypes::AffixFuzzer3::Degrees(45.0), //
             datatypes::AffixFuzzer3::Craziness(vec![datatypes::AffixFuzzer1 {
                 single_float_optional: Some(3.0),
                 single_string_required: "c".into(),
@@ -180,15 +170,11 @@ fn roundtrip() {
                 from_parent: None,
             }]),
         ]), //
-        datatypes::AffixFuzzer4::ManyOptional(Some(vec![datatypes::AffixFuzzer3::Radians(None)])), //
-        datatypes::AffixFuzzer4::ManyOptional(None), //
     ]));
 
     let fuzzy19_1 = components::AffixFuzzer19(datatypes::AffixFuzzer5 {
         single_optional_union: Some(datatypes::AffixFuzzer4::ManyRequired(vec![
-            datatypes::AffixFuzzer3::Radians(None),      //
-            datatypes::AffixFuzzer3::Degrees(45.0),      //
-            datatypes::AffixFuzzer3::Radians(Some(TAU)), //
+            datatypes::AffixFuzzer3::Degrees(45.0), //
             datatypes::AffixFuzzer3::Craziness(vec![datatypes::AffixFuzzer1 {
                 single_float_optional: Some(3.0),
                 single_string_required: "c".into(),
@@ -234,7 +220,7 @@ fn roundtrip() {
             fuzzy11_1.clone(),
             fuzzy12_1.clone(),
             fuzzy13_1.clone(),
-            fuzzy14_2.clone(),
+            fuzzy14_1.clone(),
             fuzzy15_1.clone(),
             fuzzy16_2.clone(),
             fuzzy17_2.clone(),
@@ -299,7 +285,7 @@ fn roundtrip() {
             [fuzzy11_1.clone(), fuzzy11_2.clone(), fuzzy11_1.clone()],
             [fuzzy12_1.clone(), fuzzy12_2.clone(), fuzzy12_1.clone()],
             [fuzzy13_1.clone(), fuzzy13_2.clone(), fuzzy13_1.clone()],
-            [fuzzy14_1.clone(), fuzzy14_2.clone(), fuzzy14_3.clone()],
+            [fuzzy14_1.clone(), fuzzy14_1.clone(), fuzzy14_1.clone()],
             [fuzzy15_1.clone(), fuzzy15_2.clone(), fuzzy15_1.clone()],
             [fuzzy16_1.clone(), fuzzy16_2.clone(), fuzzy16_1.clone()],
             [fuzzy17_1.clone(), fuzzy17_2.clone(), fuzzy17_1.clone()],
@@ -355,7 +341,6 @@ fn roundtrip() {
             .with_fuzz2009(fuzzy9_1.clone())
             .with_fuzz2011(fuzzy11_1.clone())
             .with_fuzz2013(fuzzy13_1.clone())
-            .with_fuzz2014(fuzzy14_3.clone())
             .with_fuzz2015(fuzzy15_1.clone())
             .with_fuzz2016(fuzzy16_1.clone())
             .with_fuzz2017(fuzzy17_1.clone())
@@ -408,7 +393,7 @@ fn roundtrip() {
             .with_fuzz2108([fuzzy8_1.clone(), fuzzy8_2.clone(), fuzzy8_1.clone()])
             .with_fuzz2110([fuzzy10_1.clone(), fuzzy10_2.clone(), fuzzy10_1.clone()])
             .with_fuzz2112([fuzzy12_1.clone(), fuzzy12_2.clone(), fuzzy12_1.clone()])
-            .with_fuzz2114([fuzzy14_1.clone(), fuzzy14_2.clone(), fuzzy14_3.clone()])
+            .with_fuzz2114([fuzzy14_1.clone(), fuzzy14_1.clone(), fuzzy14_1.clone()])
             .with_fuzz2115([fuzzy15_1.clone(), fuzzy15_2.clone(), fuzzy15_1.clone()])
             .with_fuzz2116([fuzzy16_1.clone(), fuzzy16_2.clone(), fuzzy16_1.clone()])
             .with_fuzz2117([fuzzy17_1.clone(), fuzzy17_2.clone(), fuzzy17_1.clone()])

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt8,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -122,7 +122,6 @@ impl ::re_types_core::Loggable for RootContainer {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -137,10 +136,7 @@ impl ::re_types_core::Loggable for RootContainer {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt8,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -119,7 +119,6 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                             .unwrap_or_default()
                     })
                     .flatten()
-                    .map(Some)
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                     data0_bitmap.as_ref().map(|bitmap| {
@@ -134,10 +133,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                     Self::arrow_datatype(),
                     PrimitiveArray::new(
                         DataType::UInt8,
-                        data0_inner_data
-                            .into_iter()
-                            .map(|v| v.unwrap_or_default())
-                            .collect(),
+                        data0_inner_data.into_iter().collect(),
                         data0_inner_bitmap,
                     )
                     .boxed(),

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -402,7 +402,7 @@ fn quote_arrow_field_serializer(
     datatype: &DataType,
     quoted_datatype: &dyn quote::ToTokens,
     obj_field: Option<&ObjectField>,
-    bitmap_dst: &proc_macro2::Ident,
+    bitmap_src: &proc_macro2::Ident,
     elements_are_nullable: bool,
     data_src: &proc_macro2::Ident,
     inner_repr: InnerRepr,
@@ -472,7 +472,7 @@ fn quote_arrow_field_serializer(
                         // NOTE: We need values for all slots, regardless of what the bitmap says,
                         // hence `unwrap_or_default`.
                         #data_src.into_iter() #quoted_transparent_mapping .collect(),
-                        #bitmap_dst,
+                        #bitmap_src,
                     ).boxed()
                 }
             } else {
@@ -483,14 +483,14 @@ fn quote_arrow_field_serializer(
                         PrimitiveArray::new(
                             #quoted_datatype,
                             #data_src,
-                            #bitmap_dst,
+                            #bitmap_src,
                         ).boxed()
                     },
                     InnerRepr::NativeIterable => quote! {
                         PrimitiveArray::new(
                             #quoted_datatype,
                             #data_src.into_iter() #quoted_transparent_mapping .collect(),
-                            #bitmap_dst,
+                            #bitmap_src,
                         ).boxed()
                     },
                 }
@@ -574,7 +574,7 @@ fn quote_arrow_field_serializer(
                 // Safety: we're building this from actual native strings, so no need to do the
                 // whole utf8 validation _again_.
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe { Utf8Array::<i32>::new_unchecked(#quoted_datatype, offsets, inner_data, #bitmap_dst) }.boxed()
+                unsafe { Utf8Array::<i32>::new_unchecked(#quoted_datatype, offsets, inner_data, #bitmap_src) }.boxed()
             }}
         }
 
@@ -741,7 +741,7 @@ fn quote_arrow_field_serializer(
                             #quoted_datatype,
                             offsets,
                             #quoted_inner,
-                            #bitmap_dst,
+                            #bitmap_src,
                         ).boxed()
                     }
                 }
@@ -750,7 +750,7 @@ fn quote_arrow_field_serializer(
                     FixedSizeListArray::new(
                         #quoted_datatype,
                         #quoted_inner,
-                        #bitmap_dst,
+                        #bitmap_src,
                     ).boxed()
                 }
             };
@@ -771,7 +771,7 @@ fn quote_arrow_field_serializer(
             {
                 quote! {
                     let #inner_bitmap_ident: Option<arrow2::bitmap::Bitmap> =
-                        #bitmap_dst.as_ref().map(|bitmap| {
+                        #bitmap_src.as_ref().map(|bitmap| {
                             bitmap
                                 .iter()
                                 .map(|i| std::iter::repeat(i).take(#count))
@@ -809,7 +809,7 @@ fn quote_arrow_field_serializer(
                                 #quoted_datatype,
                                 offsets,
                                 #quoted_inner,
-                                #bitmap_dst,
+                                #bitmap_src,
                             ).boxed()
                         }}
                     } else {
@@ -857,7 +857,7 @@ fn quote_arrow_field_serializer(
             };
 
             quote! {{
-                _ = #bitmap_dst;
+                _ = #bitmap_src;
                 #fqname_use::to_arrow_opt(#data_src #option_wrapper)?
             }}
         }

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -692,7 +692,6 @@ fn quote_arrow_field_serializer(
                     InnerRepr::NativeIterable => {
                         if let DataType::FixedSizeList(_, count) = datatype.to_logical_type() {
                             if elements_are_nullable {
-                                // TODO: always false?
                                 quote! {
                                     .flat_map(|v| match v {
                                         Some(v) => itertools::Either::Left(v.iter().cloned()),

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -97,6 +97,14 @@ impl Objects {
                         reporter.error(virtpath, &obj.fqname, format!("Field {:?} s a primitive field of type {:?}. Primitive types are only allowed on DataTypes & Components.", field.fqname, field.typ));
                     }
                 }
+
+                if obj.is_union() && field.is_nullable {
+                    reporter.error(
+                        virtpath,
+                        &obj.fqname,
+                        "Nullable fields on unions are not supported.",
+                    );
+                }
             }
         }
 

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -101,13 +101,7 @@ impl crate::Loggable for VisualizerOverrides {
             };
             {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .iter()
-                    .flatten()
-                    .flatten()
-                    .cloned()
-                    .map(Some)
-                    .collect();
+                let data0_inner_data: Vec<_> = data0.iter().flatten().flatten().cloned().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
@@ -120,15 +114,10 @@ impl crate::Loggable for VisualizerOverrides {
                     Self::arrow_datatype(),
                     offsets,
                     {
-                        let inner_data: arrow2::buffer::Buffer<u8> = data0_inner_data
-                            .iter()
-                            .flatten()
-                            .flat_map(|s| s.0.clone())
-                            .collect();
+                        let inner_data: arrow2::buffer::Buffer<u8> =
+                            data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|opt| {
-                                opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
-                            }),
+                            data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
                         .unwrap()
                         .into();

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -15,7 +15,6 @@ namespace rerun {
         static const auto datatype = arrow::dense_union({
             arrow::field("_null_markers", arrow::null(), true, nullptr),
             arrow::field("degrees", arrow::float32(), false),
-            arrow::field("radians", arrow::float32(), true),
             arrow::field(
                 "craziness",
                 arrow::list(arrow::field(
@@ -88,16 +87,6 @@ namespace rerun {
                     ARROW_RETURN_NOT_OK(
                         variant_builder->Append(union_instance.get_union_data().degrees)
                     );
-                } break;
-                case TagType::radians: {
-                    auto variant_builder =
-                        static_cast<arrow::FloatBuilder*>(variant_builder_untyped);
-                    const auto& element = union_instance.get_union_data();
-                    if (element.radians.has_value()) {
-                        ARROW_RETURN_NOT_OK(variant_builder->Append(element.radians.value()));
-                    } else {
-                        ARROW_RETURN_NOT_OK(variant_builder->AppendNull());
-                    }
                 } break;
                 case TagType::craziness: {
                     auto variant_builder =

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <memory>
 #include <new>
-#include <optional>
 #include <rerun/collection.hpp>
 #include <rerun/result.hpp>
 #include <utility>
@@ -28,7 +27,6 @@ namespace rerun::datatypes {
             /// Having a special empty state makes it possible to implement move-semantics. We need to be able to leave the object in a state which we can run the destructor on.
             None = 0,
             degrees,
-            radians,
             craziness,
             fixed_size_shenanigans,
         };
@@ -36,8 +34,6 @@ namespace rerun::datatypes {
         /// \private
         union AffixFuzzer3Data {
             float degrees;
-
-            std::optional<float> radians;
 
             rerun::Collection<rerun::datatypes::AffixFuzzer1> craziness;
 
@@ -72,7 +68,6 @@ namespace rerun::datatypes {
                     new (&_data.craziness) TypeAlias(other._data.craziness);
                 } break;
                 case detail::AffixFuzzer3Tag::degrees:
-                case detail::AffixFuzzer3Tag::radians:
                 case detail::AffixFuzzer3Tag::fixed_size_shenanigans: {
                     const void* otherbytes = reinterpret_cast<const void*>(&other._data);
                     void* thisbytes = reinterpret_cast<void*>(&this->_data);
@@ -106,9 +101,6 @@ namespace rerun::datatypes {
                 case detail::AffixFuzzer3Tag::degrees: {
                     // has a trivial destructor
                 } break;
-                case detail::AffixFuzzer3Tag::radians: {
-                    // has a trivial destructor
-                } break;
                 case detail::AffixFuzzer3Tag::craziness: {
                     using TypeAlias = rerun::Collection<rerun::datatypes::AffixFuzzer1>;
                     _data.craziness.~TypeAlias();
@@ -124,17 +116,22 @@ namespace rerun::datatypes {
             this->_data.swap(other._data);
         }
 
+        AffixFuzzer3(float degrees) : AffixFuzzer3() {
+            *this = AffixFuzzer3::degrees(std::move(degrees));
+        }
+
+        AffixFuzzer3(rerun::Collection<rerun::datatypes::AffixFuzzer1> craziness) : AffixFuzzer3() {
+            *this = AffixFuzzer3::craziness(std::move(craziness));
+        }
+
+        AffixFuzzer3(std::array<float, 3> fixed_size_shenanigans) : AffixFuzzer3() {
+            *this = AffixFuzzer3::fixed_size_shenanigans(std::move(fixed_size_shenanigans));
+        }
+
         static AffixFuzzer3 degrees(float degrees) {
             AffixFuzzer3 self;
             self._tag = detail::AffixFuzzer3Tag::degrees;
             new (&self._data.degrees) float(std::move(degrees));
-            return self;
-        }
-
-        static AffixFuzzer3 radians(std::optional<float> radians) {
-            AffixFuzzer3 self;
-            self._tag = detail::AffixFuzzer3Tag::radians;
-            new (&self._data.radians) std::optional<float>(std::move(radians));
             return self;
         }
 
@@ -158,15 +155,6 @@ namespace rerun::datatypes {
         const float* get_degrees() const {
             if (_tag == detail::AffixFuzzer3Tag::degrees) {
                 return &_data.degrees;
-            } else {
-                return nullptr;
-            }
-        }
-
-        /// Return a pointer to radians if the union is in that state, otherwise `nullptr`.
-        const std::optional<float>* get_radians() const {
-            if (_tag == detail::AffixFuzzer3Tag::radians) {
-                return &_data.radians;
             } else {
                 return nullptr;
             }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -28,15 +28,6 @@ namespace rerun {
                 )),
                 false
             ),
-            arrow::field(
-                "many_optional",
-                arrow::list(arrow::field(
-                    "item",
-                    Loggable<rerun::datatypes::AffixFuzzer3>::arrow_datatype(),
-                    false
-                )),
-                true
-            ),
         });
         return datatype;
     }
@@ -107,15 +98,6 @@ namespace rerun {
                     return rerun::Error(
                         ErrorCode::NotImplemented,
                         "Failed to serialize AffixFuzzer4::many_required: objects (Object(\"rerun.testing.datatypes.AffixFuzzer3\")) in unions not yet implemented"
-                    );
-                } break;
-                case TagType::many_optional: {
-                    auto variant_builder =
-                        static_cast<arrow::ListBuilder*>(variant_builder_untyped);
-                    (void)variant_builder;
-                    return rerun::Error(
-                        ErrorCode::NotImplemented,
-                        "Failed to serialize AffixFuzzer4::many_optional: nullable list types in unions not yet implemented"
                     );
                 } break;
             }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -9,7 +9,6 @@
 #include <cstring>
 #include <memory>
 #include <new>
-#include <optional>
 #include <rerun/collection.hpp>
 #include <rerun/result.hpp>
 #include <utility>
@@ -28,7 +27,6 @@ namespace rerun::datatypes {
             None = 0,
             single_required,
             many_required,
-            many_optional,
         };
 
         /// \private
@@ -36,8 +34,6 @@ namespace rerun::datatypes {
             rerun::datatypes::AffixFuzzer3 single_required;
 
             rerun::Collection<rerun::datatypes::AffixFuzzer3> many_required;
-
-            std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>> many_optional;
 
             AffixFuzzer4Data() {
                 std::memset(reinterpret_cast<void*>(this), 0, sizeof(AffixFuzzer4Data));
@@ -70,11 +66,6 @@ namespace rerun::datatypes {
                 case detail::AffixFuzzer4Tag::many_required: {
                     using TypeAlias = rerun::Collection<rerun::datatypes::AffixFuzzer3>;
                     new (&_data.many_required) TypeAlias(other._data.many_required);
-                } break;
-                case detail::AffixFuzzer4Tag::many_optional: {
-                    using TypeAlias =
-                        std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>>;
-                    new (&_data.many_optional) TypeAlias(other._data.many_optional);
                 } break;
                 case detail::AffixFuzzer4Tag::None: {
                 } break;
@@ -109,17 +100,21 @@ namespace rerun::datatypes {
                     using TypeAlias = rerun::Collection<rerun::datatypes::AffixFuzzer3>;
                     _data.many_required.~TypeAlias();
                 } break;
-                case detail::AffixFuzzer4Tag::many_optional: {
-                    using TypeAlias =
-                        std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>>;
-                    _data.many_optional.~TypeAlias();
-                } break;
             }
         }
 
         void swap(AffixFuzzer4& other) noexcept {
             std::swap(this->_tag, other._tag);
             this->_data.swap(other._data);
+        }
+
+        AffixFuzzer4(rerun::datatypes::AffixFuzzer3 single_required) : AffixFuzzer4() {
+            *this = AffixFuzzer4::single_required(std::move(single_required));
+        }
+
+        AffixFuzzer4(rerun::Collection<rerun::datatypes::AffixFuzzer3> many_required)
+            : AffixFuzzer4() {
+            *this = AffixFuzzer4::many_required(std::move(many_required));
         }
 
         static AffixFuzzer4 single_required(rerun::datatypes::AffixFuzzer3 single_required) {
@@ -140,18 +135,6 @@ namespace rerun::datatypes {
             return self;
         }
 
-        static AffixFuzzer4 many_optional(
-            std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>> many_optional
-        ) {
-            AffixFuzzer4 self;
-            self._tag = detail::AffixFuzzer4Tag::many_optional;
-            new (&self._data.many_optional)
-                std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>>(
-                    std::move(many_optional)
-                );
-            return self;
-        }
-
         /// Return a pointer to single_required if the union is in that state, otherwise `nullptr`.
         const rerun::datatypes::AffixFuzzer3* get_single_required() const {
             if (_tag == detail::AffixFuzzer4Tag::single_required) {
@@ -165,16 +148,6 @@ namespace rerun::datatypes {
         const rerun::Collection<rerun::datatypes::AffixFuzzer3>* get_many_required() const {
             if (_tag == detail::AffixFuzzer4Tag::many_required) {
                 return &_data.many_required;
-            } else {
-                return nullptr;
-            }
-        }
-
-        /// Return a pointer to many_optional if the union is in that state, otherwise `nullptr`.
-        const std::optional<rerun::Collection<rerun::datatypes::AffixFuzzer3>>* get_many_optional(
-        ) const {
-            if (_tag == detail::AffixFuzzer4Tag::many_optional) {
-                return &_data.many_optional;
             } else {
                 return nullptr;
             }

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -46,7 +46,6 @@ class AffixFuzzer16Type(BaseExtensionType):
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                         pa.field(
                             "craziness",
                             pa.list_(

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -46,7 +46,6 @@ class AffixFuzzer17Type(BaseExtensionType):
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                         pa.field(
                             "craziness",
                             pa.list_(

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -50,7 +50,6 @@ class AffixFuzzer18Type(BaseExtensionType):
                             pa.dense_union([
                                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                 pa.field(
                                     "craziness",
                                     pa.list_(
@@ -122,105 +121,6 @@ class AffixFuzzer18Type(BaseExtensionType):
                                     pa.dense_union([
                                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "craziness",
-                                            pa.list_(
-                                                pa.field(
-                                                    "item",
-                                                    pa.struct([
-                                                        pa.field(
-                                                            "single_float_optional",
-                                                            pa.float32(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_required",
-                                                            pa.utf8(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_optional",
-                                                            pa.utf8(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_floats_optional",
-                                                            pa.list_(
-                                                                pa.field(
-                                                                    "item", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_required",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_optional",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "flattened_scalar",
-                                                            pa.float32(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "almost_flattened_scalar",
-                                                            pa.struct([
-                                                                pa.field(
-                                                                    "value", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ]),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                )
-                                            ),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "many_optional",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.dense_union([
-                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "craziness",
                                             pa.list_(

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -28,24 +28,9 @@ class AffixFuzzer3:
 
     * degrees (float):
 
-    * radians (float):
-
     * craziness (list[datatypes.AffixFuzzer1]):
 
     * fixed_size_shenanigans (npt.NDArray[np.float32]):
-    """
-
-    kind: Literal["degrees", "radians", "craziness", "fixed_size_shenanigans"] = field(default="degrees")
-    """
-    Possible values:
-
-    * "degrees":
-
-    * "radians":
-
-    * "craziness":
-
-    * "fixed_size_shenanigans":
     """
 
 
@@ -77,7 +62,6 @@ class AffixFuzzer3Type(BaseExtensionType):
             pa.dense_union([
                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                 pa.field(
                     "craziness",
                     pa.list_(

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
+from typing import TYPE_CHECKING, Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
@@ -27,19 +27,6 @@ class AffixFuzzer4:
     * single_required (datatypes.AffixFuzzer3):
 
     * many_required (list[datatypes.AffixFuzzer3]):
-
-    * many_optional (list[datatypes.AffixFuzzer3]):
-    """
-
-    kind: Literal["single_required", "many_required", "many_optional"] = field(default="single_required")
-    """
-    Possible values:
-
-    * "single_required":
-
-    * "many_required":
-
-    * "many_optional":
     """
 
 
@@ -73,7 +60,6 @@ class AffixFuzzer4Type(BaseExtensionType):
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                         pa.field(
                             "craziness",
                             pa.list_(
@@ -135,83 +121,6 @@ class AffixFuzzer4Type(BaseExtensionType):
                             pa.dense_union([
                                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
-                                pa.field(
-                                    "craziness",
-                                    pa.list_(
-                                        pa.field(
-                                            "item",
-                                            pa.struct([
-                                                pa.field(
-                                                    "single_float_optional", pa.float32(), nullable=True, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "single_string_required", pa.utf8(), nullable=False, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "single_string_optional", pa.utf8(), nullable=True, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "many_floats_optional",
-                                                    pa.list_(
-                                                        pa.field("item", pa.float32(), nullable=False, metadata={})
-                                                    ),
-                                                    nullable=True,
-                                                    metadata={},
-                                                ),
-                                                pa.field(
-                                                    "many_strings_required",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                                    nullable=False,
-                                                    metadata={},
-                                                ),
-                                                pa.field(
-                                                    "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                                    nullable=True,
-                                                    metadata={},
-                                                ),
-                                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                                                pa.field(
-                                                    "almost_flattened_scalar",
-                                                    pa.struct([
-                                                        pa.field("value", pa.float32(), nullable=False, metadata={})
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                ),
-                                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                            ]),
-                                            nullable=False,
-                                            metadata={},
-                                        )
-                                    ),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                                pa.field(
-                                    "fixed_size_shenanigans",
-                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "many_optional",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.dense_union([
-                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                 pa.field(
                                     "craziness",
                                     pa.list_(

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -63,7 +63,6 @@ class AffixFuzzer5Type(BaseExtensionType):
                             pa.dense_union([
                                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                 pa.field(
                                     "craziness",
                                     pa.list_(
@@ -135,105 +134,6 @@ class AffixFuzzer5Type(BaseExtensionType):
                                     pa.dense_union([
                                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "craziness",
-                                            pa.list_(
-                                                pa.field(
-                                                    "item",
-                                                    pa.struct([
-                                                        pa.field(
-                                                            "single_float_optional",
-                                                            pa.float32(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_required",
-                                                            pa.utf8(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_optional",
-                                                            pa.utf8(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_floats_optional",
-                                                            pa.list_(
-                                                                pa.field(
-                                                                    "item", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_required",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_optional",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "flattened_scalar",
-                                                            pa.float32(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "almost_flattened_scalar",
-                                                            pa.struct([
-                                                                pa.field(
-                                                                    "value", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ]),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                )
-                                            ),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "many_optional",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.dense_union([
-                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field("radians", pa.float32(), nullable=False, metadata={}),
                                         pa.field(
                                             "craziness",
                                             pa.list_(


### PR DESCRIPTION
### What

Simplifies the rust serialization of unions. Disallowed the use of nullable union fields in the process.
Unfortunately this makes the codegen overall more complicated, not less. There's definitely some low hanging fruit to turn this around, but it eluded my grasp - every attempt to formulate more general rules got stuck on some other failure case.

Run `cargo test -p re_types` and `pixi run python ./tests/roundtrips.py`.

* [x] Run `main tests`

(branch name is a misnomer, too late to change)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6236?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6236?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6236)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.