### PR TITLE
Explicit seq/nanos/seconds arguments for time range boundaries in Python

### DIFF
--- a/docs/snippets/all/views/timeseriesview.py
+++ b/docs/snippets/all/views/timeseriesview.py
@@ -13,7 +13,7 @@ rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=T
 rr.log("trig/cos", rr.SeriesLine(color=[0, 0, 255], name="cos(0.01t) scaled"), static=True)
 for t in range(0, int(math.pi * 4 * 100.0)):
     rr.set_time_sequence("timeline0", t)
-    rr.set_time_sequence("timeline1", t)
+    rr.set_time_seconds("timeline1", t)
     rr.log("trig/sin", rr.Scalar(math.sin(float(t) / 100.0)))
     rr.log("trig/cos", rr.Scalar(math.cos(float(t) / 100.0)))
     rr.log("trig/cos_scaled", rr.Scalar(math.cos(float(t) / 100.0) * 2.0))
@@ -31,13 +31,13 @@ blueprint = rrb.Blueprint(
             # Sliding window depending on the time cursor for the first timeline.
             rrb.VisibleTimeRange(
                 "timeline0",
-                start=rrb.TimeRangeBoundary.cursor_relative(-100),
+                start=rrb.TimeRangeBoundary.cursor_relative(seq=-100),
                 end=rrb.TimeRangeBoundary.cursor_relative(),
             ),
             # Time range from some point to the end of the timeline for the second timeline.
             rrb.VisibleTimeRange(
                 "timeline1",
-                start=rrb.TimeRangeBoundary.absolute(300),
+                start=rrb.TimeRangeBoundary.absolute(seconds=300.0),
                 end=rrb.TimeRangeBoundary.infinite(),
             ),
         ],

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -68,6 +68,7 @@ from .datatypes import (
     RotationAxisAngle,
     Scale3D,
     TensorData,
+    TimeInt,
     TimeRange,
     TimeRangeBoundary,
     TranslationAndMat3x3,

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -37,7 +37,7 @@ class TimeSeriesView(SpaceView):
     rr.log("trig/cos", rr.SeriesLine(color=[0, 0, 255], name="cos(0.01t) scaled"), static=True)
     for t in range(0, int(math.pi * 4 * 100.0)):
         rr.set_time_sequence("timeline0", t)
-        rr.set_time_sequence("timeline1", t)
+        rr.set_time_seconds("timeline1", t)
         rr.log("trig/sin", rr.Scalar(math.sin(float(t) / 100.0)))
         rr.log("trig/cos", rr.Scalar(math.cos(float(t) / 100.0)))
         rr.log("trig/cos_scaled", rr.Scalar(math.cos(float(t) / 100.0) * 2.0))
@@ -55,13 +55,13 @@ class TimeSeriesView(SpaceView):
                 # Sliding window depending on the time cursor for the first timeline.
                 rrb.VisibleTimeRange(
                     "timeline0",
-                    start=rrb.TimeRangeBoundary.cursor_relative(-100),
+                    start=rrb.TimeRangeBoundary.cursor_relative(seq=-100),
                     end=rrb.TimeRangeBoundary.cursor_relative(),
                 ),
                 # Time range from some point to the end of the timeline for the second timeline.
                 rrb.VisibleTimeRange(
                     "timeline1",
-                    start=rrb.TimeRangeBoundary.absolute(300),
+                    start=rrb.TimeRangeBoundary.absolute(seconds=300.0),
                     end=rrb.TimeRangeBoundary.infinite(),
                 ),
             ],

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
@@ -13,19 +13,16 @@ import pyarrow as pa
 from attrs import define, field
 
 from .._baseclasses import BaseBatch, BaseExtensionType
+from .time_int_ext import TimeIntExt
 
 __all__ = ["TimeInt", "TimeIntArrayLike", "TimeIntBatch", "TimeIntLike", "TimeIntType"]
 
 
 @define(init=False)
-class TimeInt:
+class TimeInt(TimeIntExt):
     """**Datatype**: A 64-bit number describing either nanoseconds OR sequence numbers."""
 
