### PR TITLE
Send TCP protocol header to ignore non-rerun clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,6 +5013,7 @@ dependencies = [
  "re_memory",
  "re_query",
  "re_renderer",
+ "re_sdk_comms",
  "re_smart_channel",
  "re_space_view",
  "re_space_view_bar_chart",

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -17,7 +17,7 @@ pub use {buffered_client::Client, tcp_client::ClientError};
 mod server;
 
 #[cfg(feature = "server")]
-pub use server::{serve, ServerError, ServerOptions};
+pub use server::{serve, ConnectionError, ServerError, ServerOptions};
 
 pub const PROTOCOL_HEADER: &str = "rerun";
 

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -21,7 +21,7 @@ pub use server::{serve, ConnectionError, ServerError, ServerOptions};
 
 pub const PROTOCOL_VERSION_0: u16 = 0;
 
-/// Added [`PROTOCOL_HEADER`].
+/// Added [`PROTOCOL_HEADER`]. Introduced for Rerun 0.16.
 pub const PROTOCOL_VERSION_1: u16 = 1;
 
 /// Comes after version.

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -21,7 +21,8 @@ pub use server::{serve, ConnectionError, ServerError, ServerOptions};
 
 pub const PROTOCOL_HEADER: &str = "rerun";
 
-pub const PROTOCOL_VERSION: u16 = 0;
+pub const PROTOCOL_VERSION_0: u16 = 0;
+pub const PROTOCOL_VERSION_1: u16 = 1;
 
 pub const DEFAULT_SERVER_PORT: u16 = 9876;
 

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -19,6 +19,8 @@ mod server;
 #[cfg(feature = "server")]
 pub use server::{serve, ServerError, ServerOptions};
 
+pub const PROTOCOL_HEADER: &str = "rerun";
+
 pub const PROTOCOL_VERSION: u16 = 0;
 
 pub const DEFAULT_SERVER_PORT: u16 = 9876;

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -19,10 +19,13 @@ mod server;
 #[cfg(feature = "server")]
 pub use server::{serve, ConnectionError, ServerError, ServerOptions};
 
-pub const PROTOCOL_HEADER: &str = "rerun";
-
 pub const PROTOCOL_VERSION_0: u16 = 0;
+
+/// Added [`PROTOCOL_HEADER`].
 pub const PROTOCOL_VERSION_1: u16 = 1;
+
+/// Comes after version.
+pub const PROTOCOL_HEADER: &str = "rerun";
 
 pub const DEFAULT_SERVER_PORT: u16 = 9876;
 

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -196,6 +196,8 @@ fn spawn_client(
 
         let log_msg = format!("Closing connection to client at {addr_string}: {err}");
         if matches!(&err, ConnectionError::UnknownClient) {
+            // An unknown client that probably stumbled onto the wrong port.
+            // Don't log as an error (https://github.com/rerun-io/rerun/issues/5883).
             re_log::debug!("{log_msg}");
         } else {
             re_log::warn_once!("{log_msg}");

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -221,6 +221,7 @@ fn run_client(
     // if the client sends version 0
     if client_version == crate::PROTOCOL_VERSION_0 {
         // Backwards compatibility mode: no protocol header, otherwise the same as version 1.
+        re_log::warn!("Client is using an old protocol version from before 0.16.");
     } else {
         // The protocol header was added in version 1
         let mut protocol_header = [0_u8; crate::PROTOCOL_HEADER.len()];

--- a/crates/re_sdk_comms/src/tcp_client.rs
+++ b/crates/re_sdk_comms/src/tcp_client.rs
@@ -94,8 +94,8 @@ impl TcpClient {
                         re_log::debug!("Connected to {:?}.", self.addr);
 
                         if let Err(err) = stream
-                            .write(crate::PROTOCOL_HEADER.as_bytes())
-                            .and_then(|_| stream.write(&crate::PROTOCOL_VERSION.to_le_bytes()))
+                            .write(&crate::PROTOCOL_VERSION_1.to_le_bytes())
+                            .and_then(|_| stream.write(crate::PROTOCOL_HEADER.as_bytes()))
                         {
                             self.stream_state = TcpStreamState::Pending {
                                 start_time,

--- a/crates/re_sdk_comms/src/tcp_client.rs
+++ b/crates/re_sdk_comms/src/tcp_client.rs
@@ -92,7 +92,11 @@ impl TcpClient {
                 match TcpStream::connect_timeout(&self.addr, timeout) {
                     Ok(mut stream) => {
                         re_log::debug!("Connected to {:?}.", self.addr);
-                        if let Err(err) = stream.write(&crate::PROTOCOL_VERSION.to_le_bytes()) {
+
+                        if let Err(err) = stream
+                            .write(crate::PROTOCOL_HEADER.as_bytes())
+                            .and_then(|_| stream.write(&crate::PROTOCOL_VERSION.to_le_bytes()))
+                        {
                             self.stream_state = TcpStreamState::Pending {
                                 start_time,
                                 num_attempts: num_attempts + 1,

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -74,6 +74,7 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport.workspace = true
 re_ws_comms = { workspace = true, features = ["client"] }
+re_sdk_comms.workspace = true
 
 # Internal (optional):
 re_analytics = { workspace = true, optional = true }

--- a/crates/re_viewer/Cargo.toml
+++ b/crates/re_viewer/Cargo.toml
@@ -56,6 +56,7 @@ re_log_types.workspace = true
 re_memory.workspace = true
 re_query.workspace = true
 re_renderer = { workspace = true, default-features = false }
+re_sdk_comms.workspace = true
 re_smart_channel.workspace = true
 re_space_view.workspace = true
 re_space_view_bar_chart.workspace = true
@@ -74,7 +75,6 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport.workspace = true
 re_ws_comms = { workspace = true, features = ["client"] }
-re_sdk_comms.workspace = true
 
 # Internal (optional):
 re_analytics = { workspace = true, optional = true }

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -968,9 +968,9 @@ impl App {
                             .downcast_ref::<ConnectionError>()
                             .is_some_and(|e| matches!(e, ConnectionError::UnknownClient))
                         {
-                            re_log::debug!("{}", log_msg);
+                            re_log::debug!("{log_msg}");
                         } else {
-                            re_log::warn!("{}", log_msg);
+                            re_log::warn!("{log_msg}");
                         }
                     } else {
                         re_log::debug!("Data source {} has finished", msg.source);


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
Now we send a special header in the TCP connection before sending the protocol version. It helps the server recognize if the client is a rerun client or something else.

**Edit**
Have changed the approach to send the header _after_ the protocol version. See the discussion in comments.

* Fixes #5883 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6253?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6253?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6253)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.