### PR TITLE
Don't automatically fall back to automatic port if web socket port is already in use, only recommend using 0 instead

### DIFF
--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -34,6 +34,9 @@ pub enum RerunServerError {
     #[error("Failed to bind to WebSocket port {0}: {1}")]
     BindFailed(RerunServerPort, std::io::Error),
 
+    #[error("Failed to bind to WebSocket port {0} since the address is already in use. Use port 0 to let the OS choose a free port.")]
+    BindFailedAddrInUse(RerunServerPort),
+
     #[error("Received an invalid message")]
     InvalidMessagePrefix,
 


### PR DESCRIPTION
### What

* Fixes #6222

Running this scrip twice:
```py
#!/usr/bin/env python3
import rerun as rr
import time

def main() -> None:
    rr.init("rerun_example_serve")
    rr.serve(web_port=57158, ws_port=57159)

    try:
        while True:
            time.sleep(1)
    except KeyboardInterrupt:
        print("Ctrl-C received. Exiting.")

if __name__ == "__main__":
    main()
```

Gives now this error:

```sh
Traceback (most recent call last):
  File "/Users/andreas/dev/rerun-io/rerun/test.py", line 18, in <module>
    main()
  File "/Users/andreas/dev/rerun-io/rerun/test.py", line 8, in main
    rr.serve(web_port=57158, ws_port=57159)
  File "/Users/andreas/dev/rerun-io/rerun/rerun_py/rerun_sdk/rerun/sinks.py", line 252, in serve
    bindings.serve(
RuntimeError: Failed to bind to WebSocket port 57159 since the address is already in use. Use port 0 to let the OS choose a free port.
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6296?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6296?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6296)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.