### PR TITLE
Fix possible hang when using torch.multiprocessing

### DIFF
--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -1403,6 +1403,11 @@ impl RecordingStream {
     /// If the current sink is in a broken state (e.g. a TCP sink with a broken connection that
     /// cannot be repaired), all pending data in its buffers will be dropped.
     pub fn set_sink(&self, sink: Box<dyn LogSink>) {
+        if self.is_forked_child() {
+            re_log::error_once!("Fork detected during set_sink. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            return;
+        }
+
         let f = move |inner: &RecordingStreamInner| {
             // NOTE: Internal channels can never be closed outside of the `Drop` impl, all these sends
             // are safe.
@@ -1435,6 +1440,11 @@ impl RecordingStream {
     /// This does **not** wait for the flush to propagate (see [`Self::flush_blocking`]).
     /// See [`RecordingStream`] docs for ordering semantics and multithreading guarantees.
     pub fn flush_async(&self) {
+        if self.is_forked_child() {
+            re_log::error_once!("Fork detected during flush_async. cleanup_if_forked() should always be called after forking. This is likely a bug in the SDK.");
+            return;
+        }
+
         let f = move |inner: &RecordingStreamInner| {
             // NOTE: Internal channels can never be closed outside of the `Drop` impl, all these sends
             // are safe.

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -243,7 +243,13 @@ class RecordingStream:
 
     def __del__(self):  # type: ignore[no-untyped-def]
         recording = RecordingStream.to_native(self)
-        bindings.flush(blocking=False, recording=recording)
+        # TODO(jleibs): I'm 98% sure this flush is redundant, but removing it requires more thorough testing.
+        # However, it's definitely a problem if we are in a forked child process. The rerun SDK will still
+        # detect this case and prevent a hang internally, but will do so with a warning that we should avoid.
+        #
+        # See: https://github.com/rerun-io/rerun/issues/6223 for context on why this is necessary.
+        if recording is not None and not recording.is_forked_child():
+            bindings.flush(blocking=False, recording=recording)
 
 
 def binary_stream(recording: RecordingStream | None = None) -> BinaryStream:

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -312,6 +312,16 @@ fn shutdown(py: Python<'_>) {
 #[derive(Clone)]
 struct PyRecordingStream(RecordingStream);
 
+#[pymethods]
+impl PyRecordingStream {
+    /// Read the bytes from the binary sink.
+    ///
+    /// If `flush` is `true`, the sink will be flushed before reading.
+    fn is_forked_child(&self) -> bool {
+        self.0.is_forked_child()
+    }
+}
+
 impl std::ops::Deref for PyRecordingStream {
     type Target = RecordingStream;
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -317,7 +317,7 @@ impl PyRecordingStream {
     /// Determine if this stream is operating in the context of a forked child process.
     ///
     /// This means the stream was created in the parent process. It now exists in the child
-    /// process by way of fork, but it is effectively a zombie since it's batcher and sink
+    /// process by way of fork, but it is effectively a zombie since its batcher and sink
     /// threads would not have been copied.
     ///
     /// Calling operations such as flush or set_sink will result in an error.

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -314,9 +314,13 @@ struct PyRecordingStream(RecordingStream);
 
 #[pymethods]
 impl PyRecordingStream {
-    /// Read the bytes from the binary sink.
+    /// Determine if this stream is operating in the context of a forked child process.
     ///
-    /// If `flush` is `true`, the sink will be flushed before reading.
+    /// This means the stream was created in the parent process. It now exists in the child
+    /// process by way of fork, but it is effectively a zombie since it's batcher and sink
+    /// threads would not have been copied.
+    ///
+    /// Calling operations such as flush or set_sink will result in an error.
     fn is_forked_child(&self) -> bool {
         self.0.is_forked_child()
     }

--- a/rerun_py/tests/unit/test_multiprocessing_gc.py
+++ b/rerun_py/tests/unit/test_multiprocessing_gc.py
@@ -14,6 +14,9 @@ except ImportError:
 
 
 def task() -> None:
+    # Forcing a gc in the multiprocess task can cause issues, most notably
+    # hangs, if recording streams were leaked across the fork. We see this
+    # happen specifically using the `torch.multiprocessing` module.
     gc.collect()
 
 

--- a/rerun_py/tests/unit/test_multiprocessing_gc.py
+++ b/rerun_py/tests/unit/test_multiprocessing_gc.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import gc
+
+import rerun as rr
+
+# If torch is available, use torch.multiprocessing instead of multiprocessing
+# since it causes more issues. But, it's annoying to always require it so at
+# least for the tests in other contexts, we'll use the standard library version.
+try:
+    from torch import multiprocessing
+except ImportError:
+    import multiprocessing
+
+
+def task() -> None:
+    gc.collect()
+
+
+def test_multiprocessing_gc() -> None:
+    rr.init("rerun_example_multiprocessing_gc")
+
+    proc = multiprocessing.Process(
+        target=task,
+    )
+    proc.start()
+    proc.join(1)
+    if proc.is_alive():
+        # Terminate so our test doesn't get stuck
+        proc.terminate()
+        assert False, "Process deadlocked during gc.collect()"

--- a/rerun_py/tests/unit/test_multiprocessing_gc.py
+++ b/rerun_py/tests/unit/test_multiprocessing_gc.py
@@ -8,9 +8,9 @@ import rerun as rr
 # since it causes more issues. But, it's annoying to always require it so at
 # least for the tests in other contexts, we'll use the standard library version.
 try:
-    from torch import multiprocessing
+    import torch.multiprocessing as multiprocessing
 except ImportError:
-    import multiprocessing
+    import multiprocessing  # ignore[no-redef]
 
 
 def task() -> None:


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/6223

Although we already have a fork-handler that cleans up our global/thread-local recording streams, it's apparently still possible for an allocated PyRecordingStream to leak into the subprocess via fork (at least based on how pytorch multiprocessing works).

During `__del__`, we make one last call to a non-blocking flush.

While previously this was fine, we added an internal blocking batcher flush to our non-blocking sink flush, which still hangs for the same reason (the batcher processing thread is gone in the fork).

### The fixes:
- Add a new unit test that repros the error.
- Check for `is_forked_child` in all the methods that issue `inner.batcher.flush_blocking()`
- Check for `is_forked_child` from `__del__` and don't call flush to avoid getting a gratuitous warning printout.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6271?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6271?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6271)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.