### PR TITLE
Reduce number of unwrap calls and make clippy warning for it opt-out per crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -444,7 +444,7 @@ missing_errors_doc = "allow"
 # This would be nice to enable, but we have way too many unwraps right now 😭
 # Enabling this lint in 2023-04-27 yielded 556 hits.
 # Enabling this lint in 2023-09-23 yielded 352 hits
-unwrap_used = "allow"
+unwrap_used = "warn"
 
 [patch.crates-io]
 # Try to avoid patching crates! It prevents us from publishing the crates on crates.io.

--- a/crates/re_analytics/examples/end_to_end.rs
+++ b/crates/re_analytics/examples/end_to_end.rs
@@ -4,17 +4,17 @@ use re_analytics::Event;
 use re_analytics::Properties;
 use re_analytics::{Analytics, AnalyticsEvent};
 
-fn main() -> ! {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     re_log::setup_logging();
 
-    let analytics = Analytics::new(Duration::from_secs(3)).unwrap();
+    let analytics = Analytics::new(Duration::from_secs(3))?;
     let application_id = "end_to_end_example".to_owned();
     let recording_id = uuid::Uuid::new_v4().to_string();
 
     println!("any non-empty line written here will be sent as an analytics datapoint");
     loop {
         let mut input = String::new();
-        std::io::stdin().read_line(&mut input).unwrap();
+        std::io::stdin().read_line(&mut input)?;
 
         let input = input.trim();
         if !input.is_empty() {

--- a/crates/re_analytics/src/native/config.rs
+++ b/crates/re_analytics/src/native/config.rs
@@ -106,7 +106,9 @@ impl Config {
     }
 
     pub fn config_dir(&self) -> &Path {
-        self.config_file_path.parent().unwrap()
+        self.config_file_path
+            .parent()
+            .expect("config file has no parent")
     }
 
     pub fn config_file(&self) -> &Path {

--- a/crates/re_build_info/src/build_info.rs
+++ b/crates/re_build_info/src/build_info.rs
@@ -166,8 +166,8 @@ fn crate_version_from_build_info_string() {
 
     {
         let expected_crate_version = build_info.version;
-        let crate_version = CrateVersion::try_parse_from_build_info_string(build_info_str).unwrap();
+        let crate_version = CrateVersion::try_parse_from_build_info_string(build_info_str);
 
-        assert_eq!(expected_crate_version, crate_version);
+        assert_eq!(Ok(expected_crate_version), crate_version);
     }
 }

--- a/crates/re_build_tools/src/hashing.rs
+++ b/crates/re_build_tools/src/hashing.rs
@@ -12,7 +12,7 @@ use crate::{rerun_if_changed, rerun_if_changed_or_doesnt_exist};
 fn encode_hex(bytes: &[u8]) -> String {
     let mut s = String::with_capacity(bytes.len() * 2);
     for &b in bytes {
-        write!(&mut s, "{b:02x}").unwrap();
+        write!(&mut s, "{b:02x}").expect("writing to string should never fail");
     }
     s
 }

--- a/crates/re_data_store/benches/arrow2.rs
+++ b/crates/re_data_store/benches/arrow2.rs
@@ -1,5 +1,8 @@
 //! Keeping track of performance issues/regressions in `arrow2` that directly affect us.
 
+// Allow unwrap() in benchmarks
+#![allow(clippy::unwrap_used)]
+
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -1,3 +1,6 @@
+// Allow unwrap() in benchmarks
+#![allow(clippy::unwrap_used)]
+
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/crates/re_data_store/src/lib.rs
+++ b/crates/re_data_store/src/lib.rs
@@ -14,6 +14,9 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod arrow_util;
 mod store;
 mod store_arrow;

--- a/crates/re_data_store/tests/correctness.rs
+++ b/crates/re_data_store/tests/correctness.rs
@@ -2,6 +2,9 @@
 //!
 //! Bending and twisting the datastore APIs in all kinds of weird ways to try and break them.
 
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use rand::Rng;
 
 use re_data_store::{

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -2,6 +2,9 @@
 //!
 //! Testing & demonstrating expected usage of the datastore APIs, no funny stuff.
 
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use itertools::Itertools;
 use rand::Rng;
 use re_data_store::{

--- a/crates/re_data_store/tests/dump.rs
+++ b/crates/re_data_store/tests/dump.rs
@@ -1,5 +1,8 @@
 //! Dumping a datastore to log messages and back.
 
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use itertools::Itertools;
 use re_data_store::{
     test_row,

--- a/crates/re_data_store/tests/internals.rs
+++ b/crates/re_data_store/tests/internals.rs
@@ -2,6 +2,9 @@
 //!
 //! They're awful, but sometimes you just have to…
 
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use re_data_store::{DataStore, DataStoreConfig};
 use re_log_types::{
     build_frame_nr, example_components::MyIndex, DataRow, EntityPath, RowId, TimePoint,

--- a/crates/re_data_store/tests/memory_test.rs
+++ b/crates/re_data_store/tests/memory_test.rs
@@ -1,5 +1,8 @@
 //! Measures the memory overhead of the data store.
 
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 thread_local! {

--- a/crates/re_dev_tools/src/main.rs
+++ b/crates/re_dev_tools/src/main.rs
@@ -2,6 +2,9 @@
 //!
 //! To get an overview over all tools run `pixi run dev-tools --help`.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use argh::FromArgs;
 
 mod build_examples;

--- a/crates/re_entity_db/examples/memory_usage.rs
+++ b/crates/re_entity_db/examples/memory_usage.rs
@@ -1,3 +1,6 @@
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 thread_local! {

--- a/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
+++ b/crates/re_entity_db/src/blueprint/components/entity_properties_component.rs
@@ -104,8 +104,7 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
                     buffers
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |buf| buf.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
                 let data0_inner_data: Buffer<u8> = buffers
@@ -114,13 +113,13 @@ impl ::re_types_core::Loggable for EntityPropertiesComponent {
                     .collect::<Vec<_>>()
                     .concat()
                     .into();
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     PrimitiveArray::new(DataType::UInt8, data0_inner_data, data0_inner_bitmap)
                         .boxed(),
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_entity_db/src/lib.rs
+++ b/crates/re_entity_db/src/lib.rs
@@ -4,6 +4,9 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 pub mod entity_db;
 pub mod entity_properties;
 pub mod entity_tree;

--- a/crates/re_entity_db/tests/clear.rs
+++ b/crates/re_entity_db/tests/clear.rs
@@ -1,3 +1,6 @@
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use re_data_store::{DataStore, LatestAtQuery};
 use re_entity_db::EntityDb;
 use re_log_types::{

--- a/crates/re_entity_db/tests/time_histograms.rs
+++ b/crates/re_entity_db/tests/time_histograms.rs
@@ -1,3 +1,6 @@
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use std::collections::BTreeSet;
 
 use re_data_store::GarbageCollectionOptions;

--- a/crates/re_format_arrow/src/lib.rs
+++ b/crates/re_format_arrow/src/lib.rs
@@ -1,5 +1,8 @@
 //! Formatting for tables of Arrow arrays
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::fmt::Formatter;
 
 use arrow2::{

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -1,3 +1,6 @@
+// Allow unwrap() in benchmarks
+#![allow(clippy::unwrap_used)]
+
 #[cfg(not(all(feature = "decoder", feature = "encoder")))]
 compile_error!("msg_encode_benchmark requires 'decoder' and 'encoder' features.");
 

--- a/crates/re_log_encoding/src/lib.rs
+++ b/crates/re_log_encoding/src/lib.rs
@@ -135,12 +135,14 @@ impl FileHeader {
 
     #[cfg(feature = "decoder")]
     pub fn decode(read: &mut impl std::io::Read) -> Result<Self, decoder::DecodeError> {
+        let to_array_4b = |slice: &[u8]| slice.try_into().expect("always returns an Ok() variant");
+
         let mut buffer = [0_u8; Self::SIZE];
         read.read_exact(&mut buffer)
             .map_err(decoder::DecodeError::Read)?;
-        let magic = buffer[0..4].try_into().unwrap();
-        let version = buffer[4..8].try_into().unwrap();
-        let options = EncodingOptions::from_bytes(buffer[8..].try_into().unwrap())?;
+        let magic = to_array_4b(&buffer[0..4]);
+        let version = to_array_4b(&buffer[4..8]);
+        let options = EncodingOptions::from_bytes(to_array_4b(&buffer[8..]))?;
         Ok(Self {
             magic,
             version,

--- a/crates/re_log_encoding/src/stream_rrd_from_http.rs
+++ b/crates/re_log_encoding/src/stream_rrd_from_http.rs
@@ -118,6 +118,8 @@ pub fn stream_rrd_from_http(url: String, on_msg: Arc<HttpMessageCallback>) {
 }
 
 #[cfg(target_arch = "wasm32")]
+// TODO(#3408): remove unwrap()
+#[allow(clippy::unwrap_used)]
 mod web_event_listener {
     use super::HttpMessageCallback;
     use js_sys::Uint8Array;
@@ -157,6 +159,8 @@ mod web_event_listener {
 pub use web_event_listener::stream_rrd_from_event_listener;
 
 #[cfg(target_arch = "wasm32")]
+// TODO(#3408): remove unwrap()
+#[allow(clippy::unwrap_used)]
 pub mod web_decode {
     use super::{HttpMessage, HttpMessageCallback};
     use std::sync::Arc;

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -17,6 +17,9 @@
 //! e.g. the entity `foo/bar/baz` is has the transform that is the product of
 //! `foo.transform * foo/bar.transform * foo/bar/baz.transform`.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 pub mod arrow_msg;
 pub mod example_components;
 pub mod hash;

--- a/crates/re_query/benches/latest_at.rs
+++ b/crates/re_query/benches/latest_at.rs
@@ -1,6 +1,9 @@
 //! Contains:
 //! - A 1:1 port of the benchmarks in `crates/re_query/benches/query_benchmarks.rs`, with caching enabled.
 
+// Allow unwrap() in benchmarks
+#![allow(clippy::unwrap_used)]
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use itertools::Itertools;

--- a/crates/re_query/src/latest_at/results.rs
+++ b/crates/re_query/src/latest_at/results.rs
@@ -285,5 +285,8 @@ fn downcast<C: Component>(cached: &(dyn ErasedFlatVecDeque + Send + Sync)) -> cr
     if cached.num_entries() != 1 {
         return Err(anyhow::anyhow!("latest_at deque must be single entry").into());
     }
-    Ok(cached.iter().next().expect("checked just above ^^^"))
+    Ok(cached
+        .iter()
+        .next()
+        .expect("checked existence of cached value already"))
 }

--- a/crates/re_query/src/latest_at/results.rs
+++ b/crates/re_query/src/latest_at/results.rs
@@ -285,6 +285,5 @@ fn downcast<C: Component>(cached: &(dyn ErasedFlatVecDeque + Send + Sync)) -> cr
     if cached.num_entries() != 1 {
         return Err(anyhow::anyhow!("latest_at deque must be single entry").into());
     }
-    // unwrap checked just above ^^^
-    Ok(cached.iter().next().unwrap())
+    Ok(cached.iter().next().expect("checked just above ^^^"))
 }

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -1,5 +1,8 @@
 //! Caching datastructures for `re_query`.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod cache;
 mod cache_stats;
 mod flat_vec_deque;

--- a/crates/re_query/tests/latest_at.rs
+++ b/crates/re_query/tests/latest_at.rs
@@ -1,3 +1,6 @@
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use re_data_store::{DataStore, LatestAtQuery, StoreSubscriber};
 use re_log_types::{
     build_frame_nr,

--- a/crates/re_query/tests/range.rs
+++ b/crates/re_query/tests/range.rs
@@ -1,3 +1,6 @@
+// https://github.com/rust-lang/rust-clippy/issues/10011
+#![cfg(test)]
+
 use itertools::Itertools as _;
 
 use re_data_store::{DataStore, RangeQuery, ResolvedTimeRange, StoreSubscriber as _, TimeInt};

--- a/crates/re_renderer/src/lib.rs
+++ b/crates/re_renderer/src/lib.rs
@@ -7,6 +7,9 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 pub mod config;
 pub mod importer;
 pub mod mesh;

--- a/crates/re_renderer_examples/2d.rs
+++ b/crates/re_renderer_examples/2d.rs
@@ -2,6 +2,9 @@
 //!
 //! On the left is a 2D view, on the right a 3D view of the same scene.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use itertools::Itertools as _;
 use re_renderer::Hsva;
 

--- a/crates/re_renderer_examples/depth_cloud.rs
+++ b/crates/re_renderer_examples/depth_cloud.rs
@@ -13,6 +13,9 @@
 //! cargo run-wasm --example depth_cloud
 //! ```
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::f32::consts::TAU;
 
 use glam::Vec3;

--- a/crates/re_renderer_examples/depth_offset.rs
+++ b/crates/re_renderer_examples/depth_offset.rs
@@ -7,6 +7,9 @@
 //! Press arrow up/down to increase/decrease the distance of the camera to the z==0 plane in tandem with the scale of the rectangles.
 //! Press arrow left/right to increase/decrease the near plane distance.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use re_renderer::Hsva;
 use re_renderer::{
     renderer::{ColormappedTexture, RectangleDrawData, RectangleOptions, TexturedRect},

--- a/crates/re_renderer_examples/framework.rs
+++ b/crates/re_renderer_examples/framework.rs
@@ -1,5 +1,8 @@
 //! Example framework
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::sync::Arc;
 
 use anyhow::Context as _;

--- a/crates/re_renderer_examples/multiview.rs
+++ b/crates/re_renderer_examples/multiview.rs
@@ -1,5 +1,8 @@
 //! Example with several independent views, using various primitives.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::f32::consts::TAU;
 
 use framework::Example;

--- a/crates/re_renderer_examples/outlines.rs
+++ b/crates/re_renderer_examples/outlines.rs
@@ -1,5 +1,8 @@
 //! Demonstrates outline rendering.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use itertools::Itertools;
 use re_renderer::{
     renderer::MeshInstance,

--- a/crates/re_renderer_examples/picking.rs
+++ b/crates/re_renderer_examples/picking.rs
@@ -1,5 +1,8 @@
 //! Demonstrates the dedicated picking layer support.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use itertools::Itertools as _;
 use rand::Rng;
 use re_renderer::{

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -10,6 +10,8 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
 
 // ----------------

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -311,7 +311,10 @@ impl RecordingStreamBuilder {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect(self) -> RecordingStreamResult<RecordingStream> {
-        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout())
+        self.connect_opts(
+            crate::default_server_addr(),
+            Some(crate::default_flush_timeout()),
+        )
     }
 
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
@@ -325,7 +328,7 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
-    ///     .connect_opts(re_sdk::default_server_addr(), re_sdk::default_flush_timeout())?;
+    ///     .connect_opts(re_sdk::default_server_addr(), Some(re_sdk::default_flush_timeout()))?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect_opts(
@@ -422,7 +425,7 @@ impl RecordingStreamBuilder {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn spawn(self) -> RecordingStreamResult<RecordingStream> {
-        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
+        self.spawn_opts(&Default::default(), Some(crate::default_flush_timeout()))
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then creates a new
@@ -442,7 +445,7 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
-    ///     .spawn_opts(&re_sdk::SpawnOptions::default(), re_sdk::default_flush_timeout())?;
+    ///     .spawn_opts(&re_sdk::SpawnOptions::default(), Some(re_sdk::default_flush_timeout()))?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn spawn_opts(
@@ -1510,7 +1513,10 @@ impl RecordingStream {
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
     pub fn connect(&self) {
-        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout());
+        self.connect_opts(
+            crate::default_server_addr(),
+            Some(crate::default_flush_timeout()),
+        );
     }
 
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
@@ -1552,7 +1558,7 @@ impl RecordingStream {
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
     pub fn spawn(&self) -> RecordingStreamResult<()> {
-        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
+        self.spawn_opts(&Default::default(), Some(crate::default_flush_timeout()))
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then swaps the

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -311,10 +311,7 @@ impl RecordingStreamBuilder {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect(self) -> RecordingStreamResult<RecordingStream> {
-        self.connect_opts(
-            crate::default_server_addr(),
-            Some(crate::default_flush_timeout()),
-        )
+        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout())
     }
 
     /// Creates a new [`RecordingStream`] that is pre-configured to stream the data through to a
@@ -328,7 +325,7 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
-    ///     .connect_opts(re_sdk::default_server_addr(), Some(re_sdk::default_flush_timeout()))?;
+    ///     .connect_opts(re_sdk::default_server_addr(), re_sdk::default_flush_timeout())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn connect_opts(
@@ -425,7 +422,7 @@ impl RecordingStreamBuilder {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn spawn(self) -> RecordingStreamResult<RecordingStream> {
-        self.spawn_opts(&Default::default(), Some(crate::default_flush_timeout()))
+        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then creates a new
@@ -445,7 +442,7 @@ impl RecordingStreamBuilder {
     ///
     /// ```no_run
     /// let rec = re_sdk::RecordingStreamBuilder::new("rerun_example_app")
-    ///     .spawn_opts(&re_sdk::SpawnOptions::default(), Some(re_sdk::default_flush_timeout()))?;
+    ///     .spawn_opts(&re_sdk::SpawnOptions::default(), re_sdk::default_flush_timeout())?;
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn spawn_opts(
@@ -1513,10 +1510,7 @@ impl RecordingStream {
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
     pub fn connect(&self) {
-        self.connect_opts(
-            crate::default_server_addr(),
-            Some(crate::default_flush_timeout()),
-        );
+        self.connect_opts(crate::default_server_addr(), crate::default_flush_timeout());
     }
 
     /// Swaps the underlying sink for a [`crate::log_sink::TcpSink`] sink pre-configured to use
@@ -1558,7 +1552,7 @@ impl RecordingStream {
     /// terms of data durability and ordering.
     /// See [`Self::set_sink`] for more information.
     pub fn spawn(&self) -> RecordingStreamResult<()> {
-        self.spawn_opts(&Default::default(), Some(crate::default_flush_timeout()))
+        self.spawn_opts(&Default::default(), crate::default_flush_timeout())
     }
 
     /// Spawns a new Rerun Viewer process from an executable available in PATH, then swaps the

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -29,6 +29,8 @@ pub fn default_server_addr() -> std::net::SocketAddr {
 }
 
 /// The default amount of time to wait for the TCP connection to resume during a flush
-pub fn default_flush_timeout() -> std::time::Duration {
-    std::time::Duration::from_secs(2)
+#[allow(clippy::unnecessary_wraps)]
+pub fn default_flush_timeout() -> Option<std::time::Duration> {
+    // NOTE: This is part of the SDK and meant to be used where we accept `Option<std::time::Duration>` values.
+    Some(std::time::Duration::from_secs(2))
 }

--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -29,7 +29,6 @@ pub fn default_server_addr() -> std::net::SocketAddr {
 }
 
 /// The default amount of time to wait for the TCP connection to resume during a flush
-#[allow(clippy::unnecessary_wraps)]
-pub fn default_flush_timeout() -> Option<std::time::Duration> {
-    Some(std::time::Duration::from_secs(2))
+pub fn default_flush_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(2)
 }

--- a/crates/re_sdk_comms/src/server.rs
+++ b/crates/re_sdk_comms/src/server.rs
@@ -332,7 +332,11 @@ impl CongestionManager {
                 // decision on a time we've previously seen,
                 // thus sending parts of a sequence-time instead of all-or-nothing.
                 while timeline_history.send_time.len() > 1024 {
-                    let oldest_time = *timeline_history.send_time.keys().next().unwrap();
+                    let oldest_time = *timeline_history
+                        .send_time
+                        .keys()
+                        .next()
+                        .expect("safe because checked above");
                     timeline_history.send_time.remove(&oldest_time);
                 }
 

--- a/crates/re_space_view_spatial/src/lib.rs
+++ b/crates/re_space_view_spatial/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! Space Views that show entities in a 2D or 3D spatial relationship.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod contexts;
 mod eye;
 mod heuristics;

--- a/crates/re_space_view_tensor/src/lib.rs
+++ b/crates/re_space_view_tensor/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! A Space View dedicated to visualizing tensors with arbitrary dimensionality.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod dimension_mapping;
 mod space_view_class;
 mod tensor_dimension_mapper;

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! A Space View that shows plots over Rerun timelines.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod aggregation;
 mod line_visualizer_system;
 mod overrides;

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate provides a panel that shows allows to control time & timelines,
 //! as well as all necessary ui elements that make it up.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod data_density_graph;
 mod paint_ticks;
 mod time_axis;

--- a/crates/re_types/Cargo.toml
+++ b/crates/re_types/Cargo.toml
@@ -15,7 +15,6 @@ version.workspace = true
 [lints]
 workspace = true
 
-
 [package.metadata.docs.rs]
 all-features = false
 no-default-features = true

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -109,8 +109,7 @@ impl ::re_types_core::Loggable for ActiveTab {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -110,8 +110,7 @@ impl ::re_types_core::Loggable for IncludedContent {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -114,8 +114,7 @@ impl ::re_types_core::Loggable for QueryExpression {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -105,8 +105,7 @@ impl ::re_types_core::Loggable for SpaceViewClass {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -105,8 +105,7 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/components/annotation_context.rs
+++ b/crates/re_types/src/components/annotation_context.rs
@@ -104,12 +104,11 @@ impl ::re_types_core::Loggable for AnnotationContext {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -119,7 +118,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
                         )?
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/components/blob.rs
+++ b/crates/re_types/src/components/blob.rs
@@ -102,8 +102,7 @@ impl ::re_types_core::Loggable for Blob {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.num_instances())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Buffer<_> = data0
                     .iter()
@@ -113,13 +112,13 @@ impl ::re_types_core::Loggable for Blob {
                     .concat()
                     .into();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     PrimitiveArray::new(DataType::UInt8, data0_inner_data, data0_inner_bitmap)
                         .boxed(),
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -195,6 +195,7 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -194,8 +194,8 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/half_sizes2d.rs
+++ b/crates/re_types/src/components/half_sizes2d.rs
@@ -194,8 +194,9 @@ impl ::re_types_core::Loggable for HalfSizes2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -195,6 +195,7 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -194,8 +194,9 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/half_sizes3d.rs
+++ b/crates/re_types/src/components/half_sizes3d.rs
@@ -194,8 +194,8 @@ impl ::re_types_core::Loggable for HalfSizes3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -224,6 +224,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -223,8 +223,9 @@ impl ::re_types_core::Loggable for LineStrip2D {
                                             .get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/components/line_strip2d.rs
+++ b/crates/re_types/src/components/line_strip2d.rs
@@ -104,12 +104,11 @@ impl ::re_types_core::Loggable for LineStrip2D {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -136,7 +135,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
                         .boxed()
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })
@@ -224,8 +223,8 @@ impl ::re_types_core::Loggable for LineStrip2D {
                                             .get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(2usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -104,12 +104,11 @@ impl ::re_types_core::Loggable for LineStrip3D {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -136,7 +135,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                         .boxed()
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })
@@ -224,8 +223,8 @@ impl ::re_types_core::Loggable for LineStrip3D {
                                             .get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(3usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -223,8 +223,9 @@ impl ::re_types_core::Loggable for LineStrip3D {
                                             .get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/components/line_strip3d.rs
+++ b/crates/re_types/src/components/line_strip3d.rs
@@ -224,6 +224,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -108,8 +108,7 @@ impl ::re_types_core::Loggable for MediaType {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -105,8 +105,7 @@ impl ::re_types_core::Loggable for Name {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -202,6 +202,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -201,8 +201,9 @@ impl ::re_types_core::Loggable for PinholeProjection {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(9usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -201,8 +201,8 @@ impl ::re_types_core::Loggable for PinholeProjection {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(9usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for Position2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for Position2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for Position2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for Position3D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for Position3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for Position3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for Range1D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for Range1D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for Range1D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -193,8 +193,9 @@ impl ::re_types_core::Loggable for Resolution {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -194,6 +194,7 @@ impl ::re_types_core::Loggable for Resolution {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -193,8 +193,8 @@ impl ::re_types_core::Loggable for Resolution {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -207,8 +207,8 @@ impl ::re_types_core::Loggable for Texcoord2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -208,6 +208,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -207,8 +207,9 @@ impl ::re_types_core::Loggable for Texcoord2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -105,8 +105,7 @@ impl ::re_types_core::Loggable for Text {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -113,8 +113,7 @@ impl ::re_types_core::Loggable for TextLogLevel {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> = data0
                     .into_iter()

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for TriangleIndices {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for TriangleIndices {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for Vector2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for Vector2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for Vector2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for Vector3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for Vector3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for Vector3D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -207,6 +207,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -206,8 +206,9 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/components/view_coordinates.rs
+++ b/crates/re_types/src/components/view_coordinates.rs
@@ -206,8 +206,8 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/annotation_info.rs
+++ b/crates/re_types/src/datatypes/annotation_info.rs
@@ -134,14 +134,14 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                                 label.iter().map(|opt| {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
-                            )
-                            .map_err(|err| std::sync::Arc::new(err))?
+                            )?
                             .into();
                             let inner_data: arrow2::buffer::Buffer<u8> = label
                                 .into_iter()
                                 .flatten()
                                 .flat_map(|datum| datum.0 .0)
                                 .collect();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/datatypes/class_description.rs
+++ b/crates/re_types/src/datatypes/class_description.rs
@@ -166,8 +166,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 keypoint_annotations
                                     .iter()
                                     .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let keypoint_annotations_inner_data: Vec<_> = keypoint_annotations
                                 .into_iter()
@@ -176,7 +175,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 .collect();
                             let keypoint_annotations_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     <crate::datatypes::AnnotationInfo>::arrow_datatype(),
@@ -190,7 +189,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                     )?
                                 },
                                 keypoint_annotations_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },
@@ -214,8 +213,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 keypoint_connections
                                     .iter()
                                     .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let keypoint_connections_inner_data: Vec<_> = keypoint_connections
                                 .into_iter()
@@ -224,7 +222,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                 .collect();
                             let keypoint_connections_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     <crate::datatypes::KeypointPair>::arrow_datatype(),
@@ -238,7 +236,7 @@ impl ::re_types_core::Loggable for ClassDescription {
                                     )?
                                 },
                                 keypoint_connections_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -199,8 +199,8 @@ impl ::re_types_core::Loggable for Mat3x3 {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(9usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -199,8 +199,9 @@ impl ::re_types_core::Loggable for Mat3x3 {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(9usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -200,6 +200,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -200,8 +200,8 @@ impl ::re_types_core::Loggable for Mat4x4 {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(16usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -200,8 +200,9 @@ impl ::re_types_core::Loggable for Mat4x4 {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(16usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -201,6 +201,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -191,6 +191,7 @@ impl ::re_types_core::Loggable for Quaternion {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -190,8 +190,9 @@ impl ::re_types_core::Loggable for Quaternion {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(4usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -190,8 +190,8 @@ impl ::re_types_core::Loggable for Quaternion {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(4usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for Range1D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for Range1D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for Range1D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -296,6 +296,7 @@ impl ::re_types_core::Loggable for Range2D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })
@@ -378,6 +379,7 @@ impl ::re_types_core::Loggable for Range2D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -295,8 +295,8 @@ impl ::re_types_core::Loggable for Range2D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(2usize))
                                 })
                                 .transpose()
                             })
@@ -376,8 +376,8 @@ impl ::re_types_core::Loggable for Range2D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(2usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/range2d.rs
+++ b/crates/re_types/src/datatypes/range2d.rs
@@ -295,8 +295,9 @@ impl ::re_types_core::Loggable for Range2D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })
@@ -376,8 +377,9 @@ impl ::re_types_core::Loggable for Range2D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -295,6 +295,7 @@ impl ::re_types_core::Loggable for Rotation3D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -294,8 +294,9 @@ impl ::re_types_core::Loggable for Rotation3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(4usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/rotation3d.rs
+++ b/crates/re_types/src/datatypes/rotation3d.rs
@@ -294,8 +294,8 @@ impl ::re_types_core::Loggable for Rotation3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(4usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -259,8 +259,8 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(3usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -259,8 +259,9 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/re_types/src/datatypes/rotation_axis_angle.rs
@@ -260,6 +260,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -283,8 +283,8 @@ impl ::re_types_core::Loggable for Scale3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(3usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -284,6 +284,7 @@ impl ::re_types_core::Loggable for Scale3D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/scale3d.rs
+++ b/crates/re_types/src/datatypes/scale3d.rs
@@ -283,8 +283,9 @@ impl ::re_types_core::Loggable for Scale3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/re_types/src/datatypes/tensor_buffer.rs
@@ -320,8 +320,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u8.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let u8_inner_data: Buffer<_> = u8
                             .iter()
@@ -330,7 +329,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let u8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt8,
@@ -340,7 +339,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::UInt8, u8_inner_data, u8_inner_bitmap)
                                 .boxed(),
                             u8_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -357,8 +356,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u16.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let u16_inner_data: Buffer<_> = u16
                             .iter()
@@ -367,7 +365,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let u16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt16,
@@ -377,7 +375,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::UInt16, u16_inner_data, u16_inner_bitmap)
                                 .boxed(),
                             u16_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -394,8 +392,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u32.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let u32_inner_data: Buffer<_> = u32
                             .iter()
@@ -404,7 +401,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let u32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt32,
@@ -414,7 +411,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::UInt32, u32_inner_data, u32_inner_bitmap)
                                 .boxed(),
                             u32_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -431,8 +428,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             u64.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let u64_inner_data: Buffer<_> = u64
                             .iter()
@@ -441,7 +437,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let u64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt64,
@@ -451,7 +447,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::UInt64, u64_inner_data, u64_inner_bitmap)
                                 .boxed(),
                             u64_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -468,8 +464,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i8.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let i8_inner_data: Buffer<_> = i8
                             .iter()
@@ -478,7 +473,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let i8_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Int8,
@@ -488,7 +483,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::Int8, i8_inner_data, i8_inner_bitmap)
                                 .boxed(),
                             i8_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -505,8 +500,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i16.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let i16_inner_data: Buffer<_> = i16
                             .iter()
@@ -515,7 +509,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let i16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Int16,
@@ -525,7 +519,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::Int16, i16_inner_data, i16_inner_bitmap)
                                 .boxed(),
                             i16_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -542,8 +536,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i32.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let i32_inner_data: Buffer<_> = i32
                             .iter()
@@ -552,7 +545,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let i32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Int32,
@@ -562,7 +555,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::Int32, i32_inner_data, i32_inner_bitmap)
                                 .boxed(),
                             i32_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -579,8 +572,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             i64.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let i64_inner_data: Buffer<_> = i64
                             .iter()
@@ -589,7 +581,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let i64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Int64,
@@ -599,7 +591,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             PrimitiveArray::new(DataType::Int64, i64_inner_data, i64_inner_bitmap)
                                 .boxed(),
                             i64_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -616,8 +608,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f16.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let f16_inner_data: Buffer<_> = f16
                             .iter()
@@ -626,7 +617,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let f16_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Float16,
@@ -640,7 +631,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             f16_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -657,8 +648,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f32.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let f32_inner_data: Buffer<_> = f32
                             .iter()
@@ -667,7 +657,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let f32_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Float32,
@@ -681,7 +671,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             f32_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -698,8 +688,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             f64.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let f64_inner_data: Buffer<_> = f64
                             .iter()
@@ -708,7 +697,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let f64_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::Float64,
@@ -722,7 +711,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             f64_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -739,8 +728,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             jpeg.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let jpeg_inner_data: Buffer<_> = jpeg
                             .iter()
@@ -749,7 +737,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let jpeg_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt8,
@@ -763,7 +751,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             jpeg_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -780,8 +768,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             nv12.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let nv12_inner_data: Buffer<_> = nv12
                             .iter()
@@ -790,7 +777,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let nv12_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt8,
@@ -804,7 +791,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             nv12_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -821,8 +808,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             yuy2.iter().map(|datum| datum.num_instances()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let yuy2_inner_data: Buffer<_> = yuy2
                             .iter()
@@ -831,7 +817,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             .concat()
                             .into();
                         let yuy2_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 DataType::UInt8,
@@ -845,7 +831,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             )
                             .boxed(),
                             yuy2_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },

--- a/crates/re_types/src/datatypes/tensor_data.rs
+++ b/crates/re_types/src/datatypes/tensor_data.rs
@@ -131,13 +131,12 @@ impl ::re_types_core::Loggable for TensorData {
                                 shape
                                     .iter()
                                     .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let shape_inner_data: Vec<_> =
                                 shape.into_iter().flatten().flatten().collect();
                             let shape_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     <crate::datatypes::TensorDimension>::arrow_datatype(),
@@ -151,7 +150,7 @@ impl ::re_types_core::Loggable for TensorData {
                                     )?
                                 },
                                 shape_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },

--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -628,7 +628,9 @@ impl TensorData {
 
         let mut decoder = JpegDecoder::new(&jpeg_bytes);
         decoder.decode_headers()?;
-        let (w, h) = decoder.dimensions().unwrap(); // Can't fail after a successful decode_headers
+        let (w, h) = decoder
+            .dimensions()
+            .expect("can't fail after a successful decode_headers");
 
         Ok(Self {
             shape: vec![

--- a/crates/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/re_types/src/datatypes/tensor_dimension.rs
@@ -124,8 +124,7 @@ impl ::re_types_core::Loggable for TensorDimension {
                             let offsets =
                                 arrow2::offset::Offsets::<i32>::try_from_lengths(name.iter().map(
                                     |opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default(),
-                                ))
-                                .map_err(|err| std::sync::Arc::new(err))?
+                                ))?
                                 .into();
                             let inner_data: arrow2::buffer::Buffer<u8> =
                                 name.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -331,8 +331,8 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(3usize))
                                 })
                                 .transpose()
                             })
@@ -412,8 +412,8 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(9usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -331,8 +331,9 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })
@@ -412,8 +413,9 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(9usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/translation_and_mat3x3.rs
+++ b/crates/re_types/src/datatypes/translation_and_mat3x3.rs
@@ -332,6 +332,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })
@@ -414,6 +415,7 @@ impl ::re_types_core::Loggable for TranslationAndMat3x3 {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -329,6 +329,7 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -328,8 +328,9 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
+++ b/crates/re_types/src/datatypes/translation_rotation_scale3d.rs
@@ -328,8 +328,8 @@ impl ::re_types_core::Loggable for TranslationRotationScale3D {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(3usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -192,6 +192,7 @@ impl ::re_types_core::Loggable for Uuid {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -191,8 +191,8 @@ impl ::re_types_core::Loggable for Uuid {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(16usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uuid.rs
+++ b/crates/re_types/src/datatypes/uuid.rs
@@ -191,8 +191,9 @@ impl ::re_types_core::Loggable for Uuid {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(16usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for UVec2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for UVec2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for UVec2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for UVec3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for UVec3D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for UVec3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for UVec4D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(4usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for UVec4D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for UVec4D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(4usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for Vec2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(2usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for Vec2D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(2usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for Vec2D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for Vec3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for Vec3D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for Vec3D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(3usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -189,6 +189,7 @@ impl ::re_types_core::Loggable for Vec4D {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -188,8 +188,9 @@ impl ::re_types_core::Loggable for Vec4D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(4usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -188,8 +188,8 @@ impl ::re_types_core::Loggable for Vec4D {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(4usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -172,6 +172,7 @@
 //!
 
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
+#![deny(clippy::unwrap_used)] // See #3408, remove once we remove all the unwrap's
 
 // ---
 

--- a/crates/re_types/src/lib.rs
+++ b/crates/re_types/src/lib.rs
@@ -172,7 +172,6 @@
 //!
 
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
-#![deny(clippy::unwrap_used)] // See #3408, remove once we remove all the unwrap's
 
 // ---
 

--- a/crates/re_types/src/tensor_data.rs
+++ b/crates/re_types/src/tensor_data.rs
@@ -589,7 +589,9 @@ impl DecodedTensor {
 
         let mut decoder = JpegDecoder::new_with_options(jpeg_bytes, options);
         let pixels = decoder.decode()?;
-        let (w, h) = decoder.dimensions().unwrap(); // Can't fail after a successful decode
+        let (w, h) = decoder
+            .dimensions()
+            .expect("can't fail after a successful decode");
 
         let (w, h) = (w as u64, h as u64);
 

--- a/crates/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer10.rs
@@ -95,8 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> =
                     data0.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer11.rs
@@ -100,8 +100,7 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.num_instances())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Buffer<_> = data0
                     .iter()
@@ -111,13 +110,13 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                     .concat()
                     .into();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     PrimitiveArray::new(DataType::Float32, data0_inner_data, data0_inner_bitmap)
                         .boxed(),
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer12.rs
@@ -100,19 +100,17 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.len()),
-                        )
-                        .map_err(|err| std::sync::Arc::new(err))?
+                        )?
                         .into();
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.into_iter().flat_map(|s| s.0).collect();
@@ -129,7 +127,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                         .boxed()
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer13.rs
@@ -100,19 +100,17 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.len()),
-                        )
-                        .map_err(|err| std::sync::Arc::new(err))?
+                        )?
                         .into();
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.into_iter().flat_map(|s| s.0).collect();
@@ -129,7 +127,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                         .boxed()
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer16.rs
@@ -94,12 +94,11 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -109,7 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                         )?
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer17.rs
@@ -94,12 +94,11 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -109,7 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                         )?
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer18.rs
@@ -94,12 +94,11 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -109,7 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                         )?
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer7.rs
@@ -94,12 +94,11 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
@@ -109,7 +108,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                         )?
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer9.rs
@@ -95,8 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> =
                     data0.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -186,8 +186,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 single_string_required.iter().map(|opt| {
                                     opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                                 }),
-                            )
-                            .map_err(|err| std::sync::Arc::new(err))?
+                            )?
                             .into();
                             let inner_data: arrow2::buffer::Buffer<u8> = single_string_required
                                 .into_iter()
@@ -226,8 +225,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 single_string_optional.iter().map(|opt| {
                                     opt.as_ref().map(|datum| datum.len()).unwrap_or_default()
                                 }),
-                            )
-                            .map_err(|err| std::sync::Arc::new(err))?
+                            )?
                             .into();
                             let inner_data: arrow2::buffer::Buffer<u8> = single_string_optional
                                 .into_iter()
@@ -267,8 +265,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 many_floats_optional.iter().map(|opt| {
                                     opt.as_ref().map_or(0, |datum| datum.num_instances())
                                 }),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let many_floats_optional_inner_data: Buffer<_> = many_floats_optional
                                 .iter()
@@ -279,7 +276,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .into();
                             let many_floats_optional_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     DataType::Float32,
@@ -293,7 +290,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 )
                                 .boxed(),
                                 many_floats_optional_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },
@@ -317,8 +314,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 many_strings_required
                                     .iter()
                                     .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let many_strings_required_inner_data: Vec<_> = many_strings_required
                                 .into_iter()
@@ -327,7 +323,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .collect();
                             let many_strings_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     DataType::Utf8,
@@ -339,8 +335,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                         many_strings_required_inner_data
                                             .iter()
                                             .map(|datum| datum.len()),
-                                    )
-                                    .map_err(|err| std::sync::Arc::new(err))?
+                                    )?
                                     .into();
                                     let inner_data: arrow2::buffer::Buffer<u8> =
                                         many_strings_required_inner_data
@@ -359,7 +354,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     .boxed()
                                 },
                                 many_strings_required_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },
@@ -384,8 +379,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 many_strings_optional
                                     .iter()
                                     .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let many_strings_optional_inner_data: Vec<_> = many_strings_optional
                                 .into_iter()
@@ -394,7 +388,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                 .collect();
                             let many_strings_optional_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
                                 None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     DataType::Utf8,
@@ -406,8 +400,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                         many_strings_optional_inner_data
                                             .iter()
                                             .map(|datum| datum.len()),
-                                    )
-                                    .map_err(|err| std::sync::Arc::new(err))?
+                                    )?
                                     .into();
                                     let inner_data: arrow2::buffer::Buffer<u8> =
                                         many_strings_optional_inner_data
@@ -426,7 +419,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     .boxed()
                                 },
                                 many_strings_optional_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -131,14 +131,14 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                                 s.iter().map(|opt| {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
-                            )
-                            .map_err(|err| std::sync::Arc::new(err))?
+                            )?
                             .into();
                             let inner_data: arrow2::buffer::Buffer<u8> = s
                                 .into_iter()
                                 .flatten()
                                 .flat_map(|datum| datum.0 .0)
                                 .collect();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -133,8 +133,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                                 many_halves.iter().map(|opt| {
                                     opt.as_ref().map_or(0, |datum| datum.num_instances())
                                 }),
-                            )
-                            .unwrap()
+                            )?
                             .into();
                             let many_halves_inner_data: Buffer<_> = many_halves
                                 .iter()
@@ -144,7 +143,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                                 .concat()
                                 .into();
                             let many_halves_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                            ListArray::new(
+                            ListArray::try_new(
                                 DataType::List(std::sync::Arc::new(Field::new(
                                     "item",
                                     DataType::Float16,
@@ -158,7 +157,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                                 )
                                 .boxed(),
                                 many_halves_bitmap,
-                            )
+                            )?
                             .boxed()
                         }
                     },

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -250,8 +250,9 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    array_init::from_iter(data)
-                                        .ok_or(DeserializationError::array_init_underrun(4usize))
+
+                                    #[allow(clippy::unwrap_used)]
+                                    Ok(array_init::from_iter(data).unwrap())
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -250,8 +250,8 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                                         arrow_data_inner.get_unchecked(start as usize..end as usize)
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
-                                    let arr = array_init::from_iter(data).unwrap();
-                                    Ok(arr)
+                                    array_init::from_iter(data)
+                                        .ok_or(DeserializationError::array_init_underrun(4usize))
                                 })
                                 .transpose()
                             })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -251,6 +251,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                                     };
                                     let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                                    // NOTE: Unwrapping cannot fail: the length must be correct.
                                     #[allow(clippy::unwrap_used)]
                                     Ok(array_init::from_iter(data).unwrap())
                                 })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -454,8 +454,9 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                                 .iter()
                                                 .cloned()
                                                 .map(Option::unwrap_or_default);
-                                            array_init::from_iter(data)
-                                                .ok_or(DeserializationError::array_init_underrun(3usize))
+
+                                            #[allow(clippy::unwrap_used)]
+                                            Ok(array_init::from_iter(data).unwrap())
                                         })
                                         .transpose()
                                 })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -455,6 +455,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                                 .cloned()
                                                 .map(Option::unwrap_or_default);
 
+                                            // NOTE: Unwrapping cannot fail: the length must be correct.
                                             #[allow(clippy::unwrap_used)]
                                             Ok(array_init::from_iter(data).unwrap())
                                         })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -151,13 +151,12 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             craziness.iter().map(|datum| datum.len()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let craziness_inner_data: Vec<_> =
                             craziness.into_iter().flatten().collect();
                         let craziness_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
@@ -171,7 +170,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                 )?
                             },
                             craziness_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },
@@ -455,8 +454,8 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                                                 .iter()
                                                 .cloned()
                                                 .map(Option::unwrap_or_default);
-                                            let arr = array_init::from_iter(data).unwrap();
-                                            Ok(arr)
+                                            array_init::from_iter(data)
+                                                .ok_or(DeserializationError::array_init_underrun(3usize))
                                         })
                                         .transpose()
                                 })

--- a/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -139,13 +139,12 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                         use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             many_required.iter().map(|datum| datum.len()),
-                        )
-                        .unwrap()
+                        )?
                         .into();
                         let many_required_inner_data: Vec<_> =
                             many_required.into_iter().flatten().collect();
                         let many_required_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                        ListArray::new(
+                        ListArray::try_new(
                             DataType::List(std::sync::Arc::new(Field::new(
                                 "item",
                                 <crate::testing::datatypes::AffixFuzzer3>::arrow_datatype(),
@@ -159,7 +158,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                                 )?
                             },
                             many_required_bitmap,
-                        )
+                        )?
                         .boxed()
                     }
                 },

--- a/crates/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/re_types/src/testing/datatypes/string_component.rs
@@ -96,8 +96,7 @@ impl ::re_types_core::Loggable for StringComponent {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> =
                     data0.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -192,8 +192,8 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(16usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -193,6 +193,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -192,8 +192,9 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(16usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -195,8 +195,9 @@ impl ::re_types_core::Loggable for RootContainer {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(16usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -196,6 +196,7 @@ impl ::re_types_core::Loggable for RootContainer {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -195,8 +195,8 @@ impl ::re_types_core::Loggable for RootContainer {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(16usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -194,8 +194,8 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        let arr = array_init::from_iter(data).unwrap();
-                        Ok(arr)
+                        array_init::from_iter(data)
+                            .ok_or(DeserializationError::array_init_underrun(16usize))
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -194,8 +194,9 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                         let data =
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
-                        array_init::from_iter(data)
-                            .ok_or(DeserializationError::array_init_underrun(16usize))
+
+                        #[allow(clippy::unwrap_used)]
+                        Ok(array_init::from_iter(data).unwrap())
                     })
                     .transpose()
                 })

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -195,6 +195,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
                             unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
                         let data = data.iter().cloned().map(Option::unwrap_or_default);
 
+                        // NOTE: Unwrapping cannot fail: the length must be correct.
                         #[allow(clippy::unwrap_used)]
                         Ok(array_init::from_iter(data).unwrap())
                     })

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -70,12 +70,14 @@ fn main() {
 
     // NOTE: This requires `flatc` to be in $PATH, but only for contributors, not end users.
     // Even for contributors, `flatc` won't be needed unless they edit some of the .fbs files.
-    let sh = Shell::new().unwrap();
+    let sh = Shell::new().expect("Shell::new() failed");
+    #[allow(clippy::unwrap_used)] // unwrap is okay here
     cmd!(
         sh,
         "flatc -o src/ --rust --gen-onefile --filename-suffix '' {FBS_REFLECTION_DEFINITION_PATH}"
     )
     .run()
+    .map_err(|e| eprintln!("flatc failed with error: {e:?}"))
     .unwrap();
 
     // NOTE: We're purposefully ignoring the error here.

--- a/crates/re_types_builder/build.rs
+++ b/crates/re_types_builder/build.rs
@@ -77,7 +77,7 @@ fn main() {
         "flatc -o src/ --rust --gen-onefile --filename-suffix '' {FBS_REFLECTION_DEFINITION_PATH}"
     )
     .run()
-    .map_err(|e| eprintln!("flatc failed with error: {e:?}"))
+    .map_err(|err| eprintln!("flatc failed with error: {err}"))
     .unwrap();
 
     // NOTE: We're purposefully ignoring the error here.

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -3,7 +3,7 @@
 //! It is easiest to call this using `just codegen`,
 //! which will set up the necessary tools.
 
-// TODO(#3408): allow it just for code generation, but fix this eventually
+// TODO(#3408): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
 use re_build_tools::{

--- a/crates/re_types_builder/src/bin/build_re_types.rs
+++ b/crates/re_types_builder/src/bin/build_re_types.rs
@@ -3,6 +3,9 @@
 //! It is easiest to call this using `just codegen`,
 //! which will set up the necessary tools.
 
+// TODO(#3408): allow it just for code generation, but fix this eventually
+#![allow(clippy::unwrap_used)]
+
 use re_build_tools::{
     read_versioning_hash, set_output_cargo_build_instructions, write_versioning_hash,
 };

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -1,4 +1,4 @@
-// TODO(#3408): allow it just for code generation, but fix this eventually
+// TODO(#3408): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
 /// Implements the codegen pass.

--- a/crates/re_types_builder/src/codegen/mod.rs
+++ b/crates/re_types_builder/src/codegen/mod.rs
@@ -1,3 +1,6 @@
+// TODO(#3408): allow it just for code generation, but fix this eventually
+#![allow(clippy::unwrap_used)]
+
 /// Implements the codegen pass.
 pub trait CodeGenerator {
     /// Generates user-facing code from [`crate::Objects`].

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -654,7 +654,8 @@ fn quote_arrow_field_deserializer(
                                 // .collect::<DeserializationResult<Vec<_>>>()?;
 
                                 // NOTE: Unwrapping cannot fail: the length must be correct.
-                                array_init::from_iter(data).ok_or(DeserializationError::array_init_underrun(#length))
+                                #[allow(clippy::unwrap_used)]
+                                Ok(array_init::from_iter(data).unwrap())
                             }).transpose()
                         )
                         #quoted_iter_transparency

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -5,7 +5,7 @@ use quote::{format_ident, quote};
 use crate::{
     codegen::rust::{
         arrow::{is_backed_by_arrow_buffer, quote_fqname_as_type_path, ArrowDataTypeTokenizer},
-        util::is_tuple_struct_from_obj,
+        util::{is_tuple_struct_from_obj, quote_comment},
     },
     ArrowRegistry, Object, ObjectField, ObjectKind, Objects,
 };
@@ -586,6 +586,9 @@ fn quote_arrow_field_deserializer(
                 None,
             );
 
+            let comment_note_unwrap =
+                quote_comment("NOTE: Unwrapping cannot fail: the length must be correct.");
+
             quote! {{
                 let #data_src = #quoted_downcast?;
                 if #data_src.is_empty() {
@@ -653,7 +656,7 @@ fn quote_arrow_field_deserializer(
                                 // .map(|opt| opt.ok_or_else(DeserializationError::missing_data))
                                 // .collect::<DeserializationResult<Vec<_>>>()?;
 
-                                // NOTE: Unwrapping cannot fail: the length must be correct.
+                                #comment_note_unwrap
                                 #[allow(clippy::unwrap_used)]
                                 Ok(array_init::from_iter(data).unwrap())
                             }).transpose()

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -654,9 +654,7 @@ fn quote_arrow_field_deserializer(
                                 // .collect::<DeserializationResult<Vec<_>>>()?;
 
                                 // NOTE: Unwrapping cannot fail: the length must be correct.
-                                let arr = array_init::from_iter(data).unwrap();
-
-                                Ok(arr)
+                                array_init::from_iter(data).ok_or(DeserializationError::array_init_underrun(#length))
                             }).transpose()
                         )
                         #quoted_iter_transparency

--- a/crates/re_types_builder/src/codegen/rust/serializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/serializer.rs
@@ -573,8 +573,7 @@ fn quote_arrow_field_serializer(
                 quote! {
                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                         #data_src.iter().map(|opt| opt.as_ref() #quoted_transparent_length .unwrap_or_default())
-                    )
-                    .map_err(|err| std::sync::Arc::new(err))?
+                    )?
                     .into();
 
                     // NOTE: Flattening to remove the guaranteed layer of nullability: we don't care
@@ -586,8 +585,7 @@ fn quote_arrow_field_serializer(
                 quote! {
                     let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                         #data_src.iter() #quoted_transparent_length
-                    )
-                    .map_err(|err| std::sync::Arc::new(err))?
+                    )?
                     .into();
 
                     let inner_data: arrow2::buffer::Buffer<u8> =
@@ -775,7 +773,7 @@ fn quote_arrow_field_serializer(
                     quote! {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             #data_src.iter(). #map_to_length
-                        ).unwrap().into();
+                        )?.into();
                     }
                 }
             } else {
@@ -787,12 +785,12 @@ fn quote_arrow_field_serializer(
                     quote! {}
                 } else {
                     quote! {
-                        ListArray::new(
+                        ListArray::try_new(
                             #quoted_datatype,
                             offsets,
                             #quoted_inner,
                             #bitmap_src,
-                        ).boxed()
+                        )?.boxed()
                     }
                 }
             } else {
@@ -847,18 +845,18 @@ fn quote_arrow_field_serializer(
 
                             let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                                 buffers.iter().map(|opt| opt.as_ref().map_or(0, |buf| buf.len()))
-                            ).unwrap().into();
+                            )?.into();
 
                             #quoted_inner_bitmap
 
                             let #quoted_inner_data: Buffer<u8> = buffers.into_iter().flatten().collect::<Vec<_>>().concat().into();
 
-                            ListArray::new(
+                            ListArray::try_new(
                                 #quoted_datatype,
                                 offsets,
                                 #quoted_inner,
                                 #bitmap_src,
-                            ).boxed()
+                            )?.boxed()
                         }}
                     } else {
                         quote! {{

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -100,7 +100,7 @@
 
 // ---
 
-// TODO(#3408): allow it just for code generation, but fix this eventually
+// TODO(#3408): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
 // NOTE: Official generated code from flatbuffers; ignore _everything_.

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -100,6 +100,9 @@
 
 // ---
 
+// TODO(#3408): allow it just for code generation, but fix this eventually
+#![allow(clippy::unwrap_used)]
+
 // NOTE: Official generated code from flatbuffers; ignore _everything_.
 #[allow(
     warnings,

--- a/crates/re_types_core/benches/bench_tuid.rs
+++ b/crates/re_types_core/benches/bench_tuid.rs
@@ -1,3 +1,6 @@
+// Allow unwrap() in benchmarks
+#![allow(clippy::unwrap_used)]
+
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn bench_arrow(c: &mut Criterion) {

--- a/crates/re_types_core/src/components/visualizer_overrides.rs
+++ b/crates/re_types_core/src/components/visualizer_overrides.rs
@@ -102,19 +102,17 @@ impl crate::Loggable for VisualizerOverrides {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map_or(0, |datum| datum.len())),
-                )
-                .unwrap()
+                )?
                 .into();
                 let data0_inner_data: Vec<_> = data0.into_iter().flatten().flatten().collect();
                 let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> = None;
-                ListArray::new(
+                ListArray::try_new(
                     Self::arrow_datatype(),
                     offsets,
                     {
                         let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
                             data0_inner_data.iter().map(|datum| datum.len()),
-                        )
-                        .map_err(|err| std::sync::Arc::new(err))?
+                        )?
                         .into();
                         let inner_data: arrow2::buffer::Buffer<u8> =
                             data0_inner_data.into_iter().flat_map(|s| s.0).collect();
@@ -131,7 +129,7 @@ impl crate::Loggable for VisualizerOverrides {
                         .boxed()
                     },
                     data0_bitmap,
-                )
+                )?
                 .boxed()
             }
         })

--- a/crates/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/re_types_core/src/datatypes/entity_path.rs
@@ -97,8 +97,7 @@ impl crate::Loggable for EntityPath {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> =
                     data0.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types_core/src/datatypes/utf8.rs
+++ b/crates/re_types_core/src/datatypes/utf8.rs
@@ -97,8 +97,7 @@ impl crate::Loggable for Utf8 {
                     data0
                         .iter()
                         .map(|opt| opt.as_ref().map(|datum| datum.len()).unwrap_or_default()),
-                )
-                .map_err(|err| std::sync::Arc::new(err))?
+                )?
                 .into();
                 let inner_data: arrow2::buffer::Buffer<u8> =
                     data0.into_iter().flatten().flat_map(|s| s.0).collect();

--- a/crates/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/re_types_core/src/datatypes/visible_time_range.rs
@@ -113,14 +113,14 @@ impl crate::Loggable for VisibleTimeRange {
                                 timeline.iter().map(|opt| {
                                     opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()
                                 }),
-                            )
-                            .map_err(|err| std::sync::Arc::new(err))?
+                            )?
                             .into();
                             let inner_data: arrow2::buffer::Buffer<u8> = timeline
                                 .into_iter()
                                 .flatten()
                                 .flat_map(|datum| datum.0 .0)
                                 .collect();
+
                             #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
                             unsafe {
                                 Utf8Array::<i32>::new_unchecked(

--- a/crates/re_types_core/src/lib.rs
+++ b/crates/re_types_core/src/lib.rs
@@ -15,6 +15,9 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 // ---
 
 /// Describes the interface for interpreting an object as a bundle of [`Component`]s.

--- a/crates/re_types_core/src/result.rs
+++ b/crates/re_types_core/src/result.rs
@@ -1,3 +1,5 @@
+use std::{fmt::Display, ops::Deref};
+
 use crate::ComponentName;
 
 // ---
@@ -34,8 +36,8 @@ pub enum SerializationError {
     },
 
     /// E.g. too many values (overflows i32).
-    #[error("Arrow error")]
-    ArrowError(#[from] std::sync::Arc<arrow2::error::Error>),
+    #[error(transparent)]
+    ArrowError(#[from] ArcArrowError),
 }
 
 impl std::fmt::Debug for SerializationError {
@@ -90,6 +92,40 @@ impl SerializationError {
             | Self::NotImplemented { backtrace, .. } => Some(backtrace.clone()),
             Self::ArrowError { .. } | Self::Context { .. } => None,
         }
+    }
+}
+
+/// A cloneable wrapper around `arrow2::error::Error`, for easier use.
+///
+/// The motivation behind this type is that we often use code that can return a `arrow2::error::Error`
+/// inside functions that return a `SerializationError`. By wrapping it we can use the ? operator and simplify the code.
+/// Second, normally also `arrow2::error::Error` isn't clonable, but `SerializationError` is.
+#[derive(Clone, Debug)]
+pub struct ArcArrowError(std::sync::Arc<arrow2::error::Error>);
+
+impl From<arrow2::error::Error> for ArcArrowError {
+    fn from(e: arrow2::error::Error) -> Self {
+        Self(std::sync::Arc::new(e))
+    }
+}
+
+impl From<arrow2::error::Error> for SerializationError {
+    fn from(e: arrow2::error::Error) -> Self {
+        SerializationError::ArrowError(ArcArrowError::from(e))
+    }
+}
+
+impl Deref for ArcArrowError {
+    type Target = arrow2::error::Error;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl Display for ArcArrowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
     }
 }
 
@@ -170,6 +206,9 @@ pub enum DeserializationError {
         len: usize,
         backtrace: _Backtrace,
     },
+
+    #[error("Array is smaller than the expected size of {size}")]
+    ArrayInitUnderrun { size: usize, backtrace: _Backtrace },
 
     #[error("serde-based deserialization (`attr.rust.serde_type`) failed: {reason}")]
     SerdeFailure {
@@ -282,6 +321,14 @@ impl DeserializationError {
     }
 
     #[inline]
+    pub fn array_init_underrun(size: usize) -> Self {
+        Self::ArrayInitUnderrun {
+            size,
+            backtrace: ::backtrace::Backtrace::new_unresolved(),
+        }
+    }
+
+    #[inline]
     pub fn serde_failure(reason: impl AsRef<str>) -> Self {
         Self::SerdeFailure {
             reason: reason.as_ref().into(),
@@ -308,6 +355,7 @@ impl DeserializationError {
             | DeserializationError::DatatypeMismatch { backtrace, .. }
             | DeserializationError::OffsetOutOfBounds { backtrace, .. }
             | DeserializationError::OffsetSliceOutOfBounds { backtrace, .. }
+            | DeserializationError::ArrayInitUnderrun { backtrace, .. }
             | DeserializationError::SerdeFailure { backtrace, .. } => Some(backtrace.clone()),
             DeserializationError::DataCellError(_) | DeserializationError::ValidationError(_) => {
                 None

--- a/crates/re_types_core/src/result.rs
+++ b/crates/re_types_core/src/result.rs
@@ -207,9 +207,6 @@ pub enum DeserializationError {
         backtrace: _Backtrace,
     },
 
-    #[error("Array is smaller than the expected size of {size}")]
-    ArrayInitUnderrun { size: usize, backtrace: _Backtrace },
-
     #[error("serde-based deserialization (`attr.rust.serde_type`) failed: {reason}")]
     SerdeFailure {
         reason: String,
@@ -321,14 +318,6 @@ impl DeserializationError {
     }
 
     #[inline]
-    pub fn array_init_underrun(size: usize) -> Self {
-        Self::ArrayInitUnderrun {
-            size,
-            backtrace: ::backtrace::Backtrace::new_unresolved(),
-        }
-    }
-
-    #[inline]
     pub fn serde_failure(reason: impl AsRef<str>) -> Self {
         Self::SerdeFailure {
             reason: reason.as_ref().into(),
@@ -355,7 +344,6 @@ impl DeserializationError {
             | DeserializationError::DatatypeMismatch { backtrace, .. }
             | DeserializationError::OffsetOutOfBounds { backtrace, .. }
             | DeserializationError::OffsetSliceOutOfBounds { backtrace, .. }
-            | DeserializationError::ArrayInitUnderrun { backtrace, .. }
             | DeserializationError::SerdeFailure { backtrace, .. } => Some(backtrace.clone()),
             DeserializationError::DataCellError(_) | DeserializationError::ValidationError(_) => {
                 None

--- a/crates/re_types_core/src/result.rs
+++ b/crates/re_types_core/src/result.rs
@@ -118,6 +118,7 @@ impl From<arrow2::error::Error> for SerializationError {
 impl Deref for ArcArrowError {
     type Target = arrow2::error::Error;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
     }

--- a/crates/re_ui/examples/re_ui_example/main.rs
+++ b/crates/re_ui/examples/re_ui_example/main.rs
@@ -98,7 +98,7 @@ pub struct ExampleApp {
 impl ExampleApp {
     fn new(re_ui: re_ui::ReUi) -> Self {
         let (logger, text_log_rx) = re_log::ChannelLogger::new(re_log::LevelFilter::Info);
-        re_log::add_boxed_logger(Box::new(logger)).unwrap();
+        re_log::add_boxed_logger(Box::new(logger)).expect("Failed to add logger");
 
         let tree = egui_tiles::Tree::new_tabs("my_tree", vec![1, 2, 3]);
 

--- a/crates/re_viewer/src/lib.rs
+++ b/crates/re_viewer/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate contains all the GUI code for the Rerun Viewer,
 //! including all 2D and 3D visualization code.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 mod app;
 mod app_blueprint;
 mod app_state;

--- a/crates/re_viewport/src/lib.rs
+++ b/crates/re_viewport/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! This crate provides the central panel that contains all space views.
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 pub const VIEWPORT_PATH: &str = "viewport";
 
 mod add_space_view_or_container_modal;

--- a/crates/re_ws_comms/src/lib.rs
+++ b/crates/re_ws_comms/src/lib.rs
@@ -4,6 +4,9 @@
 #![doc = document_features::document_features!()]
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 #[cfg(feature = "client")]
 mod client;
 use std::{fmt::Display, str::FromStr};

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -112,7 +112,7 @@ impl RerunArgs {
 
             RerunBehavior::Connect(addr) => Ok((
                 RecordingStreamBuilder::new(application_id)
-                    .connect_opts(addr, crate::default_flush_timeout())?,
+                    .connect_opts(addr, Some(crate::default_flush_timeout()))?,
                 Default::default(),
             )),
 

--- a/crates/rerun/src/clap.rs
+++ b/crates/rerun/src/clap.rs
@@ -112,7 +112,7 @@ impl RerunArgs {
 
             RerunBehavior::Connect(addr) => Ok((
                 RecordingStreamBuilder::new(application_id)
-                    .connect_opts(addr, Some(crate::default_flush_timeout()))?,
+                    .connect_opts(addr, crate::default_flush_timeout())?,
                 Default::default(),
             )),
 

--- a/crates/rerun/src/lib.rs
+++ b/crates/rerun/src/lib.rs
@@ -101,6 +101,8 @@
 //! See [`Logger`].
 //!
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
 #![warn(missing_docs)] // Let's keep the this crate well-documented!
 
 #[cfg(feature = "run")]

--- a/crates/rerun_c/src/lib.rs
+++ b/crates/rerun_c/src/lib.rs
@@ -215,8 +215,9 @@ pub struct CError {
 #[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn rr_version_string() -> *const c_char {
-    static VERSION: Lazy<CString> =
-        Lazy::new(|| CString::new(re_sdk::build_info().version.to_string()).unwrap()); // unwrap: there won't be any NUL bytes in the string
+    static VERSION: Lazy<CString> = Lazy::new(|| {
+        CString::new(re_sdk::build_info().version.to_string()).expect("CString::new failed")
+    }); // unwrap: there won't be any NUL bytes in the string
 
     VERSION.as_ptr()
 }

--- a/docs/snippets/build.rs
+++ b/docs/snippets/build.rs
@@ -6,6 +6,9 @@
 //!
 //! Motivation: <https://github.com/rerun-io/rerun/issues/4623>
 
+// TODO(#3408): remove unwrap()
+#![allow(clippy::unwrap_used)]
+
 use std::{fs, path::Path};
 
 use itertools::Itertools as _;
@@ -82,7 +85,7 @@ fn main() {
         let args: Vec<String> = std::env::args().skip(1).collect();
 
         if args.is_empty() {
-            eprintln!("Usage: {} <snippet-name>\n", std::env::args().next().unwrap());
+            eprintln!("Usage: {} <snippet-name>\n", std::env::args().next().unwrap_or("snippets".to_owned()));
             eprintln!("Available snippets ${SNIPPETS}:\n");
             std::process::exit(1);
         }

--- a/rerun_py/build.rs
+++ b/rerun_py/build.rs
@@ -15,7 +15,7 @@ fn main() {
 
         #[cfg(not(target_os = "windows"))]
         let rerun_bin = std::env::current_dir()
-            .unwrap()
+            .expect("std::env::current_dir() failed")
             .join("rerun_sdk/rerun_cli/rerun");
 
         if !rerun_bin.exists() {

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -549,7 +549,7 @@ fn spawn(
 }
 
 #[pyfunction]
-#[pyo3(signature = (addr = None, flush_timeout_sec=re_sdk::default_flush_timeout().as_secs_f32(), default_blueprint = None, recording = None))]
+#[pyo3(signature = (addr = None, flush_timeout_sec=re_sdk::default_flush_timeout().expect("always Some()").as_secs_f32(), default_blueprint = None, recording = None))]
 fn connect(
     addr: Option<String>,
     flush_timeout_sec: Option<f32>,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -549,7 +549,7 @@ fn spawn(
 }
 
 #[pyfunction]
-#[pyo3(signature = (addr = None, flush_timeout_sec=re_sdk::default_flush_timeout().unwrap().as_secs_f32(), default_blueprint = None, recording = None))]
+#[pyo3(signature = (addr = None, flush_timeout_sec=re_sdk::default_flush_timeout().as_secs_f32(), default_blueprint = None, recording = None))]
 fn connect(
     addr: Option<String>,
     flush_timeout_sec: Option<f32>,

--- a/run_wasm/src/main.rs
+++ b/run_wasm/src/main.rs
@@ -68,10 +68,14 @@ fn main() {
 
     use pico_args::Arguments;
     let mut args = Arguments::from_env();
-    let host: Option<String> = args.opt_value_from_str("--host").unwrap();
-    let port: Option<String> = args.opt_value_from_str("--port").unwrap();
-    let host = host.as_deref().unwrap_or("localhost");
-    let port = port.as_deref().unwrap_or("8000");
+    let host = args
+        .opt_value_from_str("--host")
+        .unwrap_or(None)
+        .unwrap_or("localhost".to_owned());
+    let port = args
+        .opt_value_from_str("--port")
+        .unwrap_or(None)
+        .unwrap_or("8000".to_owned());
 
     let thread = std::thread::Builder::new()
         .name("cargo_run_wasm".into())
@@ -81,7 +85,7 @@ fn main() {
         .expect("Failed to spawn thread");
 
     if args.contains("--build-only") {
-        thread.join().unwrap();
+        thread.join().expect("std::thread::join() failed");
     } else {
         // It would be nice to start a web-browser, but we can't really know when the server is ready.
         // So we just sleep for a while and hope it works.

--- a/tests/rust/roundtrips/image/src/main.rs
+++ b/tests/rust/roundtrips/image/src/main.rs
@@ -1,5 +1,8 @@
 //! Logs an `Image` archetype for roundtrip checks.
 
+// Allow unwrap() in tests (allow-unwrap-in-tests doesn't apply)
+#![allow(clippy::unwrap_used)]
+
 use half::f16;
 use image::{Rgb, RgbImage};
 use ndarray::{Array, ShapeBuilder};

--- a/tests/rust/test_image_memory/src/main.rs
+++ b/tests/rust/test_image_memory/src/main.rs
@@ -1,5 +1,8 @@
 //! Logs a bunch of big images to test Rerun memory usage.
 
+// Allow unwrap() in tests (allow-unwrap-in-tests doesn't apply)
+#![allow(clippy::unwrap_used)]
+
 use mimalloc::MiMalloc;
 
 use re_memory::AccountingAllocator;


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
Resolves #3408: Remove all usages of unwrap() and forbid it's use (if applicable).

*If applicable* because even after the first batch of changes there are over 800(!) usages of unwrap() in the code - for various reasons, and often explicitly allowed. So I think it's probably unrealistic to get rid of all of them, and probably also not necessary.

The strategy:
1. Warn on all usages of `unwrap()`.
2. Remove `unwrap()` module by module.
3. Where `unwrap()` would be theoretically okay use `expect("error msg")`.
4. Leave build tools as they are for now - panics there are annoying but not critical (can happen when e.g. some command line tool is missing).
5. For tests and benchmarks unwrap is totally okay imho (`allow-unwrap-in-tests` was anyway already set in `clippy.toml`)
6. Where errors are returned combine error types and "?-ify" the code, or use some other idiomatic Rust expression.
7. Goal: eventually deny `clippy::unwrap_used` everywhere, unless explicitly allowed.

*Note: as this is my first PR, early feedback is greatly appreciated*🙏
Also - rookie question - what (or where) are the guidelines for the last three items in the checklist? Are they needed for this PR, as this is just a cleanup?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG

- [PR Build Summary](https://build.rerun.io/pr/6311)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.