### PR TITLE
Better handle redundant time ranges

### DIFF
--- a/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/archetypes/visible_time_ranges.fbs
@@ -25,6 +25,6 @@ table VisibleTimeRanges (
 ) {
     /// The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
     ///
-    /// If a timeline is listed twice, the first entry will be used.
+    /// If a timeline is specified more than once, the first entry will be used.
     ranges: [rerun.blueprint.components.VisibleTimeRange] ("attr.rerun.component_required", order: 1000);
 }

--- a/crates/re_types/definitions/rerun/blueprint/views/spatial2d.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/views/spatial2d.fbs
@@ -16,6 +16,8 @@ table Spatial2DView (
     visual_bounds: rerun.blueprint.archetypes.VisualBounds (order: 2000);
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the latest state of each component.
+    /// If a timeline is specified more than once, the first entry will be used.
     time_ranges: rerun.blueprint.archetypes.VisibleTimeRanges (order: 10000);
-
 }

--- a/crates/re_types/definitions/rerun/blueprint/views/spatial3d.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/views/spatial3d.fbs
@@ -12,5 +12,8 @@ table Spatial3DView (
     background: rerun.blueprint.archetypes.Background (order: 1000);
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the latest state of each component.
+    /// If a timeline is specified more than once, the first entry will be used.
     time_ranges: rerun.blueprint.archetypes.VisibleTimeRanges (order: 10000);
 }

--- a/crates/re_types/definitions/rerun/blueprint/views/time_series.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/views/time_series.fbs
@@ -15,5 +15,8 @@ table TimeSeriesView (
     plot_legend: rerun.blueprint.archetypes.PlotLegend (order: 2000);
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the entire timeline.
+    /// If a timeline is specified more than once, the first entry will be used.
     time_ranges: rerun.blueprint.archetypes.VisibleTimeRanges (order: 10000);
 }

--- a/crates/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -35,7 +35,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub struct VisibleTimeRanges {
     /// The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
     ///
-    /// If a timeline is listed twice, the first entry will be used.
+    /// If a timeline is specified more than once, the first entry will be used.
     pub ranges: Vec<crate::blueprint::components::VisibleTimeRange>,
 }
 

--- a/crates/re_types/src/blueprint/views/spatial2d_view.rs
+++ b/crates/re_types/src/blueprint/views/spatial2d_view.rs
@@ -35,6 +35,9 @@ pub struct Spatial2DView {
     pub visual_bounds: crate::blueprint::archetypes::VisualBounds,
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the latest state of each component.
+    /// If a timeline is specified more than once, the first entry will be used.
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 

--- a/crates/re_types/src/blueprint/views/spatial3d_view.rs
+++ b/crates/re_types/src/blueprint/views/spatial3d_view.rs
@@ -29,6 +29,9 @@ pub struct Spatial3DView {
     pub background: crate::blueprint::archetypes::Background,
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the latest state of each component.
+    /// If a timeline is specified more than once, the first entry will be used.
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 

--- a/crates/re_types/src/blueprint/views/time_series_view.rs
+++ b/crates/re_types/src/blueprint/views/time_series_view.rs
@@ -32,6 +32,9 @@ pub struct TimeSeriesView {
     pub plot_legend: crate::blueprint::archetypes::PlotLegend,
 
     /// Configures which range on each timeline is shown by this view (unless specified differently per entity).
+    ///
+    /// If not specified, the default is to show the entire timeline.
+    /// If a timeline is specified more than once, the first entry will be used.
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -1283,7 +1283,7 @@ fn quote_array_method_from_obj(
     ))
 }
 
-/// Automatically implement `__str__`, `__int__`, or `__float__` method if the object has a single
+/// Automatically implement `__str__`, `__int__`, or `__float__` as well as `__hash__` methods if the object has a single
 /// field of the corresponding type that is not optional.
 ///
 /// Only applies to datatypes and components.
@@ -1309,6 +1309,9 @@ fn quote_native_types_method_from_obj(objects: &Objects, obj: &Object) -> String
         "
         def __{typ}__(self) -> {typ}:
             return {typ}(self.{field_name})
+
+        def __hash__(self) -> int:
+            return hash(self.{field_name})
         ",
     ))
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -265,13 +265,16 @@ pip = ">=23"
 # around that and executes `rerun` from the system shell within the context of the pixi environment.
 rerun-from-path = "rerun"
 
