### PR TITLE
Increase timeout for test_multiprocessing_gc failure

### DIFF
--- a/rerun_py/tests/unit/test_multiprocessing_gc.py
+++ b/rerun_py/tests/unit/test_multiprocessing_gc.py
@@ -27,7 +27,7 @@ def test_multiprocessing_gc() -> None:
         target=task,
     )
     proc.start()
-    proc.join(1)
+    proc.join(5)
     if proc.is_alive():
         # Terminate so our test doesn't get stuck
         proc.terminate()


### PR DESCRIPTION
### What
Seeing intermittent test failures such as: https://github.com/rerun-io/rerun/actions/runs/9079263975/job/24949470254

1s seems like it should have been plenty, but maybe this is a system load timeout issue? We only hit this timeout if the test is failing so increasing it some shouldn't hurt anything.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
