### PR TITLE
Improve UI of various components in the selection panel

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -29,7 +29,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
                 small_color_ui(ui, &class.info);
                 let mut text = format!("{}", self.0);
                 if let Some(label) = &class.info.label {
-                    text.push_str(" ");
+                    text.push(' ');
                     text.push_str(label.as_str());
                 }
                 label_for_ui_layout(ui, ui_layout, text);
@@ -75,7 +75,7 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
                 small_color_ui(ui, &info);
                 let mut text = format!("{}", self.0);
                 if let Some(label) = &info.label {
-                    text.push_str(" ");
+                    text.push(' ');
                     text.push_str(label.as_str());
                 }
 

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -7,7 +7,7 @@ use re_types::datatypes::{
 };
 use re_viewer_context::{auto_color, UiLayout, ViewerContext};
 
-use super::{label_for_ui_layout, table_for_ui_layout, DataUi};
+use super::{data_label_for_ui_layout, label_for_ui_layout, table_for_ui_layout, DataUi};
 
 impl crate::EntityDataUi for re_types::components::ClassId {
     fn entity_data_ui(
@@ -79,10 +79,10 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
                     text.push_str(label.as_str());
                 }
 
-                label_for_ui_layout(ui, ui_layout, text);
+                data_label_for_ui_layout(ui, ui_layout, text);
             });
         } else {
-            label_for_ui_layout(ui, ui_layout, format!("{}", self.0));
+            data_label_for_ui_layout(ui, ui_layout, format!("{}", self.0));
         }
     }
 }

--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -7,7 +7,7 @@ use re_types::datatypes::{
 };
 use re_viewer_context::{auto_color, UiLayout, ViewerContext};
 
-use super::{table_for_ui_layout, DataUi};
+use super::{label_for_ui_layout, table_for_ui_layout, DataUi};
 
 impl crate::EntityDataUi for re_types::components::ClassId {
     fn entity_data_ui(
@@ -27,10 +27,12 @@ impl crate::EntityDataUi for re_types::components::ClassId {
             let response = ui.horizontal(|ui| {
                 // Color first, to keep subsequent rows of the same things aligned
                 small_color_ui(ui, &class.info);
-                ui.label(format!("{}", self.0));
+                let mut text = format!("{}", self.0);
                 if let Some(label) = &class.info.label {
-                    ui.label(label.as_str());
+                    text.push_str(" ");
+                    text.push_str(label.as_str());
                 }
+                label_for_ui_layout(ui, ui_layout, text);
             });
 
             let id = self.0;
@@ -40,7 +42,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
                         || !class.keypoint_annotations.is_empty()
                     {
                         response.response.on_hover_ui(|ui| {
-                            class_description_ui(ctx, ui, ui_layout, class, id);
+                            class_description_ui(ctx, ui, UiLayout::Tooltip, class, id);
                         });
                     }
                 }
@@ -52,7 +54,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
                 }
             }
         } else {
-            ui.label(format!("{}", self.0));
+            label_for_ui_layout(ui, ui_layout, format!("{}", self.0));
         }
     }
 }
@@ -62,7 +64,7 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         entity_path: &re_log_types::EntityPath,
         query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
@@ -71,13 +73,16 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
             ui.horizontal(|ui| {
                 // Color first, to keep subsequent rows of the same things aligned
                 small_color_ui(ui, &info);
-                ui.label(format!("{}", self.0));
+                let mut text = format!("{}", self.0);
                 if let Some(label) = &info.label {
-                    ui.label(label.as_str());
+                    text.push_str(" ");
+                    text.push_str(label.as_str());
                 }
+
+                label_for_ui_layout(ui, ui_layout, text);
             });
         } else {
-            ui.label(format!("{}", self.0));
+            label_for_ui_layout(ui, ui_layout, format!("{}", self.0));
         }
     }
 }
