### PR TITLE
Fix egui id clash in selection panel

### DIFF
--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -442,7 +442,7 @@ impl<'a> ListItem<'a> {
 
         // we want to be able to select/hover the item across its full span, so we sense that and
         // update the response accordingly.
-        let full_span_response = ui.interact(bg_rect, response.id, sense);
+        let full_span_response = ui.interact(bg_rect, response.id.with("full_span_check"), sense);
         response.clicked = full_span_response.clicked;
         response.contains_pointer = full_span_response.contains_pointer;
         response.hovered = full_span_response.hovered;


### PR DESCRIPTION
### What

- Fixes #6300

The legacy list item was interacting twice with the same ID. In some case, this would trigger an egui ID clash. For some reason, this clash was "hidden"/no trigged due to my app.ron file—I had to delete it to reproduce the bug. I'm not sure what's going on there...

Note that `list_item2` has a different implementation which should in principle not be affected by the same bug.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6305?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6305?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6305)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.