### PR TITLE
Fix visual glitch when extending the time panel

### DIFF
--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -358,7 +358,7 @@ impl AppState {
         let show_welcome =
             store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
 
-        //TODO(ab): workaround for https://github.com/emilk/egui/issues/4475
+        //TODO(#6256): workaround for https://github.com/emilk/egui/issues/4475
         left_panel = left_panel
             .frame(egui::Frame::default())
             .show_separator_line(false);
@@ -367,7 +367,7 @@ impl AppState {
             ui,
             app_blueprint.blueprint_panel_expanded,
             |ui: &mut egui::Ui| {
-                //TODO(ab): workaround for https://github.com/emilk/egui/issues/4475
+                //TODO(#6256): workaround for https://github.com/emilk/egui/issues/4475
                 ui.painter()
                     .rect_filled(ui.max_rect(), 0.0, ui.visuals().panel_fill);
                 ui.painter().vline(

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -368,14 +368,15 @@ impl AppState {
             app_blueprint.blueprint_panel_expanded,
             |ui: &mut egui::Ui| {
                 //TODO(#6256): workaround for https://github.com/emilk/egui/issues/4475
+                let max_rect = ui.max_rect();
                 ui.painter()
-                    .rect_filled(ui.max_rect(), 0.0, ui.visuals().panel_fill);
+                    .rect_filled(max_rect, 0.0, ui.visuals().panel_fill);
                 ui.painter().vline(
-                    ui.max_rect().right(),
-                    ui.max_rect().y_range(),
+                    max_rect.right(),
+                    max_rect.y_range(),
                     ui.visuals().widgets.noninteractive.bg_stroke,
                 );
-                ui.set_clip_rect(ui.max_rect());
+                ui.set_clip_rect(max_rect);
 
                 re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
                     // ListItem don't need vertical spacing so we disable it, but restore it

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -301,6 +301,10 @@ impl AppState {
             focused_item,
         };
 
+        //
+        // Blueprint time panel
+        //
+
         if app_options.inspect_blueprint_timeline {
             blueprint_panel.show_panel(
                 &ctx,
@@ -311,6 +315,11 @@ impl AppState {
                 true,
             );
         }
+
+        //
+        // Time panel
+        //
+
         time_panel.show_panel(
             &ctx,
             &viewport_blueprint,
@@ -320,6 +329,10 @@ impl AppState {
             app_blueprint.time_panel_expanded,
         );
 
+        //
+        // Selection Panel
+        //
+
         selection_panel.show_panel(
             &ctx,
             ui,
@@ -327,67 +340,80 @@ impl AppState {
             app_blueprint.selection_panel_expanded,
         );
 
-        let central_panel_frame = egui::Frame {
+        //
+        // Left panel (recordings and blueprint)
+        //
+
+        let mut left_panel = egui::SidePanel::left("blueprint_panel")
+            .resizable(true)
+            .frame(egui::Frame {
+                fill: ui.visuals().panel_fill,
+                ..Default::default()
+            })
+            .min_width(120.0)
+            .default_width(default_blueprint_panel_width(
+                ui.ctx().screen_rect().width(),
+            ));
+
+        let show_welcome =
+            store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
+
+        //TODO(ab): workaround for https://github.com/emilk/egui/issues/4475
+        left_panel = left_panel
+            .frame(egui::Frame::default())
+            .show_separator_line(false);
+
+        left_panel.show_animated_inside(
+            ui,
+            app_blueprint.blueprint_panel_expanded,
+            |ui: &mut egui::Ui| {
+                //TODO(ab): workaround for https://github.com/emilk/egui/issues/4475
+                ui.painter()
+                    .rect_filled(ui.max_rect(), 0.0, ui.visuals().panel_fill);
+                ui.painter().vline(
+                    ui.max_rect().right(),
+                    ui.max_rect().y_range(),
+                    ui.visuals().widgets.noninteractive.bg_stroke,
+                );
+                ui.set_clip_rect(ui.max_rect());
+
+                re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
+                    // ListItem don't need vertical spacing so we disable it, but restore it
+                    // before drawing the blueprint panel.
+                    ui.spacing_mut().item_spacing.y = 0.0;
+
+                    let pre_cursor = ui.cursor();
+                    recordings_panel_ui(&ctx, rx, ui);
+                    let any_recording_shows = pre_cursor == ui.cursor();
+
+                    if any_recording_shows {
+                        ui.add_space(4.0);
+                    }
+
+                    if !show_welcome {
+                        blueprint_panel_ui(&mut viewport, &ctx, ui);
+                    }
+                });
+            },
+        );
+
+        //
+        // Viewport
+        //
+
+        let viewport_frame = egui::Frame {
             fill: ui.style().visuals.panel_fill,
-            inner_margin: egui::Margin::same(0.0),
             ..Default::default()
         };
 
         egui::CentralPanel::default()
-            .frame(central_panel_frame)
+            .frame(viewport_frame)
             .show_inside(ui, |ui| {
-                let left_panel = egui::SidePanel::left("blueprint_panel")
-                    .resizable(true)
-                    .frame(egui::Frame {
-                        fill: ui.visuals().panel_fill,
-                        ..Default::default()
-                    })
-                    .min_width(120.0)
-                    .default_width(default_blueprint_panel_width(
-                        ui.ctx().screen_rect().width(),
-                    ));
-
-                let show_welcome =
-                    store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
-
-                left_panel.show_animated_inside(
-                    ui,
-                    app_blueprint.blueprint_panel_expanded,
-                    |ui: &mut egui::Ui| {
-                        re_ui::full_span::full_span_scope(ui, ui.max_rect().x_range(), |ui| {
-                            // ListItem don't need vertical spacing so we disable it, but restore it
-                            // before drawing the blueprint panel.
-                            ui.spacing_mut().item_spacing.y = 0.0;
-
-                            let pre_cursor = ui.cursor();
-                            recordings_panel_ui(&ctx, rx, ui);
-                            let any_recording_shows = pre_cursor == ui.cursor();
-
-                            if any_recording_shows {
-                                ui.add_space(4.0);
-                            }
-
-                            if !show_welcome {
-                                blueprint_panel_ui(&mut viewport, &ctx, ui);
-                            }
-                        });
-                    },
-                );
-
-                let viewport_frame = egui::Frame {
-                    fill: ui.style().visuals.panel_fill,
-                    ..Default::default()
-                };
-
-                egui::CentralPanel::default()
-                    .frame(viewport_frame)
-                    .show_inside(ui, |ui| {
-                        if show_welcome {
-                            welcome_screen.ui(ui, re_ui, command_sender, welcome_screen_opacity);
-                        } else {
-                            viewport.viewport_ui(ui, &ctx);
-                        }
-                    });
+                if show_welcome {
+                    welcome_screen.ui(ui, re_ui, command_sender, welcome_screen_opacity);
+                } else {
+                    viewport.viewport_ui(ui, &ctx);
+                }
             });
 
         // Process deferred layout operations and apply updates back to blueprint


### PR DESCRIPTION
### What

- Fixes #6227

A workaround for https://github.com/emilk/egui/issues/4475 was needed that will need to be cleaned:
- #6256

**NOTE**: chained to #6248 to minimise conflicts.

Note that this doesn't _entirely_ fix the visual glitch, but makes it much less visible. Now the time panel must be disproportionately be stretched _and_ one must hover the separator:

<img width="445" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/d66ccccb-2a22-4d00-bb8e-7c020c806928">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6255?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6255?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6255)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.