@@ -108,16 +113,18 @@ impl DataUi for AnnotationContext {
     ) {
         match ui_layout {
             UiLayout::List | UiLayout::Tooltip => {
-                if self.0.len() == 1 {
+                let text = if self.0.len() == 1 {
                     let descr = &self.0[0].class_description;
-                    ui.label(format!(
+
+                    format!(
                         "One class containing {} keypoints and {} connections",
                         descr.keypoint_annotations.len(),
                         descr.keypoint_connections.len()
-                    ));
+                    )
                 } else {
-                    ui.label(format!("{} classes", self.0.len()));
-                }
+                    format!("{} classes", self.0.len())
+                };
+                label_for_ui_layout(ui, ui_layout, text);
             }
             UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
                 ui.vertical(|ui| {

--- a/crates/re_data_ui/src/component_ui_registry.rs
+++ b/crates/re_data_ui/src/component_ui_registry.rs
@@ -20,6 +20,8 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
     add_to_registry::<re_types::components::KeypointId>(&mut registry);
     add_to_registry::<re_types::components::LineStrip2D>(&mut registry);
     add_to_registry::<re_types::components::LineStrip3D>(&mut registry);
+    add_to_registry::<re_types::components::Range1D>(&mut registry);
+    add_to_registry::<re_types::components::Range2D>(&mut registry);
     add_to_registry::<re_types::components::Resolution>(&mut registry);
     add_to_registry::<re_types::components::Rotation3D>(&mut registry);
     add_to_registry::<re_types::components::Material>(&mut registry);

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -4,7 +4,7 @@ use re_format::format_f32;
 use re_types::components::{Color, LineStrip2D, LineStrip3D, ViewCoordinates};
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use super::{table_for_ui_layout, DataUi};
+use super::{label_for_ui_layout, table_for_ui_layout, DataUi};
 
 /// Default number of ui points to show a number.
 const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
@@ -62,13 +62,13 @@ impl DataUi for ViewCoordinates {
     ) {
         match ui_layout {
             UiLayout::List => {
-                ui.label(self.describe_short())
+                label_for_ui_layout(ui, ui_layout, self.describe_short())
                     .on_hover_text(self.describe());
             }
             UiLayout::SelectionPanelFull
             | UiLayout::SelectionPanelLimitHeight
             | UiLayout::Tooltip => {
-                ui.label(self.describe());
+                label_for_ui_layout(ui, ui_layout, self.describe());
             }
         }
     }
@@ -107,11 +107,11 @@ impl DataUi for re_types::datatypes::Vec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -120,11 +120,11 @@ impl DataUi for re_types::datatypes::Vec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -133,11 +133,11 @@ impl DataUi for re_types::datatypes::Vec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -146,11 +146,11 @@ impl DataUi for re_types::datatypes::UVec2D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -159,11 +159,11 @@ impl DataUi for re_types::datatypes::UVec3D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -172,11 +172,11 @@ impl DataUi for re_types::datatypes::UVec4D {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        ui.label(self.to_string());
+        label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -191,7 +191,7 @@ impl DataUi for LineStrip2D {
     ) {
         match ui_layout {
             UiLayout::List | UiLayout::Tooltip => {
-                ui.label(format!("{} positions", self.0.len()));
+                label_for_ui_layout(ui, ui_layout, format!("{} positions", self.0.len()));
             }
             UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
                 use egui_extras::Column;
@@ -238,7 +238,7 @@ impl DataUi for LineStrip3D {
     ) {
         match ui_layout {
             UiLayout::List | UiLayout::Tooltip => {
-                ui.label(format!("{} positions", self.0.len()));
+                label_for_ui_layout(ui, ui_layout, format!("{} positions", self.0.len()));
             }
             UiLayout::SelectionPanelFull | UiLayout::SelectionPanelLimitHeight => {
                 use egui_extras::Column;

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -1,7 +1,9 @@
-use egui::Vec2;
+use egui::{Ui, Vec2};
+use re_data_store::LatestAtQuery;
+use re_entity_db::EntityDb;
 
 use re_format::format_f32;
-use re_types::components::{Color, LineStrip2D, LineStrip3D, ViewCoordinates};
+use re_types::components::{Color, LineStrip2D, LineStrip3D, Range1D, Range2D, ViewCoordinates};
 use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::{label_for_ui_layout, table_for_ui_layout, DataUi};
@@ -175,6 +177,32 @@ impl DataUi for re_types::datatypes::UVec4D {
         ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
+    ) {
+        label_for_ui_layout(ui, ui_layout, self.to_string());
+    }
+}
+
+impl DataUi for Range1D {
+    fn data_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        ui: &mut Ui,
+        ui_layout: UiLayout,
+        _query: &LatestAtQuery,
+        _db: &EntityDb,
+    ) {
+        label_for_ui_layout(ui, ui_layout, self.to_string());
+    }
+}
+
+impl DataUi for Range2D {
+    fn data_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        ui: &mut Ui,
+        ui_layout: UiLayout,
+        _query: &LatestAtQuery,
+        _db: &EntityDb,
     ) {
         label_for_ui_layout(ui, ui_layout, self.to_string());
     }

--- a/crates/re_data_ui/src/data.rs
+++ b/crates/re_data_ui/src/data.rs
@@ -6,7 +6,7 @@ use re_format::format_f32;
 use re_types::components::{Color, LineStrip2D, LineStrip3D, Range1D, Range2D, ViewCoordinates};
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use super::{label_for_ui_layout, table_for_ui_layout, DataUi};
+use super::{data_label_for_ui_layout, label_for_ui_layout, table_for_ui_layout, DataUi};
 
 /// Default number of ui points to show a number.
 const DEFAULT_NUMBER_WIDTH: f32 = 52.0;
@@ -113,7 +113,7 @@ impl DataUi for re_types::datatypes::Vec2D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -126,7 +126,7 @@ impl DataUi for re_types::datatypes::Vec3D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -139,7 +139,7 @@ impl DataUi for re_types::datatypes::Vec4D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -152,7 +152,7 @@ impl DataUi for re_types::datatypes::UVec2D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -165,7 +165,7 @@ impl DataUi for re_types::datatypes::UVec3D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -178,7 +178,7 @@ impl DataUi for re_types::datatypes::UVec4D {
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -191,7 +191,7 @@ impl DataUi for Range1D {
         _query: &LatestAtQuery,
         _db: &EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 
@@ -204,7 +204,7 @@ impl DataUi for Range2D {
         _query: &LatestAtQuery,
         _db: &EntityDb,
     ) {
-        label_for_ui_layout(ui, ui_layout, self.to_string());
+        data_label_for_ui_layout(ui, ui_layout, self.to_string());
     }
 }
 

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -32,14 +32,14 @@ pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
                 }
             )
         })
-        .join(if labelled { " x " } else { "x" });
+        .join(if labelled { " × " } else { "×" });
     format!(
         "{shapes}{}",
         if shape.len() > MAX_SHOWN {
             if labelled {
-                " x …"
+                " × …"
             } else {
-                "x…"
+                "×…"
             }
         } else {
             ""

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -12,7 +12,7 @@ use re_viewer_context::{
     ViewerContext,
 };
 
-use crate::image_meaning_for_entity;
+use crate::{image_meaning_for_entity, label_for_ui_layout};
 
 use super::EntityDataUi;
 
@@ -64,7 +64,7 @@ impl EntityDataUi for re_types::components::TensorData {
                 );
             }
             Err(err) => {
-                ui.label(ctx.re_ui.error_text(err.to_string()));
+                label_for_ui_layout(ui, ui_layout, ctx.re_ui.error_text(err.to_string()));
             }
         }
     }
@@ -157,7 +157,7 @@ pub fn tensor_ui(
                     ],
                     None => tensor.shape.clone(),
                 };
-                ui.add(egui::Label::new(format_tensor_shape_single_line(&shape)).wrap(true))
+                label_for_ui_layout(ui, ui_layout, format_tensor_shape_single_line(&shape))
                     .on_hover_ui(|ui| {
                         tensor_summary_ui(
                             ctx.re_ui,

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -18,10 +18,9 @@ use super::EntityDataUi;
 
 pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
     const MAX_SHOWN: usize = 4; // should be enough for width/height/depth and then some!
-    let labelled = shape.iter().any(|dim| dim.name.is_some());
-    let shapes = shape
-        .iter()
-        .take(MAX_SHOWN)
+    let iter = shape.iter().take(MAX_SHOWN);
+    let labelled = iter.clone().any(|dim| dim.name.is_some());
+    let shapes = iter
         .map(|dim| {
             format!(
                 "{}{}",

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -19,11 +19,10 @@ use super::EntityDataUi;
 pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
     const MAX_SHOWN: usize = 4; // should be enough for width/height/depth and then some!
     let shapes = shape.iter().take(MAX_SHOWN).join(", ");
-    if shape.len() > MAX_SHOWN {
-        format!("{shapes}…")
-    } else {
-        shapes
-    }
+    format!(
+        "shape: {shapes}{}",
+        if shape.len() > MAX_SHOWN { ",…" } else { "" }
+    )
 }
 
 impl EntityDataUi for re_types::components::TensorData {

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -219,7 +219,7 @@ pub fn label_for_ui_layout(
     match ui_layout {
         UiLayout::List => label = label.truncate(true),
         UiLayout::Tooltip | UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
-            label = label.wrap(true)
+            label = label.wrap(true);
         }
     }
 

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -234,7 +234,7 @@ pub fn label_for_ui_layout(
 ///
 /// Import: for data only, labels should use [`crate::label_for_ui_layout`] instead.
 // TODO(#6315): must be merged with `label_for_ui_layout` and have an improved API
-fn data_label_for_ui_layout(ui: &mut egui::Ui, ui_layout: UiLayout, string: impl AsRef<str>) {
+pub fn data_label_for_ui_layout(ui: &mut egui::Ui, ui_layout: UiLayout, string: impl AsRef<str>) {
     let string = string.as_ref();
     let font_id = egui::TextStyle::Monospace.resolve(ui.style());
     let color = ui.visuals().text_color();

--- a/crates/re_data_ui/src/lib.rs
+++ b/crates/re_data_ui/src/lib.rs
@@ -208,3 +208,20 @@ pub fn table_for_ui_layout(
         }
     }
 }
+
+pub fn label_for_ui_layout(
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    text: impl Into<egui::WidgetText>,
+) -> egui::Response {
+    let mut label = egui::Label::new(text);
+
+    match ui_layout {
+        UiLayout::List => label = label.truncate(true),
+        UiLayout::Tooltip | UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
+            label = label.wrap(true)
+        }
+    }
+
+    ui.add(label)
+}

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -1,7 +1,7 @@
 use re_types::components::{PinholeProjection, Resolution};
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use crate::DataUi;
+use crate::{label_for_ui_layout, DataUi};
 
 impl DataUi for PinholeProjection {
     fn data_ui(
@@ -12,24 +12,32 @@ impl DataUi for PinholeProjection {
         query: &re_data_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        if ui_layout == UiLayout::List {
-            // See if this is a trivial pinhole, and can be displayed as such:
-            let fl = self.focal_length_in_pixels();
-            let pp = self.principal_point();
-            if *self == Self::from_focal_length_and_principal_point(fl, pp) {
-                let fl = if fl.x() == fl.y() {
-                    fl.x().to_string()
-                } else {
-                    fl.to_string()
-                };
+        match ui_layout {
+            UiLayout::List => {
+                // See if this is a trivial pinhole, and can be displayed as such:
+                let fl = self.focal_length_in_pixels();
+                let pp = self.principal_point();
+                if *self == Self::from_focal_length_and_principal_point(fl, pp) {
+                    let fl = if fl.x() == fl.y() {
+                        fl.x().to_string()
+                    } else {
+                        fl.to_string()
+                    };
 
-                ui.label(format!("Focal length: {fl}\nPrincipal point: {pp}"))
-                    .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
-                return;
+                    label_for_ui_layout(
+                        ui,
+                        ui_layout,
+                        format!("Focal length: {fl}, principal point: {pp}"),
+                    )
+                } else {
+                    label_for_ui_layout(ui, ui_layout, "3x3 projection matrix")
+                }
+                .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
+            }
+            _ => {
+                self.0.data_ui(ctx, ui, ui_layout, query, db);
             }
         }
-
-        self.0.data_ui(ctx, ui, ui_layout, query, db);
     }
 }
 
@@ -38,11 +46,11 @@ impl DataUi for Resolution {
         &self,
         _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        _ui_layout: UiLayout,
+        ui_layout: UiLayout,
         _query: &re_data_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         let [x, y] = self.0 .0;
-        ui.monospace(format!("{x}x{y}"));
+        label_for_ui_layout(ui, ui_layout, format!("{x}x{y}"));
     }
 }

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -30,7 +30,7 @@ impl DataUi for PinholeProjection {
                         format!("Focal length: {fl}, principal point: {pp}"),
                     )
                 } else {
-                    label_for_ui_layout(ui, ui_layout, "3x3 projection matrix")
+                    label_for_ui_layout(ui, ui_layout, "3×3 projection matrix")
                 }
                 .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
             }
@@ -51,6 +51,6 @@ impl DataUi for Resolution {
         _db: &re_entity_db::EntityDb,
     ) {
         let [x, y] = self.0 .0;
-        label_for_ui_layout(ui, ui_layout, format!("{x}x{y}"));
+        label_for_ui_layout(ui, ui_layout, format!("{x}×{y}"));
     }
 }

--- a/crates/re_data_ui/src/pinhole.rs
+++ b/crates/re_data_ui/src/pinhole.rs
@@ -1,7 +1,7 @@
 use re_types::components::{PinholeProjection, Resolution};
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use crate::{label_for_ui_layout, DataUi};
+use crate::{data_label_for_ui_layout, label_for_ui_layout, DataUi};
 
 impl DataUi for PinholeProjection {
     fn data_ui(
@@ -51,6 +51,6 @@ impl DataUi for Resolution {
         _db: &re_entity_db::EntityDb,
     ) {
         let [x, y] = self.0 .0;
-        label_for_ui_layout(ui, ui_layout, format!("{x}×{y}"));
+        data_label_for_ui_layout(ui, ui_layout, format!("{x}×{y}"));
     }
 }

--- a/crates/re_data_ui/src/rotation3d.rs
+++ b/crates/re_data_ui/src/rotation3d.rs
@@ -4,7 +4,7 @@ use re_types::{
 };
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use crate::{label_for_ui_layout, DataUi};
+use crate::{data_label_for_ui_layout, label_for_ui_layout, DataUi};
 
 impl DataUi for components::Rotation3D {
     fn data_ui(
@@ -31,11 +31,12 @@ impl DataUi for datatypes::Rotation3D {
         match self {
             datatypes::Rotation3D::Quaternion(q) => {
                 // TODO(andreas): Better formatting for quaternions.
-                label_for_ui_layout(ui, ui_layout, format!("{q:?}"));
+                data_label_for_ui_layout(ui, ui_layout, format!("{q:?}"));
             }
             datatypes::Rotation3D::AxisAngle(RotationAxisAngle { axis, angle }) => {
                 match ui_layout {
                     UiLayout::List => {
+                        // TODO(#6315): should be mixed label/data formatting
                         label_for_ui_layout(ui, ui_layout, format!("angle: {angle}, axis: {axis}"));
                     }
                     _ => {

--- a/crates/re_data_ui/src/rotation3d.rs
+++ b/crates/re_data_ui/src/rotation3d.rs
@@ -4,7 +4,7 @@ use re_types::{
 };
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use crate::DataUi;
+use crate::{label_for_ui_layout, DataUi};
 
 impl DataUi for components::Rotation3D {
     fn data_ui(
@@ -31,27 +31,34 @@ impl DataUi for datatypes::Rotation3D {
         match self {
             datatypes::Rotation3D::Quaternion(q) => {
                 // TODO(andreas): Better formatting for quaternions.
-                ui.label(format!("{q:?}"));
+                label_for_ui_layout(ui, ui_layout, format!("{q:?}"));
             }
             datatypes::Rotation3D::AxisAngle(RotationAxisAngle { axis, angle }) => {
-                egui::Grid::new("axis_angle").num_columns(2).show(ui, |ui| {
-                    ui.label("axis");
-                    axis.data_ui(ctx, ui, ui_layout, query, db);
-                    ui.end_row();
-
-                    ui.label("angle");
-                    match angle {
-                        Angle::Radians(v) => {
-                            ui.label(format!("{}rad", re_format::format_f32(*v)));
-                        }
-                        Angle::Degrees(v) => {
-                            // TODO(andreas): Convert to arc minutes/seconds for very small angles.
-                            // That code should be in re_format!
-                            ui.label(format!("{}°", re_format::format_f32(*v),));
-                        }
+                match ui_layout {
+                    UiLayout::List => {
+                        label_for_ui_layout(ui, ui_layout, format!("angle: {angle}, axis: {axis}"));
                     }
-                    ui.end_row();
-                });
+                    _ => {
+                        egui::Grid::new("axis_angle").num_columns(2).show(ui, |ui| {
+                            ui.label("axis");
+                            axis.data_ui(ctx, ui, ui_layout, query, db);
+                            ui.end_row();
+
+                            ui.label("angle");
+                            match angle {
+                                Angle::Radians(v) => {
+                                    ui.label(format!("{}rad", re_format::format_f32(*v)));
+                                }
+                                Angle::Degrees(v) => {
+                                    // TODO(andreas): Convert to arc minutes/seconds for very small angles.
+                                    // That code should be in re_format!
+                                    ui.label(format!("{}°", re_format::format_f32(*v),));
+                                }
+                            }
+                            ui.end_row();
+                        });
+                    }
+                }
             }
         }
     }

--- a/crates/re_data_ui/src/transform3d.rs
+++ b/crates/re_data_ui/src/transform3d.rs
@@ -1,7 +1,7 @@
 use re_types::datatypes::{Scale3D, Transform3D, TranslationAndMat3x3, TranslationRotationScale3D};
 use re_viewer_context::{UiLayout, ViewerContext};
 
-use crate::DataUi;
+use crate::{label_for_ui_layout, DataUi};
 
 impl DataUi for re_types::components::Transform3D {
     #[allow(clippy::only_used_in_recursion)]
@@ -16,8 +16,8 @@ impl DataUi for re_types::components::Transform3D {
         match ui_layout {
             UiLayout::List => {
                 // TODO(andreas): Preview some information instead of just a label with hover ui.
-                ui.label("3D transform").on_hover_ui(|ui| {
-                    self.data_ui(ctx, ui, UiLayout::SelectionPanelLimitHeight, query, db);
+                label_for_ui_layout(ui, ui_layout, "3D transform").on_hover_ui(|ui| {
+                    self.data_ui(ctx, ui, UiLayout::Tooltip, query, db);
                 });
             }
 
@@ -35,9 +35,9 @@ impl DataUi for re_types::components::Transform3D {
                 };
 
                 ui.vertical(|ui| {
-                    ui.label("3D transform");
+                    label_for_ui_layout(ui, ui_layout, "3D transform");
                     ui.indent("transform_repr", |ui| {
-                        ui.label(dir_string);
+                        label_for_ui_layout(ui, ui_layout, dir_string);
                         self.0.data_ui(ctx, ui, ui_layout, query, db);
                     });
                 });

--- a/crates/re_types/src/components/range1d_ext.rs
+++ b/crates/re_types/src/components/range1d_ext.rs
@@ -1,4 +1,5 @@
 use crate::datatypes;
+use std::fmt::Display;
 
 use super::Range1D;
 
@@ -26,5 +27,11 @@ impl From<Range1D> for emath::Rangef {
     #[inline]
     fn from(range2d: Range1D) -> Self {
         Self::from(range2d.0)
+    }
+}
+
+impl Display for Range1D {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}, {}]", self.start(), self.end(),)
     }
 }

--- a/crates/re_types/src/datatypes/angle_ext.rs
+++ b/crates/re_types/src/datatypes/angle_ext.rs
@@ -1,4 +1,5 @@
 use super::Angle;
+use std::fmt::Formatter;
 
 impl Angle {
     /// Angle in radians independent of the underlying representation.
@@ -16,6 +17,21 @@ impl Angle {
         match self {
             Self::Radians(v) => v.to_degrees(),
             Self::Degrees(v) => *v,
+        }
+    }
+}
+
+impl std::fmt::Display for Angle {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Radians(v) => {
+                v.fmt(f)?;
+                write!(f, " rad",)
+            }
+            Self::Degrees(v) => {
+                v.fmt(f)?;
+                write!(f, " deg")
+            }
         }
     }
 }

--- a/crates/re_types/src/datatypes/range2d_ext.rs
+++ b/crates/re_types/src/datatypes/range2d_ext.rs
@@ -16,3 +16,13 @@ impl From<Range2D> for emath::Rect {
         emath::Rect::from_x_y_ranges(range2d.x_range, range2d.y_range)
     }
 }
+
+impl std::fmt::Display for Range2D {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "[{}, {}]x[{}, {}]",
+            self.x_range.0[0], self.x_range.0[1], self.y_range.0[0], self.y_range.0[1],
+        )
+    }
+}

--- a/crates/re_types/src/datatypes/range2d_ext.rs
+++ b/crates/re_types/src/datatypes/range2d_ext.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for Range2D {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "[{}, {}]x[{}, {}]",
+            "[{}, {}]×[{}, {}]",
             self.x_range.0[0], self.x_range.0[1], self.y_range.0[0], self.y_range.0[1],
         )
     }

--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -89,7 +89,12 @@ ALL_COMPONENTS: dict[str, TestCase] = {
             ),
         )
     ]),
-    "BlobBatch": TestCase(b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"),
+    "BlobBatch": TestCase(
+        alternatives=[
+            b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09",
+            np.random.randint(0, 255, (10, 10), dtype=np.uint8).tobytes(),
+        ]
+    ),
     "ClassIdBatch": TestCase(batch=[1, 2, 3, 6]),
     "ClearIsRecursiveBatch": TestCase(disabled=True),  # disabled because it messes with the logging
     "ColorBatch": TestCase(batch=[(255, 0, 0, 255), (0, 255, 0, 255), (0, 0, 255, 255)]),

--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -145,6 +145,10 @@ ALL_COMPONENTS: dict[str, TestCase] = {
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (10, 10), dtype=np.uint8)),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4), dtype=np.uint8)),
+            rr.datatypes.TensorData(
+                array=np.random.randint(0, 255, (5, 3, 6, 4), dtype=np.uint8),
+                dim_names=[None, "hello", None, "world", None],
+            ),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4, 3), dtype=np.uint8)),
         ]
     ),

--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -145,6 +145,7 @@ ALL_COMPONENTS: dict[str, TestCase] = {
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (10, 10), dtype=np.uint8)),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (10, 10, 3), dtype=np.uint8)),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4), dtype=np.uint8)),
+            rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4, 3), dtype=np.uint8)),
         ]
     ),
     "Texcoord2DBatch": TestCase(batch=[(0, 0), (1, 1), (2, 2)]),


