### PR TITLE
Show Cargo.lock in GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 * text=auto eol=lf
 *.zip -text diff
-**/source_hash.txt linguist-generated=true
-Cargo.lock linguist-generated=true
+Cargo.lock linguist-generated=false
 pixi.lock linguist-generated=true


### PR DESCRIPTION
This was backwards. We want to show the Cargo.lock changes, not hide them.

The pixi.lock changes I care much less about (and are way too big anyways).