-    def __init__(self: Any, value: TimeIntLike):
-        """Create a new instance of the TimeInt datatype."""
-
-        # You can define your own __init__ function as a member of TimeIntExt in time_int_ext.py
-        self.__attrs_init__(value=value)
+    # __init__ can be found in time_int_ext.py
 
     value: int = field(converter=int)
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int_ext.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class TimeIntExt:
+    """Extension for [TimeInt][rerun.datatypes.TimeInt]."""
+
+    def __init__(self: Any, *, seq: int | None = None, seconds: float | None = None, nanos: int | None = None) -> None:
+        """
+        Create a new instance of the TimeInt datatype.
+
+        Parameters
+        ----------
+        seq:
+            Time as a sequence number. Mutually exclusive with seconds and nanos.
+        seconds:
+            Time in seconds. Mutually exclusive with seq and nanos.
+        nanos:
+            Time in nanoseconds. Mutually exclusive with seq and seconds.
+
+        """
+
+        if seq is not None:
+            if seconds is not None or nanos is not None:
+                raise ValueError("Only one of seq, seconds, or nanos can be provided.")
+            self.__attrs_init__(value=seq)
+        elif seconds is not None:
+            if nanos is not None:
+                raise ValueError("Only one of seq, seconds, or nanos can be provided.")
+            self.__attrs_init__(value=int(seconds * 1e9))
+        elif nanos is not None:
+            self.__attrs_init__(value=int(nanos))
+        else:
+            raise ValueError("One of seq, seconds, or nanos must be provided.")

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary_ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import TimeInt, TimeIntLike
+from . import TimeInt
 
 if TYPE_CHECKING:
     from .time_range_boundary import TimeRangeBoundary
@@ -12,23 +12,50 @@ class TimeRangeBoundaryExt:
     """Extension for [TimeRangeBoundary][rerun.datatypes.TimeRangeBoundary]."""
 
     @staticmethod
-    def cursor_relative(time: TimeIntLike = 0) -> TimeRangeBoundary:
+    def cursor_relative(
+        offset: TimeInt | None = None, *, seq: int | None = None, seconds: float | None = None, nanos: int | None = None
+    ) -> TimeRangeBoundary:
         """
         Boundary that is relative to the timeline cursor.
 
+        The offset can be positive or negative.
+        An offset of zero (the default) means the cursor time itself.
+
         Parameters
         ----------
-        time:
-            Offset from the cursor time, can be positive or negative.
+        offset:
+            Offset from the cursor time.
+
+            Mutually exclusive with seq, seconds and nanos.
+        seq:
+            Offset in sequence numbers.
+
+            Use this for sequence timelines.
+            Mutually exclusive with time, seconds and nanos.
+        seconds:
+            Offset in seconds.
+
+            Use this for time based timelines.
+            Mutually exclusive with time, seq and nanos.
+        nanos:
+            Offset in nanoseconds.
+
+            Use this for time based timelines.
+            Mutually exclusive with time, seq and seconds.
 
         """
 
         from .time_range_boundary import TimeRangeBoundary
 
-        if not isinstance(time, TimeInt):
-            time = TimeInt(time)
+        if offset is None:
+            if seq is None and seconds is None and nanos is None:
+                offset = TimeInt(seq=0)
+            else:
+                offset = TimeInt(seq=seq, seconds=seconds, nanos=nanos)
+        elif seq is not None or seconds is not None or nanos is not None:
+            raise ValueError("Only one of time, seq, seconds, or nanos can be provided.")
 
-        return TimeRangeBoundary(inner=time, kind="cursor_relative")
+        return TimeRangeBoundary(inner=offset, kind="cursor_relative")
 
     @staticmethod
     def infinite() -> TimeRangeBoundary:
@@ -43,20 +70,41 @@ class TimeRangeBoundaryExt:
         return TimeRangeBoundary(inner=None, kind="infinite")
 
     @staticmethod
-    def absolute(time: TimeIntLike) -> TimeRangeBoundary:
+    def absolute(
+        time: TimeInt | None = None, *, seq: int | None = None, seconds: float | None = None, nanos: int | None = None
+    ) -> TimeRangeBoundary:
         """
         Boundary that is at an absolute time.
 
         Parameters
         ----------
         time:
-            Absolute time value.
+            Absolute time.
+
+            Mutually exclusive with seq, seconds and nanos.
+        seq:
+            Absolute time in sequence numbers.
+
+            Use this for sequence timelines.
+            Mutually exclusive with time, seconds and nanos.
+        seconds:
+            Absolute time in seconds.
+
+            Use this for time based timelines.
+            Mutually exclusive with time, seq and nanos.
+        nanos:
+            Absolute time in nanoseconds.
+
+            Use this for time based timelines.
+            Mutually exclusive with time, seq and seconds.
 
         """
 
         from .time_range_boundary import TimeRangeBoundary
 
