### PR TITLE
Add support for exact width to `PropertyContent`

### DIFF
--- a/crates/re_ui/src/list_item2/scope.rs
+++ b/crates/re_ui/src/list_item2/scope.rs
@@ -280,7 +280,7 @@ pub fn list_item_scope<R>(
     };
 
     // push, run, pop
-    LayoutInfoStack::push(ui.ctx(), state.clone());
+    LayoutInfoStack::push(ui.ctx(), state);
     let result = ui
         .scope(|ui| {
             ui.spacing_mut().item_spacing.y = 0.0;


### PR DESCRIPTION
### What

This PR adds support for `PropertyContent::exact_width(true)`, which makes it possible to create lists which only use the needed width (as opposed to using `ui.available_width()`. This was previous available for `LabelContent` and used (in the future) in the streams view.

`LabelContent` exploits the fact that the content is mainly a label, the width of which can be computed with `egui`. For `PropertyContent` it's tricker because we delegate the second column to a closure. Instead, we track the max width in each `list_item_context` on frame n, and request that width in frame n+1. 

The major drawback of this approach is the potential flicker on the first frame. Since the plan is to use it for tooltip, it will greatly help to have https://github.com/emilk/egui/issues/4471

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6325?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6325?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6325)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.