### PR TITLE
Generate simpler code

### DIFF
--- a/crates/re_data_store/Cargo.toml
+++ b/crates/re_data_store/Cargo.toml
@@ -57,7 +57,7 @@ anyhow.workspace = true
 criterion.workspace = true
 insta.workspace = true
 mimalloc.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std", "std_rng"] }
 similar-asserts.workspace = true
 tinyvec.workspace = true
 

--- a/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
@@ -103,7 +103,7 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     buffers
                         .iter()
-                        .map(|opt| opt.as_ref().map(|buf| buf.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |buf| buf.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
@@ -75,10 +75,7 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -96,10 +96,7 @@ impl ::re_types_core::Loggable for ActiveTab {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -110,14 +110,13 @@ impl ::re_types_core::Loggable for ActiveTab {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -108,18 +108,12 @@ impl ::re_types_core::Loggable for ActiveTab {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::EntityPath(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::EntityPath(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/blueprint/components/column_share.rs
+++ b/crates/re_types/src/blueprint/components/column_share.rs
@@ -86,10 +86,7 @@ impl ::re_types_core::Loggable for ColumnShare {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for IncludedContent {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -111,14 +111,13 @@ impl ::re_types_core::Loggable for IncludedContent {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -109,18 +109,12 @@ impl ::re_types_core::Loggable for IncludedContent {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::EntityPath(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::EntityPath(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -109,14 +109,7 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Bool(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -94,10 +94,7 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/panel_expanded.rs
+++ b/crates/re_types/src/blueprint/components/panel_expanded.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for PanelExpanded {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/panel_expanded.rs
+++ b/crates/re_types/src/blueprint/components/panel_expanded.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for PanelExpanded {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Bool(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for QueryExpression {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -115,14 +115,13 @@ impl ::re_types_core::Loggable for QueryExpression {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -113,18 +113,12 @@ impl ::re_types_core::Loggable for QueryExpression {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/blueprint/components/row_share.rs
+++ b/crates/re_types/src/blueprint/components/row_share.rs
@@ -86,10 +86,7 @@ impl ::re_types_core::Loggable for RowShare {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -104,18 +104,12 @@ impl ::re_types_core::Loggable for SpaceViewClass {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -106,14 +106,13 @@ impl ::re_types_core::Loggable for SpaceViewClass {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for SpaceViewClass {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -106,14 +106,13 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -104,18 +104,12 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::EntityPath(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::EntityPath(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -109,14 +109,7 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::UInt64(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -94,10 +94,7 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/visible.rs
+++ b/crates/re_types/src/blueprint/components/visible.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for Visible {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -105,10 +105,7 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -90,10 +90,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -106,14 +106,13 @@ impl ::re_types_core::Loggable for Blob {
                     .concat()
                     .into();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.num_instances())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.num_instances())),
+                )
+                .unwrap()
+                .into();
                 ListArray::new(
                     Self::arrow_datatype(),
                     offsets,

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -88,10 +88,7 @@ impl ::re_types_core::Loggable for Blob {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for ClassId {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -112,14 +112,7 @@ impl ::re_types_core::Loggable for ClassId {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::ClassId(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Color {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -110,14 +110,7 @@ impl ::re_types_core::Loggable for Color {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Rgba32(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for DepthMeter {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/disconnected_space.rs
+++ b/crates/re_types/src/components/disconnected_space.rs
@@ -94,10 +94,7 @@ impl ::re_types_core::Loggable for DisconnectedSpace {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/draw_order.rs
+++ b/crates/re_types/src/components/draw_order.rs
@@ -90,10 +90,7 @@ impl ::re_types_core::Loggable for DrawOrder {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -109,14 +109,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -109,14 +109,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec3D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -114,14 +114,7 @@ impl ::re_types_core::Loggable for KeypointId {
                 Self::arrow_datatype(),
                 data0
                     .into_iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::KeypointId(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .collect(),
                 data0_bitmap,
             )

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -99,10 +99,7 @@ impl ::re_types_core::Loggable for KeypointId {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -90,10 +90,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -116,10 +116,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let data0_inner_data_inner_data: Vec<_> = data0_inner_data
                             .iter()
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum.clone();
-                                data0
-                            })
+                            .map(|datum| datum.0.clone())
                             .flatten()
                             .collect();
                         let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -90,10 +90,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -116,10 +116,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let data0_inner_data_inner_data: Vec<_> = data0_inner_data
                             .iter()
-                            .map(|datum| {
-                                let crate::datatypes::Vec3D(data0) = datum.clone();
-                                data0
-                            })
+                            .map(|datum| datum.0.clone())
                             .flatten()
                             .collect();
                         let data0_inner_data_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;

--- a/crates/re_types/src/components/marker_size.rs
+++ b/crates/re_types/src/components/marker_size.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for MarkerSize {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Material {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -107,18 +107,12 @@ impl ::re_types_core::Loggable for MediaType {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -109,14 +109,13 @@ impl ::re_types_core::Loggable for MediaType {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for MediaType {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for Name {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -106,14 +106,13 @@ impl ::re_types_core::Loggable for Name {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -104,18 +104,12 @@ impl ::re_types_core::Loggable for Name {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -112,10 +112,7 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -104,10 +104,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -116,14 +116,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Mat3x3(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Position2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for Position2D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for Position3D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec3D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Position3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/radius.rs
+++ b/crates/re_types/src/components/radius.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for Radius {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Range1D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for Range1D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Range1D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/range2d.rs
+++ b/crates/re_types/src/components/range2d.rs
@@ -103,10 +103,7 @@ impl ::re_types_core::Loggable for Range2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -108,14 +108,7 @@ impl ::re_types_core::Loggable for Resolution {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -96,10 +96,7 @@ impl ::re_types_core::Loggable for Resolution {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -110,10 +110,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/scalar.rs
+++ b/crates/re_types/src/components/scalar.rs
@@ -86,10 +86,7 @@ impl ::re_types_core::Loggable for Scalar {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/scalar_scattering.rs
+++ b/crates/re_types/src/components/scalar_scattering.rs
@@ -83,10 +83,7 @@ impl ::re_types_core::Loggable for ScalarScattering {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/stroke_width.rs
+++ b/crates/re_types/src/components/stroke_width.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for StrokeWidth {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -119,10 +119,7 @@ impl ::re_types_core::Loggable for TensorData {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -110,10 +110,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -122,14 +122,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -104,18 +104,12 @@ impl ::re_types_core::Loggable for Text {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for Text {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -106,14 +106,13 @@ impl ::re_types_core::Loggable for Text {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -112,18 +112,12 @@ impl ::re_types_core::Loggable for TextLogLevel {
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .iter()
                     .flatten()
-                    .flat_map(|datum| {
-                        let crate::datatypes::Utf8(data0) = datum;
-                        data0.0.clone()
-                    })
+                    .flat_map(|datum| datum.0 .0.clone())
                     .collect();
                 let offsets =
                     arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
                         opt.as_ref()
-                            .map(|datum| {
-                                let crate::datatypes::Utf8(data0) = datum;
-                                data0.0.len()
-                            })
+                            .map(|datum| datum.0 .0.len())
                             .unwrap_or_default()
                     }))
                     .unwrap()

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -114,14 +114,13 @@ impl ::re_types_core::Loggable for TextLogLevel {
                     .flatten()
                     .flat_map(|datum| datum.0 .0.clone())
                     .collect();
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.0 .0.len())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                )
+                .unwrap()
+                .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                 unsafe {

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -100,10 +100,7 @@ impl ::re_types_core::Loggable for TextLogLevel {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -110,10 +110,7 @@ impl ::re_types_core::Loggable for Transform3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::UVec3D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Vector2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for Vector2D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec2D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for Vector3D {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Vec3D(data0) = datum;
-                                data0
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for Vector3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -105,10 +105,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -137,9 +137,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 label.iter().map(|opt| {
-                                    opt.as_ref()
-                                        .map(|datum| datum.0 .0.len())
-                                        .unwrap_or_default()
+                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
                             .unwrap()

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -180,14 +180,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                             DataType::UInt32,
                             color
                                 .into_iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Rgba32(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .collect(),
                             color_bitmap,
                         )

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -133,24 +133,17 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                             let inner_data: arrow2::buffer::Buffer<u8> = label
                                 .iter()
                                 .flatten()
-                                .flat_map(|datum| {
-                                    let crate::datatypes::Utf8(data0) = datum;
-                                    data0.0.clone()
-                                })
+                                .flat_map(|datum| datum.0 .0.clone())
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 label.iter().map(|opt| {
                                     opt.as_ref()
-                                        .map(|datum| {
-                                            let crate::datatypes::Utf8(data0) = datum;
-                                            data0.0.len()
-                                        })
+                                        .map(|datum| datum.0 .0.len())
                                         .unwrap_or_default()
                                 }),
                             )
                             .unwrap()
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                         let (somes, id): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { id, .. } = &**datum;
-                                    id.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.id.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -123,13 +120,8 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                         let (somes, label): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { label, .. } = &**datum;
-                                        label.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.label.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -175,13 +167,8 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                         let (somes, color): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { color, .. } = &**datum;
-                                        color.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.color.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/bool.rs
+++ b/crates/re_types/src/datatypes/bool.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for Bool {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -133,10 +133,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                         let (somes, info): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { info, .. } = &**datum;
-                                    info.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.info.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -153,13 +150,9 @@ impl ::re_types_core::Loggable for ClassDescription {
                         let (somes, keypoint_annotations): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        keypoint_annotations,
-                                        ..
-                                    } = &**datum;
-                                    keypoint_annotations.clone()
-                                });
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| datum.keypoint_annotations.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -206,13 +199,9 @@ impl ::re_types_core::Loggable for ClassDescription {
                         let (somes, keypoint_connections): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        keypoint_connections,
-                                        ..
-                                    } = &**datum;
-                                    keypoint_connections.clone()
-                                });
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| datum.keypoint_connections.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -171,9 +171,9 @@ impl ::re_types_core::Loggable for ClassDescription {
                             let keypoint_annotations_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                keypoint_annotations.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                                }),
+                                keypoint_annotations
+                                    .iter()
+                                    .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                             )
                             .unwrap()
                             .into();
@@ -220,9 +220,9 @@ impl ::re_types_core::Loggable for ClassDescription {
                             let keypoint_connections_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                keypoint_connections.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                                }),
+                                keypoint_connections
+                                    .iter()
+                                    .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                             )
                             .unwrap()
                             .into();

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -102,10 +102,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                         let (somes, class_id): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { class_id, .. } = &**datum;
-                                    class_id.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.class_id.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -134,12 +131,8 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                         let (somes, class_description): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        class_description, ..
-                                    } = &**datum;
-                                    class_description.clone()
-                                });
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.class_description.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/re_types/src/datatypes/class_description_map_elem.rs
@@ -114,14 +114,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                             DataType::UInt16,
                             class_id
                                 .into_iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::ClassId(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .collect(),
                             class_id_bitmap,
                         )

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -99,10 +99,7 @@ impl ::re_types_core::Loggable for ClassId {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for KeypointId {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -100,10 +100,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                         let (somes, keypoint0): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { keypoint0, .. } = &**datum;
-                                    keypoint0.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.keypoint0.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -132,10 +129,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                         let (somes, keypoint1): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { keypoint1, .. } = &**datum;
-                                    keypoint1.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.keypoint1.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/re_types/src/datatypes/keypoint_pair.rs
@@ -112,14 +112,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                             DataType::UInt16,
                             keypoint0
                                 .into_iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::KeypointId(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .collect(),
                             keypoint0_bitmap,
                         )
@@ -141,14 +134,7 @@ impl ::re_types_core::Loggable for KeypointPair {
                             DataType::UInt16,
                             keypoint1
                                 .into_iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::KeypointId(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .collect(),
                             keypoint1_bitmap,
                         )

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -98,10 +98,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -99,10 +99,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -115,10 +115,7 @@ impl ::re_types_core::Loggable for Material {
                         .map(|datum| {
                             let datum = datum
                                 .as_ref()
-                                .map(|datum| {
-                                    let Self { albedo_factor, .. } = &**datum;
-                                    albedo_factor.clone()
-                                })
+                                .map(|datum| datum.albedo_factor.clone())
                                 .flatten();
                             (datum.is_some(), datum)
                         })

--- a/crates/re_types/src/datatypes/material.rs
+++ b/crates/re_types/src/datatypes/material.rs
@@ -128,14 +128,7 @@ impl ::re_types_core::Loggable for Material {
                         DataType::UInt32,
                         albedo_factor
                             .into_iter()
-                            .map(|datum| {
-                                datum
-                                    .map(|datum| {
-                                        let crate::datatypes::Rgba32(data0) = datum;
-                                        data0
-                                    })
-                                    .unwrap_or_default()
-                            })
+                            .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                             .collect(),
                         albedo_factor_bitmap,
                     )

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -89,10 +89,7 @@ impl ::re_types_core::Loggable for Quaternion {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for Range1D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -113,14 +113,7 @@ impl ::re_types_core::Loggable for Range2D {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let x_range_inner_data: Vec<_> = x_range
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Range1D(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let x_range_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
@@ -168,14 +161,7 @@ impl ::re_types_core::Loggable for Range2D {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let y_range_inner_data: Vec<_> = y_range
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Range1D(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let y_range_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for Range2D {
                         let (somes, x_range): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { x_range, .. } = &**datum;
-                                    x_range.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.x_range.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -159,10 +156,7 @@ impl ::re_types_core::Loggable for Range2D {
                         let (somes, y_range): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { y_range, .. } = &**datum;
-                                    y_range.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.y_range.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/rgba32.rs
+++ b/crates/re_types/src/datatypes/rgba32.rs
@@ -89,10 +89,7 @@ impl ::re_types_core::Loggable for Rgba32 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -121,10 +121,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let quaternion_inner_data: Vec<_> = quaternion
                             .iter()
-                            .map(|datum| {
-                                let crate::datatypes::Quaternion(data0) = datum.clone();
-                                data0
-                            })
+                            .map(|datum| datum.0.clone())
                             .flatten()
                             .collect();
                         let quaternion_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -96,10 +96,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                         let (somes, axis): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { axis, .. } = &**datum;
-                                    axis.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.axis.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -154,10 +151,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                         let (somes, angle): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { angle, .. } = &**datum;
-                                    angle.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.angle.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -108,14 +108,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let axis_inner_data: Vec<_> = axis
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Vec3D(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let axis_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -113,10 +113,7 @@ impl ::re_types_core::Loggable for Scale3D {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let three_d_inner_data: Vec<_> = three_d
                             .iter()
-                            .map(|datum| {
-                                let crate::datatypes::Vec3D(data0) = datum.clone();
-                                data0
-                            })
+                            .map(|datum| datum.0.clone())
                             .flatten()
                             .collect();
                         let three_d_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -130,12 +130,13 @@ impl ::re_types_core::Loggable for TensorData {
                             let shape_inner_data: Vec<_> =
                                 shape.iter().flatten().flatten().cloned().collect();
                             let shape_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                            let offsets =
-                                arrow2::offset::Offsets::<i32>::try_from_lengths(shape.iter().map(
-                                    |opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default(),
-                                ))
-                                .unwrap()
-                                .into();
+                            let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                                shape
+                                    .iter()
+                                    .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
+                            )
+                            .unwrap()
+                            .into();
                             ListArray::new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -117,10 +117,7 @@ impl ::re_types_core::Loggable for TensorData {
                         let (somes, shape): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { shape, .. } = &**datum;
-                                    shape.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.shape.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -161,10 +158,7 @@ impl ::re_types_core::Loggable for TensorData {
                         let (somes, buffer): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { buffer, .. } = &**datum;
-                                    buffer.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.buffer.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -123,13 +123,12 @@ impl ::re_types_core::Loggable for TensorDimension {
                         {
                             let inner_data: arrow2::buffer::Buffer<u8> =
                                 name.iter().flatten().flat_map(|s| s.0.clone()).collect();
-                            let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                name.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
-                                }),
-                            )
-                            .unwrap()
-                            .into();
+                            let offsets =
+                                arrow2::offset::Offsets::<i32>::try_from_lengths(name.iter().map(
+                                    |opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default(),
+                                ))
+                                .unwrap()
+                                .into();
 
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -92,10 +92,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                         let (somes, size): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { size, .. } = &**datum;
-                                    size.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.size.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -114,13 +111,8 @@ impl ::re_types_core::Loggable for TensorDimension {
                         let (somes, name): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { name, .. } = &**datum;
-                                        name.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.name.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -138,6 +130,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                             )
                             .unwrap()
                             .into();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -111,10 +111,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self { translation, .. } = &**datum;
-                                        translation.clone()
-                                    })
+                                    .map(|datum| datum.translation.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -170,13 +167,8 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                         let (somes, mat3x3): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { mat3x3, .. } = &**datum;
-                                        mat3x3.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.mat3x3.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -231,10 +223,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                         let (somes, from_parent): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { from_parent, .. } = &**datum;
-                                    from_parent.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.from_parent.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -124,14 +124,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let translation_inner_data: Vec<_> = translation
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Vec3D(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let translation_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
@@ -180,14 +173,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let mat3x3_inner_data: Vec<_> = mat3x3
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Mat3x3(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let mat3x3_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -119,10 +119,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self { translation, .. } = &**datum;
-                                        translation.clone()
-                                    })
+                                    .map(|datum| datum.translation.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -178,13 +175,8 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                         let (somes, rotation): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { rotation, .. } = &**datum;
-                                        rotation.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.rotation.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -201,13 +193,8 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                         let (somes, scale): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum
-                                    .as_ref()
-                                    .map(|datum| {
-                                        let Self { scale, .. } = &**datum;
-                                        scale.clone()
-                                    })
-                                    .flatten();
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.scale.clone()).flatten();
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -224,10 +211,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                         let (somes, from_parent): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { from_parent, .. } = &**datum;
-                                    from_parent.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.from_parent.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -132,14 +132,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                             use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                             let translation_inner_data: Vec<_> = translation
                                 .iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::datatypes::Vec3D(data0) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .flatten()
                                 .collect();
                             let translation_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -90,10 +90,7 @@ impl ::re_types_core::Loggable for Uuid {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self { bytes } = datum.into_owned();
-                        bytes
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().bytes);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for UVec2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for UVec3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for UVec4D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for Vec2D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for Vec3D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -87,10 +87,7 @@ impl ::re_types_core::Loggable for Vec4D {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -128,10 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -82,12 +82,7 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -96,7 +96,7 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -104,14 +104,13 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                     .concat()
                     .into();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                let offsets =
-                    arrow2::offset::Offsets::<i32>::try_from_lengths(data0.iter().map(|opt| {
-                        opt.as_ref()
-                            .map(|datum| datum.num_instances())
-                            .unwrap_or_default()
-                    }))
-                    .unwrap()
-                    .into();
+                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
+                    data0
+                        .iter()
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.num_instances())),
+                )
+                .unwrap()
+                .into();
                 ListArray::new(
                     Self::arrow_datatype(),
                     offsets,

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -86,12 +86,7 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -112,7 +112,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|datum| datum.0.len()),
+                            data0_inner_data.iter().map(|datum| datum.len()),
                         )
                         .unwrap()
                         .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -86,10 +86,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -101,7 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -101,7 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -86,12 +86,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -112,7 +112,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|datum| datum.0.len()),
+                            data0_inner_data.iter().map(|datum| datum.len()),
                         )
                         .unwrap()
                         .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -115,10 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer15.rs
@@ -115,12 +115,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -80,10 +80,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -95,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -95,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -80,12 +80,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -80,12 +80,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -95,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -94,10 +94,7 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -128,10 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer22.rs
@@ -97,12 +97,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -128,10 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer4.rs
@@ -128,12 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer5.rs
@@ -128,12 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer6.rs
@@ -128,12 +128,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -80,12 +80,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -95,7 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer8.rs
@@ -82,12 +82,7 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -82,10 +82,7 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -96,7 +96,7 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -148,13 +148,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self {
-                                            single_float_optional,
-                                            ..
-                                        } = &**datum;
-                                        single_float_optional.clone()
-                                    })
+                                    .map(|datum| datum.single_float_optional.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -177,13 +171,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let (somes, single_string_required): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        single_string_required,
-                                        ..
-                                    } = &**datum;
-                                    single_string_required.clone()
-                                });
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| datum.single_string_required.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -222,13 +212,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self {
-                                            single_string_optional,
-                                            ..
-                                        } = &**datum;
-                                        single_string_optional.clone()
-                                    })
+                                    .map(|datum| datum.single_string_optional.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -268,13 +252,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self {
-                                            many_floats_optional,
-                                            ..
-                                        } = &**datum;
-                                        many_floats_optional.clone()
-                                    })
+                                    .map(|datum| datum.many_floats_optional.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -325,13 +303,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let (somes, many_strings_required): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        many_strings_required,
-                                        ..
-                                    } = &**datum;
-                                    many_strings_required.clone()
-                                });
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| datum.many_strings_required.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -398,13 +372,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self {
-                                            many_strings_optional,
-                                            ..
-                                        } = &**datum;
-                                        many_strings_optional.clone()
-                                    })
+                                    .map(|datum| datum.many_strings_optional.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })
@@ -470,12 +438,8 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let (somes, flattened_scalar): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        flattened_scalar, ..
-                                    } = &**datum;
-                                    flattened_scalar.clone()
-                                });
+                                let datum =
+                                    datum.as_ref().map(|datum| datum.flattened_scalar.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -497,13 +461,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let (somes, almost_flattened_scalar): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self {
-                                        almost_flattened_scalar,
-                                        ..
-                                    } = &**datum;
-                                    almost_flattened_scalar.clone()
-                                });
+                                let datum = datum
+                                    .as_ref()
+                                    .map(|datum| datum.almost_flattened_scalar.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -524,10 +484,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             .map(|datum| {
                                 let datum = datum
                                     .as_ref()
-                                    .map(|datum| {
-                                        let Self { from_parent, .. } = &**datum;
-                                        from_parent.clone()
-                                    })
+                                    .map(|datum| datum.from_parent.clone())
                                     .flatten();
                                 (datum.is_some(), datum)
                             })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -274,9 +274,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 many_floats_optional.iter().map(|opt| {
-                                    opt.as_ref()
-                                        .map(|datum| datum.num_instances())
-                                        .unwrap_or_default()
+                                    opt.as_ref().map_or(0, |datum| datum.num_instances())
                                 }),
                             )
                             .unwrap()
@@ -324,9 +322,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             let many_strings_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                many_strings_required.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                                }),
+                                many_strings_required
+                                    .iter()
+                                    .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                             )
                             .unwrap()
                             .into();
@@ -392,9 +390,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             let many_strings_optional_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                many_strings_optional.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
-                                }),
+                                many_strings_optional
+                                    .iter()
+                                    .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                             )
                             .unwrap()
                             .into();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -189,7 +189,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 single_string_required.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                                 }),
                             )
                             .unwrap()
@@ -229,7 +229,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 single_string_optional.iter().map(|opt| {
-                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
+                                    opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                                 }),
                             )
                             .unwrap()
@@ -346,7 +346,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                         many_strings_required_inner_data
                                             .iter()
-                                            .map(|datum| datum.0.len()),
+                                            .map(|datum| datum.len()),
                                     )
                                     .unwrap()
                                     .into();
@@ -414,7 +414,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                         many_strings_optional_inner_data
                                             .iter()
-                                            .map(|datum| datum.0.len()),
+                                            .map(|datum| datum.len()),
                                     )
                                     .unwrap()
                                     .into();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -82,12 +82,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum
-                        .map(|datum| {
-                            let Self(data0) = datum.into_owned();
-                            data0
-                        })
-                        .flatten();
+                    let datum = datum.map(|datum| datum.into_owned().0).flatten();
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                         let (somes, p): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { p, .. } = &**datum;
-                                    p.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.p.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -130,10 +127,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                         let (somes, s): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { s, .. } = &**datum;
-                                    s.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.s.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -130,25 +130,17 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                             let inner_data: arrow2::buffer::Buffer<u8> = s
                                 .iter()
                                 .flatten()
-                                .flat_map(|datum| {
-                                    let crate::testing::datatypes::StringComponent(data0) = datum;
-                                    data0.0.clone()
-                                })
+                                .flat_map(|datum| datum.0 .0.clone())
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 s.iter().map(|opt| {
                                     opt.as_ref()
-                                        .map(|datum| {
-                                            let crate::testing::datatypes::StringComponent(data0) =
-                                                datum;
-                                            data0.0.len()
-                                        })
+                                        .map(|datum| datum.0 .0.len())
                                         .unwrap_or_default()
                                 }),
                             )
                             .unwrap()
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -134,9 +134,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 s.iter().map(|opt| {
-                                    opt.as_ref()
-                                        .map(|datum| datum.0 .0.len())
-                                        .unwrap_or_default()
+                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
                             .unwrap()

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -108,16 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                         PrimitiveArray::new(
                             DataType::UInt32,
                             p.into_iter()
-                                .map(|datum| {
-                                    datum
-                                        .map(|datum| {
-                                            let crate::testing::datatypes::PrimitiveComponent(
-                                                data0,
-                                            ) = datum;
-                                            data0
-                                        })
-                                        .unwrap_or_default()
-                                })
+                                .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
                                 .collect(),
                             p_bitmap,
                         )

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -139,9 +139,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                             let many_halves_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 many_halves.iter().map(|opt| {
-                                    opt.as_ref()
-                                        .map(|datum| datum.num_instances())
-                                        .unwrap_or_default()
+                                    opt.as_ref().map_or(0, |datum| datum.num_instances())
                                 }),
                             )
                             .unwrap()

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -97,10 +97,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                         let (somes, single_half): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { single_half, .. } = &**datum;
-                                    single_half.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.single_half.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -122,10 +119,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                         let (somes, many_halves): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { many_halves, .. } = &**datum;
-                                    many_halves.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.many_halves.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -104,12 +104,8 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                     let (somes, fixed_sized_native): (Vec<_>, Vec<_>) = data
                         .iter()
                         .map(|datum| {
-                            let datum = datum.as_ref().map(|datum| {
-                                let Self {
-                                    fixed_sized_native, ..
-                                } = &**datum;
-                                fixed_sized_native.clone()
-                            });
+                            let datum =
+                                datum.as_ref().map(|datum| datum.fixed_sized_native.clone());
                             (datum.is_some(), datum)
                         })
                         .unzip();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -113,13 +113,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                         .map(|datum| {
                             let datum = datum
                                 .as_ref()
-                                .map(|datum| {
-                                    let Self {
-                                        single_optional_union,
-                                        ..
-                                    } = &**datum;
-                                    single_optional_union.clone()
-                                })
+                                .map(|datum| datum.single_optional_union.clone())
                                 .flatten();
                             (datum.is_some(), datum)
                         })

--- a/crates/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -101,10 +101,7 @@ impl ::re_types_core::Loggable for FlattenedScalar {
                     let (somes, value): (Vec<_>, Vec<_>) = data
                         .iter()
                         .map(|datum| {
-                            let datum = datum.as_ref().map(|datum| {
-                                let Self { value, .. } = &**datum;
-                                value.clone()
-                            });
+                            let datum = datum.as_ref().map(|datum| datum.value.clone());
                             (datum.is_some(), datum)
                         })
                         .unzip();

--- a/crates/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/re_types/src/testing/datatypes/primitive_component.rs
@@ -83,10 +83,7 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -83,10 +83,7 @@ impl ::re_types_core::Loggable for StringComponent {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -97,7 +97,7 @@ impl ::re_types_core::Loggable for StringComponent {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types_blueprint/src/blueprint/components/auto_layout.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/auto_layout.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for AutoLayout {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_blueprint/src/blueprint/components/auto_space_views.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/auto_space_views.rs
@@ -84,10 +84,7 @@ impl ::re_types_core::Loggable for AutoSpaceViews {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_blueprint/src/blueprint/components/grid_columns.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/grid_columns.rs
@@ -86,10 +86,7 @@ impl ::re_types_core::Loggable for GridColumns {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Uuid { bytes } = datum;
-                                bytes
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.bytes).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -98,10 +98,7 @@ impl ::re_types_core::Loggable for RootContainer {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -110,14 +110,7 @@ impl ::re_types_core::Loggable for RootContainer {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Uuid { bytes } = datum;
-                                bytes
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.bytes).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -107,14 +107,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                 use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                 let data0_inner_data: Vec<_> = data0
                     .iter()
-                    .map(|datum| {
-                        datum
-                            .map(|datum| {
-                                let crate::datatypes::Uuid { bytes } = datum;
-                                bytes
-                            })
-                            .unwrap_or_default()
-                    })
+                    .map(|datum| datum.map(|datum| datum.bytes).unwrap_or_default())
                     .flatten()
                     .collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -95,10 +95,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -549,7 +549,7 @@ fn quote_arrow_field_serializer(
                         },
                         quote! {
                             .map(|datum| {
-                                datum.#quoted_member_accessor.0.len()
+                                datum.#quoted_member_accessor.len()
                             })
                         },
                     )
@@ -560,7 +560,7 @@ fn quote_arrow_field_serializer(
                             .flat_map(|s| s.0.clone())
                         },
                         quote! {
-                            .map(|datum| datum.0.len())
+                            .map(|datum| datum.len())
                         },
                     )
                 };

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -453,18 +453,10 @@ fn quote_arrow_field_serializer(
                 let inner_obj = inner_obj.as_ref().unwrap();
                 let quoted_inner_obj_type = quote_fqname_as_type_path(&inner_obj.fqname);
                 let is_tuple_struct = is_tuple_struct_from_obj(inner_obj);
-                let quoted_data_dst = format_ident!(
-                    "{}",
-                    if is_tuple_struct {
-                        "data0"
-                    } else {
-                        inner_obj.fields[0].name.as_str()
-                    }
-                );
-                let quoted_binding = if is_tuple_struct {
-                    quote!(#quoted_inner_obj_type(#quoted_data_dst))
+                let quoted_member_accessor = if is_tuple_struct {
+                    quote!(0)
                 } else {
-                    quote!(#quoted_inner_obj_type { #quoted_data_dst })
+                    quote!(#quoted_inner_obj_type)
                 };
 
                 if elements_are_nullable {
@@ -472,8 +464,7 @@ fn quote_arrow_field_serializer(
                         .map(|datum| {
                             datum
                                 .map(|datum| {
-                                    let #quoted_binding = datum;
-                                    #quoted_data_dst
+                                    datum.#quoted_member_accessor
                                 })
                                 .unwrap_or_default()
                         })
@@ -481,8 +472,7 @@ fn quote_arrow_field_serializer(
                 } else {
                     quote! {
                         .map(|datum| {
-                            let #quoted_binding = datum;
-                            #quoted_data_dst
+                            datum.#quoted_member_accessor
                         })
                     }
                 }

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -64,10 +64,10 @@ pub fn quote_arrow_serializer(
         );
         let bitmap_dst = format_ident!("{quoted_data_dst}_bitmap");
 
-        let quoted_binding = if is_tuple_struct {
-            quote!(Self(#quoted_data_dst))
+        let quoted_member_accessor = if is_tuple_struct {
+            quote!(0)
         } else {
-            quote!(Self { #quoted_data_dst })
+            quote!(#quoted_data_dst)
         };
 
         let datatype = &arrow_registry.get(&obj_field.fqname);
@@ -97,8 +97,7 @@ pub fn quote_arrow_serializer(
 
                     let datum = datum
                         .map(|datum| {
-                            let #quoted_binding = datum.into_owned();
-                            #quoted_data_dst
+                            datum.into_owned().#quoted_member_accessor
                         })
                         #quoted_flatten;
 

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -814,7 +814,7 @@ fn quote_arrow_field_serializer(
                                 #quoted_transparent_mapping;
 
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                                buffers.iter().map(|opt| opt.as_ref().map(|buf| buf.len()).unwrap_or_default())
+                                buffers.iter().map(|opt| opt.as_ref().map_or(0, |buf| buf.len()))
                             ).unwrap().into();
 
                             #quoted_inner_bitmap

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -112,8 +112,6 @@ pub fn quote_arrow_serializer(
             #quoted_serializer
         }}
     } else {
-        let data_src = data_src.clone();
-
         // NOTE: This can only be struct or union/enum at this point.
         match datatype.to_logical_type() {
             DataType::Struct(_) => {

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -146,8 +146,7 @@ pub fn quote_arrow_serializer(
                                 let datum = datum
                                     .as_ref()
                                     .map(|datum| {
-                                        let Self { #data_dst, .. } = &**datum;
-                                        #data_dst.clone()
+                                        datum.#data_dst.clone()
                                     })
                                     #quoted_flatten;
 

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -743,7 +743,7 @@ fn quote_arrow_field_serializer(
                     quote! {}
                 } else {
                     let map_to_length = if elements_are_nullable {
-                        quote! { map(|opt| opt.as_ref().map(|datum| datum. #quoted_num_instances).unwrap_or_default()) }
+                        quote! { map(|opt| opt.as_ref().map_or(0, |datum| datum. #quoted_num_instances)) }
                     } else {
                         quote! { map(|datum| datum. #quoted_num_instances) }
                     };

--- a/crates/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/re_types_core/src/components/clear_is_recursive.rs
@@ -86,10 +86,7 @@ impl crate::Loggable for ClearIsRecursive {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -88,10 +88,7 @@ impl crate::Loggable for VisualizerOverrides {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -114,7 +114,7 @@ impl crate::Loggable for VisualizerOverrides {
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.iter().flat_map(|s| s.0.clone()).collect();
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                            data0_inner_data.iter().map(|datum| datum.0.len()),
+                            data0_inner_data.iter().map(|datum| datum.len()),
                         )
                         .unwrap()
                         .into();

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -103,7 +103,7 @@ impl crate::Loggable for VisualizerOverrides {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/re_types_core/src/datatypes/entity_path.rs
@@ -84,10 +84,7 @@ impl crate::Loggable for EntityPath {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/re_types_core/src/datatypes/entity_path.rs
@@ -98,7 +98,7 @@ impl crate::Loggable for EntityPath {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types_core/src/datatypes/float32.rs
+++ b/crates/re_types_core/src/datatypes/float32.rs
@@ -83,10 +83,7 @@ impl crate::Loggable for Float32 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/time_int.rs
+++ b/crates/re_types_core/src/datatypes/time_int.rs
@@ -83,10 +83,7 @@ impl crate::Loggable for TimeInt {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/time_range.rs
+++ b/crates/re_types_core/src/datatypes/time_range.rs
@@ -101,10 +101,7 @@ impl crate::Loggable for TimeRange {
                         let (somes, start): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { start, .. } = &**datum;
-                                    start.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.start.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -121,10 +118,7 @@ impl crate::Loggable for TimeRange {
                         let (somes, end): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { end, .. } = &**datum;
-                                    end.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.end.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/re_types_core/src/datatypes/time_range_boundary.rs
@@ -125,13 +125,7 @@ impl crate::Loggable for TimeRangeBoundary {
                     let cursor_relative_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     PrimitiveArray::new(
                         DataType::Int64,
-                        cursor_relative
-                            .into_iter()
-                            .map(|datum| {
-                                let crate::datatypes::TimeInt(data0) = datum;
-                                data0
-                            })
-                            .collect(),
+                        cursor_relative.into_iter().map(|datum| datum.0).collect(),
                         cursor_relative_bitmap,
                     )
                     .boxed()
@@ -147,13 +141,7 @@ impl crate::Loggable for TimeRangeBoundary {
                     let absolute_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                     PrimitiveArray::new(
                         DataType::Int64,
-                        absolute
-                            .into_iter()
-                            .map(|datum| {
-                                let crate::datatypes::TimeInt(data0) = datum;
-                                data0
-                            })
-                            .collect(),
+                        absolute.into_iter().map(|datum| datum.0).collect(),
                         absolute_bitmap,
                     )
                     .boxed()

--- a/crates/re_types_core/src/datatypes/uint32.rs
+++ b/crates/re_types_core/src/datatypes/uint32.rs
@@ -83,10 +83,7 @@ impl crate::Loggable for UInt32 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/uint64.rs
+++ b/crates/re_types_core/src/datatypes/uint64.rs
@@ -83,10 +83,7 @@ impl crate::Loggable for UInt64 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/utf8.rs
+++ b/crates/re_types_core/src/datatypes/utf8.rs
@@ -98,7 +98,7 @@ impl crate::Loggable for Utf8 {
                 let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                     data0
                         .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
+                        .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
                 )
                 .unwrap()
                 .into();

--- a/crates/re_types_core/src/datatypes/utf8.rs
+++ b/crates/re_types_core/src/datatypes/utf8.rs
@@ -84,10 +84,7 @@ impl crate::Loggable for Utf8 {
                 .into_iter()
                 .map(|datum| {
                     let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| {
-                        let Self(data0) = datum.into_owned();
-                        data0
-                    });
+                    let datum = datum.map(|datum| datum.into_owned().0);
                     (datum.is_some(), datum)
                 })
                 .unzip();

--- a/crates/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range.rs
@@ -100,10 +100,7 @@ impl crate::Loggable for VisibleTimeRange {
                         let (somes, timeline): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { timeline, .. } = &**datum;
-                                    timeline.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.timeline.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();
@@ -132,7 +129,6 @@ impl crate::Loggable for VisibleTimeRange {
                             )
                             .unwrap()
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
@@ -149,10 +145,7 @@ impl crate::Loggable for VisibleTimeRange {
                         let (somes, range): (Vec<_>, Vec<_>) = data
                             .iter()
                             .map(|datum| {
-                                let datum = datum.as_ref().map(|datum| {
-                                    let Self { range, .. } = &**datum;
-                                    range.clone()
-                                });
+                                let datum = datum.as_ref().map(|datum| datum.range.clone());
                                 (datum.is_some(), datum)
                             })
                             .unzip();

--- a/crates/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range.rs
@@ -116,9 +116,7 @@ impl crate::Loggable for VisibleTimeRange {
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 timeline.iter().map(|opt| {
-                                    opt.as_ref()
-                                        .map(|datum| datum.0 .0.len())
-                                        .unwrap_or_default()
+                                    opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
                             .unwrap()

--- a/crates/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range.rs
@@ -112,18 +112,12 @@ impl crate::Loggable for VisibleTimeRange {
                             let inner_data: arrow2::buffer::Buffer<u8> = timeline
                                 .iter()
                                 .flatten()
-                                .flat_map(|datum| {
-                                    let crate::datatypes::Utf8(data0) = datum;
-                                    data0.0.clone()
-                                })
+                                .flat_map(|datum| datum.0 .0.clone())
                                 .collect();
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 timeline.iter().map(|opt| {
                                     opt.as_ref()
-                                        .map(|datum| {
-                                            let crate::datatypes::Utf8(data0) = datum;
-                                            data0.0.len()
-                                        })
+                                        .map(|datum| datum.0 .0.len())
                                         .unwrap_or_default()
                                 }),
                             )


### PR DESCRIPTION
### What
My attempt at making the generated rust code shorter and more readable.
Because I couldn't sleep.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6273?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6273?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6273)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.