### PR TITLE
Keep rerun viewer from dying on ctrl-c by setting sid on unix systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,9 +2829,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libloading"
@@ -4581,6 +4581,7 @@ dependencies = [
  "crossbeam",
  "document-features",
  "itertools 0.12.0",
+ "libc",
  "ndarray",
  "ndarray-rand",
  "once_cell",

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -76,6 +76,9 @@ re_web_viewer_server = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 webbrowser = { workspace = true, optional = true }
 
+# Native unix dependencies:
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "windows")))'.dependencies]
+libc.workspace = true
 
 [dev-dependencies]
 re_data_store.workspace = true

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -77,7 +77,7 @@ anyhow = { workspace = true, optional = true }
 webbrowser = { workspace = true, optional = true }
 
 # Native unix dependencies:
-[target.'cfg(not(any(target_arch = "wasm32", target_os = "windows")))'.dependencies]
+[target.'cfg(target_family = "unix")'.dependencies]
 libc.workspace = true
 
 [dev-dependencies]

--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -134,8 +134,7 @@ impl std::fmt::Debug for SpawnError {
 /// to [`crate::RecordingStream::connect`] or use [`crate::RecordingStream::spawn`] directly.
 #[allow(unsafe_code)]
 pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
-    #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_family = "unix")]
     use std::os::unix::process::CommandExt as _;
 
     use std::{net::TcpStream, process::Command, time::Duration};
@@ -263,8 +262,7 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
 
     // SAFETY: This code is only run in the child fork, we are not modifying any memory
     // that is shared with the parent process.
-    #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_family = "unix")]
     unsafe {
         rerun_bin.pre_exec(|| {
             // On unix systems, we want to make sure that the child process becomes its

--- a/crates/re_sdk/src/spawn.rs
+++ b/crates/re_sdk/src/spawn.rs
@@ -132,7 +132,12 @@ impl std::fmt::Debug for SpawnError {
 ///
 /// This only starts a Viewer process: if you'd like to connect to it and start sending data, refer
 /// to [`crate::RecordingStream::connect`] or use [`crate::RecordingStream::spawn`] directly.
+#[allow(unsafe_code)]
 pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_os = "windows"))]
+    use std::os::unix::process::CommandExt as _;
+
     use std::{net::TcpStream, process::Command, time::Duration};
 
     // NOTE: These are indented on purpose, it just looks better and reads easier.
@@ -244,17 +249,33 @@ pub fn spawn(opts: &SpawnOptions) -> Result<(), SpawnError> {
         }
     }
 
-    let rerun_bin = Command::new(&executable_path)
-        // By default stdin is inherited which may cause issues in some debugger setups.
-        // Also, there's really no reason to forward stdin to the child process in this case.
-        // `stdout`/`stderr` we leave at default inheritance because it can be useful to see the Viewer's output.
+    let mut rerun_bin = Command::new(&executable_path);
+
+    // By default stdin is inherited which may cause issues in some debugger setups.
+    // Also, there's really no reason to forward stdin to the child process in this case.
+    // `stdout`/`stderr` we leave at default inheritance because it can be useful to see the Viewer's output.
+    rerun_bin
         .stdin(std::process::Stdio::null())
         .arg(format!("--port={port}"))
         .arg(format!("--memory-limit={memory_limit}"))
         .arg("--expect-data-soon")
-        .args(opts.extra_args.clone())
-        .spawn()
-        .map_err(map_err)?;
+        .args(opts.extra_args.clone());
+
+    // SAFETY: This code is only run in the child fork, we are not modifying any memory
+    // that is shared with the parent process.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_os = "windows"))]
+    unsafe {
+        rerun_bin.pre_exec(|| {
+            // On unix systems, we want to make sure that the child process becomes its
+            // own session leader, so that it doesn't die if the parent process crashes
+            // or is killed.
+            libc::setsid();
+
+            Ok(())
+        })
+    };
+    rerun_bin.spawn().map_err(map_err)?;
 
     if opts.wait_for_bind {
         // Give the newly spawned Rerun Viewer some time to bind.


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/6186

Testing:
 - [x] Works on linux
 - [x] Works on Mac
 - [x] Works on Windows

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6260?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6260?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6260)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.