-        if not isinstance(time, TimeInt):
-            time = TimeInt(time)
+        if time is None:
+            time = TimeInt(seq=seq, seconds=seconds, nanos=nanos)
+        elif seq is not None or seconds is not None or nanos is not None:
+            raise ValueError("Only one of time, seq, seconds, or nanos can be provided.")
 
         return TimeRangeBoundary(inner=time, kind="absolute")

--- a/rerun_py/tests/unit/test_time_range_boundary.py
+++ b/rerun_py/tests/unit/test_time_range_boundary.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+import rerun as rr
+
+
+def test_time_range_boundary_failure_cases() -> None:
+    # Too many arguments for absolute.
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(rr.TimeInt(seq=0), seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(rr.TimeInt(seq=0), seconds=123.0)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(rr.TimeInt(seq=0), nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(seq=123, seconds=123.0)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(seq=123, nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(seconds=123, seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(seconds=123, nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(nanos=123, seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute(nanos=123, seconds=123.0)
+
+    # No argument for absolute.
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.absolute()
+
+    # Too many arguments for cursor_relative.
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(rr.TimeInt(seq=0), seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(rr.TimeInt(seq=0), seconds=123.0)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(rr.TimeInt(seq=0), nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(seq=123, seconds=123.0)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(seq=123, nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(seconds=123, seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(seconds=123, nanos=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(nanos=123, seq=123)
+    with pytest.raises(ValueError):
+        rr.TimeRangeBoundary.cursor_relative(nanos=123, seconds=123.0)
+
+
+def test_time_range_boundary() -> None:
+    # Test infinite.
+    assert rr.TimeRangeBoundary.infinite().kind == "infinite"
+    assert rr.TimeRangeBoundary.infinite().inner is None
+
+    # Test absolute.
+    assert rr.TimeRangeBoundary.absolute(seq=123).kind == "absolute"
+    assert rr.TimeRangeBoundary.absolute(seq=123).inner == rr.TimeInt(seq=123)
+    assert rr.TimeRangeBoundary.absolute(seq=123).inner == rr.TimeInt(nanos=123)
+    assert rr.TimeRangeBoundary.absolute(seconds=1.0).inner == rr.TimeInt(nanos=int(1e9))
+
+    # Test cursor_relative.
+    assert rr.TimeRangeBoundary.cursor_relative(seq=123).kind == "cursor_relative"
+    assert rr.TimeRangeBoundary.cursor_relative(seq=123).inner == rr.TimeInt(seq=123)
+    assert rr.TimeRangeBoundary.cursor_relative(seq=123).inner == rr.TimeInt(nanos=123)
+    assert rr.TimeRangeBoundary.cursor_relative(nanos=123).inner == rr.TimeInt(nanos=123)
+    assert rr.TimeRangeBoundary.cursor_relative(seconds=1.0).inner == rr.TimeInt(nanos=int(1e9))
+    assert rr.TimeRangeBoundary.cursor_relative().kind == "cursor_relative"
+    assert rr.TimeRangeBoundary.cursor_relative().inner == rr.TimeInt(seq=0)

--- a/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
+++ b/tests/python/release_checklist/check_parallelism_caching_reentrancy.py
@@ -32,8 +32,8 @@ def blueprint() -> rrb.BlueprintLike:
                 origin="/plots",
                 time_ranges=rrb.VisibleTimeRange(
                     "frame_nr",
-                    start=rrb.TimeRangeBoundary.cursor_relative(50 - i * 10),
-                    end=rrb.TimeRangeBoundary.cursor_relative(50 - i * 10 + 10),
+                    start=rrb.TimeRangeBoundary.cursor_relative(seq=50 - i * 10),
+                    end=rrb.TimeRangeBoundary.cursor_relative(seq=50 - i * 10 + 10),
                 ),
             )
             for i in range(0, 10)


### PR DESCRIPTION
### What

* First half of #6276

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
