### PR TITLE
Improve error message when using an under-powered GPU

### DIFF
--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -152,7 +152,8 @@ impl<E: Example + 'static> Application<E> {
                 output_format_color,
                 device_caps,
             },
-        );
+        )
+        .map_err(|err| anyhow::format_err!("{err}"))?;
 
         let example = E::new(&re_ctx);
 

--- a/crates/re_viewer/src/native.rs
+++ b/crates/re_viewer/src/native.rs
@@ -18,7 +18,7 @@ pub fn run_native_app(
         window_title,
         native_options,
         Box::new(move |cc| {
-            let re_ui = crate::customize_eframe(cc);
+            let re_ui = crate::customize_eframe_and_setup_renderer(cc);
             app_creator(cc, re_ui)
         }),
     )

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -229,7 +229,7 @@ fn create_app(
         expect_data_soon: None,
         force_wgpu_backend: None,
     };
-    let re_ui = crate::customize_eframe(cc);
+    let re_ui = crate::customize_eframe_and_setup_renderer(cc);
 
     let mut app = crate::App::new(build_info, &app_env, startup_options, re_ui, cc.storage);
 

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         window_title,
         native_options,
         Box::new(move |cc| {
-            let re_ui = re_viewer::customize_eframe(cc);
+            let re_ui = re_viewer::customize_eframe_and_setup_renderer(cc);
 
             let mut rerun_app = re_viewer::App::new(
                 re_viewer::build_info(),


### PR DESCRIPTION
### What
Using `scripts/fetch_crashes.py` to look at our analytics, I noticed that missing wgpu capabilities would lead to a assert/panic, which is not a nice way to report errors to users.

I added an egui issue to improve this further in the future:
* https://github.com/emilk/egui/issues/4474

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6252?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6252?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6252)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.