### PR TITLE
Keep track of the RRD protocol version and display it where relevant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4619,6 +4619,7 @@ dependencies = [
  "crossbeam",
  "document-features",
  "rand",
+ "re_build_info",
  "re_log",
  "re_log_encoding",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,9 @@ dependencies = [
 [[package]]
 name = "re_build_info"
 version = "0.16.0-alpha.4"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "re_build_tools"
@@ -4188,6 +4191,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rayon",
+ "re_build_info",
  "re_build_tools",
  "re_log",
  "re_log_encoding",
@@ -4317,6 +4321,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "rand",
+ "re_build_info",
  "re_data_store",
  "re_format",
  "re_int_histogram",
@@ -4428,6 +4433,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "re_arrow2",
+ "re_build_info",
  "re_format",
  "re_format_arrow",
  "re_log",

--- a/crates/re_analytics/src/event.rs
+++ b/crates/re_analytics/src/event.rs
@@ -88,6 +88,9 @@ pub struct StoreInfo {
     /// Where data is being logged.
     pub store_source: String,
 
+    /// The Rerun version that was used to encode the RRD data.
+    pub store_version: String,
+
     // Various versions of the host environment.
     pub rust_version: Option<String>,
     pub llvm_version: Option<String>,
@@ -193,16 +196,29 @@ impl Properties for OpenRecording {
         event.insert("app_env", app_env);
 
         if let Some(store_info) = store_info {
-            event.insert("application_id", store_info.application_id);
-            event.insert("recording_id", store_info.recording_id);
-            event.insert("store_source", store_info.store_source);
-            event.insert_opt("rust_version", store_info.rust_version);
-            event.insert_opt("llvm_version", store_info.llvm_version);
-            event.insert_opt("python_version", store_info.python_version);
-            event.insert("is_official_example", store_info.is_official_example);
+            let StoreInfo {
+                application_id,
+                recording_id,
+                store_source,
+                store_version,
+                rust_version,
+                llvm_version,
+                python_version,
+                is_official_example,
+                app_id_starts_with_rerun_example,
+            } = store_info;
+
+            event.insert("application_id", application_id);
+            event.insert("recording_id", recording_id);
+            event.insert("store_source", store_source);
+            event.insert("store_version", store_version);
+            event.insert_opt("rust_version", rust_version);
+            event.insert_opt("llvm_version", llvm_version);
+            event.insert_opt("python_version", python_version);
+            event.insert("is_official_example", is_official_example);
             event.insert(
                 "app_id_starts_with_rerun_example",
-                store_info.app_id_starts_with_rerun_example,
+                app_id_starts_with_rerun_example,
             );
         }
 

--- a/crates/re_build_info/Cargo.toml
+++ b/crates/re_build_info/Cargo.toml
@@ -17,3 +17,16 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+
+[features]
+default = []
+
+## Enable (de)serialization using serde.
+serde = ["dep:serde"]
+
+
+[dependencies]
+
+# Optional dependencies:
+serde = { workspace = true, optional = true, features = ["derive", "rc"] }

--- a/crates/re_build_info/src/crate_version.rs
+++ b/crates/re_build_info/src/crate_version.rs
@@ -41,6 +41,7 @@ mod meta {
 /// - `01NNNNNN` -> `-rc.N`
 /// - `00000000` -> none of the above
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CrateVersion {
     pub major: u8,
     pub minor: u8,
@@ -48,7 +49,12 @@ pub struct CrateVersion {
     pub meta: Option<Meta>,
 }
 
+impl CrateVersion {
+    pub const LOCAL: Self = Self::parse(env!("CARGO_PKG_VERSION"));
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Meta {
     Rc(u8),
     Alpha(u8),

--- a/crates/re_data_loader/Cargo.toml
+++ b/crates/re_data_loader/Cargo.toml
@@ -24,6 +24,7 @@ default = []
 
 
 [dependencies]
+re_build_info.workspace = true
 re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_log.workspace = true

--- a/crates/re_data_loader/src/load_file.rs
+++ b/crates/re_data_loader/src/load_file.rs
@@ -113,6 +113,10 @@ pub(crate) fn prepare_store_info(
                 is_official_example: false,
                 started: re_log_types::Time::now(),
                 store_source,
+                // NOTE: Since this cannot be an RRD file, either the current process or an external data
+                // loader will have to do the logging.
+                // In both case we can assume that the protocol version is the local one.
+                store_version: Some(re_build_info::CrateVersion::LOCAL),
             },
         })
     })

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -44,6 +44,7 @@ impl crate::DataUi for EntityDb {
                     is_official_example: _,
                     started,
                     store_source,
+                    store_version,
                 } = store_info;
 
                 if let Some(cloned_from) =  cloned_from {
@@ -59,6 +60,14 @@ impl crate::DataUi for EntityDb {
                 re_ui.grid_left_hand_label(ui, "Source");
                 ui.label(store_source.to_string());
                 ui.end_row();
+
+                if let Some(store_version) = store_version {
+                    re_ui.grid_left_hand_label(ui, "Protocol Version");
+                    ui.label(store_version.to_string());
+                    ui.end_row();
+                } else {
+                    re_log::debug_once!("store version is undefined for this recording, this is a bug");
+                }
 
                 re_ui.grid_left_hand_label(ui, "Kind");
                 ui.label(store_id.kind.to_string());

--- a/crates/re_data_ui/src/entity_db.rs
+++ b/crates/re_data_ui/src/entity_db.rs
@@ -62,7 +62,7 @@ impl crate::DataUi for EntityDb {
                 ui.end_row();
 
                 if let Some(store_version) = store_version {
-                    re_ui.grid_left_hand_label(ui, "Protocol Version");
+                    re_ui.grid_left_hand_label(ui, "Source RRD version");
                     ui.label(store_version.to_string());
                     ui.end_row();
                 } else {

--- a/crates/re_data_ui/src/log_msg.rs
+++ b/crates/re_data_ui/src/log_msg.rs
@@ -48,6 +48,7 @@ impl DataUi for SetStoreInfo {
             started,
             store_source,
             is_official_example,
+            store_version,
         } = info;
 
         let re_ui = &ctx.re_ui;
@@ -76,6 +77,14 @@ impl DataUi for SetStoreInfo {
             re_ui.grid_left_hand_label(ui, "store_source:");
             ui.label(format!("{store_source}"));
             ui.end_row();
+
+            if let Some(store_version) = store_version {
+                re_ui.grid_left_hand_label(ui, "store_version:");
+                ui.label(format!("{store_version}"));
+                ui.end_row();
+            } else {
+                re_log::debug_once!("store version is undefined for this recording, this is a bug");
+            }
 
             re_ui.grid_left_hand_label(ui, "is_official_example:");
             ui.label(format!("{is_official_example}"));

--- a/crates/re_entity_db/Cargo.toml
+++ b/crates/re_entity_db/Cargo.toml
@@ -27,6 +27,7 @@ serde = ["dep:serde", "dep:rmp-serde", "re_log_types/serde"]
 
 
 [dependencies]
+re_build_info.workspace = true
 re_data_store.workspace = true
 re_format.workspace = true
 re_int_histogram.workspace = true

--- a/crates/re_entity_db/examples/memory_usage.rs
+++ b/crates/re_entity_db/examples/memory_usage.rs
@@ -63,8 +63,13 @@ fn log_messages() {
     fn encode_log_msg(log_msg: &LogMsg) -> Vec<u8> {
         let mut bytes = vec![];
         let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-        re_log_encoding::encoder::encode(encoding_options, std::iter::once(log_msg), &mut bytes)
-            .unwrap();
+        re_log_encoding::encoder::encode(
+            re_build_info::CrateVersion::LOCAL,
+            encoding_options,
+            std::iter::once(log_msg),
+            &mut bytes,
+        )
+        .unwrap();
         bytes
     }
 

--- a/crates/re_entity_db/src/store_bundle.rs
+++ b/crates/re_entity_db/src/store_bundle.rs
@@ -107,6 +107,7 @@ impl StoreBundle {
                     is_official_example: false,
                     started: re_log_types::Time::now(),
                     store_source: re_log_types::StoreSource::Other("viewer".to_owned()),
+                    store_version: Some(re_build_info::CrateVersion::LOCAL),
                 },
             });
 

--- a/crates/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -30,7 +30,13 @@ criterion_main!(benches);
 fn encode_log_msgs(messages: &[LogMsg]) -> Vec<u8> {
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let mut bytes = vec![];
-    re_log_encoding::encoder::encode(encoding_options, messages.iter(), &mut bytes).unwrap();
+    re_log_encoding::encoder::encode(
+        re_build_info::CrateVersion::LOCAL,
+        encoding_options,
+        messages.iter(),
+        &mut bytes,
+    )
+    .unwrap();
     assert!(bytes.len() > messages.len());
     bytes
 }

--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -37,23 +37,22 @@ fn warn_on_version_mismatch(
         CrateVersion::from_bytes(encoded_version)
     };
 
-    const LOCAL_VERSION: CrateVersion = CrateVersion::parse(env!("CARGO_PKG_VERSION"));
-
-    if encoded_version.is_compatible_with(LOCAL_VERSION) {
+    if encoded_version.is_compatible_with(CrateVersion::LOCAL) {
         Ok(())
     } else {
         match version_policy {
             VersionPolicy::Warn => {
                 re_log::warn_once!(
                     "Found log stream with Rerun version {encoded_version}, \
-                     which is incompatible with the local Rerun version {LOCAL_VERSION}. \
-                     Loading will try to continue, but might fail in subtle ways."
+                     which is incompatible with the local Rerun version {}. \
+                     Loading will try to continue, but might fail in subtle ways.",
+                    CrateVersion::LOCAL,
                 );
                 Ok(())
             }
             VersionPolicy::Error => Err(DecodeError::IncompatibleRerunVersion {
                 file: encoded_version,
-                local: LOCAL_VERSION,
+                local: CrateVersion::LOCAL,
             }),
         }
     }
@@ -109,7 +108,7 @@ pub fn decode_bytes(
 pub fn read_options(
     version_policy: VersionPolicy,
     bytes: &[u8],
-) -> Result<EncodingOptions, DecodeError> {
+) -> Result<(CrateVersion, EncodingOptions), DecodeError> {
     let mut read = std::io::Cursor::new(bytes);
 
     let FileHeader {
@@ -130,10 +129,11 @@ pub fn read_options(
         Serializer::MsgPack => {}
     }
 
-    Ok(options)
+    Ok((CrateVersion::from_bytes(version), options))
 }
 
 pub struct Decoder<R: std::io::Read> {
+    version: CrateVersion,
     compression: Compression,
     read: R,
     uncompressed: Vec<u8>, // scratch space
@@ -146,14 +146,23 @@ impl<R: std::io::Read> Decoder<R> {
 
         let mut data = [0_u8; FileHeader::SIZE];
         read.read_exact(&mut data).map_err(DecodeError::Read)?;
-        let compression = read_options(version_policy, &data)?.compression;
+
+        let (version, options) = read_options(version_policy, &data)?;
+        let compression = options.compression;
 
         Ok(Self {
+            version,
             compression,
             read,
             uncompressed: vec![],
             compressed: vec![],
         })
+    }
+
+    /// Returns the Rerun version that was used to encode the data in the first place.
+    #[inline]
+    pub fn version(&self) -> CrateVersion {
+        self.version
     }
 }
 
@@ -211,6 +220,12 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 
         re_tracing::profile_scope!("MsgPack deser");
         match rmp_serde::from_slice(&self.uncompressed[..uncompressed_len]) {
+            Ok(re_log_types::LogMsg::SetStoreInfo(mut msg)) => {
+                // Propagate the protocol version from the header into the `StoreInfo` so that all
+                // parts of the app can easily access it.
+                msg.info.store_version = Some(self.version());
+                Some(Ok(re_log_types::LogMsg::SetStoreInfo(msg)))
+            }
             Ok(msg) => Some(Ok(msg)),
             Err(err) => Some(Err(err.into())),
         }
@@ -239,6 +254,7 @@ fn test_encode_decode() {
                 rustc_version: String::new(),
                 llvm_version: String::new(),
             },
+            store_version: Some(CrateVersion::LOCAL),
         },
     })];
 

--- a/crates/re_log_encoding/src/decoder/mod.rs
+++ b/crates/re_log_encoding/src/decoder/mod.rs
@@ -242,6 +242,8 @@ fn test_encode_decode() {
         Time,
     };
 
+    let rrd_version = CrateVersion::LOCAL;
+
     let messages = vec![LogMsg::SetStoreInfo(SetStoreInfo {
         row_id: RowId::new(),
         info: StoreInfo {
@@ -254,7 +256,7 @@ fn test_encode_decode() {
                 rustc_version: String::new(),
                 llvm_version: String::new(),
             },
-            store_version: Some(CrateVersion::LOCAL),
+            store_version: Some(rrd_version),
         },
     })];
 
@@ -271,7 +273,7 @@ fn test_encode_decode() {
 
     for options in options {
         let mut file = vec![];
-        crate::encoder::encode(options, messages.iter(), &mut file).unwrap();
+        crate::encoder::encode(rrd_version, options, messages.iter(), &mut file).unwrap();
 
         let decoded_messages = Decoder::new(VersionPolicy::Error, &mut file.as_slice())
             .unwrap()

--- a/crates/re_log_encoding/src/decoder/stream.rs
+++ b/crates/re_log_encoding/src/decoder/stream.rs
@@ -265,7 +265,7 @@ mod tests {
         let messages: Vec<_> = (0..n).map(|_| fake_log_msg()).collect();
 
         let mut buffer = Vec::new();
-        let mut encoder = Encoder::new(options, &mut buffer).unwrap();
+        let mut encoder = Encoder::new(CrateVersion::LOCAL, options, &mut buffer).unwrap();
         for message in &messages {
             encoder.append(message).unwrap();
         }

--- a/crates/re_log_encoding/src/decoder/stream.rs
+++ b/crates/re_log_encoding/src/decoder/stream.rs
@@ -256,7 +256,7 @@ mod tests {
                 is_official_example: false,
                 started: Time::from_ns_since_epoch(0),
                 store_source: StoreSource::Unknown,
-                store_version: None,
+                store_version: Some(CrateVersion::LOCAL),
             },
         })
     }

--- a/crates/re_log_encoding/src/file_sink.rs
+++ b/crates/re_log_encoding/src/file_sink.rs
@@ -75,7 +75,11 @@ impl FileSink {
 
         let file = std::fs::File::create(&path)
             .map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-        let encoder = crate::encoder::Encoder::new(encoding_options, file)?;
+        let encoder = crate::encoder::Encoder::new(
+            re_build_info::CrateVersion::LOCAL,
+            encoding_options,
+            file,
+        )?;
         let join_handle = spawn_and_stream(Some(&path), encoder, rx)?;
 
         Ok(Self {
@@ -93,7 +97,11 @@ impl FileSink {
 
         re_log::debug!("Writing to stdout…");
 
-        let encoder = crate::encoder::Encoder::new(encoding_options, std::io::stdout())?;
+        let encoder = crate::encoder::Encoder::new(
+            re_build_info::CrateVersion::LOCAL,
+            encoding_options,
+            std::io::stdout(),
+        )?;
         let join_handle = spawn_and_stream(None, encoder, rx)?;
 
         Ok(Self {

--- a/crates/re_log_types/Cargo.toml
+++ b/crates/re_log_types/Cargo.toml
@@ -32,6 +32,7 @@ default = []
 serde = [
   "dep:serde",
   "dep:serde_bytes",
+  "re_build_info/serde",
   "re_string_interner/serde",
   "re_tuid/serde",
   "re_types_core/serde",
@@ -40,6 +41,7 @@ serde = [
 [dependencies]
 
 # Rerun
+re_build_info.workspace = true
 re_format.workspace = true
 re_format_arrow.workspace = true
 re_log.workspace = true

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -368,7 +368,7 @@ pub struct StoreInfo {
     ///
     // NOTE: The version comes directly from the decoded RRD stream's header, duplicating it here
     // would probably only lead to more issues down the line.
-    #[serde(skip, default = "Option::default")]
+    #[serde(skip)]
     pub store_version: Option<CrateVersion>,
 }
 

--- a/crates/re_log_types/src/lib.rs
+++ b/crates/re_log_types/src/lib.rs
@@ -37,6 +37,8 @@ mod data_table_batcher;
 
 use std::sync::Arc;
 
+use re_build_info::CrateVersion;
+
 pub use self::arrow_msg::{ArrowChunkReleaseCallback, ArrowMsg};
 pub use self::data_cell::{DataCell, DataCellError, DataCellInner, DataCellResult};
 pub use self::data_row::{
@@ -361,6 +363,13 @@ pub struct StoreInfo {
     pub started: Time,
 
     pub store_source: StoreSource,
+
+    /// The Rerun version used to encoded the RRD data.
+    ///
+    // NOTE: The version comes directly from the decoded RRD stream's header, duplicating it here
+    // would probably only lead to more issues down the line.
+    #[serde(skip, default = "Option::default")]
+    pub store_version: Option<CrateVersion>,
 }
 
 impl StoreInfo {

--- a/crates/re_sdk/src/binary_stream_sink.rs
+++ b/crates/re_sdk/src/binary_stream_sink.rs
@@ -133,8 +133,11 @@ impl BinaryStreamSink {
 
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let encoder =
-            re_log_encoding::encoder::Encoder::new(encoding_options, storage.inner.clone())?;
+        let encoder = re_log_encoding::encoder::Encoder::new(
+            re_build_info::CrateVersion::LOCAL,
+            encoding_options,
+            storage.inner.clone(),
+        )?;
 
         let join_handle = spawn_and_stream(encoder, rx)?;
 

--- a/crates/re_sdk/src/lib.rs
+++ b/crates/re_sdk/src/lib.rs
@@ -183,6 +183,7 @@ pub fn new_store_info(
             rustc_version: env!("RE_BUILD_RUSTC_VERSION").into(),
             llvm_version: env!("RE_BUILD_LLVM_VERSION").into(),
         },
+        store_version: Some(re_build_info::CrateVersion::LOCAL),
     }
 }
 

--- a/crates/re_sdk/src/log_sink.rs
+++ b/crates/re_sdk/src/log_sink.rs
@@ -255,8 +255,11 @@ impl MemorySinkStorage {
 
         {
             let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-            let mut encoder =
-                re_log_encoding::encoder::Encoder::new(encoding_options, &mut buffer)?;
+            let mut encoder = re_log_encoding::encoder::Encoder::new(
+                re_build_info::CrateVersion::LOCAL,
+                encoding_options,
+                &mut buffer,
+            )?;
             for sink in sinks {
                 // NOTE: It's fine, this is an in-memory sink so by definition there's no I/O involved
                 // in this flush; it's just a matter of making the table batcher tick early.
@@ -285,8 +288,11 @@ impl MemorySinkStorage {
 
         {
             let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-            let mut encoder =
-                re_log_encoding::encoder::Encoder::new(encoding_options, &mut buffer)?;
+            let mut encoder = re_log_encoding::encoder::Encoder::new(
+                re_build_info::CrateVersion::LOCAL,
+                encoding_options,
+                &mut buffer,
+            )?;
 
             let mut inner = self.inner.lock();
             inner.has_been_used = true;

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -555,6 +555,7 @@ impl RecordingStreamBuilder {
             is_official_example,
             started: Time::now(),
             store_source,
+            store_version: Some(re_build_info::CrateVersion::LOCAL),
         };
 
         let batcher_config =

--- a/crates/re_sdk_comms/Cargo.toml
+++ b/crates/re_sdk_comms/Cargo.toml
@@ -28,6 +28,7 @@ server = ["rand", "re_log_encoding/decoder"]
 
 
 [dependencies]
+re_build_info.workspace = true
 re_log_encoding.workspace = true
 re_log_types = { workspace = true, features = ["serde"] }
 re_log.workspace = true

--- a/crates/re_sdk_comms/src/buffered_client.rs
+++ b/crates/re_sdk_comms/src/buffered_client.rs
@@ -177,7 +177,10 @@ fn msg_encode(
 
                 let packet_msg = match &msg_msg {
                     MsgMsg::LogMsg(log_msg) => {
-                        match re_log_encoding::encoder::encode_to_bytes(encoding_options, std::iter::once(log_msg)) {
+                        match re_log_encoding::encoder::encode_to_bytes(
+                            re_build_info::CrateVersion::LOCAL,
+                            encoding_options, std::iter::once(log_msg),
+                        ) {
                             Ok(packet) => {
                                 re_log::trace!("Encoded message of size {}", packet.len());
                                 Some(PacketMsg::Packet(packet))

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -1792,7 +1792,7 @@ fn save_entity_db(
         let messages = to_log_messages()?;
 
         wasm_bindgen_futures::spawn_local(async move {
-            if let Err(err) = async_save_dialog(&file_name, &title, &messages).await {
+            if let Err(err) = async_save_dialog(rrd_version, &file_name, &title, &messages).await {
                 re_log::error!("File saving failed: {err}");
             }
         });
@@ -1822,6 +1822,7 @@ fn save_entity_db(
 
 #[cfg(target_arch = "wasm32")]
 async fn async_save_dialog(
+    rrd_version: CrateVersion,
     file_name: &str,
     title: &str,
     messages: &[LogMsg],
@@ -1839,6 +1840,7 @@ async fn async_save_dialog(
     };
 
     let bytes = re_log_encoding::encoder::encode_as_bytes(
+        rrd_version,
         re_log_encoding::EncodingOptions::COMPRESSED,
         messages.iter(),
     )?;

--- a/crates/re_viewer/src/saving.rs
+++ b/crates/re_viewer/src/saving.rs
@@ -61,6 +61,7 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn encode_to_file<'a>(
+    version: re_build_info::CrateVersion,
     path: &std::path::Path,
     messages: impl Iterator<Item = &'a re_log_types::LogMsg>,
 ) -> anyhow::Result<()> {
@@ -71,6 +72,6 @@ pub fn encode_to_file<'a>(
         .with_context(|| format!("Failed to create file at {path:?}"))?;
 
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-    re_log_encoding::encoder::encode(encoding_options, messages, &mut file)
+    re_log_encoding::encoder::encode(version, encoding_options, messages, &mut file)
         .context("Message encode")
 }

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -870,7 +870,11 @@ fn stream_to_rrd_on_disk(
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let file =
         std::fs::File::create(path).map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-    let mut encoder = re_log_encoding::encoder::Encoder::new(encoding_options, file)?;
+    let mut encoder = re_log_encoding::encoder::Encoder::new(
+        re_build_info::CrateVersion::LOCAL,
+        encoding_options,
+        file,
+    )?;
 
     loop {
         match rx.recv() {

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -527,6 +527,7 @@ impl PrintCommand {
         let rrd_file = std::fs::File::open(rrd_path)?;
         let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
         let decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)?;
+        println!("Decoded RRD stream v{}\n---", decoder.version());
         for msg in decoder {
             let msg = msg.context("decode rrd message")?;
             match msg {


### PR DESCRIPTION
This augments `StoreInfo` with an in-memory only (!) `store_version` field.
Our `Decoder` and `StreamDecoder` have been patched to fill out this field using the RRD version present in the stream's header.

This version is now visible in the UI, using the CLI, and in the analytics.

Viewer:
![image](https://github.com/rerun-io/rerun/assets/2910679/c7b7f211-1a16-41d4-b43a-d8c661819122)

CLI:
![image](https://github.com/rerun-io/rerun/assets/2910679/df15efa9-e2a0-42b8-b17a-b2c10dc7a46d)

Analytics:
![image](https://github.com/rerun-io/rerun/assets/2910679/b9cf5745-2eb1-4f8a-8a4c-2db9cb874c0b)


- Fixes https://github.com/rerun-io/rerun/issues/6280

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6324?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6324?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6324)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.