### PR DESCRIPTION
### What

- Follow up to #6291 
- Fixes #6245 
- Unblocks https://github.com/rerun-io/rerun/issues/4161
- Limitation https://github.com/rerun-io/rerun/issues/6315

This PR fixes the `UiLayout::List` implementations of `DataUi` such that they all fit on a single line and are deal with potentially narrow space (mostly via truncation).

This PR unearthed quite some inconsistencies in how we're using monospace font for data. For now, `text_ui` (which uses monospace) has been renamed `data_label_for_ui_layout` to parallel the new `label_for_ui_layout` (which uses proportional). In the future (#6315), we must unify both with a better, flexible API that also allows mixed styles.

TODO:
- [x] blob: check with large binaries -> OK (could certainly be improved but it truncates correct 🤷🏻)
- [x] tensor data: fix ui for `size(shape) > 3`
- [x] range2d: improve label

### Screenshots

<img width="488" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e82c83c1-0f2b-4d64-9e76-71d28e3cba5c">
<img width="501" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/da811427-cad2-463e-8285-9ae096441fc5">
<img width="369" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/987af231-43c6-44e5-babb-52efdf110e30">
<img width="314" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/2a4174bf-8117-46e5-9734-5e3ac05dd209">
<img width="231" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/4fdc4e02-f6ff-43fc-8a68-163985ee0186">
<br/><br/>

When truncated:

<img width="228" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/cbfbbb79-df18-48e9-be82-0401feec9d93">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6297?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6297?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6297)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.