### PR TITLE
fix `None` type handling on union codegen

### DIFF
--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -2089,13 +2089,20 @@ return pa.UnionArray.from_buffers(
                 .sorted() // Make order not dependent on hash shenanigans (also looks nicer often).
                 .filter(|typename| !typename.contains('[')) // If we keep these we unfortunately get: `TypeError: Subscripted generics cannot be used with class and instance checks`
                 .filter(|typename| !typename.ends_with("Like")) // `xLike` types are union types and checking those is not supported until Python 3.10.
+                .map(|typename| {
+                    if typename == "None" {
+                        "NoneType".to_owned()
+                    } else {
+                        typename
+                    }
+                })
                 .join(", ");
 
             let batch_type_imports = quote_local_batch_type_imports(&obj.fields);
             Ok(format!(
                 r##"
 {batch_type_imports}
-from typing import cast
+from typing import cast, NoneType
 
 # TODO(#2623): There should be a separate overridable `coerce_to_array` method that can be overridden.
 # If we can call iter, it may be that one of the variants implements __iter__.

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -2091,7 +2091,7 @@ return pa.UnionArray.from_buffers(
                 .filter(|typename| !typename.ends_with("Like")) // `xLike` types are union types and checking those is not supported until Python 3.10.
                 .map(|typename| {
                     if typename == "None" {
-                        "NoneType".to_owned()
+                        "type(None)".to_owned() // `NoneType` requires Python 3.10.
                     } else {
                         typename
                     }
@@ -2102,7 +2102,7 @@ return pa.UnionArray.from_buffers(
             Ok(format!(
                 r##"
 {batch_type_imports}
-from typing import cast, NoneType
+from typing import cast
 
 # TODO(#2623): There should be a separate overridable `coerce_to_array` method that can be overridden.
 # If we can call iter, it may be that one of the variants implements __iter__.

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
@@ -95,13 +95,13 @@ class TimeRangeBoundaryBatch(BaseBatch[TimeRangeBoundaryArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: TimeRangeBoundaryArrayLike, data_type: pa.DataType) -> pa.Array:
-        from typing import NoneType, cast
+        from typing import cast
 
         from rerun.datatypes import TimeIntBatch
 
         # TODO(#2623): There should be a separate overridable `coerce_to_array` method that can be overridden.
         # If we can call iter, it may be that one of the variants implements __iter__.
-        if not hasattr(data, "__iter__") or isinstance(data, (NoneType, TimeRangeBoundary, datatypes.TimeInt)):  # type: ignore[arg-type]
+        if not hasattr(data, "__iter__") or isinstance(data, (type(None), TimeRangeBoundary, datatypes.TimeInt)):  # type: ignore[arg-type]
             data = [data]  # type: ignore[list-item]
         data = cast(Sequence[TimeRangeBoundaryLike], data)  # type: ignore[redundant-cast]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
@@ -95,13 +95,13 @@ class TimeRangeBoundaryBatch(BaseBatch[TimeRangeBoundaryArrayLike]):
 
     @staticmethod
     def _native_to_pa_array(data: TimeRangeBoundaryArrayLike, data_type: pa.DataType) -> pa.Array:
-        from typing import cast
+        from typing import NoneType, cast
 
         from rerun.datatypes import TimeIntBatch
 
         # TODO(#2623): There should be a separate overridable `coerce_to_array` method that can be overridden.
         # If we can call iter, it may be that one of the variants implements __iter__.
-        if not hasattr(data, "__iter__") or isinstance(data, (None, TimeRangeBoundary, datatypes.TimeInt)):  # type: ignore[arg-type]
+        if not hasattr(data, "__iter__") or isinstance(data, (NoneType, TimeRangeBoundary, datatypes.TimeInt)):  # type: ignore[arg-type]
             data = [data]  # type: ignore[list-item]
         data = cast(Sequence[TimeRangeBoundaryLike], data)  # type: ignore[redundant-cast]
 


### PR DESCRIPTION
### What

Worked on my machine and got missed because of that (python versioning things)?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6269?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6269?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6269)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.