### PR TITLE
Fix crash on `i32` overflow during arrow serialization

### DIFF
--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -125,7 +125,7 @@ impl ::re_types_core::Loggable for ActiveTab {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -126,7 +126,7 @@ impl ::re_types_core::Loggable for IncludedContent {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -130,7 +130,7 @@ impl ::re_types_core::Loggable for QueryExpression {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -121,7 +121,7 @@ impl ::re_types_core::Loggable for SpaceViewClass {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -121,7 +121,7 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -124,7 +124,7 @@ impl ::re_types_core::Loggable for MediaType {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -121,7 +121,7 @@ impl ::re_types_core::Loggable for Name {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -121,7 +121,7 @@ impl ::re_types_core::Loggable for Text {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -129,7 +129,7 @@ impl ::re_types_core::Loggable for TextLogLevel {
                             })
                             .unwrap_or_default()
                     }))
-                    .unwrap()
+                    .map_err(|err| std::sync::Arc::new(err))?
                     .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -156,9 +156,8 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                                         .unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -136,7 +136,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -103,7 +103,7 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
                 )
-                .unwrap()
+                .map_err(|err| std::sync::Arc::new(err))?
                 .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -117,7 +117,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
-                        .unwrap()
+                        .map_err(|err| std::sync::Arc::new(err))?
                         .into();
 
                         #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -119,7 +119,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
-                        .unwrap()
+                        .map_err(|err| std::sync::Arc::new(err))?
                         .into();
 
                         #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -101,7 +101,7 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
                 )
-                .unwrap()
+                .map_err(|err| std::sync::Arc::new(err))?
                 .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -202,8 +202,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
@@ -248,8 +249,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(
@@ -374,7 +376,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                             .iter()
                                             .map(|datum| datum.0.len()),
                                     )
-                                    .unwrap()
+                                    .map_err(|err| std::sync::Arc::new(err))?
                                     .into();
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {
@@ -448,7 +450,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                             .iter()
                                             .map(|datum| datum.0.len()),
                                     )
-                                    .unwrap()
+                                    .map_err(|err| std::sync::Arc::new(err))?
                                     .into();
                                     #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                                     unsafe {

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -161,9 +161,8 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                                         .unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -102,7 +102,7 @@ impl ::re_types_core::Loggable for StringComponent {
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
                 )
-                .unwrap()
+                .map_err(|err| std::sync::Arc::new(err))?
                 .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -591,7 +591,9 @@ fn quote_arrow_field_serializer(
 
                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                         #data_src.iter().map(|opt| opt.as_ref() #quoted_transparent_length .unwrap_or_default())
-                    ).unwrap().into();
+                    )
+                    .map_err(|err| std::sync::Arc::new(err))?
+                    .into();
                 }
             } else {
                 quote! {
@@ -600,7 +602,9 @@ fn quote_arrow_field_serializer(
 
                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                         #data_src.iter() #quoted_transparent_length
-                    ).unwrap().into();
+                    )
+                    .map_err(|err| std::sync::Arc::new(err))?
+                    .into();
                 }
             };
 

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -119,7 +119,7 @@ impl crate::Loggable for VisualizerOverrides {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.0.len()),
                         )
-                        .unwrap()
+                        .map_err(|err| std::sync::Arc::new(err))?
                         .into();
 
                         #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/re_types_core/src/datatypes/entity_path.rs
@@ -103,7 +103,7 @@ impl crate::Loggable for EntityPath {
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
                 )
-                .unwrap()
+                .map_err(|err| std::sync::Arc::new(err))?
                 .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types_core/src/datatypes/utf8.rs
+++ b/crates/re_types_core/src/datatypes/utf8.rs
@@ -103,7 +103,7 @@ impl crate::Loggable for Utf8 {
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
                 )
-                .unwrap()
+                .map_err(|err| std::sync::Arc::new(err))?
                 .into();
 
                 #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]

--- a/crates/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range.rs
@@ -130,9 +130,8 @@ impl crate::Loggable for VisibleTimeRange {
                                         .unwrap_or_default()
                                 }),
                             )
-                            .unwrap()
+                            .map_err(|err| std::sync::Arc::new(err))?
                             .into();
-
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types_core/src/result.rs
+++ b/crates/re_types_core/src/result.rs
@@ -32,6 +32,10 @@ pub enum SerializationError {
         reason: String,
         backtrace: _Backtrace,
     },
+
+    /// E.g. too many values (overflows i32).
+    #[error("Arrow error")]
+    ArrowError(#[from] std::sync::Arc<arrow2::error::Error>),
 }
 
 impl std::fmt::Debug for SerializationError {
@@ -84,7 +88,7 @@ impl SerializationError {
             Self::MissingExtensionMetadata { backtrace, .. }
             | Self::SerdeFailure { backtrace, .. }
             | Self::NotImplemented { backtrace, .. } => Some(backtrace.clone()),
-            SerializationError::Context { .. } => None,
+            Self::ArrowError { .. } | Self::Context { .. } => None,
         }
     }
 }


### PR DESCRIPTION
* Part of https://github.com/rerun-io/rerun/issues/3408

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6285?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6285?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6285)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.