### PR TITLE
Fix: Preserve history state

### DIFF
--- a/crates/re_viewer/src/web_tools.rs
+++ b/crates/re_viewer/src/web_tools.rs
@@ -86,8 +86,13 @@ pub fn push_history(new_relative_url: &str) -> Option<()> {
             .history()
             .map_err(|err| format!("Failed to get History API: {}", string_from_js_value(err)))
             .ok_or_log_error()?;
+        // Instead of setting state to `null`, try to preserve existing state.
+        // This helps with ensuring JS frameworks can perform client-side routing.
+        // If we ever need to store anything in `state`, we should rethink how
+        // we handle this.
+        let existing_state = history.state().unwrap_or(JsValue::NULL);
         history
-            .push_state_with_url(&JsValue::NULL, "", Some(new_relative_url))
+            .push_state_with_url(&existing_state, "", Some(new_relative_url))
             .map_err(|err| {
                 format!(
                     "Failed to push history state: {}",
@@ -105,9 +110,10 @@ pub fn replace_history(new_relative_url: &str) -> Option<()> {
         .history()
         .map_err(|err| format!("Failed to get History API: {}", string_from_js_value(err)))
         .ok_or_log_error()?;
-
+    // NOTE: See `existing_state` in `push_history` above for info on why this is here.
+    let existing_state = history.state().unwrap_or(JsValue::NULL);
     history
-        .replace_state_with_url(&JsValue::NULL, "", Some(new_relative_url))
+        .replace_state_with_url(&existing_state, "", Some(new_relative_url))
         .map_err(|err| {
             format!(
                 "Failed to push history state: {}",


### PR DESCRIPTION
### What

Instead of setting state to `null`, try to preserve existing state.
This helps with ensuring JS frameworks can continue to do their own client-side routing.
If we ever need to store anything in `state`, we should rethink how we handle this.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6302?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6302?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6302)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.