+# Duplicate of `py-build` but within the `wheel-test` environment.
+py-build-wheel-test = { cmd = "pixi run -e wheel-test py-build" }
+
 # Run the Python tests.
 # Don't call this on CI - use `nox` to run tests on all supported Python versions instead.
 py-test = { cmd = "python -m pytest -vv rerun_py/tests/unit", depends_on = [
-  "py-build",
+  "py-build-wheel-test",
 ] }
 py-bench = { cmd = "python -m pytest -c rerun_py/pyproject.toml --benchmark-only", depends_on = [
-  "py-build",
+  "py-build-wheel-test",
 ] }
 
 [feature.base.dependencies]

--- a/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
+++ b/rerun_cpp/src/rerun/blueprint/archetypes/visible_time_ranges.hpp
@@ -26,7 +26,7 @@ namespace rerun::blueprint::archetypes {
     struct VisibleTimeRanges {
         /// The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
         ///
-        /// If a timeline is listed twice, the first entry will be used.
+        /// If a timeline is specified more than once, the first entry will be used.
         Collection<rerun::blueprint::components::VisibleTimeRange> ranges;
 
       public:

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
@@ -49,7 +49,7 @@ class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
     )
     # The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
     #
-    # If a timeline is listed twice, the first entry will be used.
+    # If a timeline is specified more than once, the first entry will be used.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
@@ -5,20 +5,17 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from attrs import define, field
 
-from ... import datatypes
 from ..._baseclasses import Archetype
 from ...blueprint import components as blueprint_components
-from ...error_utils import catch_and_log_exceptions
+from .visible_time_ranges_ext import VisibleTimeRangesExt
 
 __all__ = ["VisibleTimeRanges"]
 
 
 @define(str=False, repr=False, init=False)
-class VisibleTimeRanges(Archetype):
+class VisibleTimeRanges(VisibleTimeRangesExt, Archetype):
     """
     **Archetype**: Configures what range of each timeline is shown on a view.
 
@@ -31,24 +28,7 @@ class VisibleTimeRanges(Archetype):
     - For any other view, the default is to apply latest-at semantics.
     """
 
-    def __init__(self: Any, ranges: datatypes.VisibleTimeRangeArrayLike):
-        """
-        Create a new instance of the VisibleTimeRanges archetype.
-
-        Parameters
-        ----------
-        ranges:
-            The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
-
-            If a timeline is listed twice, the first entry will be used.
-
-        """
-
-        # You can define your own __init__ function as a member of VisibleTimeRangesExt in visible_time_ranges_ext.py
-        with catch_and_log_exceptions(context=self.__class__.__name__):
-            self.__attrs_init__(ranges=ranges)
-            return
-        self.__attrs_clear__()
+    # __init__ can be found in visible_time_ranges_ext.py
 
     def __attrs_clear__(self) -> None:
         """Convenience method for calling `__attrs_init__` with all `None`s."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
@@ -27,12 +27,12 @@ class VisibleTimeRangesExt:
 
         timelines = set()
         for range in ranges:
-            if range.timeline.value in timelines:
+            if range.timeline in timelines:
                 _send_warning_or_raise(
                     f"Warning: Timeline {range.timeline} is listed twice in the list of visible time ranges. Only the first entry will be used.",
                     1,
                 )
-            timelines.add(range.timeline.value)
+            timelines.add(range.timeline)
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(ranges=ranges)

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
@@ -27,11 +27,12 @@ class VisibleTimeRangesExt:
 
         timelines = set()
         for range in ranges:
-            if range.timeline in timelines:
+            if range.timeline.value in timelines:
                 _send_warning_or_raise(
-                    f"Warning: Timeline {range.timeline} is listed twice in the list of visible time ranges. Only the first entry will be used."
+                    f"Warning: Timeline {range.timeline} is listed twice in the list of visible time ranges. Only the first entry will be used.",
+                    1,
                 )
-            timelines.add(range.timeline)
+            timelines.add(range.timeline.value)
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(ranges=ranges)

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges_ext.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ... import datatypes
+from ...error_utils import _send_warning_or_raise, catch_and_log_exceptions
+
+
+class VisibleTimeRangesExt:
+    """Extension for [VisibleTimeRanges][rerun.blueprint.archetypes.VisibleTimeRanges]."""
+
+    def __init__(self: Any, ranges: datatypes.VisibleTimeRangeArrayLike):
+        """
+        Create a new instance of the VisibleTimeRanges archetype.
+
+        Parameters
+        ----------
+        ranges:
+            The time ranges to show for each timeline unless specified otherwise on a per-entity basis.
+
+            If a timeline is listed twice, a warning will be issued and the first entry will be used.
+
+        """
+
+        if isinstance(ranges, datatypes.VisibleTimeRange):
+            ranges = [ranges]
+
+        timelines = set()
+        for range in ranges:
+            if range.timeline in timelines:
+                _send_warning_or_raise(
+                    f"Warning: Timeline {range.timeline} is listed twice in the list of visible time ranges. Only the first entry will be used."
+                )
+            timelines.add(range.timeline)
+
+        with catch_and_log_exceptions(context=self.__class__.__name__):
+            self.__attrs_init__(ranges=ranges)
+            return
+        self.__attrs_clear__()

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
@@ -47,6 +47,9 @@ class ColumnShare:
     def __float__(self) -> float:
         return float(self.share)
 
+    def __hash__(self) -> int:
+        return hash(self.share)
+
 
 if TYPE_CHECKING:
     ColumnShareLike = Union[ColumnShare, float]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
@@ -47,6 +47,9 @@ class GridColumns:
     def __int__(self) -> int:
         return int(self.columns)
 
+    def __hash__(self) -> int:
+        return hash(self.columns)
+
 
 if TYPE_CHECKING:
     GridColumnsLike = Union[GridColumns, int]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
@@ -47,6 +47,9 @@ class RowShare:
     def __float__(self) -> float:
         return float(self.share)
 
+    def __hash__(self) -> int:
+        return hash(self.share)
+
 
 if TYPE_CHECKING:
     RowShareLike = Union[RowShare, float]

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -64,6 +64,9 @@ class Spatial2DView(SpaceView):
         time_ranges:
             Configures which range on each timeline is shown by this view (unless specified differently per entity).
 
+            If not specified, the default is to show the latest state of each component.
+            If a timeline is specified more than once, the first entry will be used.
+
         """
 
         properties: dict[str, AsComponents] = {}

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -90,6 +90,9 @@ class Spatial3DView(SpaceView):
         time_ranges:
             Configures which range on each timeline is shown by this view (unless specified differently per entity).
 
+            If not specified, the default is to show the latest state of each component.
+            If a timeline is specified more than once, the first entry will be used.
+
         """
 
         properties: dict[str, AsComponents] = {}

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -112,6 +112,9 @@ class TimeSeriesView(SpaceView):
         time_ranges:
             Configures which range on each timeline is shown by this view (unless specified differently per entity).
 
+            If not specified, the default is to show the entire timeline.
+            If a timeline is specified more than once, the first entry will be used.
+
         """
 
         properties: dict[str, AsComponents] = {}

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -36,6 +36,9 @@ class DepthMeter:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     DepthMeterLike = Union[DepthMeter, float]

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -44,6 +44,9 @@ class DrawOrder:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     DrawOrderLike = Union[DrawOrder, float]

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -36,6 +36,9 @@ class MarkerSize:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     MarkerSizeLike = Union[MarkerSize, float]

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -36,6 +36,9 @@ class Radius:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     RadiusLike = Union[Radius, float]

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -40,6 +40,9 @@ class Scalar:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     ScalarLike = Union[Scalar, float]

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -36,6 +36,9 @@ class StrokeWidth:
     def __float__(self) -> float:
         return float(self.width)
 
+    def __hash__(self) -> int:
+        return hash(self.width)
+
 
 if TYPE_CHECKING:
     StrokeWidthLike = Union[StrokeWidth, float]

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -36,6 +36,9 @@ class ClassId:
     def __int__(self) -> int:
         return int(self.id)
 
+    def __hash__(self) -> int:
+        return hash(self.id)
+
 
 if TYPE_CHECKING:
     ClassIdLike = Union[ClassId, int]

--- a/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
@@ -30,6 +30,9 @@ class EntityPath:
     def __str__(self) -> str:
         return str(self.path)
 
+    def __hash__(self) -> int:
+        return hash(self.path)
+
 
 if TYPE_CHECKING:
     EntityPathLike = Union[EntityPath, str]

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -36,6 +36,9 @@ class Float32:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     Float32Like = Union[Float32, float]

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -43,6 +43,9 @@ class KeypointId:
     def __int__(self) -> int:
         return int(self.id)
 
+    def __hash__(self) -> int:
+        return hash(self.id)
+
 
 if TYPE_CHECKING:
     KeypointIdLike = Union[KeypointId, int]

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -48,6 +48,9 @@ class Rgba32(Rgba32Ext):
     def __int__(self) -> int:
         return int(self.rgba)
 
+    def __hash__(self) -> int:
+        return hash(self.rgba)
+
 
 if TYPE_CHECKING:
     Rgba32Like = Union[Rgba32, int, Sequence[Union[int, float]], npt.NDArray[Union[np.uint8, np.float32, np.float64]]]

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
@@ -33,6 +33,9 @@ class TimeInt(TimeIntExt):
     def __int__(self) -> int:
         return int(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     TimeIntLike = Union[TimeInt, int]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
@@ -36,6 +36,9 @@ class UInt32:
     def __int__(self) -> int:
         return int(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     UInt32Like = Union[UInt32, int]

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
@@ -36,6 +36,9 @@ class UInt64:
     def __int__(self) -> int:
         return int(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     UInt64Like = Union[UInt64, int]

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -30,6 +30,9 @@ class Utf8:
     def __str__(self) -> str:
         return str(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 if TYPE_CHECKING:
     Utf8Like = Union[Utf8, str]

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -27,6 +27,9 @@ class AffixFuzzer9:
     def __str__(self) -> str:
         return str(self.single_string_required)
 
+    def __hash__(self) -> int:
+        return hash(self.single_string_required)
+
 
 AffixFuzzer9Like = AffixFuzzer9
 AffixFuzzer9ArrayLike = Union[

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -39,6 +39,9 @@ class FlattenedScalar:
     def __float__(self) -> float:
         return float(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 FlattenedScalarLike = FlattenedScalar
 FlattenedScalarArrayLike = Union[

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -39,6 +39,9 @@ class PrimitiveComponent:
     def __int__(self) -> int:
         return int(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 PrimitiveComponentLike = PrimitiveComponent
 PrimitiveComponentArrayLike = Union[

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -33,6 +33,9 @@ class StringComponent:
     def __str__(self) -> str:
         return str(self.value)
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
 
 StringComponentLike = StringComponent
 StringComponentArrayLike = Union[

--- a/rerun_py/tests/unit/test_visible_time_ranges.py
+++ b/rerun_py/tests/unit/test_visible_time_ranges.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+import rerun as rr
+
+
+def test_visible_time_ranges_warns_on_duplicate_entry() -> None:
+    rr.set_strict_mode(True)
+
+    with pytest.raises(ValueError):
+        rr.blueprint.archetypes.VisibleTimeRanges([
+            rr.VisibleTimeRange("timeline", start=rr.TimeRangeBoundary.infinite(), end=rr.TimeRangeBoundary.infinite()),
+            rr.VisibleTimeRange(
+                "timeline", start=rr.TimeRangeBoundary.absolute(seconds=1.0), end=rr.TimeRangeBoundary.cursor_relative()
+            ),
+        ])
+
+
+def test_visible_time_ranges_from_single() -> None:
+    time_range = rr.VisibleTimeRange(
+        "timeline", start=rr.TimeRangeBoundary.cursor_relative(), end=rr.TimeRangeBoundary.absolute(seconds=1.0)
+    )
+    assert rr.blueprint.archetypes.VisibleTimeRanges(time_range) == rr.blueprint.archetypes.VisibleTimeRanges([
+        time_range
+    ])


### PR DESCRIPTION
### What

* Fixes #6276
* Better doc visibility
* Warn if a timeline is specified twice

Collateral:
* generate `__hash__` methods for trivial python classes
* fix issue with `pixi run py-test`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
