### PR TITLE
Set a minimum version of pillow in `rerun_py/pyproject.toml`

### DIFF
--- a/examples/python/raw_mesh/pyproject.toml
+++ b/examples/python/raw_mesh/pyproject.toml
@@ -2,13 +2,7 @@
 name = "raw_mesh"
 version = "0.1.0"
 readme = "README.md"
-dependencies = [
-  "numpy",
-  "requests>=2.31,<3",
-  "rerun-sdk",
-  "trimesh==3.15.2",
-  "pillow",
-]
+dependencies = ["numpy", "requests>=2.31,<3", "rerun-sdk", "trimesh==3.15.2"]
 
 [project.scripts]
 raw_mesh = "raw_mesh.__main__:main"

--- a/pixi.lock
+++ b/pixi.lock
@@ -1881,7 +1881,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d4/22c2909b5a0b36e69471e699d673c2985f7691ca29870798a29e0a3d0e2b/peewee-3.17.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/81/ff/ad3c942d865f9e45ce84eeb31795e6d4d94e1f1eea51026d5154028510d7/pillow-10.3.0-cp311-cp311-manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/14/619e24a4c70df2901e1f4dbc50a6291eb63a759172558df326347dce1f0d/protobuf-3.20.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c5/4f/0e22aaa246f96d6ac87fe5ebb9c5a693fbe8877f537a1022527c47ca43c5/psutil-5.9.8-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -1889,7 +1889,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/bf/06/18c0e17eb245b7caeb861f2ff747adb0575500183b6ec4282d5350d29e9f/pynndescent-0.5.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/33/ef0e3b40a3f4cbfcfb93511652673fb19d07bafac0611f01f6237d1978ed/PyOpenGL-3.1.0.zip
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/26/b67fe94cb53c489c5ccaed118f257a5100e7775071515942c9f45d8cd40f/pyopf-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
@@ -2040,7 +2040,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d4/22c2909b5a0b36e69471e699d673c2985f7691ca29870798a29e0a3d0e2b/peewee-3.17.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/e5/51/e4b35e394b4e5ca24983e50361a1db3d7da05b1758074f9c4f5b4be4b22a/pillow-10.3.0-cp311-cp311-macosx_10_10_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/14/619e24a4c70df2901e1f4dbc50a6291eb63a759172558df326347dce1f0d/protobuf-3.20.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -2048,7 +2048,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/bf/06/18c0e17eb245b7caeb861f2ff747adb0575500183b6ec4282d5350d29e9f/pynndescent-0.5.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/33/ef0e3b40a3f4cbfcfb93511652673fb19d07bafac0611f01f6237d1978ed/PyOpenGL-3.1.0.zip
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/26/b67fe94cb53c489c5ccaed118f257a5100e7775071515942c9f45d8cd40f/pyopf-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
@@ -2198,7 +2198,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d4/22c2909b5a0b36e69471e699d673c2985f7691ca29870798a29e0a3d0e2b/peewee-3.17.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/00/5c/7633f291def20082bad31b844fe5ed07742aae8504e4cfe2f331ee727178/pillow-10.3.0-cp311-cp311-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/14/619e24a4c70df2901e1f4dbc50a6291eb63a759172558df326347dce1f0d/protobuf-3.20.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -2206,7 +2206,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/bf/06/18c0e17eb245b7caeb861f2ff747adb0575500183b6ec4282d5350d29e9f/pynndescent-0.5.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/33/ef0e3b40a3f4cbfcfb93511652673fb19d07bafac0611f01f6237d1978ed/PyOpenGL-3.1.0.zip
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/26/b67fe94cb53c489c5ccaed118f257a5100e7775071515942c9f45d8cd40f/pyopf-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
@@ -2368,7 +2368,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/d4/22c2909b5a0b36e69471e699d673c2985f7691ca29870798a29e0a3d0e2b/peewee-3.17.5.tar.gz
       - pypi: https://files.pythonhosted.org/packages/0a/16/c83877524c47976f16703d2e05c363244bc1e60ab439e078b3cd046d07db/pillow-10.3.0-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8d/14/619e24a4c70df2901e1f4dbc50a6291eb63a759172558df326347dce1f0d/protobuf-3.20.3-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/93/52/3e39d26feae7df0aa0fd510b14012c3678b36ed068f7d78b8d8784d61f0e/psutil-5.9.8-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -2376,7 +2376,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/30/93/4d02ac696f16a2ad8fff0e78be28ab4ec0b990d2b3569fe07e27a258cb02/pyglet-2.0.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/bf/06/18c0e17eb245b7caeb861f2ff747adb0575500183b6ec4282d5350d29e9f/pynndescent-0.5.12-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ce/33/ef0e3b40a3f4cbfcfb93511652673fb19d07bafac0611f01f6237d1978ed/PyOpenGL-3.1.0.zip
+      - pypi: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/a8/26/b67fe94cb53c489c5ccaed118f257a5100e7775071515942c9f45d8cd40f/pyopf-1.1.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/28/88/174c28b9d3d03cf6d8edb6f637458f30f1cf1a2bd7a617cbd9dadb1740f6/pyrender-0.1.45-py3-none-any.whl
@@ -3407,25 +3407,25 @@ packages:
   url: https://files.pythonhosted.org/packages/e9/bb/1edd2c836071e91d2bd331b9542bbd592e23d1474645b9c6fd56232caace/accelerate-0.30.1-py3-none-any.whl
   sha256: 8dd4edd532a4dac72558c5fe6fe8cb70d0c8ec9e8733f48db97d51ee41cbe763
   requires_dist:
-  - numpy >=1.17
-  - packaging >=20.0
+  - numpy>=1.17
+  - packaging>=20.0
   - psutil
   - pyyaml
-  - torch >=1.10.0
+  - torch>=1.10.0
   - huggingface-hub
-  - safetensors >=0.3.1
-  - deepspeed <=0.14.0 ; extra == 'deepspeed'
-  - black ~=23.1 ; extra == 'dev'
-  - hf-doc-builder >=0.3.0 ; extra == 'dev'
-  - ruff ~=0.2.1 ; extra == 'dev'
-  - pytest <=8.0.0, >=7.2.0 ; extra == 'dev'
+  - safetensors>=0.3.1
+  - deepspeed<=0.14.0 ; extra == 'deepspeed'
+  - black~=23.1 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev'
+  - ruff~=0.2.1 ; extra == 'dev'
+  - pytest<=8.0.0,>=7.2.0 ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
   - pytest-subtests ; extra == 'dev'
   - parameterized ; extra == 'dev'
   - datasets ; extra == 'dev'
   - diffusers ; extra == 'dev'
   - evaluate ; extra == 'dev'
-  - torchpippy >=0.2.0 ; extra == 'dev'
+  - torchpippy>=0.2.0 ; extra == 'dev'
   - transformers ; extra == 'dev'
   - scipy ; extra == 'dev'
   - scikit-learn ; extra == 'dev'
@@ -3433,22 +3433,22 @@ packages:
   - bitsandbytes ; extra == 'dev'
   - timm ; extra == 'dev'
   - rich ; extra == 'dev'
-  - black ~=23.1 ; extra == 'quality'
-  - hf-doc-builder >=0.3.0 ; extra == 'quality'
-  - ruff ~=0.2.1 ; extra == 'quality'
+  - black~=23.1 ; extra == 'quality'
+  - hf-doc-builder>=0.3.0 ; extra == 'quality'
+  - ruff~=0.2.1 ; extra == 'quality'
   - rich ; extra == 'rich'
   - sagemaker ; extra == 'sagemaker'
   - datasets ; extra == 'test_dev'
   - diffusers ; extra == 'test_dev'
   - evaluate ; extra == 'test_dev'
-  - torchpippy >=0.2.0 ; extra == 'test_dev'
+  - torchpippy>=0.2.0 ; extra == 'test_dev'
   - transformers ; extra == 'test_dev'
   - scipy ; extra == 'test_dev'
   - scikit-learn ; extra == 'test_dev'
   - tqdm ; extra == 'test_dev'
   - bitsandbytes ; extra == 'test_dev'
   - timm ; extra == 'test_dev'
-  - pytest <=8.0.0, >=7.2.0 ; extra == 'test_prod'
+  - pytest<=8.0.0,>=7.2.0 ; extra == 'test_prod'
   - pytest-xdist ; extra == 'test_prod'
   - pytest-subtests ; extra == 'test_prod'
   - parameterized ; extra == 'test_prod'
@@ -3456,14 +3456,14 @@ packages:
   - comet-ml ; extra == 'test_trackers'
   - tensorboard ; extra == 'test_trackers'
   - dvclive ; extra == 'test_trackers'
-  - pytest <=8.0.0, >=7.2.0 ; extra == 'testing'
+  - pytest<=8.0.0,>=7.2.0 ; extra == 'testing'
   - pytest-xdist ; extra == 'testing'
   - pytest-subtests ; extra == 'testing'
   - parameterized ; extra == 'testing'
   - datasets ; extra == 'testing'
   - diffusers ; extra == 'testing'
   - evaluate ; extra == 'testing'
-  - torchpippy >=0.2.0 ; extra == 'testing'
+  - torchpippy>=0.2.0 ; extra == 'testing'
   - transformers ; extra == 'testing'
   - scipy ; extra == 'testing'
   - scikit-learn ; extra == 'testing'
@@ -3656,7 +3656,7 @@ packages:
   requires_dist:
   - importlib-metadata ; python_version < '3.8'
   - attrs[tests] ; extra == 'cov'
-  - coverage[toml] >=5.3 ; extra == 'cov'
+  - coverage[toml]>=5.3 ; extra == 'cov'
   - attrs[tests] ; extra == 'dev'
   - pre-commit ; extra == 'dev'
   - furo ; extra == 'docs'
@@ -3668,14 +3668,14 @@ packages:
   - zope-interface ; extra == 'docs'
   - attrs[tests-no-zope] ; extra == 'tests'
   - zope-interface ; extra == 'tests'
-  - mypy >=1.6 ; (platform_python_implementation == 'CPython' and python_version >= '3.8') and extra == 'tests-mypy'
+  - mypy>=1.6 ; (platform_python_implementation == 'CPython' and python_version >= '3.8') and extra == 'tests-mypy'
   - pytest-mypy-plugins ; (platform_python_implementation == 'CPython' and python_version >= '3.8') and extra == 'tests-mypy'
   - attrs[tests-mypy] ; extra == 'tests-no-zope'
   - cloudpickle ; platform_python_implementation == 'CPython' and extra == 'tests-no-zope'
   - hypothesis ; extra == 'tests-no-zope'
   - pympler ; extra == 'tests-no-zope'
   - pytest-xdist[psutil] ; extra == 'tests-no-zope'
-  - pytest >=4.3.0 ; extra == 'tests-no-zope'
+  - pytest>=4.3.0 ; extra == 'tests-no-zope'
   requires_python: '>=3.7'
 - kind: conda
   name: attrs
@@ -6892,7 +6892,7 @@ packages:
   url: https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl
   sha256: b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed
   requires_dist:
-  - soupsieve >1.2
+  - soupsieve>1.2
   - cchardet ; extra == 'cchardet'
   - chardet ; extra == 'chardet'
   - charset-normalizer ; extra == 'charset-normalizer'
@@ -7080,42 +7080,22 @@ packages:
 - kind: pypi
   name: black
   version: 24.4.2
-  url: https://files.pythonhosted.org/packages/9b/f7/591d601c3046ceb65b97291dfe87fa25124cffac3d97aaaba89d0f0d7bdf/black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474
-  requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: black
-  version: 24.4.2
   url: https://files.pythonhosted.org/packages/c5/48/34176b522e8cff4620a5d96c2e323ff2413f574870eb25efa8025885e028/black-24.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: e151054aa00bad1f4e1f04919542885f89f5f7d086b8a59e5000e6c616896ffb
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp!=3.9.0,>=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
+  - aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -7123,19 +7103,19 @@ packages:
   url: https://files.pythonhosted.org/packages/74/ce/e8eec1a77edbfa982bee3b5460dcdd4fe0e4e3165fc15d8ec44d04da7776/black-24.4.2-cp311-cp311-win_amd64.whl
   sha256: 7e122b1c4fb252fd85df3ca93578732b4749d9be076593076ef4d07a0233c3e1
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp!=3.9.0,>=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
+  - aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: black
@@ -7143,19 +7123,39 @@ packages:
   url: https://files.pythonhosted.org/packages/c9/17/5e0036b265bbf6bc44970d93d48febcbc03701b671db3c9603fd43ebc616/black-24.4.2-cp311-cp311-macosx_11_0_arm64.whl
   sha256: bdde6f877a18f24844e381d45e9947a49e97933573ac9d4345399be37621e26c
   requires_dist:
-  - click >=8.0.0
-  - mypy-extensions >=0.4.3
-  - packaging >=22.0
-  - pathspec >=0.9.0
-  - platformdirs >=2
-  - tomli >=1.1.0 ; python_version < '3.11'
-  - typing-extensions >=4.0.1 ; python_version < '3.11'
-  - colorama >=0.4.3 ; extra == 'colorama'
-  - aiohttp !=3.9.0, >=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
-  - aiohttp >=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
-  - ipython >=7.8.0 ; extra == 'jupyter'
-  - tokenize-rt >=3.2.0 ; extra == 'jupyter'
-  - uvloop >=0.15.2 ; extra == 'uvloop'
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp!=3.9.0,>=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
+  - aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: black
+  version: 24.4.2
+  url: https://files.pythonhosted.org/packages/9b/f7/591d601c3046ceb65b97291dfe87fa25124cffac3d97aaaba89d0f0d7bdf/black-24.4.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 257d724c2c9b1660f353b36c802ccece186a30accc7742c176d29c146df6e474
+  requires_dist:
+  - click>=8.0.0
+  - mypy-extensions>=0.4.3
+  - packaging>=22.0
+  - pathspec>=0.9.0
+  - platformdirs>=2
+  - tomli>=1.1.0 ; python_version < '3.11'
+  - typing-extensions>=4.0.1 ; python_version < '3.11'
+  - colorama>=0.4.3 ; extra == 'colorama'
+  - aiohttp!=3.9.0,>=3.7.4 ; (sys_platform == 'win32' and implementation_name == 'pypy') and extra == 'd'
+  - aiohttp>=3.7.4 ; (sys_platform != 'win32' or implementation_name != 'pypy') and extra == 'd'
+  - ipython>=7.8.0 ; extra == 'jupyter'
+  - tokenize-rt>=3.2.0 ; extra == 'jupyter'
+  - uvloop>=0.15.2 ; extra == 'uvloop'
   requires_python: '>=3.8'
 - kind: pypi
   name: blueprint
@@ -7759,24 +7759,8 @@ packages:
 - kind: pypi
   name: cffi
   version: 1.16.0
-  url: https://files.pythonhosted.org/packages/18/6c/0406611f3d5aadf4c5b08f6c095d874aed8dfc2d3a19892707d72536d5dc/cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl
-  sha256: 1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417
-  requires_dist:
-  - pycparser
-  requires_python: '>=3.8'
-- kind: pypi
-  name: cffi
-  version: 1.16.0
-  url: https://files.pythonhosted.org/packages/5a/c7/694814b3757878b29da39bc2f0cf9d20295f4c1e0a0bde7971708d5f23f8/cffi-1.16.0-cp311-cp311-win_amd64.whl
-  sha256: db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba
-  requires_dist:
-  - pycparser
-  requires_python: '>=3.8'
-- kind: pypi
-  name: cffi
-  version: 1.16.0
-  url: https://files.pythonhosted.org/packages/9b/89/a31c81e36bbb793581d8bba4406a8aac4ba84b2559301c44eef81f4cf5df/cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e
+  url: https://files.pythonhosted.org/packages/95/c8/ce05a6cba2bec12d4b28285e66c53cc88dd7385b102dea7231da3b74cfef/cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404
   requires_dist:
   - pycparser
   requires_python: '>=3.8'
@@ -7791,11 +7775,45 @@ packages:
 - kind: pypi
   name: cffi
   version: 1.16.0
-  url: https://files.pythonhosted.org/packages/95/c8/ce05a6cba2bec12d4b28285e66c53cc88dd7385b102dea7231da3b74cfef/cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404
+  url: https://files.pythonhosted.org/packages/9b/89/a31c81e36bbb793581d8bba4406a8aac4ba84b2559301c44eef81f4cf5df/cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e
   requires_dist:
   - pycparser
   requires_python: '>=3.8'
+- kind: pypi
+  name: cffi
+  version: 1.16.0
+  url: https://files.pythonhosted.org/packages/18/6c/0406611f3d5aadf4c5b08f6c095d874aed8dfc2d3a19892707d72536d5dc/cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl
+  sha256: 1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417
+  requires_dist:
+  - pycparser
+  requires_python: '>=3.8'
+- kind: pypi
+  name: cffi
+  version: 1.16.0
+  url: https://files.pythonhosted.org/packages/5a/c7/694814b3757878b29da39bc2f0cf9d20295f4c1e0a0bde7971708d5f23f8/cffi-1.16.0-cp311-cp311-win_amd64.whl
+  sha256: db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba
+  requires_dist:
+  - pycparser
+  requires_python: '>=3.8'
+- kind: pypi
+  name: charset-normalizer
+  version: 3.3.2
+  url: https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96
+  requires_python: '>=3.7.0'
+- kind: pypi
+  name: charset-normalizer
+  version: 3.3.2
+  url: https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  sha256: f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f
+  requires_python: '>=3.7.0'
+- kind: pypi
+  name: charset-normalizer
+  version: 3.3.2
+  url: https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8
+  requires_python: '>=3.7.0'
 - kind: pypi
   name: charset-normalizer
   version: 3.3.2
@@ -7807,24 +7825,6 @@ packages:
   version: 3.3.2
   url: https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl
   sha256: 663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77
-  requires_python: '>=3.7.0'
-- kind: pypi
-  name: charset-normalizer
-  version: 3.3.2
-  url: https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8
-  requires_python: '>=3.7.0'
-- kind: pypi
-  name: charset-normalizer
-  version: 3.3.2
-  url: https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  sha256: f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f
-  requires_python: '>=3.7.0'
-- kind: pypi
-  name: charset-normalizer
-  version: 3.3.2
-  url: https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96
   requires_python: '>=3.7.0'
 - kind: conda
   name: clang
@@ -8997,42 +8997,18 @@ packages:
 - kind: pypi
   name: contourpy
   version: 1.2.1
-  url: https://files.pythonhosted.org/packages/33/0e/51ff72fac17e2500baf30b6b2a24be423a8d27e1625e5de99f585b852d74/contourpy-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 6022cecf8f44e36af10bd9118ca71f371078b4c168b6e0fab43d4a889985dbb5
-  requires_dist:
-  - numpy >=1.20
-  - furo ; extra == 'docs'
-  - sphinx >=7.2 ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - bokeh ; extra == 'bokeh'
-  - selenium ; extra == 'bokeh'
-  - contourpy[bokeh,docs] ; extra == 'mypy'
-  - docutils-stubs ; extra == 'mypy'
-  - mypy ==1.8.0 ; extra == 'mypy'
-  - types-pillow ; extra == 'mypy'
-  - contourpy[test-no-images] ; extra == 'test'
-  - matplotlib ; extra == 'test'
-  - pillow ; extra == 'test'
-  - pytest ; extra == 'test-no-images'
-  - pytest-cov ; extra == 'test-no-images'
-  - pytest-xdist ; extra == 'test-no-images'
-  - wurlitzer ; extra == 'test-no-images'
-  requires_python: '>=3.9'
-- kind: pypi
-  name: contourpy
-  version: 1.2.1
   url: https://files.pythonhosted.org/packages/ee/c0/9bd123d676eb61750e116a2cd915b06483fc406143cfc36c7f263f0f5368/contourpy-1.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: d4492d82b3bc7fbb7e3610747b159869468079fe149ec5c4d771fa1f614a14df
   requires_dist:
-  - numpy >=1.20
+  - numpy>=1.20
   - furo ; extra == 'docs'
-  - sphinx >=7.2 ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - bokeh ; extra == 'bokeh'
   - selenium ; extra == 'bokeh'
   - contourpy[bokeh,docs] ; extra == 'mypy'
   - docutils-stubs ; extra == 'mypy'
-  - mypy ==1.8.0 ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
   - types-pillow ; extra == 'mypy'
   - contourpy[test-no-images] ; extra == 'test'
   - matplotlib ; extra == 'test'
@@ -9048,15 +9024,15 @@ packages:
   url: https://files.pythonhosted.org/packages/d6/4f/76d0dd0bca417691918484c26c74dd9dd44fbf528bbfeb30d754886e2c54/contourpy-1.2.1-cp311-cp311-win_amd64.whl
   sha256: 2855c8b0b55958265e8b5888d6a615ba02883b225f2227461aa9127c578a4922
   requires_dist:
-  - numpy >=1.20
+  - numpy>=1.20
   - furo ; extra == 'docs'
-  - sphinx >=7.2 ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - bokeh ; extra == 'bokeh'
   - selenium ; extra == 'bokeh'
   - contourpy[bokeh,docs] ; extra == 'mypy'
   - docutils-stubs ; extra == 'mypy'
-  - mypy ==1.8.0 ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
   - types-pillow ; extra == 'mypy'
   - contourpy[test-no-images] ; extra == 'test'
   - matplotlib ; extra == 'test'
@@ -9072,15 +9048,39 @@ packages:
   url: https://files.pythonhosted.org/packages/9f/6b/8a1ca4b81d426c104fe42b3cfad9488eaaef0a03fcf98eaecc22b628a013/contourpy-1.2.1-cp311-cp311-macosx_11_0_arm64.whl
   sha256: ef5adb9a3b1d0c645ff694f9bca7702ec2c70f4d734f9922ea34de02294fdf72
   requires_dist:
-  - numpy >=1.20
+  - numpy>=1.20
   - furo ; extra == 'docs'
-  - sphinx >=7.2 ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - bokeh ; extra == 'bokeh'
   - selenium ; extra == 'bokeh'
   - contourpy[bokeh,docs] ; extra == 'mypy'
   - docutils-stubs ; extra == 'mypy'
-  - mypy ==1.8.0 ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
+  - types-pillow ; extra == 'mypy'
+  - contourpy[test-no-images] ; extra == 'test'
+  - matplotlib ; extra == 'test'
+  - pillow ; extra == 'test'
+  - pytest ; extra == 'test-no-images'
+  - pytest-cov ; extra == 'test-no-images'
+  - pytest-xdist ; extra == 'test-no-images'
+  - wurlitzer ; extra == 'test-no-images'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: contourpy
+  version: 1.2.1
+  url: https://files.pythonhosted.org/packages/33/0e/51ff72fac17e2500baf30b6b2a24be423a8d27e1625e5de99f585b852d74/contourpy-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 6022cecf8f44e36af10bd9118ca71f371078b4c168b6e0fab43d4a889985dbb5
+  requires_dist:
+  - numpy>=1.20
+  - furo ; extra == 'docs'
+  - sphinx>=7.2 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - bokeh ; extra == 'bokeh'
+  - selenium ; extra == 'bokeh'
+  - contourpy[bokeh,docs] ; extra == 'mypy'
+  - docutils-stubs ; extra == 'mypy'
+  - mypy==1.8.0 ; extra == 'mypy'
   - types-pillow ; extra == 'mypy'
   - contourpy[test-no-images] ; extra == 'test'
   - matplotlib ; extra == 'test'
@@ -9097,34 +9097,34 @@ packages:
   sha256: 8ae055c0b8b0dd7757e4e666f6163172859044d4090830aecbec3460cdb318ee
   requires_dist:
   - accelerate
-  - diffusers ==0.27.2
-  - numpy
   - opencv-python
   - pillow
-  - rerun-sdk
-  - torch ==2.2.2
+  - diffusers==0.27.2
+  - numpy
+  - torch==2.2.2
   - transformers
+  - rerun-sdk
   requires_python: '>=3.10'
   editable: true
 - kind: pypi
   name: cryptography
   version: 38.0.4
-  url: https://files.pythonhosted.org/packages/75/7a/2ea7dd2202638cf1053aaa8fbbaddded0b78c78832b3d03cafa0416a6c84/cryptography-38.0.4-cp36-abi3-macosx_10_10_universal2.whl
-  sha256: 2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70
+  url: https://files.pythonhosted.org/packages/52/1b/49ebc2b59e9126f1f378ae910e98704d54a3f48b78e2d6d6c8cfe6fbe06f/cryptography-38.0.4-cp36-abi3-macosx_10_10_x86_64.whl
+  sha256: 1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb
   requires_dist:
-  - cffi >=1.12
-  - sphinx !=1.8.0, !=3.1.0, !=3.1.1, >=1.6.5 ; extra == 'docs'
+  - cffi>=1.12
+  - sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
-  - pyenchant >=1.6.11 ; extra == 'docstest'
-  - twine >=1.12.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling >=4.0.1 ; extra == 'docstest'
+  - pyenchant>=1.6.11 ; extra == 'docstest'
+  - twine>=1.12.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=4.0.1 ; extra == 'docstest'
   - black ; extra == 'pep8test'
   - flake8 ; extra == 'pep8test'
   - flake8-import-order ; extra == 'pep8test'
   - pep8-naming ; extra == 'pep8test'
-  - setuptools-rust >=0.11.4 ; extra == 'sdist'
-  - bcrypt >=3.1.5 ; extra == 'ssh'
-  - pytest >=6.2.0 ; extra == 'test'
+  - setuptools-rust>=0.11.4 ; extra == 'sdist'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - pytest>=6.2.0 ; extra == 'test'
   - pytest-benchmark ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-subtests ; extra == 'test'
@@ -9132,63 +9132,7 @@ packages:
   - pretend ; extra == 'test'
   - iso8601 ; extra == 'test'
   - pytz ; extra == 'test'
-  - hypothesis !=3.79.2, >=1.11.4 ; extra == 'test'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: cryptography
-  version: 38.0.4
-  url: https://files.pythonhosted.org/packages/c0/eb/f52b165db2abd662cda0a76efb7579a291fed1a7979cf41146cdc19e0d7a/cryptography-38.0.4-cp36-abi3-win_amd64.whl
-  sha256: 8e45653fb97eb2f20b8c96f9cd2b3a0654d742b47d638cf2897afbd97f80fa6d
-  requires_dist:
-  - cffi >=1.12
-  - sphinx !=1.8.0, !=3.1.0, !=3.1.1, >=1.6.5 ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - pyenchant >=1.6.11 ; extra == 'docstest'
-  - twine >=1.12.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling >=4.0.1 ; extra == 'docstest'
-  - black ; extra == 'pep8test'
-  - flake8 ; extra == 'pep8test'
-  - flake8-import-order ; extra == 'pep8test'
-  - pep8-naming ; extra == 'pep8test'
-  - setuptools-rust >=0.11.4 ; extra == 'sdist'
-  - bcrypt >=3.1.5 ; extra == 'ssh'
-  - pytest >=6.2.0 ; extra == 'test'
-  - pytest-benchmark ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-subtests ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - pretend ; extra == 'test'
-  - iso8601 ; extra == 'test'
-  - pytz ; extra == 'test'
-  - hypothesis !=3.79.2, >=1.11.4 ; extra == 'test'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: cryptography
-  version: 38.0.4
-  url: https://files.pythonhosted.org/packages/26/f8/a81170a816679fca9ccd907b801992acfc03c33f952440421c921af2cc57/cryptography-38.0.4-cp36-abi3-manylinux_2_28_x86_64.whl
-  sha256: ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c
-  requires_dist:
-  - cffi >=1.12
-  - sphinx !=1.8.0, !=3.1.0, !=3.1.1, >=1.6.5 ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - pyenchant >=1.6.11 ; extra == 'docstest'
-  - twine >=1.12.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling >=4.0.1 ; extra == 'docstest'
-  - black ; extra == 'pep8test'
-  - flake8 ; extra == 'pep8test'
-  - flake8-import-order ; extra == 'pep8test'
-  - pep8-naming ; extra == 'pep8test'
-  - setuptools-rust >=0.11.4 ; extra == 'sdist'
-  - bcrypt >=3.1.5 ; extra == 'ssh'
-  - pytest >=6.2.0 ; extra == 'test'
-  - pytest-benchmark ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-subtests ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - pretend ; extra == 'test'
-  - iso8601 ; extra == 'test'
-  - pytz ; extra == 'test'
-  - hypothesis !=3.79.2, >=1.11.4 ; extra == 'test'
+  - hypothesis!=3.79.2,>=1.11.4 ; extra == 'test'
   requires_python: '>=3.6'
 - kind: pypi
   name: cryptography
@@ -9196,19 +9140,19 @@ packages:
   url: https://files.pythonhosted.org/packages/a2/8f/6c52b1f9d650863e8f67edbe062c04f1c8455579eaace1593d8fe469319a/cryptography-38.0.4-cp36-abi3-manylinux_2_28_aarch64.whl
   sha256: bfe6472507986613dc6cc00b3d492b2f7564b02b3b3682d25ca7f40fa3fd321b
   requires_dist:
-  - cffi >=1.12
-  - sphinx !=1.8.0, !=3.1.0, !=3.1.1, >=1.6.5 ; extra == 'docs'
+  - cffi>=1.12
+  - sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
-  - pyenchant >=1.6.11 ; extra == 'docstest'
-  - twine >=1.12.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling >=4.0.1 ; extra == 'docstest'
+  - pyenchant>=1.6.11 ; extra == 'docstest'
+  - twine>=1.12.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=4.0.1 ; extra == 'docstest'
   - black ; extra == 'pep8test'
   - flake8 ; extra == 'pep8test'
   - flake8-import-order ; extra == 'pep8test'
   - pep8-naming ; extra == 'pep8test'
-  - setuptools-rust >=0.11.4 ; extra == 'sdist'
-  - bcrypt >=3.1.5 ; extra == 'ssh'
-  - pytest >=6.2.0 ; extra == 'test'
+  - setuptools-rust>=0.11.4 ; extra == 'sdist'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - pytest>=6.2.0 ; extra == 'test'
   - pytest-benchmark ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-subtests ; extra == 'test'
@@ -9216,27 +9160,27 @@ packages:
   - pretend ; extra == 'test'
   - iso8601 ; extra == 'test'
   - pytz ; extra == 'test'
-  - hypothesis !=3.79.2, >=1.11.4 ; extra == 'test'
+  - hypothesis!=3.79.2,>=1.11.4 ; extra == 'test'
   requires_python: '>=3.6'
 - kind: pypi
   name: cryptography
   version: 38.0.4
-  url: https://files.pythonhosted.org/packages/52/1b/49ebc2b59e9126f1f378ae910e98704d54a3f48b78e2d6d6c8cfe6fbe06f/cryptography-38.0.4-cp36-abi3-macosx_10_10_x86_64.whl
-  sha256: 1f13ddda26a04c06eb57119caf27a524ccae20533729f4b1e4a69b54e07035eb
+  url: https://files.pythonhosted.org/packages/26/f8/a81170a816679fca9ccd907b801992acfc03c33f952440421c921af2cc57/cryptography-38.0.4-cp36-abi3-manylinux_2_28_x86_64.whl
+  sha256: ce127dd0a6a0811c251a6cddd014d292728484e530d80e872ad9806cfb1c5b3c
   requires_dist:
-  - cffi >=1.12
-  - sphinx !=1.8.0, !=3.1.0, !=3.1.1, >=1.6.5 ; extra == 'docs'
+  - cffi>=1.12
+  - sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
-  - pyenchant >=1.6.11 ; extra == 'docstest'
-  - twine >=1.12.0 ; extra == 'docstest'
-  - sphinxcontrib-spelling >=4.0.1 ; extra == 'docstest'
+  - pyenchant>=1.6.11 ; extra == 'docstest'
+  - twine>=1.12.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=4.0.1 ; extra == 'docstest'
   - black ; extra == 'pep8test'
   - flake8 ; extra == 'pep8test'
   - flake8-import-order ; extra == 'pep8test'
   - pep8-naming ; extra == 'pep8test'
-  - setuptools-rust >=0.11.4 ; extra == 'sdist'
-  - bcrypt >=3.1.5 ; extra == 'ssh'
-  - pytest >=6.2.0 ; extra == 'test'
+  - setuptools-rust>=0.11.4 ; extra == 'sdist'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - pytest>=6.2.0 ; extra == 'test'
   - pytest-benchmark ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-subtests ; extra == 'test'
@@ -9244,7 +9188,63 @@ packages:
   - pretend ; extra == 'test'
   - iso8601 ; extra == 'test'
   - pytz ; extra == 'test'
-  - hypothesis !=3.79.2, >=1.11.4 ; extra == 'test'
+  - hypothesis!=3.79.2,>=1.11.4 ; extra == 'test'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: cryptography
+  version: 38.0.4
+  url: https://files.pythonhosted.org/packages/75/7a/2ea7dd2202638cf1053aaa8fbbaddded0b78c78832b3d03cafa0416a6c84/cryptography-38.0.4-cp36-abi3-macosx_10_10_universal2.whl
+  sha256: 2fa36a7b2cc0998a3a4d5af26ccb6273f3df133d61da2ba13b3286261e7efb70
+  requires_dist:
+  - cffi>=1.12
+  - sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - pyenchant>=1.6.11 ; extra == 'docstest'
+  - twine>=1.12.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=4.0.1 ; extra == 'docstest'
+  - black ; extra == 'pep8test'
+  - flake8 ; extra == 'pep8test'
+  - flake8-import-order ; extra == 'pep8test'
+  - pep8-naming ; extra == 'pep8test'
+  - setuptools-rust>=0.11.4 ; extra == 'sdist'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - pytest>=6.2.0 ; extra == 'test'
+  - pytest-benchmark ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-subtests ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pretend ; extra == 'test'
+  - iso8601 ; extra == 'test'
+  - pytz ; extra == 'test'
+  - hypothesis!=3.79.2,>=1.11.4 ; extra == 'test'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: cryptography
+  version: 38.0.4
+  url: https://files.pythonhosted.org/packages/c0/eb/f52b165db2abd662cda0a76efb7579a291fed1a7979cf41146cdc19e0d7a/cryptography-38.0.4-cp36-abi3-win_amd64.whl
+  sha256: 8e45653fb97eb2f20b8c96f9cd2b3a0654d742b47d638cf2897afbd97f80fa6d
+  requires_dist:
+  - cffi>=1.12
+  - sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - pyenchant>=1.6.11 ; extra == 'docstest'
+  - twine>=1.12.0 ; extra == 'docstest'
+  - sphinxcontrib-spelling>=4.0.1 ; extra == 'docstest'
+  - black ; extra == 'pep8test'
+  - flake8 ; extra == 'pep8test'
+  - flake8-import-order ; extra == 'pep8test'
+  - pep8-naming ; extra == 'pep8test'
+  - setuptools-rust>=0.11.4 ; extra == 'sdist'
+  - bcrypt>=3.1.5 ; extra == 'ssh'
+  - pytest>=6.2.0 ; extra == 'test'
+  - pytest-benchmark ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-subtests ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pretend ; extra == 'test'
+  - iso8601 ; extra == 'test'
+  - pytz ; extra == 'test'
+  - hypothesis!=3.79.2,>=1.11.4 ; extra == 'test'
   requires_python: '>=3.6'
 - kind: conda
   name: cxx-compiler
@@ -9324,8 +9324,8 @@ packages:
   url: https://files.pythonhosted.org/packages/92/70/382283d80cb998ebc0089428b109bbe606ec9dce891a3cb1468c03ed0ad6/dataclasses_json-0.6.6-py3-none-any.whl
   sha256: e54c5c87497741ad454070ba0ed411523d46beb5da102e221efb873801b0ba85
   requires_dist:
-  - marshmallow >=3.18.0, <4.0.0
-  - typing-inspect >=0.4.0, <1
+  - marshmallow>=3.18.0,<4.0.0
+  - typing-inspect>=0.4.0,<1
   requires_python: '>=3.7,<4.0'
 - kind: pypi
   name: deprecated
@@ -9333,12 +9333,12 @@ packages:
   url: https://files.pythonhosted.org/packages/20/8d/778b7d51b981a96554f29136cd59ca7880bf58094338085bcf2a979a0e6a/Deprecated-1.2.14-py2.py3-none-any.whl
   sha256: 6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c
   requires_dist:
-  - wrapt <2, >=1.10
+  - wrapt<2,>=1.10
   - tox ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-cov ; extra == 'dev'
-  - bump2version <1 ; extra == 'dev'
-  - sphinx <2 ; extra == 'dev'
+  - bump2version<1 ; extra == 'dev'
+  - sphinx<2 ; extra == 'dev'
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
 - kind: pypi
   name: detect-and-track-objects
@@ -9347,13 +9347,13 @@ packages:
   sha256: 6c88082f8ff9c5949f5786584edf771078e3f1be6202f7225ad02268f96d9292
   requires_dist:
   - numpy
-  - opencv-contrib-python >4.6
-  - opencv-python >4.6
+  - opencv-contrib-python>4.6
+  - opencv-python>4.6
   - pillow
-  - requests <3, >=2.31
+  - requests>=2.31,<3
   - rerun-sdk
-  - timm ==0.9.11
-  - torch ==2.2.2
+  - timm==0.9.11
+  - torch==2.2.2
   - transformers
   editable: true
 - kind: pypi
@@ -9362,12 +9362,12 @@ packages:
   path: examples/python/dicom_mri
   sha256: 98cb91dc5758ae59e3cd0fb797f86f40fcf627f63e659365806f59feed4618d8
   requires_dist:
-  - dicom-numpy ==0.6.2
+  - dicom-numpy==0.6.2
   - numpy
-  - pydicom ==2.3.0
-  - requests <3, >=2.31
+  - pydicom==2.3.0
+  - requests>=2.31,<3
   - rerun-sdk
-  - types-requests <3, >=2.31
+  - types-requests>=2.31,<3
   editable: true
 - kind: pypi
   name: dicom-numpy
@@ -9375,7 +9375,7 @@ packages:
   url: https://files.pythonhosted.org/packages/a4/d2/6d475e8925fa3f46f676263bfc6bdcf1e20273a433b296b1d63abecd2426/dicom_numpy-0.6.2-py2.py3-none-any.whl
   sha256: 361c8dfc52d625bf3344e5c2745e9c928d263999a4c094fe285d9fe461895ea9
   requires_dist:
-  - pydicom >=1.0
+  - pydicom>=1.0
   - numpy
   - check-manifest ; extra == 'dev'
   - sphinx ; extra == 'dev'
@@ -9391,74 +9391,74 @@ packages:
   requires_dist:
   - importlib-metadata
   - filelock
-  - huggingface-hub >=0.20.2
+  - huggingface-hub>=0.20.2
   - numpy
-  - regex !=2019.12.17
+  - regex!=2019.12.17
   - requests
-  - safetensors >=0.3.1
+  - safetensors>=0.3.1
   - pillow
-  - urllib3 <=2.0.0 ; extra == 'dev'
-  - isort >=5.5.4 ; extra == 'dev'
-  - ruff ==0.1.5 ; extra == 'dev'
-  - hf-doc-builder >=0.3.0 ; extra == 'dev'
-  - compel ==0.1.8 ; extra == 'dev'
-  - gitpython <3.1.19 ; extra == 'dev'
+  - urllib3<=2.0.0 ; extra == 'dev'
+  - isort>=5.5.4 ; extra == 'dev'
+  - ruff==0.1.5 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev'
+  - compel==0.1.8 ; extra == 'dev'
+  - gitpython<3.1.19 ; extra == 'dev'
   - datasets ; extra == 'dev'
   - jinja2 ; extra == 'dev'
-  - invisible-watermark >=0.2.0 ; extra == 'dev'
-  - k-diffusion >=0.0.12 ; extra == 'dev'
+  - invisible-watermark>=0.2.0 ; extra == 'dev'
+  - k-diffusion>=0.0.12 ; extra == 'dev'
   - librosa ; extra == 'dev'
   - parameterized ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-timeout ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
-  - requests-mock ==1.10.0 ; extra == 'dev'
-  - safetensors >=0.3.1 ; extra == 'dev'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'dev'
+  - requests-mock==1.10.0 ; extra == 'dev'
+  - safetensors>=0.3.1 ; extra == 'dev'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'dev'
   - scipy ; extra == 'dev'
   - torchvision ; extra == 'dev'
-  - transformers >=4.25.1 ; extra == 'dev'
-  - accelerate >=0.11.0 ; extra == 'dev'
-  - protobuf <4, >=3.20.3 ; extra == 'dev'
+  - transformers>=4.25.1 ; extra == 'dev'
+  - accelerate>=0.11.0 ; extra == 'dev'
+  - protobuf<4,>=3.20.3 ; extra == 'dev'
   - tensorboard ; extra == 'dev'
-  - peft >=0.6.0 ; extra == 'dev'
-  - torch >=1.4 ; extra == 'dev'
-  - jax >=0.4.1 ; extra == 'dev'
-  - jaxlib >=0.4.1 ; extra == 'dev'
-  - flax >=0.4.1 ; extra == 'dev'
-  - hf-doc-builder >=0.3.0 ; extra == 'docs'
-  - jax >=0.4.1 ; extra == 'flax'
-  - jaxlib >=0.4.1 ; extra == 'flax'
-  - flax >=0.4.1 ; extra == 'flax'
-  - urllib3 <=2.0.0 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - ruff ==0.1.5 ; extra == 'quality'
-  - hf-doc-builder >=0.3.0 ; extra == 'quality'
-  - compel ==0.1.8 ; extra == 'test'
-  - gitpython <3.1.19 ; extra == 'test'
+  - peft>=0.6.0 ; extra == 'dev'
+  - torch>=1.4 ; extra == 'dev'
+  - jax>=0.4.1 ; extra == 'dev'
+  - jaxlib>=0.4.1 ; extra == 'dev'
+  - flax>=0.4.1 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'docs'
+  - jax>=0.4.1 ; extra == 'flax'
+  - jaxlib>=0.4.1 ; extra == 'flax'
+  - flax>=0.4.1 ; extra == 'flax'
+  - urllib3<=2.0.0 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - ruff==0.1.5 ; extra == 'quality'
+  - hf-doc-builder>=0.3.0 ; extra == 'quality'
+  - compel==0.1.8 ; extra == 'test'
+  - gitpython<3.1.19 ; extra == 'test'
   - datasets ; extra == 'test'
   - jinja2 ; extra == 'test'
-  - invisible-watermark >=0.2.0 ; extra == 'test'
-  - k-diffusion >=0.0.12 ; extra == 'test'
+  - invisible-watermark>=0.2.0 ; extra == 'test'
+  - k-diffusion>=0.0.12 ; extra == 'test'
   - librosa ; extra == 'test'
   - parameterized ; extra == 'test'
   - pytest ; extra == 'test'
   - pytest-timeout ; extra == 'test'
   - pytest-xdist ; extra == 'test'
-  - requests-mock ==1.10.0 ; extra == 'test'
-  - safetensors >=0.3.1 ; extra == 'test'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'test'
+  - requests-mock==1.10.0 ; extra == 'test'
+  - safetensors>=0.3.1 ; extra == 'test'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'test'
   - scipy ; extra == 'test'
   - torchvision ; extra == 'test'
-  - transformers >=4.25.1 ; extra == 'test'
-  - torch >=1.4 ; extra == 'torch'
-  - accelerate >=0.11.0 ; extra == 'torch'
-  - accelerate >=0.11.0 ; extra == 'training'
+  - transformers>=4.25.1 ; extra == 'test'
+  - torch>=1.4 ; extra == 'torch'
+  - accelerate>=0.11.0 ; extra == 'torch'
+  - accelerate>=0.11.0 ; extra == 'training'
   - datasets ; extra == 'training'
-  - protobuf <4, >=3.20.3 ; extra == 'training'
+  - protobuf<4,>=3.20.3 ; extra == 'training'
   - tensorboard ; extra == 'training'
   - jinja2 ; extra == 'training'
-  - peft >=0.6.0 ; extra == 'training'
+  - peft>=0.6.0 ; extra == 'training'
   requires_python: '>=3.8.0'
 - kind: pypi
   name: distlib
@@ -9601,10 +9601,10 @@ packages:
   path: examples/python/face_tracking
   sha256: b8725fe4d36c11aad2c6c936ba2b57c7f65a856aa179badca5d041db63119d55
   requires_dist:
-  - mediapipe ==0.10.11 ; sys_platform != 'darwin'
-  - mediapipe ==0.10.9 ; sys_platform == 'darwin'
+  - mediapipe==0.10.11 ; sys_platform != 'darwin'
+  - mediapipe==0.10.9 ; sys_platform == 'darwin'
   - numpy
-  - opencv-python >4.6
+  - opencv-python>4.6
   - requests
   - rerun-sdk
   - tqdm
@@ -9616,17 +9616,17 @@ packages:
   url: https://files.pythonhosted.org/packages/41/24/0b023b6537dfc9bae2c779353998e3e99ac7dfff4222fc6126650e93c3f3/filelock-3.14.0-py3-none-any.whl
   sha256: 43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f
   requires_dist:
-  - furo >=2023.9.10 ; extra == 'docs'
-  - sphinx-autodoc-typehints !=1.23.4, >=1.25.2 ; extra == 'docs'
-  - sphinx >=7.2.6 ; extra == 'docs'
-  - covdefaults >=2.3 ; extra == 'testing'
-  - coverage >=7.3.2 ; extra == 'testing'
-  - diff-cover >=8.0.1 ; extra == 'testing'
-  - pytest-cov >=4.1 ; extra == 'testing'
-  - pytest-mock >=3.12 ; extra == 'testing'
-  - pytest-timeout >=2.2 ; extra == 'testing'
-  - pytest >=7.4.3 ; extra == 'testing'
-  - typing-extensions >=4.8 ; python_version < '3.11' and extra == 'typing'
+  - furo>=2023.9.10 ; extra == 'docs'
+  - sphinx-autodoc-typehints!=1.23.4,>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - covdefaults>=2.3 ; extra == 'testing'
+  - coverage>=7.3.2 ; extra == 'testing'
+  - diff-cover>=8.0.1 ; extra == 'testing'
+  - pytest-cov>=4.1 ; extra == 'testing'
+  - pytest-mock>=3.12 ; extra == 'testing'
+  - pytest-timeout>=2.2 ; extra == 'testing'
+  - pytest>=7.4.3 ; extra == 'testing'
+  - typing-extensions>=4.8 ; python_version < '3.11' and extra == 'typing'
   requires_python: '>=3.8'
 - kind: pypi
   name: flatbuffers
@@ -9788,76 +9788,39 @@ packages:
 - kind: pypi
   name: fonttools
   version: 4.51.0
-  url: https://files.pythonhosted.org/packages/84/51/8203a3e6e475e6766ac950638d42f45470f36c6a4f0615ff0a1c1f2ed0d6/fonttools-4.51.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 8ac27f436e8af7779f0bb4d5425aa3535270494d3bc5459ed27de3f03151e4c2
-  requires_dist:
-  - fs <3, >=2.2.0 ; extra == 'all'
-  - lxml >=4.0 ; extra == 'all'
-  - zopfli >=0.1.4 ; extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'all'
-  - pycairo ; extra == 'all'
-  - matplotlib ; extra == 'all'
-  - sympy ; extra == 'all'
-  - skia-pathops >=0.5.0 ; extra == 'all'
-  - uharfbuzz >=0.23.0 ; extra == 'all'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'all'
-  - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'graphite'
-  - pycairo ; extra == 'interpolatable'
-  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
-  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - lxml >=4.0 ; extra == 'lxml'
-  - skia-pathops >=0.5.0 ; extra == 'pathops'
-  - matplotlib ; extra == 'plot'
-  - uharfbuzz >=0.23.0 ; extra == 'repacker'
-  - sympy ; extra == 'symfont'
-  - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - fs <3, >=2.2.0 ; extra == 'ufo'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
-  - zopfli >=0.1.4 ; extra == 'woff'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: fonttools
-  version: 4.51.0
   url: https://files.pythonhosted.org/packages/c6/b5/dc17e93f60567fa1b0fa3720c2f28e0df5293927e2356e066e87af9adaba/fonttools-4.51.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: b2b92381f37b39ba2fc98c3a45a9d6383bfc9916a87d66ccb6553f7bdd129097
   requires_dist:
-  - fs <3, >=2.2.0 ; extra == 'all'
-  - lxml >=4.0 ; extra == 'all'
-  - zopfli >=0.1.4 ; extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'all'
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
   - pycairo ; extra == 'all'
   - matplotlib ; extra == 'all'
   - sympy ; extra == 'all'
-  - skia-pathops >=0.5.0 ; extra == 'all'
-  - uharfbuzz >=0.23.0 ; extra == 'all'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
   - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'graphite'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
   - pycairo ; extra == 'interpolatable'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - lxml >=4.0 ; extra == 'lxml'
-  - skia-pathops >=0.5.0 ; extra == 'pathops'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
   - matplotlib ; extra == 'plot'
-  - uharfbuzz >=0.23.0 ; extra == 'repacker'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
   - sympy ; extra == 'symfont'
   - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - fs <3, >=2.2.0 ; extra == 'ufo'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
-  - zopfli >=0.1.4 ; extra == 'woff'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
   requires_python: '>=3.8'
 - kind: pypi
   name: fonttools
@@ -9865,36 +9828,36 @@ packages:
   url: https://files.pythonhosted.org/packages/c5/d4/f426fa1ca42e47bcfff0c878fa9d49d9c03379d00903a7c178f95b97867a/fonttools-4.51.0-cp311-cp311-win_amd64.whl
   sha256: 0f08c901d3866a8905363619e3741c33f0a83a680d92a9f0e575985c2634fcc1
   requires_dist:
-  - fs <3, >=2.2.0 ; extra == 'all'
-  - lxml >=4.0 ; extra == 'all'
-  - zopfli >=0.1.4 ; extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'all'
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
   - pycairo ; extra == 'all'
   - matplotlib ; extra == 'all'
   - sympy ; extra == 'all'
-  - skia-pathops >=0.5.0 ; extra == 'all'
-  - uharfbuzz >=0.23.0 ; extra == 'all'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
   - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'graphite'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
   - pycairo ; extra == 'interpolatable'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - lxml >=4.0 ; extra == 'lxml'
-  - skia-pathops >=0.5.0 ; extra == 'pathops'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
   - matplotlib ; extra == 'plot'
-  - uharfbuzz >=0.23.0 ; extra == 'repacker'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
   - sympy ; extra == 'symfont'
   - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - fs <3, >=2.2.0 ; extra == 'ufo'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
-  - zopfli >=0.1.4 ; extra == 'woff'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
   requires_python: '>=3.8'
 - kind: pypi
   name: fonttools
@@ -9902,43 +9865,74 @@ packages:
   url: https://files.pythonhosted.org/packages/33/47/f2ca671af61757eaaac608963dda5b76ec9100621e45d0fd63a153fd8cd7/fonttools-4.51.0-cp311-cp311-macosx_10_9_universal2.whl
   sha256: a8feca65bab31479d795b0d16c9a9852902e3a3c0630678efb0b2b7941ea9c74
   requires_dist:
-  - fs <3, >=2.2.0 ; extra == 'all'
-  - lxml >=4.0 ; extra == 'all'
-  - zopfli >=0.1.4 ; extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'all'
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
   - pycairo ; extra == 'all'
   - matplotlib ; extra == 'all'
   - sympy ; extra == 'all'
-  - skia-pathops >=0.5.0 ; extra == 'all'
-  - uharfbuzz >=0.23.0 ; extra == 'all'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
   - xattr ; sys_platform == 'darwin' and extra == 'all'
-  - lz4 >=1.7.4.2 ; extra == 'graphite'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
   - pycairo ; extra == 'interpolatable'
   - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
   - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
-  - lxml >=4.0 ; extra == 'lxml'
-  - skia-pathops >=0.5.0 ; extra == 'pathops'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
   - matplotlib ; extra == 'plot'
-  - uharfbuzz >=0.23.0 ; extra == 'repacker'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
   - sympy ; extra == 'symfont'
   - xattr ; sys_platform == 'darwin' and extra == 'type1'
-  - fs <3, >=2.2.0 ; extra == 'ufo'
-  - unicodedata2 >=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
-  - zopfli >=0.1.4 ; extra == 'woff'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
-  - brotli >=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
   requires_python: '>=3.8'
 - kind: pypi
-  name: freetype-py
-  version: 2.4.0
-  url: https://files.pythonhosted.org/packages/7c/77/faec42d1ffac2b970f606860a5bb083d606f1c673a5c57ab26382c8efec1/freetype_py-2.4.0-py3-none-macosx_10_9_universal2.whl
-  sha256: 3e0f5a91bc812f42d98a92137e86bac4ed037a29e43dafdb76d716d5732189e8
-  requires_python: '>=3.7'
+  name: fonttools
+  version: 4.51.0
+  url: https://files.pythonhosted.org/packages/84/51/8203a3e6e475e6766ac950638d42f45470f36c6a4f0615ff0a1c1f2ed0d6/fonttools-4.51.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 8ac27f436e8af7779f0bb4d5425aa3535270494d3bc5459ed27de3f03151e4c2
+  requires_dist:
+  - fs<3,>=2.2.0 ; extra == 'all'
+  - lxml>=4.0 ; extra == 'all'
+  - zopfli>=0.1.4 ; extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'all'
+  - pycairo ; extra == 'all'
+  - matplotlib ; extra == 'all'
+  - sympy ; extra == 'all'
+  - skia-pathops>=0.5.0 ; extra == 'all'
+  - uharfbuzz>=0.23.0 ; extra == 'all'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'all'
+  - xattr ; sys_platform == 'darwin' and extra == 'all'
+  - lz4>=1.7.4.2 ; extra == 'graphite'
+  - pycairo ; extra == 'interpolatable'
+  - scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+  - munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+  - lxml>=4.0 ; extra == 'lxml'
+  - skia-pathops>=0.5.0 ; extra == 'pathops'
+  - matplotlib ; extra == 'plot'
+  - uharfbuzz>=0.23.0 ; extra == 'repacker'
+  - sympy ; extra == 'symfont'
+  - xattr ; sys_platform == 'darwin' and extra == 'type1'
+  - fs<3,>=2.2.0 ; extra == 'ufo'
+  - unicodedata2>=15.1.0 ; python_version <= '3.12' and extra == 'unicode'
+  - zopfli>=0.1.4 ; extra == 'woff'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+  - brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+  requires_python: '>=3.8'
 - kind: pypi
   name: freetype-py
   version: 2.4.0
@@ -9950,6 +9944,12 @@ packages:
   version: 2.4.0
   url: https://files.pythonhosted.org/packages/b4/f5/4b8bb492464247236bd3dabd7734b3ea49adc63cf2e53160e830ebccb39d/freetype_py-2.4.0-py3-none-win_amd64.whl
   sha256: a2620788d4f0c00bd75fee2dfca61635ab0da856131598c96e2355d5257f70e5
+  requires_python: '>=3.7'
+- kind: pypi
+  name: freetype-py
+  version: 2.4.0
+  url: https://files.pythonhosted.org/packages/7c/77/faec42d1ffac2b970f606860a5bb083d606f1c673a5c57ab26382c8efec1/freetype_py-2.4.0-py3-none-macosx_10_9_universal2.whl
+  sha256: 3e0f5a91bc812f42d98a92137e86bac4ed037a29e43dafdb76d716d5732189e8
   requires_python: '>=3.7'
 - kind: pypi
   name: frozendict
@@ -10057,7 +10057,7 @@ packages:
   requires_dist:
   - adlfs ; extra == 'abfs'
   - adlfs ; extra == 'adl'
-  - pyarrow >=1 ; extra == 'arrow'
+  - pyarrow>=1 ; extra == 'arrow'
   - dask ; extra == 'dask'
   - distributed ; extra == 'dask'
   - pytest ; extra == 'devel'
@@ -10066,7 +10066,7 @@ packages:
   - requests ; extra == 'dropbox'
   - dropbox ; extra == 'dropbox'
   - adlfs ; extra == 'full'
-  - aiohttp !=4.0.0a0, !=4.0.0a1 ; extra == 'full'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'full'
   - dask ; extra == 'full'
   - distributed ; extra == 'full'
   - dropbox ; extra == 'full'
@@ -10077,7 +10077,7 @@ packages:
   - ocifs ; extra == 'full'
   - panel ; extra == 'full'
   - paramiko ; extra == 'full'
-  - pyarrow >=1 ; extra == 'full'
+  - pyarrow>=1 ; extra == 'full'
   - pygit2 ; extra == 'full'
   - requests ; extra == 'full'
   - s3fs ; extra == 'full'
@@ -10089,8 +10089,8 @@ packages:
   - requests ; extra == 'github'
   - gcsfs ; extra == 'gs'
   - panel ; extra == 'gui'
-  - pyarrow >=1 ; extra == 'hdfs'
-  - aiohttp !=4.0.0a0, !=4.0.0a1 ; extra == 'http'
+  - pyarrow>=1 ; extra == 'hdfs'
+  - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'http'
   - libarchive-c ; extra == 'libarchive'
   - ocifs ; extra == 'oci'
   - s3fs ; extra == 's3'
@@ -10211,11 +10211,11 @@ packages:
   path: examples/python/gesture_detection
   sha256: 36dfc4cc822ee47f7aa29ba951bab8a94e96b9fd737daa324a441e6962a620bd
   requires_dist:
-  - mediapipe ==0.10.11 ; sys_platform != 'darwin'
-  - mediapipe ==0.10.9 ; sys_platform == 'darwin'
+  - mediapipe==0.10.11 ; sys_platform != 'darwin'
+  - mediapipe==0.10.9 ; sys_platform == 'darwin'
   - numpy
-  - opencv-python >4.9
-  - requests <3, >=2.31
+  - opencv-python>4.9
+  - requests>=2.31,<3
   - rerun-sdk
   - tqdm
   requires_python: <3.12
@@ -10531,17 +10531,17 @@ packages:
   url: https://files.pythonhosted.org/packages/86/75/59a3ad90d9b4ff5b3e0537611dbe885aeb96124521c9d35aa079f1e0f2c9/google_api_core-2.18.0-py3-none-any.whl
   sha256: 5a63aa102e0049abe85b5b88cb9409234c1f70afcda21ce1e40b285b9629c1d6
   requires_dist:
-  - googleapis-common-protos <2.0.dev0, >=1.56.2
-  - protobuf !=3.20.0, !=3.20.1, !=4.21.0, !=4.21.1, !=4.21.2, !=4.21.3, !=4.21.4, !=4.21.5, <5.0.0.dev0, >=3.19.5
-  - proto-plus <2.0.0.dev0, >=1.22.3
-  - google-auth <3.0.dev0, >=2.14.1
-  - requests <3.0.0.dev0, >=2.18.0
-  - grpcio <2.0.dev0, >=1.33.2 ; extra == 'grpc'
-  - grpcio-status <2.0.dev0, >=1.33.2 ; extra == 'grpc'
-  - grpcio <2.0.dev0, >=1.49.1 ; python_version >= '3.11' and extra == 'grpc'
-  - grpcio-status <2.0.dev0, >=1.49.1 ; python_version >= '3.11' and extra == 'grpc'
-  - grpcio-gcp <1.0.dev0, >=0.2.2 ; extra == 'grpcgcp'
-  - grpcio-gcp <1.0.dev0, >=0.2.2 ; extra == 'grpcio-gcp'
+  - googleapis-common-protos<2.0.dev0,>=1.56.2
+  - protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5
+  - proto-plus<2.0.0.dev0,>=1.22.3
+  - google-auth<3.0.dev0,>=2.14.1
+  - requests<3.0.0.dev0,>=2.18.0
+  - grpcio<2.0.dev0,>=1.33.2 ; extra == 'grpc'
+  - grpcio-status<2.0.dev0,>=1.33.2 ; extra == 'grpc'
+  - grpcio<2.0.dev0,>=1.49.1 ; python_version >= '3.11' and extra == 'grpc'
+  - grpcio-status<2.0.dev0,>=1.49.1 ; python_version >= '3.11' and extra == 'grpc'
+  - grpcio-gcp<1.0.dev0,>=0.2.2 ; extra == 'grpcgcp'
+  - grpcio-gcp<1.0.dev0,>=0.2.2 ; extra == 'grpcio-gcp'
   requires_python: '>=3.7'
 - kind: pypi
   name: google-auth
@@ -10549,17 +10549,17 @@ packages:
   url: https://files.pythonhosted.org/packages/9e/8d/ddbcf81ec751d8ee5fd18ac11ff38a0e110f39dfbf105e6d9db69d556dd0/google_auth-2.29.0-py2.py3-none-any.whl
   sha256: d452ad095688cd52bae0ad6fafe027f6a6d6f560e810fec20914e17a09526415
   requires_dist:
-  - cachetools <6.0, >=2.0.0
-  - pyasn1-modules >=0.2.1
-  - rsa <5, >=3.1.4
-  - aiohttp <4.0.0.dev0, >=3.6.2 ; extra == 'aiohttp'
-  - requests <3.0.0.dev0, >=2.20.0 ; extra == 'aiohttp'
-  - cryptography ==36.0.2 ; extra == 'enterprise_cert'
-  - pyopenssl ==22.0.0 ; extra == 'enterprise_cert'
-  - pyopenssl >=20.0.0 ; extra == 'pyopenssl'
-  - cryptography >=38.0.3 ; extra == 'pyopenssl'
-  - pyu2f >=0.1.5 ; extra == 'reauth'
-  - requests <3.0.0.dev0, >=2.20.0 ; extra == 'requests'
+  - cachetools<6.0,>=2.0.0
+  - pyasn1-modules>=0.2.1
+  - rsa<5,>=3.1.4
+  - aiohttp<4.0.0.dev0,>=3.6.2 ; extra == 'aiohttp'
+  - requests<3.0.0.dev0,>=2.20.0 ; extra == 'aiohttp'
+  - cryptography==36.0.2 ; extra == 'enterprise_cert'
+  - pyopenssl==22.0.0 ; extra == 'enterprise_cert'
+  - pyopenssl>=20.0.0 ; extra == 'pyopenssl'
+  - cryptography>=38.0.3 ; extra == 'pyopenssl'
+  - pyu2f>=0.1.5 ; extra == 'reauth'
+  - requests<3.0.0.dev0,>=2.20.0 ; extra == 'requests'
   requires_python: '>=3.7'
 - kind: pypi
   name: google-cloud-core
@@ -10567,11 +10567,11 @@ packages:
   url: https://files.pythonhosted.org/packages/5e/0f/2e2061e3fbcb9d535d5da3f58cc8de4947df1786fe6a1355960feb05a681/google_cloud_core-2.4.1-py2.py3-none-any.whl
   sha256: a9e6a4422b9ac5c29f79a0ede9485473338e2ce78d91f2370c01e730eab22e61
   requires_dist:
-  - google-api-core !=2.0.*, !=2.1.*, !=2.2.*, !=2.3.0, <3.0.0.dev0, >=1.31.6
-  - google-auth <3.0.dev0, >=1.25.0
-  - importlib-metadata >1.0.0 ; python_version < '3.8'
-  - grpcio <2.0.dev0, >=1.38.0 ; extra == 'grpc'
-  - grpcio-status <2.0.dev0, >=1.38.0 ; extra == 'grpc'
+  - google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.6
+  - google-auth<3.0.dev0,>=1.25.0
+  - importlib-metadata>1.0.0 ; python_version < '3.8'
+  - grpcio<2.0.dev0,>=1.38.0 ; extra == 'grpc'
+  - grpcio-status<2.0.dev0,>=1.38.0 ; extra == 'grpc'
   requires_python: '>=3.7'
 - kind: pypi
   name: google-cloud-storage
@@ -10579,12 +10579,36 @@ packages:
   url: https://files.pythonhosted.org/packages/74/fb/3770e7f44cf6133f502e1b8503b6739351b53272cf8313b47f1de6cf4960/google_cloud_storage-2.9.0-py2.py3-none-any.whl
   sha256: 83a90447f23d5edd045e0037982c270302e3aeb45fc1288d2c2ca713d27bad94
   requires_dist:
-  - google-auth <3.0.dev0, >=1.25.0
-  - google-api-core !=2.0.*, !=2.1.*, !=2.2.*, !=2.3.0, <3.0.0.dev0, >=1.31.5
-  - google-cloud-core <3.0.dev0, >=2.3.0
-  - google-resumable-media >=2.3.2
-  - requests <3.0.0.dev0, >=2.18.0
-  - protobuf <5.0.0.dev0 ; extra == 'protobuf'
+  - google-auth<3.0.dev0,>=1.25.0
+  - google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0.dev0,>=1.31.5
+  - google-cloud-core<3.0.dev0,>=2.3.0
+  - google-resumable-media>=2.3.2
+  - requests<3.0.0.dev0,>=2.18.0
+  - protobuf<5.0.0.dev0 ; extra == 'protobuf'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: google-crc32c
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/41/3f/8141b03ad127fc569c3efda2bfe31d64665e02e2b8b7fbf7b25ea914c27a/google_crc32c-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298
+  requires_dist:
+  - pytest ; extra == 'testing'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: google-crc32c
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/fc/76/3ef124b893aa280e45e95d2346160f1d1d5c0ffc89d3f6e446c83116fb91/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  sha256: 7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57
+  requires_dist:
+  - pytest ; extra == 'testing'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: google-crc32c
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/72/92/2a2fa23db7d0b0382accbdf09768c28f7c07fc8c354cdcf2f44a47f4314e/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906
+  requires_dist:
+  - pytest ; extra == 'testing'
   requires_python: '>=3.7'
 - kind: pypi
   name: google-crc32c
@@ -10603,39 +10627,15 @@ packages:
   - pytest ; extra == 'testing'
   requires_python: '>=3.7'
 - kind: pypi
-  name: google-crc32c
-  version: 1.5.0
-  url: https://files.pythonhosted.org/packages/72/92/2a2fa23db7d0b0382accbdf09768c28f7c07fc8c354cdcf2f44a47f4314e/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906
-  requires_dist:
-  - pytest ; extra == 'testing'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: google-crc32c
-  version: 1.5.0
-  url: https://files.pythonhosted.org/packages/fc/76/3ef124b893aa280e45e95d2346160f1d1d5c0ffc89d3f6e446c83116fb91/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  sha256: 7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57
-  requires_dist:
-  - pytest ; extra == 'testing'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: google-crc32c
-  version: 1.5.0
-  url: https://files.pythonhosted.org/packages/41/3f/8141b03ad127fc569c3efda2bfe31d64665e02e2b8b7fbf7b25ea914c27a/google_crc32c-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298
-  requires_dist:
-  - pytest ; extra == 'testing'
-  requires_python: '>=3.7'
-- kind: pypi
   name: google-resumable-media
   version: 2.7.0
   url: https://files.pythonhosted.org/packages/b2/c6/1202ef64a9336d846f713107dac1c7a0b016cb3840ca3d5615c7005a23d1/google_resumable_media-2.7.0-py2.py3-none-any.whl
   sha256: 79543cfe433b63fd81c0844b7803aba1bb8950b47bedf7d980c38fa123937e08
   requires_dist:
-  - google-crc32c <2.0.dev0, >=1.0
-  - aiohttp <4.0.0.dev0, >=3.6.2 ; extra == 'aiohttp'
-  - google-auth <2.0.dev0, >=1.22.0 ; extra == 'aiohttp'
-  - requests <3.0.0.dev0, >=2.18.0 ; extra == 'requests'
+  - google-crc32c<2.0.dev0,>=1.0
+  - aiohttp<4.0.0.dev0,>=3.6.2 ; extra == 'aiohttp'
+  - google-auth<2.0.dev0,>=1.22.0 ; extra == 'aiohttp'
+  - requests<3.0.0.dev0,>=2.18.0 ; extra == 'requests'
   requires_python: '>=3.7'
 - kind: pypi
   name: googleapis-common-protos
@@ -10643,8 +10643,8 @@ packages:
   url: https://files.pythonhosted.org/packages/dc/a6/12a0c976140511d8bc8a16ad15793b2aef29ac927baa0786ccb7ddbb6e1c/googleapis_common_protos-1.63.0-py2.py3-none-any.whl
   sha256: ae45f75702f7c08b541f750854a678bd8f534a1a6bace6afe975f1d0a82d6632
   requires_dist:
-  - protobuf !=3.20.0, !=3.20.1, !=4.21.1, !=4.21.2, !=4.21.3, !=4.21.4, !=4.21.5, <5.0.0.dev0, >=3.19.5
-  - grpcio <2.0.0.dev0, >=1.44.0 ; extra == 'grpc'
+  - protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5
+  - grpcio<2.0.0.dev0,>=1.44.0 ; extra == 'grpc'
   requires_python: '>=3.7'
 - kind: pypi
   name: grpclib
@@ -10652,9 +10652,9 @@ packages:
   url: https://files.pythonhosted.org/packages/79/b9/55936e462a5925190d7427e880b3033601d1effd13809b483d13a926061a/grpclib-0.4.7.tar.gz
   sha256: 2988ef57c02b22b7a2e8e961792c41ccf97efc2ace91ae7a5b0de03c363823c3
   requires_dist:
-  - h2 <5, >=3.1.0
+  - h2<5,>=3.1.0
   - multidict
-  - protobuf >=3.20.0 ; extra == 'protobuf'
+  - protobuf>=3.20.0 ; extra == 'protobuf'
   requires_python: '>=3.7'
 - kind: conda
   name: gxx
@@ -10764,8 +10764,8 @@ packages:
   url: https://files.pythonhosted.org/packages/2a/e5/db6d438da759efbb488c4f3fbdab7764492ff3c3f953132efa6b9f0e9e53/h2-4.1.0-py3-none-any.whl
   sha256: 03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d
   requires_dist:
-  - hyperframe <7, >=6.0
-  - hpack <5, >=4.0
+  - hyperframe<7,>=6.0
+  - hpack<5,>=4.0
   requires_python: '>=3.6.1'
 - kind: pypi
   name: hpack
@@ -10779,12 +10779,12 @@ packages:
   url: https://files.pythonhosted.org/packages/6c/dd/a834df6482147d48e225a49515aabc28974ad5a4ca3215c18a882565b028/html5lib-1.1-py2.py3-none-any.whl
   sha256: 0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d
   requires_dist:
-  - six >=1.9
+  - six>=1.9
   - webencodings
   - genshi ; extra == 'all'
-  - chardet >=2.2 ; extra == 'all'
+  - chardet>=2.2 ; extra == 'all'
   - lxml ; platform_python_implementation == 'CPython' and extra == 'all'
-  - chardet >=2.2 ; extra == 'chardet'
+  - chardet>=2.2 ; extra == 'chardet'
   - genshi ; extra == 'genshi'
   - lxml ; platform_python_implementation == 'CPython' and extra == 'lxml'
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
@@ -10795,15 +10795,15 @@ packages:
   sha256: 075c30d48ee7db2bba779190dc526d2c11d422aed6f9044c5e2fdc2c432fdb91
   requires_dist:
   - filelock
-  - fsspec >=2023.5.0
-  - packaging >=20.9
-  - pyyaml >=5.1
+  - fsspec>=2023.5.0
+  - packaging>=20.9
+  - pyyaml>=5.1
   - requests
-  - tqdm >=4.42.1
-  - typing-extensions >=3.7.4.3
-  - inquirerpy ==0.3.4 ; extra == 'all'
+  - tqdm>=4.42.1
+  - typing-extensions>=3.7.4.3
+  - inquirerpy==0.3.4 ; extra == 'all'
   - aiohttp ; extra == 'all'
-  - minijinja >=1.0 ; extra == 'all'
+  - minijinja>=1.0 ; extra == 'all'
   - jedi ; extra == 'all'
   - jinja2 ; extra == 'all'
   - pytest ; extra == 'all'
@@ -10813,25 +10813,25 @@ packages:
   - pytest-vcr ; extra == 'all'
   - pytest-asyncio ; extra == 'all'
   - pytest-rerunfailures ; extra == 'all'
-  - urllib3 <2.0 ; extra == 'all'
+  - urllib3<2.0 ; extra == 'all'
   - soundfile ; extra == 'all'
   - pillow ; extra == 'all'
   - gradio ; extra == 'all'
   - numpy ; extra == 'all'
   - fastapi ; extra == 'all'
-  - ruff >=0.3.0 ; extra == 'all'
-  - mypy ==1.5.1 ; extra == 'all'
-  - typing-extensions >=4.8.0 ; extra == 'all'
+  - ruff>=0.3.0 ; extra == 'all'
+  - mypy==1.5.1 ; extra == 'all'
+  - typing-extensions>=4.8.0 ; extra == 'all'
   - types-pyyaml ; extra == 'all'
   - types-requests ; extra == 'all'
   - types-simplejson ; extra == 'all'
   - types-toml ; extra == 'all'
   - types-tqdm ; extra == 'all'
   - types-urllib3 ; extra == 'all'
-  - inquirerpy ==0.3.4 ; extra == 'cli'
-  - inquirerpy ==0.3.4 ; extra == 'dev'
+  - inquirerpy==0.3.4 ; extra == 'cli'
+  - inquirerpy==0.3.4 ; extra == 'dev'
   - aiohttp ; extra == 'dev'
-  - minijinja >=1.0 ; extra == 'dev'
+  - minijinja>=1.0 ; extra == 'dev'
   - jedi ; extra == 'dev'
   - jinja2 ; extra == 'dev'
   - pytest ; extra == 'dev'
@@ -10841,15 +10841,15 @@ packages:
   - pytest-vcr ; extra == 'dev'
   - pytest-asyncio ; extra == 'dev'
   - pytest-rerunfailures ; extra == 'dev'
-  - urllib3 <2.0 ; extra == 'dev'
+  - urllib3<2.0 ; extra == 'dev'
   - soundfile ; extra == 'dev'
   - pillow ; extra == 'dev'
   - gradio ; extra == 'dev'
   - numpy ; extra == 'dev'
   - fastapi ; extra == 'dev'
-  - ruff >=0.3.0 ; extra == 'dev'
-  - mypy ==1.5.1 ; extra == 'dev'
-  - typing-extensions >=4.8.0 ; extra == 'dev'
+  - ruff>=0.3.0 ; extra == 'dev'
+  - mypy==1.5.1 ; extra == 'dev'
+  - typing-extensions>=4.8.0 ; extra == 'dev'
   - types-pyyaml ; extra == 'dev'
   - types-requests ; extra == 'dev'
   - types-simplejson ; extra == 'dev'
@@ -10857,21 +10857,21 @@ packages:
   - types-tqdm ; extra == 'dev'
   - types-urllib3 ; extra == 'dev'
   - toml ; extra == 'fastai'
-  - fastai >=2.4 ; extra == 'fastai'
-  - fastcore >=1.3.27 ; extra == 'fastai'
-  - hf-transfer >=0.1.4 ; extra == 'hf_transfer'
+  - fastai>=2.4 ; extra == 'fastai'
+  - fastcore>=1.3.27 ; extra == 'fastai'
+  - hf-transfer>=0.1.4 ; extra == 'hf_transfer'
   - aiohttp ; extra == 'inference'
-  - minijinja >=1.0 ; extra == 'inference'
-  - ruff >=0.3.0 ; extra == 'quality'
-  - mypy ==1.5.1 ; extra == 'quality'
+  - minijinja>=1.0 ; extra == 'inference'
+  - ruff>=0.3.0 ; extra == 'quality'
+  - mypy==1.5.1 ; extra == 'quality'
   - tensorflow ; extra == 'tensorflow'
   - pydot ; extra == 'tensorflow'
   - graphviz ; extra == 'tensorflow'
   - tensorflow ; extra == 'tensorflow-testing'
-  - keras <3.0 ; extra == 'tensorflow-testing'
-  - inquirerpy ==0.3.4 ; extra == 'testing'
+  - keras<3.0 ; extra == 'tensorflow-testing'
+  - inquirerpy==0.3.4 ; extra == 'testing'
   - aiohttp ; extra == 'testing'
-  - minijinja >=1.0 ; extra == 'testing'
+  - minijinja>=1.0 ; extra == 'testing'
   - jedi ; extra == 'testing'
   - jinja2 ; extra == 'testing'
   - pytest ; extra == 'testing'
@@ -10881,7 +10881,7 @@ packages:
   - pytest-vcr ; extra == 'testing'
   - pytest-asyncio ; extra == 'testing'
   - pytest-rerunfailures ; extra == 'testing'
-  - urllib3 <2.0 ; extra == 'testing'
+  - urllib3<2.0 ; extra == 'testing'
   - soundfile ; extra == 'testing'
   - pillow ; extra == 'testing'
   - gradio ; extra == 'testing'
@@ -10889,7 +10889,7 @@ packages:
   - fastapi ; extra == 'testing'
   - torch ; extra == 'torch'
   - safetensors ; extra == 'torch'
-  - typing-extensions >=4.8.0 ; extra == 'typing'
+  - typing-extensions>=4.8.0 ; extra == 'typing'
   - types-pyyaml ; extra == 'typing'
   - types-requests ; extra == 'typing'
   - types-simplejson ; extra == 'typing'
@@ -10903,11 +10903,11 @@ packages:
   path: examples/python/human_pose_tracking
   sha256: 8a80b67528d3f6d0c82671dc5c36cf551faa4b879f4434f0d386d8ef85666e86
   requires_dist:
-  - mediapipe ==0.10.11 ; sys_platform != 'darwin'
-  - mediapipe ==0.10.9 ; sys_platform == 'darwin'
+  - mediapipe==0.10.11 ; sys_platform != 'darwin'
+  - mediapipe==0.10.9 ; sys_platform == 'darwin'
   - numpy
-  - opencv-python >4.6
-  - requests <3, >=2.31
+  - opencv-python>4.6
+  - requests>=2.31,<3
   - rerun-sdk
   requires_python: <3.12
   editable: true
@@ -11011,7 +11011,7 @@ packages:
   sha256: 408c1d4d62f72c9e8347e7d1ca9bc11d8673328af3913868db3b828e28b40a4c
   requires_dist:
   - numpy
-  - pillow >=8.3.2
+  - pillow>=8.3.2
   - astropy ; extra == 'all-plugins'
   - av ; extra == 'all-plugins'
   - imageio-ffmpeg ; extra == 'all-plugins'
@@ -11029,7 +11029,7 @@ packages:
   - fsspec[github] ; extra == 'dev'
   - black ; extra == 'dev'
   - flake8 ; extra == 'dev'
-  - sphinx <6 ; extra == 'docs'
+  - sphinx<6 ; extra == 'docs'
   - numpydoc ; extra == 'docs'
   - pydata-sphinx-theme ; extra == 'docs'
   - imageio-ffmpeg ; extra == 'ffmpeg'
@@ -11049,7 +11049,7 @@ packages:
   - pydata-sphinx-theme ; extra == 'full'
   - pytest ; extra == 'full'
   - pytest-cov ; extra == 'full'
-  - sphinx <6 ; extra == 'full'
+  - sphinx<6 ; extra == 'full'
   - tifffile ; extra == 'full'
   - wheel ; extra == 'full'
   - gdal ; extra == 'gdal'
@@ -11069,27 +11069,27 @@ packages:
   url: https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl
   sha256: 30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570
   requires_dist:
-  - zipp >=0.5
-  - typing-extensions >=3.6.4 ; python_version < '3.8'
-  - sphinx >=3.5 ; extra == 'docs'
-  - jaraco-packaging >=9.3 ; extra == 'docs'
-  - rst-linker >=1.9 ; extra == 'docs'
+  - zipp>=0.5
+  - typing-extensions>=3.6.4 ; python_version < '3.8'
+  - sphinx>=3.5 ; extra == 'docs'
+  - jaraco-packaging>=9.3 ; extra == 'docs'
+  - rst-linker>=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
   - sphinx-lint ; extra == 'docs'
-  - jaraco-tidelift >=1.4 ; extra == 'docs'
+  - jaraco-tidelift>=1.4 ; extra == 'docs'
   - ipython ; extra == 'perf'
-  - pytest >=6 ; extra == 'testing'
-  - pytest-checkdocs >=2.4 ; extra == 'testing'
+  - pytest>=6 ; extra == 'testing'
+  - pytest-checkdocs>=2.4 ; extra == 'testing'
   - pytest-cov ; extra == 'testing'
-  - pytest-enabler >=2.2 ; extra == 'testing'
-  - pytest-ruff >=0.2.1 ; extra == 'testing'
+  - pytest-enabler>=2.2 ; extra == 'testing'
+  - pytest-ruff>=0.2.1 ; extra == 'testing'
   - packaging ; extra == 'testing'
   - pyfakefs ; extra == 'testing'
   - flufl-flake8 ; extra == 'testing'
-  - pytest-perf >=0.9.2 ; extra == 'testing'
-  - jaraco-test >=5.4 ; extra == 'testing'
+  - pytest-perf>=0.9.2 ; extra == 'testing'
+  - jaraco-test>=5.4 ; extra == 'testing'
   - pytest-mypy ; platform_python_implementation != 'PyPy' and extra == 'testing'
-  - importlib-resources >=1.3 ; python_version < '3.9' and extra == 'testing'
+  - importlib-resources>=1.3 ; python_version < '3.9' and extra == 'testing'
   requires_python: '>=3.8'
 - kind: pypi
   name: incremental-logging
@@ -11166,46 +11166,46 @@ packages:
   url: https://files.pythonhosted.org/packages/20/11/6667e8a2146d62b7e585c389cc39cede4993f7380101cae052e8dce546c2/jax-0.4.28-py3-none-any.whl
   sha256: 6a181e6b5a5b1140e19cdd2d5c4aa779e4cb4ec627757b918be322d8e81035ba
   requires_dist:
-  - ml-dtypes >=0.2.0
-  - numpy >=1.22
+  - ml-dtypes>=0.2.0
+  - numpy>=1.22
   - opt-einsum
-  - scipy >=1.9
-  - importlib-metadata >=4.6 ; python_version < '3.10'
-  - numpy >=1.23.2 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - scipy >=1.11.1 ; python_version >= '3.12'
-  - protobuf <4, >=3.13 ; extra == 'australis'
-  - jaxlib ==0.4.27 ; extra == 'ci'
-  - jaxlib ==0.4.28 ; extra == 'cpu'
-  - jaxlib ==0.4.28+cuda12.cudnn89 ; extra == 'cuda'
-  - jaxlib ==0.4.28 ; extra == 'cuda12'
-  - jax-cuda12-plugin ==0.4.28 ; extra == 'cuda12'
-  - nvidia-cublas-cu12 >=12.1.3.1 ; extra == 'cuda12'
-  - nvidia-cuda-cupti-cu12 >=12.1.105 ; extra == 'cuda12'
-  - nvidia-cuda-nvcc-cu12 >=12.1.105 ; extra == 'cuda12'
-  - nvidia-cuda-runtime-cu12 >=12.1.105 ; extra == 'cuda12'
-  - nvidia-cudnn-cu12 <9.0, >=8.9.2.26 ; extra == 'cuda12'
-  - nvidia-cufft-cu12 >=11.0.2.54 ; extra == 'cuda12'
-  - nvidia-cusolver-cu12 >=11.4.5.107 ; extra == 'cuda12'
-  - nvidia-cusparse-cu12 >=12.1.0.106 ; extra == 'cuda12'
-  - nvidia-nccl-cu12 >=2.18.1 ; extra == 'cuda12'
-  - nvidia-nvjitlink-cu12 >=12.1.105 ; extra == 'cuda12'
-  - jaxlib ==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_cudnn89'
-  - jaxlib ==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_local'
-  - jaxlib ==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_pip'
-  - nvidia-cublas-cu12 >=12.1.3.1 ; extra == 'cuda12_pip'
-  - nvidia-cuda-cupti-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cuda-nvcc-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cuda-runtime-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cudnn-cu12 <9.0, >=8.9.2.26 ; extra == 'cuda12_pip'
-  - nvidia-cufft-cu12 >=11.0.2.54 ; extra == 'cuda12_pip'
-  - nvidia-cusolver-cu12 >=11.4.5.107 ; extra == 'cuda12_pip'
-  - nvidia-cusparse-cu12 >=12.1.0.106 ; extra == 'cuda12_pip'
-  - nvidia-nccl-cu12 >=2.18.1 ; extra == 'cuda12_pip'
-  - nvidia-nvjitlink-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - jaxlib ==0.4.27 ; extra == 'minimum-jaxlib'
-  - jaxlib ==0.4.28 ; extra == 'tpu'
-  - libtpu-nightly ==0.1.dev20240508 ; extra == 'tpu'
+  - scipy>=1.9
+  - importlib-metadata>=4.6 ; python_version < '3.10'
+  - numpy>=1.23.2 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - scipy>=1.11.1 ; python_version >= '3.12'
+  - protobuf<4,>=3.13 ; extra == 'australis'
+  - jaxlib==0.4.27 ; extra == 'ci'
+  - jaxlib==0.4.28 ; extra == 'cpu'
+  - jaxlib==0.4.28+cuda12.cudnn89 ; extra == 'cuda'
+  - jaxlib==0.4.28 ; extra == 'cuda12'
+  - jax-cuda12-plugin==0.4.28 ; extra == 'cuda12'
+  - nvidia-cublas-cu12>=12.1.3.1 ; extra == 'cuda12'
+  - nvidia-cuda-cupti-cu12>=12.1.105 ; extra == 'cuda12'
+  - nvidia-cuda-nvcc-cu12>=12.1.105 ; extra == 'cuda12'
+  - nvidia-cuda-runtime-cu12>=12.1.105 ; extra == 'cuda12'
+  - nvidia-cudnn-cu12<9.0,>=8.9.2.26 ; extra == 'cuda12'
+  - nvidia-cufft-cu12>=11.0.2.54 ; extra == 'cuda12'
+  - nvidia-cusolver-cu12>=11.4.5.107 ; extra == 'cuda12'
+  - nvidia-cusparse-cu12>=12.1.0.106 ; extra == 'cuda12'
+  - nvidia-nccl-cu12>=2.18.1 ; extra == 'cuda12'
+  - nvidia-nvjitlink-cu12>=12.1.105 ; extra == 'cuda12'
+  - jaxlib==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_cudnn89'
+  - jaxlib==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_local'
+  - jaxlib==0.4.28+cuda12.cudnn89 ; extra == 'cuda12_pip'
+  - nvidia-cublas-cu12>=12.1.3.1 ; extra == 'cuda12_pip'
+  - nvidia-cuda-cupti-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cuda-nvcc-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cuda-runtime-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cudnn-cu12<9.0,>=8.9.2.26 ; extra == 'cuda12_pip'
+  - nvidia-cufft-cu12>=11.0.2.54 ; extra == 'cuda12_pip'
+  - nvidia-cusolver-cu12>=11.4.5.107 ; extra == 'cuda12_pip'
+  - nvidia-cusparse-cu12>=12.1.0.106 ; extra == 'cuda12_pip'
+  - nvidia-nccl-cu12>=2.18.1 ; extra == 'cuda12_pip'
+  - nvidia-nvjitlink-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - jaxlib==0.4.27 ; extra == 'minimum-jaxlib'
+  - jaxlib==0.4.28 ; extra == 'tpu'
+  - libtpu-nightly==0.1.dev20240508 ; extra == 'tpu'
   - requests ; extra == 'tpu'
   requires_python: '>=3.9'
 - kind: pypi
@@ -11214,20 +11214,20 @@ packages:
   url: https://files.pythonhosted.org/packages/8e/d7/65b1f5cf05d9159abd5882a51695d4d1b386bc8e26140eff7159854777f2/jaxlib-0.4.28-cp311-cp311-manylinux2014_x86_64.whl
   sha256: 45ce0f3c840cff8236cff26c37f26c9ff078695f93e0c162c320c281f5041275
   requires_dist:
-  - scipy >=1.9
-  - numpy >=1.22
-  - ml-dtypes >=0.2.0
-  - scipy >=1.11.1 ; python_version >= '3.12'
-  - nvidia-cublas-cu12 >=12.1.3.1 ; extra == 'cuda12_pip'
-  - nvidia-cuda-cupti-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cuda-nvcc-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cuda-runtime-cu12 >=12.1.105 ; extra == 'cuda12_pip'
-  - nvidia-cudnn-cu12 <9.0, >=8.9.2.26 ; extra == 'cuda12_pip'
-  - nvidia-cufft-cu12 >=11.0.2.54 ; extra == 'cuda12_pip'
-  - nvidia-cusolver-cu12 >=11.4.5.107 ; extra == 'cuda12_pip'
-  - nvidia-cusparse-cu12 >=12.1.0.106 ; extra == 'cuda12_pip'
-  - nvidia-nccl-cu12 >=2.18.1 ; extra == 'cuda12_pip'
-  - nvidia-nvjitlink-cu12 >=12.1.105 ; extra == 'cuda12_pip'
+  - scipy>=1.9
+  - numpy>=1.22
+  - ml-dtypes>=0.2.0
+  - scipy>=1.11.1 ; python_version >= '3.12'
+  - nvidia-cublas-cu12>=12.1.3.1 ; extra == 'cuda12_pip'
+  - nvidia-cuda-cupti-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cuda-nvcc-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cuda-runtime-cu12>=12.1.105 ; extra == 'cuda12_pip'
+  - nvidia-cudnn-cu12<9.0,>=8.9.2.26 ; extra == 'cuda12_pip'
+  - nvidia-cufft-cu12>=11.0.2.54 ; extra == 'cuda12_pip'
+  - nvidia-cusolver-cu12>=11.4.5.107 ; extra == 'cuda12_pip'
+  - nvidia-cusparse-cu12>=12.1.0.106 ; extra == 'cuda12_pip'
+  - nvidia-nccl-cu12>=2.18.1 ; extra == 'cuda12_pip'
+  - nvidia-nvjitlink-cu12>=12.1.105 ; extra == 'cuda12_pip'
   requires_python: '>=3.9'
 - kind: pypi
   name: jinja2
@@ -11235,8 +11235,8 @@ packages:
   url: https://files.pythonhosted.org/packages/31/80/3a54838c3fb461f6fec263ebf3a3a41771bd05190238de3486aae8540c36/jinja2-3.1.4-py3-none-any.whl
   sha256: bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d
   requires_dist:
-  - markupsafe >=2.0
-  - babel >=2.7 ; extra == 'i18n'
+  - markupsafe>=2.0
+  - babel>=2.7 ; extra == 'i18n'
   requires_python: '>=3.7'
 - kind: conda
   name: jinja2
@@ -11325,14 +11325,6 @@ packages:
 - kind: pypi
   name: kiwisolver
   version: 1.4.5
-  url: https://files.pythonhosted.org/packages/a6/94/695922e71288855fc7cace3bdb52edda9d7e50edba77abb0c9d7abb51e96/kiwisolver-1.4.5-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 8ab3919a9997ab7ef2fbbed0cc99bb28d3c13e6d4b1ad36e97e482558a91be90
-  requires_dist:
-  - typing-extensions ; python_version < '3.8'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: kiwisolver
-  version: 1.4.5
   url: https://files.pythonhosted.org/packages/17/ba/17a706b232308e65f57deeccae503c268292e6a091313f6ce833a23093ea/kiwisolver-1.4.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 040c1aebeda72197ef477a906782b5ab0d387642e93bda547336b8957c61022e
   requires_dist:
@@ -11351,6 +11343,14 @@ packages:
   version: 1.4.5
   url: https://files.pythonhosted.org/packages/4a/fe/23d7fa78f7c66086d196406beb1fb2eaf629dd7adc01c3453033303d17fa/kiwisolver-1.4.5-cp311-cp311-macosx_11_0_arm64.whl
   sha256: fcc700eadbbccbf6bc1bcb9dbe0786b4b1cb91ca0dcda336eef5c2beed37b797
+  requires_dist:
+  - typing-extensions ; python_version < '3.8'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: kiwisolver
+  version: 1.4.5
+  url: https://files.pythonhosted.org/packages/a6/94/695922e71288855fc7cace3bdb52edda9d7e50edba77abb0c9d7abb51e96/kiwisolver-1.4.5-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 8ab3919a9997ab7ef2fbbed0cc99bb28d3c13e6d4b1ad36e97e482558a91be90
   requires_dist:
   - typing-extensions ; python_version < '3.8'
   requires_python: '>=3.7'
@@ -11451,10 +11451,10 @@ packages:
   requires_dist:
   - packaging
   - importlib-metadata ; python_version < '3.8'
-  - changelist ==0.5 ; extra == 'dev'
-  - pre-commit ==3.7.0 ; extra == 'lint'
-  - pytest >=7.4 ; extra == 'test'
-  - pytest-cov >=4.1 ; extra == 'test'
+  - changelist==0.5 ; extra == 'dev'
+  - pre-commit==3.7.0 ; extra == 'lint'
+  - pytest>=7.4 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
   requires_python: '>=3.7'
 - kind: conda
   name: ld64
@@ -19895,12 +19895,6 @@ packages:
 - kind: pypi
   name: llvmlite
   version: 0.42.0
-  url: https://files.pythonhosted.org/packages/13/97/4aac09bdfc1bc35f8eb64e21ff5897224a788170e5e8cab3e62c9eb78efb/llvmlite-0.42.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: ae511caed28beaf1252dbaf5f40e663f533b79ceb408c874c01754cafabb9cbf
-  requires_python: '>=3.9'
-- kind: pypi
-  name: llvmlite
-  version: 0.42.0
   url: https://files.pythonhosted.org/packages/a4/1f/300788b5eab99aec872ed2f3647386d7d7f7bbf4f99c91e9e023b404ff7f/llvmlite-0.42.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: c5bece0cdf77f22379f19b1959ccd7aee518afa4afbd3656c6365865f84903f9
   requires_python: '>=3.9'
@@ -19917,6 +19911,12 @@ packages:
   sha256: 81e674c2fe85576e6c4474e8c7e7aba7901ac0196e864fe7985492b737dbab65
   requires_python: '>=3.9'
 - kind: pypi
+  name: llvmlite
+  version: 0.42.0
+  url: https://files.pythonhosted.org/packages/13/97/4aac09bdfc1bc35f8eb64e21ff5897224a788170e5e8cab3e62c9eb78efb/llvmlite-0.42.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: ae511caed28beaf1252dbaf5f40e663f533b79ceb408c874c01754cafabb9cbf
+  requires_python: '>=3.9'
+- kind: pypi
   name: log-file
   version: 0.1.0
   path: examples/python/log_file
@@ -19927,26 +19927,14 @@ packages:
 - kind: pypi
   name: lxml
   version: 5.2.2
-  url: https://files.pythonhosted.org/packages/4e/42/3bfe92749715c819763d2205370ecc7f586b44e277f38839e27cce7d6bb8/lxml-5.2.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: b0b3f2df149efb242cee2ffdeb6674b7f30d23c9a7af26595099afaf46ef4e88
-  requires_dist:
-  - cssselect >=0.7 ; extra == 'cssselect'
-  - html5lib ; extra == 'html5'
-  - lxml-html-clean ; extra == 'html_clean'
-  - beautifulsoup4 ; extra == 'htmlsoup'
-  - cython >=3.0.10 ; extra == 'source'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: lxml
-  version: 5.2.2
   url: https://files.pythonhosted.org/packages/ad/b7/0dc82afed00c4c189cfd0b83464f9a431c66de8e73d911063956a147276a/lxml-5.2.2-cp311-cp311-manylinux_2_28_x86_64.whl
   sha256: eb00b549b13bd6d884c863554566095bf6fa9c3cecb2e7b399c4bc7904cb33b5
   requires_dist:
-  - cssselect >=0.7 ; extra == 'cssselect'
+  - cssselect>=0.7 ; extra == 'cssselect'
   - html5lib ; extra == 'html5'
   - lxml-html-clean ; extra == 'html_clean'
   - beautifulsoup4 ; extra == 'htmlsoup'
-  - cython >=3.0.10 ; extra == 'source'
+  - cython>=3.0.10 ; extra == 'source'
   requires_python: '>=3.6'
 - kind: pypi
   name: lxml
@@ -19954,11 +19942,11 @@ packages:
   url: https://files.pythonhosted.org/packages/04/19/d6aa2d980f220a04c91d4de538d2fea1a65535e7b0a4aec0998ce46e3667/lxml-5.2.2-cp311-cp311-win_amd64.whl
   sha256: 49095a38eb333aaf44c06052fd2ec3b8f23e19747ca7ec6f6c954ffea6dbf7be
   requires_dist:
-  - cssselect >=0.7 ; extra == 'cssselect'
+  - cssselect>=0.7 ; extra == 'cssselect'
   - html5lib ; extra == 'html5'
   - lxml-html-clean ; extra == 'html_clean'
   - beautifulsoup4 ; extra == 'htmlsoup'
-  - cython >=3.0.10 ; extra == 'source'
+  - cython>=3.0.10 ; extra == 'source'
   requires_python: '>=3.6'
 - kind: pypi
   name: lxml
@@ -19966,11 +19954,23 @@ packages:
   url: https://files.pythonhosted.org/packages/da/6a/24e9f77d17668dd4ac0a6c2a56113fd3e0db07cee51e3a67afcd47c597e5/lxml-5.2.2-cp311-cp311-macosx_10_9_universal2.whl
   sha256: 45f9494613160d0405682f9eee781c7e6d1bf45f819654eb249f8f46a2c22545
   requires_dist:
-  - cssselect >=0.7 ; extra == 'cssselect'
+  - cssselect>=0.7 ; extra == 'cssselect'
   - html5lib ; extra == 'html5'
   - lxml-html-clean ; extra == 'html_clean'
   - beautifulsoup4 ; extra == 'htmlsoup'
-  - cython >=3.0.10 ; extra == 'source'
+  - cython>=3.0.10 ; extra == 'source'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: lxml
+  version: 5.2.2
+  url: https://files.pythonhosted.org/packages/4e/42/3bfe92749715c819763d2205370ecc7f586b44e277f38839e27cce7d6bb8/lxml-5.2.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: b0b3f2df149efb242cee2ffdeb6674b7f30d23c9a7af26595099afaf46ef4e88
+  requires_dist:
+  - cssselect>=0.7 ; extra == 'cssselect'
+  - html5lib ; extra == 'html5'
+  - lxml-html-clean ; extra == 'html_clean'
+  - beautifulsoup4 ; extra == 'htmlsoup'
+  - cython>=3.0.10 ; extra == 'source'
   requires_python: '>=3.6'
 - kind: conda
   name: lz4-c
@@ -20126,12 +20126,6 @@ packages:
 - kind: pypi
   name: markupsafe
   version: 2.1.5
-  url: https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2
-  requires_python: '>=3.7'
-- kind: pypi
-  name: markupsafe
-  version: 2.1.5
   url: https://files.pythonhosted.org/packages/97/18/c30da5e7a0e7f4603abfc6780574131221d9148f323752c2755d48abad30/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5
   requires_python: '>=3.7'
@@ -20146,6 +20140,12 @@ packages:
   version: 2.1.5
   url: https://files.pythonhosted.org/packages/11/e7/291e55127bb2ae67c64d66cef01432b5933859dfb7d6949daa721b89d0b3/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl
   sha256: 629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f
+  requires_python: '>=3.7'
+- kind: pypi
+  name: markupsafe
+  version: 2.1.5
+  url: https://files.pythonhosted.org/packages/6b/cb/aed7a284c00dfa7c0682d14df85ad4955a350a21d2e3b06d8240497359bf/MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2
   requires_python: '>=3.7'
 - kind: conda
   name: markupsafe
@@ -20254,15 +20254,15 @@ packages:
   url: https://files.pythonhosted.org/packages/be/24/cbb242420021a79c87768dcd22ce028f48ef40913239ad6106c8a557f52c/marshmallow-3.21.2-py3-none-any.whl
   sha256: 70b54a6282f4704d12c0a41599682c5c5450e843b9ec406308653b47c59648a1
   requires_dist:
-  - packaging >=17.0
+  - packaging>=17.0
   - marshmallow[tests] ; extra == 'dev'
   - tox ; extra == 'dev'
-  - pre-commit ~=3.5 ; extra == 'dev'
-  - sphinx ==7.3.7 ; extra == 'docs'
-  - sphinx-issues ==4.1.0 ; extra == 'docs'
-  - alabaster ==0.7.16 ; extra == 'docs'
-  - sphinx-version-warning ==1.1.2 ; extra == 'docs'
-  - autodocsumm ==0.2.12 ; extra == 'docs'
+  - pre-commit~=3.5 ; extra == 'dev'
+  - sphinx==7.3.7 ; extra == 'docs'
+  - sphinx-issues==4.1.0 ; extra == 'docs'
+  - alabaster==0.7.16 ; extra == 'docs'
+  - sphinx-version-warning==1.1.2 ; extra == 'docs'
+  - autodocsumm==0.2.12 ; extra == 'docs'
   - pytest ; extra == 'tests'
   - pytz ; extra == 'tests'
   - simplejson ; extra == 'tests'
@@ -20270,36 +20270,19 @@ packages:
 - kind: pypi
   name: matplotlib
   version: 3.8.4
-  url: https://files.pythonhosted.org/packages/36/11/62250ea25780d4b59c2c6044ec161235c47cc05a18d0ec0a05657de75b7d/matplotlib-3.8.4-cp311-cp311-macosx_10_12_x86_64.whl
-  sha256: 72f9322712e4562e792b2961971891b9fbbb0e525011e09ea0d1f416c4645661
-  requires_dist:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - kiwisolver >=1.3.1
-  - numpy >=1.21
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python-dateutil >=2.7
-  - importlib-resources >=3.2.0 ; python_version < '3.10'
-  requires_python: '>=3.9'
-- kind: pypi
-  name: matplotlib
-  version: 3.8.4
   url: https://files.pythonhosted.org/packages/80/3b/e363612ac1a514abfb5505aa209dd5b724b3232a6de98710d7759559706a/matplotlib-3.8.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: cc4ccdc64e3039fc303defd119658148f2349239871db72cd74e2eeaa9b80b71
   requires_dist:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - kiwisolver >=1.3.1
-  - numpy >=1.21
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python-dateutil >=2.7
-  - importlib-resources >=3.2.0 ; python_version < '3.10'
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
   requires_python: '>=3.9'
 - kind: pypi
   name: matplotlib
@@ -20307,16 +20290,16 @@ packages:
   url: https://files.pythonhosted.org/packages/2d/d5/6227732ecab9165586966ccb54301e3164f61b470c954c4cf6940654fbe1/matplotlib-3.8.4-cp311-cp311-win_amd64.whl
   sha256: 8080d5081a86e690d7688ffa542532e87f224c38a6ed71f8fbed34dd1d9fedae
   requires_dist:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - kiwisolver >=1.3.1
-  - numpy >=1.21
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python-dateutil >=2.7
-  - importlib-resources >=3.2.0 ; python_version < '3.10'
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
   requires_python: '>=3.9'
 - kind: pypi
   name: matplotlib
@@ -20324,16 +20307,33 @@ packages:
   url: https://files.pythonhosted.org/packages/14/60/12d4f27b859a74359306662da69c2d08826a2b05cfe7f96e66b490f41573/matplotlib-3.8.4-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 232ce322bfd020a434caaffbd9a95333f7c2491e59cfc014041d95e38ab90d1c
   requires_dist:
-  - contourpy >=1.0.1
-  - cycler >=0.10
-  - fonttools >=4.22.0
-  - kiwisolver >=1.3.1
-  - numpy >=1.21
-  - packaging >=20.0
-  - pillow >=8
-  - pyparsing >=2.3.1
-  - python-dateutil >=2.7
-  - importlib-resources >=3.2.0 ; python_version < '3.10'
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: matplotlib
+  version: 3.8.4
+  url: https://files.pythonhosted.org/packages/36/11/62250ea25780d4b59c2c6044ec161235c47cc05a18d0ec0a05657de75b7d/matplotlib-3.8.4-cp311-cp311-macosx_10_12_x86_64.whl
+  sha256: 72f9322712e4562e792b2961971891b9fbbb0e525011e09ea0d1f416c4645661
+  requires_dist:
+  - contourpy>=1.0.1
+  - cycler>=0.10
+  - fonttools>=4.22.0
+  - kiwisolver>=1.3.1
+  - numpy>=1.21
+  - packaging>=20.0
+  - pillow>=8
+  - pyparsing>=2.3.1
+  - python-dateutil>=2.7
+  - importlib-resources>=3.2.0 ; python_version < '3.10'
   requires_python: '>=3.9'
 - kind: conda
   name: maturin
@@ -20441,31 +20441,31 @@ packages:
 - kind: pypi
   name: mediapipe
   version: 0.10.9
-  url: https://files.pythonhosted.org/packages/c1/71/38b16b1e4504ff92dff875d455c19e62125fccd73d5ce7e06b560f77fd26/mediapipe-0.10.9-cp311-cp311-macosx_11_0_x86_64.whl
-  sha256: b7dde54b82732479b9b856c9230b9f7b3da55b0913dde5254a7489e20c2e3c6e
-  requires_dist:
-  - absl-py
-  - attrs >=19.1.0
-  - flatbuffers >=2.0
-  - matplotlib
-  - numpy
-  - opencv-contrib-python
-  - protobuf <4, >=3.11
-  - sounddevice >=0.4.4
-- kind: pypi
-  name: mediapipe
-  version: 0.10.9
   url: https://files.pythonhosted.org/packages/a3/3a/f309c6bdebe596cc8c960542e167331cb01ef130ec38f3da46a499718889/mediapipe-0.10.9-cp311-cp311-macosx_11_0_universal2.whl
   sha256: 8733735f582e6e6a05bf9b15c48b03a6387a0795793a2530aa1189eecfd33780
   requires_dist:
   - absl-py
-  - attrs >=19.1.0
-  - flatbuffers >=2.0
+  - attrs>=19.1.0
+  - flatbuffers>=2.0
   - matplotlib
   - numpy
   - opencv-contrib-python
-  - protobuf <4, >=3.11
-  - sounddevice >=0.4.4
+  - protobuf<4,>=3.11
+  - sounddevice>=0.4.4
+- kind: pypi
+  name: mediapipe
+  version: 0.10.9
+  url: https://files.pythonhosted.org/packages/c1/71/38b16b1e4504ff92dff875d455c19e62125fccd73d5ce7e06b560f77fd26/mediapipe-0.10.9-cp311-cp311-macosx_11_0_x86_64.whl
+  sha256: b7dde54b82732479b9b856c9230b9f7b3da55b0913dde5254a7489e20c2e3c6e
+  requires_dist:
+  - absl-py
+  - attrs>=19.1.0
+  - flatbuffers>=2.0
+  - matplotlib
+  - numpy
+  - opencv-contrib-python
+  - protobuf<4,>=3.11
+  - sounddevice>=0.4.4
 - kind: pypi
   name: mediapipe
   version: 0.10.11
@@ -20473,16 +20473,16 @@ packages:
   sha256: ea751e043909ba7bbe27e7afdbcdafd79723d50ef4165afcaae431ab428eea13
   requires_dist:
   - absl-py
-  - attrs >=19.1.0
-  - flatbuffers >=2.0
+  - attrs>=19.1.0
+  - flatbuffers>=2.0
   - jax
   - jaxlib
   - matplotlib
   - numpy
   - torch
   - opencv-contrib-python
-  - protobuf <4, >=3.11
-  - sounddevice >=0.4.4
+  - protobuf<4,>=3.11
+  - sounddevice>=0.4.4
 - kind: pypi
   name: mediapipe
   version: 0.10.11
@@ -20490,14 +20490,14 @@ packages:
   sha256: 36231eaf23cd795a923a8b015d36bd6e410a8e997c36dd9432db0157b822b181
   requires_dist:
   - absl-py
-  - attrs >=19.1.0
-  - flatbuffers >=2.0
+  - attrs>=19.1.0
+  - flatbuffers>=2.0
   - jax
   - matplotlib
   - numpy
   - opencv-contrib-python
-  - protobuf <4, >=3.11
-  - sounddevice >=0.4.4
+  - protobuf<4,>=3.11
+  - sounddevice>=0.4.4
 - kind: conda
   name: meilisearch
   version: 1.5.1
@@ -20596,14 +20596,14 @@ packages:
   url: https://files.pythonhosted.org/packages/84/17/a936d3dfad84d028ba8539a93167274b7dcd7985e0d9df487e94a62f9428/ml_dtypes-0.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: e1e2f4237b459a63c97c2c9f449baa637d7e4c20addff6a9bac486f22432f3b6
   requires_dist:
-  - numpy >1.20
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.23.3 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
+  - numpy>1.20
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.23.3 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
   - absl-py ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
-  - pylint >=2.6.0 ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.9'
 - kind: pypi
@@ -20612,14 +20612,14 @@ packages:
   url: https://files.pythonhosted.org/packages/f0/36/290745178e5776f7416818abc1334c1b19afb93c7c87fd1bef3cc99f84ca/ml_dtypes-0.4.0-cp311-cp311-win_amd64.whl
   sha256: 75b4faf99d0711b81f393db36d210b4255fd419f6f790bc6c1b461f95ffb7a9e
   requires_dist:
-  - numpy >1.20
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.23.3 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
+  - numpy>1.20
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.23.3 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
   - absl-py ; extra == 'dev'
   - pytest ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
-  - pylint >=2.6.0 ; extra == 'dev'
+  - pylint>=2.6.0 ; extra == 'dev'
   - pyink ; extra == 'dev'
   requires_python: '>=3.9'
 - kind: pypi
@@ -20628,14 +20628,14 @@ packages:
   url: https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl
   sha256: a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c
   requires_dist:
-  - pytest >=4.6 ; extra == 'develop'
+  - pytest>=4.6 ; extra == 'develop'
   - pycodestyle ; extra == 'develop'
   - pytest-cov ; extra == 'develop'
   - codecov ; extra == 'develop'
   - wheel ; extra == 'develop'
   - sphinx ; extra == 'docs'
-  - gmpy2 >=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
-  - pytest >=4.6 ; extra == 'tests'
+  - gmpy2>=2.1.0a4 ; platform_python_implementation != 'PyPy' and extra == 'gmpy'
+  - pytest>=4.6 ; extra == 'tests'
 - kind: conda
   name: msys2-conda-epoch
   version: '20160418'
@@ -20647,12 +20647,6 @@ packages:
   md5: b0309b72560df66f71a9d5e34a5efdfa
   size: 3227
   timestamp: 1608166968312
-- kind: pypi
-  name: multidict
-  version: 6.0.5
-  url: https://files.pythonhosted.org/packages/21/db/3403263f158b0bc7b0d4653766d71cb39498973f2042eead27b2e9758782/multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e
-  requires_python: '>=3.7'
 - kind: pypi
   name: multidict
   version: 6.0.5
@@ -20670,6 +20664,12 @@ packages:
   version: 6.0.5
   url: https://files.pythonhosted.org/packages/02/c1/b15ecceb6ffa5081ed2ed450aea58d65b0e0358001f2b426705f9f41f4c2/multidict-6.0.5-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 612d1156111ae11d14afaf3a0669ebf6c170dbb735e510a7438ffe2369a847fd
+  requires_python: '>=3.7'
+- kind: pypi
+  name: multidict
+  version: 6.0.5
+  url: https://files.pythonhosted.org/packages/21/db/3403263f158b0bc7b0d4653766d71cb39498973f2042eead27b2e9758782/multidict-6.0.5-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 53689bb4e102200a4fafa9de9c7c3c212ab40a7ab2c8e474491914d2305f187e
   requires_python: '>=3.7'
 - kind: conda
   name: multidict
@@ -21068,27 +21068,27 @@ packages:
   url: https://files.pythonhosted.org/packages/38/e9/5f72929373e1a0e8d142a130f3f97e6ff920070f87f91c4e13e40e0fba5a/networkx-3.3-py3-none-any.whl
   sha256: 28575580c6ebdaf4505b22c6256a2b9de86b316dc63ba9e93abde3d78dfdbcf2
   requires_dist:
-  - numpy >=1.23 ; extra == 'default'
-  - scipy !=1.11.0, !=1.11.1, >=1.9 ; extra == 'default'
-  - matplotlib >=3.6 ; extra == 'default'
-  - pandas >=1.4 ; extra == 'default'
-  - changelist ==0.5 ; extra == 'developer'
-  - pre-commit >=3.2 ; extra == 'developer'
-  - mypy >=1.1 ; extra == 'developer'
+  - numpy>=1.23 ; extra == 'default'
+  - scipy!=1.11.0,!=1.11.1,>=1.9 ; extra == 'default'
+  - matplotlib>=3.6 ; extra == 'default'
+  - pandas>=1.4 ; extra == 'default'
+  - changelist==0.5 ; extra == 'developer'
+  - pre-commit>=3.2 ; extra == 'developer'
+  - mypy>=1.1 ; extra == 'developer'
   - rtoml ; extra == 'developer'
-  - sphinx >=7 ; extra == 'doc'
-  - pydata-sphinx-theme >=0.14 ; extra == 'doc'
-  - sphinx-gallery >=0.14 ; extra == 'doc'
-  - numpydoc >=1.7 ; extra == 'doc'
-  - pillow >=9.4 ; extra == 'doc'
-  - texext >=0.6.7 ; extra == 'doc'
-  - myst-nb >=1.0 ; extra == 'doc'
-  - lxml >=4.6 ; extra == 'extra'
-  - pygraphviz >=1.12 ; extra == 'extra'
-  - pydot >=2.0 ; extra == 'extra'
-  - sympy >=1.10 ; extra == 'extra'
-  - pytest >=7.2 ; extra == 'test'
-  - pytest-cov >=4.0 ; extra == 'test'
+  - sphinx>=7 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.14 ; extra == 'doc'
+  - sphinx-gallery>=0.14 ; extra == 'doc'
+  - numpydoc>=1.7 ; extra == 'doc'
+  - pillow>=9.4 ; extra == 'doc'
+  - texext>=0.6.7 ; extra == 'doc'
+  - myst-nb>=1.0 ; extra == 'doc'
+  - lxml>=4.6 ; extra == 'extra'
+  - pygraphviz>=1.12 ; extra == 'extra'
+  - pydot>=2.0 ; extra == 'extra'
+  - sympy>=1.10 ; extra == 'extra'
+  - pytest>=7.2 ; extra == 'test'
+  - pytest-cov>=4.0 ; extra == 'test'
   requires_python: '>=3.10'
 - kind: conda
   name: ninja
@@ -21342,34 +21342,25 @@ packages:
   url: https://files.pythonhosted.org/packages/a4/28/2897c06b54cd99f41ca9e5cc7433211a085903a71aaed1cb1a1dc138d53c/nox-2024.4.15-py3-none-any.whl
   sha256: 6492236efa15a460ecb98e7b67562a28b70da006ab0be164e8821177577c0565
   requires_dist:
-  - argcomplete <4.0, >=1.9.4
-  - colorlog <7.0.0, >=2.6.1
+  - argcomplete<4.0,>=1.9.4
+  - colorlog<7.0.0,>=2.6.1
   - importlib-metadata ; python_version < '3.8'
-  - packaging >=20.9
-  - tomli >=1 ; python_version < '3.11'
-  - typing-extensions >=3.7.4 ; python_version < '3.8'
-  - virtualenv >=20.14.1
+  - packaging>=20.9
+  - tomli>=1 ; python_version < '3.11'
+  - typing-extensions>=3.7.4 ; python_version < '3.8'
+  - virtualenv>=20.14.1
   - jinja2 ; extra == 'tox_to_nox'
   - tox ; extra == 'tox_to_nox'
-  - uv >=0.1.6 ; extra == 'uv'
+  - uv>=0.1.6 ; extra == 'uv'
   requires_python: '>=3.7'
-- kind: pypi
-  name: numba
-  version: 0.59.1
-  url: https://files.pythonhosted.org/packages/5f/2d/085c21f3086eff0b830e5d03d084a1b4b10dfde0c65feeac6be8c361265c/numba-0.59.1-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 43727e7ad20b3ec23ee4fc642f5b61845c71f75dd2825b3c234390c6d8d64051
-  requires_dist:
-  - llvmlite <0.43, >=0.42.0.dev0
-  - numpy <1.27, >=1.22
-  requires_python: '>=3.9'
 - kind: pypi
   name: numba
   version: 0.59.1
   url: https://files.pythonhosted.org/packages/54/f2/7d1579037643c874fa73516ea84c07e8d30ea347fb1a88c03b198447655d/numba-0.59.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   sha256: dd2842fac03be4e5324ebbbd4d2d0c8c0fc6e0df75c09477dd45b288a0777389
   requires_dist:
-  - llvmlite <0.43, >=0.42.0.dev0
-  - numpy <1.27, >=1.22
+  - llvmlite<0.43,>=0.42.0.dev0
+  - numpy<1.27,>=1.22
   requires_python: '>=3.9'
 - kind: pypi
   name: numba
@@ -21377,8 +21368,8 @@ packages:
   url: https://files.pythonhosted.org/packages/38/f0/ad848815b0adafcf5f238e728933950034355a8d59969772be1cd57606d8/numba-0.59.1-cp311-cp311-win_amd64.whl
   sha256: 0594b3dfb369fada1f8bb2e3045cd6c61a564c62e50cf1f86b4666bc721b3450
   requires_dist:
-  - llvmlite <0.43, >=0.42.0.dev0
-  - numpy <1.27, >=1.22
+  - llvmlite<0.43,>=0.42.0.dev0
+  - numpy<1.27,>=1.22
   requires_python: '>=3.9'
 - kind: pypi
   name: numba
@@ -21386,14 +21377,17 @@ packages:
   url: https://files.pythonhosted.org/packages/70/7d/0d1419479997319ca72ef735791c2ee50819f9c200adea96142ee7499fae/numba-0.59.1-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 411df625372c77959570050e861981e9d196cc1da9aa62c3d6a836b5cc338966
   requires_dist:
-  - llvmlite <0.43, >=0.42.0.dev0
-  - numpy <1.27, >=1.22
+  - llvmlite<0.43,>=0.42.0.dev0
+  - numpy<1.27,>=1.22
   requires_python: '>=3.9'
 - kind: pypi
-  name: numpy
-  version: 1.26.4
-  url: https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71
+  name: numba
+  version: 0.59.1
+  url: https://files.pythonhosted.org/packages/5f/2d/085c21f3086eff0b830e5d03d084a1b4b10dfde0c65feeac6be8c361265c/numba-0.59.1-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 43727e7ad20b3ec23ee4fc642f5b61845c71f75dd2825b3c234390c6d8d64051
+  requires_dist:
+  - llvmlite<0.43,>=0.42.0.dev0
+  - numpy<1.27,>=1.22
   requires_python: '>=3.9'
 - kind: pypi
   name: numpy
@@ -21412,6 +21406,12 @@ packages:
   version: 1.26.4
   url: https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl
   sha256: edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef
+  requires_python: '>=3.9'
+- kind: pypi
+  name: numpy
+  version: 1.26.4
+  url: https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71
   requires_python: '>=3.9'
 - kind: conda
   name: numpy
@@ -21540,9 +21540,9 @@ packages:
   path: examples/python/nv12
   sha256: c8ca97c5d8c04037cd5eb9a65be7b1e7d667c11d4dba3ee9aad5956ccf926dc4
   requires_dist:
-  - numpy
+  - rerun-sdk>=0.10
   - opencv-python
-  - rerun-sdk >=0.10
+  - numpy
   editable: true
 - kind: pypi
   name: nvidia-cublas-cu12
@@ -21632,8 +21632,8 @@ packages:
   requires_dist:
   - betterproto[compiler]
   - numpy
-  - opencv-python >4.6
-  - requests <3, >=2.31
+  - opencv-python>4.6
+  - requests>=2.31,<3
   - rerun-sdk
   - scipy
   editable: true
@@ -21654,36 +21654,19 @@ packages:
 - kind: pypi
   name: opencv-contrib-python
   version: 4.9.0.80
-  url: https://files.pythonhosted.org/packages/16/07/bf25df600eeaedddf8fece3f1ff837bf72865b93a03651cf7375ce8172be/opencv_contrib_python-4.9.0.80-cp37-abi3-macosx_10_16_x86_64.whl
-  sha256: 86078d3653ec3107877536c9178622b1f98b51acf59e554ddbc552785cba55fa
-  requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: opencv-contrib-python
-  version: 4.9.0.80
   url: https://files.pythonhosted.org/packages/8a/ea/aea6289058480b93157ad698ecd7f13cae4892ae0a4750abf33b3ac12f91/opencv_contrib_python-4.9.0.80-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 89ca1508dd895ae42176640bdd503cac82772f6efa25120738a469a6a69de321
   requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
   requires_python: '>=3.6'
 - kind: pypi
   name: opencv-contrib-python
@@ -21691,16 +21674,16 @@ packages:
   url: https://files.pythonhosted.org/packages/aa/2e/576ac47f21d555b459ca837bb3fb937e50339b8fbfd294945ea2f5290416/opencv_contrib_python-4.9.0.80-cp37-abi3-win_amd64.whl
   sha256: fdd9b14028f74af8dbb69f90e6e4a956ce2eb5b59947df28ba0b79d337431477
   requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
   requires_python: '>=3.6'
 - kind: pypi
   name: opencv-contrib-python
@@ -21708,84 +21691,33 @@ packages:
   url: https://files.pythonhosted.org/packages/4c/c3/ccff2e1bfe2bb47a7eaebc4280e93bd2f97ebbe5b3573d48bcfcc0c32387/opencv_contrib_python-4.9.0.80-cp37-abi3-macosx_11_0_arm64.whl
   sha256: b52e381144f774b486729ccee69911bdc7d16b5ced4830502e906ad803373ab0
   requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
   requires_python: '>=3.6'
 - kind: pypi
-  name: opencv-python
+  name: opencv-contrib-python
   version: 4.9.0.80
-  url: https://files.pythonhosted.org/packages/77/df/b56175c3fb5bc058774bdcf35f5a71cf9c3c5b909f98a1c688eb71cd3b1f/opencv_python-4.9.0.80-cp37-abi3-macosx_11_0_arm64.whl
-  sha256: 71dfb9555ccccdd77305fc3dcca5897fbf0cf28b297c51ee55e079c065d812a3
+  url: https://files.pythonhosted.org/packages/16/07/bf25df600eeaedddf8fece3f1ff837bf72865b93a03651cf7375ce8172be/opencv_contrib_python-4.9.0.80-cp37-abi3-macosx_10_16_x86_64.whl
+  sha256: 86078d3653ec3107877536c9178622b1f98b51acf59e554ddbc552785cba55fa
   requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: opencv-python
-  version: 4.9.0.80
-  url: https://files.pythonhosted.org/packages/c7/ec/9dabb6a9abfdebb3c45b0cc52dec901caafef2b2c7e7d6a839ed86d81e91/opencv_python-4.9.0.80-cp37-abi3-win_amd64.whl
-  sha256: 3f16f08e02b2a2da44259c7cc712e779eff1dd8b55fdb0323e8cab09548086c0
-  requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: opencv-python
-  version: 4.9.0.80
-  url: https://files.pythonhosted.org/packages/d9/64/7fdfb9386511cd6805451e012c537073a79a958a58795c4e602e538c388c/opencv_python-4.9.0.80-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: e4088cab82b66a3b37ffc452976b14a3c599269c247895ae9ceb4066d8188a57
-  requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: opencv-python
-  version: 4.9.0.80
-  url: https://files.pythonhosted.org/packages/52/00/2adf376707c7965bb4569f28f73fafe303c404d01047b10e3b52761be086/opencv_python-4.9.0.80-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-  sha256: 7b34a52e9da36dda8c151c6394aed602e4b17fa041df0b9f5b93ae10b0fcca2a
-  requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
   requires_python: '>=3.6'
 - kind: pypi
   name: opencv-python
@@ -21793,16 +21725,84 @@ packages:
   url: https://files.pythonhosted.org/packages/35/69/b657974ddcbba54d59d7d62b01e60a8b815e35f415b996e4d355be0ac7b4/opencv_python-4.9.0.80-cp37-abi3-macosx_10_16_x86_64.whl
   sha256: 7e5f7aa4486651a6ebfa8ed4b594b65bd2d2f41beeb4241a3e4b1b85acbbbadb
   requires_dist:
-  - numpy >=1.13.3 ; python_version < '3.7'
-  - numpy >=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
-  - numpy >=1.21.2 ; python_version >= '3.10'
-  - numpy >=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
-  - numpy >=1.23.5 ; python_version >= '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - numpy >=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
-  - numpy >=1.17.0 ; python_version >= '3.7'
-  - numpy >=1.17.3 ; python_version >= '3.8'
-  - numpy >=1.19.3 ; python_version >= '3.9'
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: opencv-python
+  version: 4.9.0.80
+  url: https://files.pythonhosted.org/packages/52/00/2adf376707c7965bb4569f28f73fafe303c404d01047b10e3b52761be086/opencv_python-4.9.0.80-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+  sha256: 7b34a52e9da36dda8c151c6394aed602e4b17fa041df0b9f5b93ae10b0fcca2a
+  requires_dist:
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: opencv-python
+  version: 4.9.0.80
+  url: https://files.pythonhosted.org/packages/d9/64/7fdfb9386511cd6805451e012c537073a79a958a58795c4e602e538c388c/opencv_python-4.9.0.80-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: e4088cab82b66a3b37ffc452976b14a3c599269c247895ae9ceb4066d8188a57
+  requires_dist:
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: opencv-python
+  version: 4.9.0.80
+  url: https://files.pythonhosted.org/packages/77/df/b56175c3fb5bc058774bdcf35f5a71cf9c3c5b909f98a1c688eb71cd3b1f/opencv_python-4.9.0.80-cp37-abi3-macosx_11_0_arm64.whl
+  sha256: 71dfb9555ccccdd77305fc3dcca5897fbf0cf28b297c51ee55e079c065d812a3
+  requires_dist:
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: opencv-python
+  version: 4.9.0.80
+  url: https://files.pythonhosted.org/packages/c7/ec/9dabb6a9abfdebb3c45b0cc52dec901caafef2b2c7e7d6a839ed86d81e91/opencv_python-4.9.0.80-cp37-abi3-win_amd64.whl
+  sha256: 3f16f08e02b2a2da44259c7cc712e779eff1dd8b55fdb0323e8cab09548086c0
+  requires_dist:
+  - numpy>=1.13.3 ; python_version < '3.7'
+  - numpy>=1.21.0 ; python_version <= '3.9' and platform_system == 'Darwin' and platform_machine == 'arm64'
+  - numpy>=1.21.2 ; python_version >= '3.10'
+  - numpy>=1.21.4 ; python_version >= '3.10' and platform_system == 'Darwin'
+  - numpy>=1.23.5 ; python_version >= '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - numpy>=1.19.3 ; python_version >= '3.6' and platform_system == 'Linux' and platform_machine == 'aarch64'
+  - numpy>=1.17.0 ; python_version >= '3.7'
+  - numpy>=1.17.3 ; python_version >= '3.8'
+  - numpy>=1.19.3 ; python_version >= '3.9'
   requires_python: '>=3.6'
 - kind: conda
   name: openssl
@@ -21985,8 +21985,8 @@ packages:
   url: https://files.pythonhosted.org/packages/bc/19/404708a7e54ad2798907210462fd950c3442ea51acc8790f3da48d2bee8b/opt_einsum-3.3.0-py3-none-any.whl
   sha256: 2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147
   requires_dist:
-  - numpy >=1.7
-  - sphinx ==1.2.3 ; extra == 'docs'
+  - numpy>=1.7
+  - sphinx==1.2.3 ; extra == 'docs'
   - sphinxcontrib-napoleon ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
   - numpydoc ; extra == 'docs'
@@ -22299,186 +22299,94 @@ packages:
 - kind: pypi
   name: pandas
   version: 2.2.2
-  url: https://files.pythonhosted.org/packages/1b/70/61704497903d43043e288017cb2b82155c0d41e15f5c17807920877b45c2/pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288
-  requires_dist:
-  - numpy >=1.22.4 ; python_version < '3.11'
-  - numpy >=1.23.2 ; python_version == '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - python-dateutil >=2.8.2
-  - pytz >=2020.1
-  - tzdata >=2022.7
-  - hypothesis >=6.46.1 ; extra == 'test'
-  - pytest >=7.3.2 ; extra == 'test'
-  - pytest-xdist >=2.2.0 ; extra == 'test'
-  - pyarrow >=10.0.1 ; extra == 'pyarrow'
-  - bottleneck >=1.3.6 ; extra == 'performance'
-  - numba >=0.56.4 ; extra == 'performance'
-  - numexpr >=2.8.4 ; extra == 'performance'
-  - scipy >=1.10.0 ; extra == 'computation'
-  - xarray >=2022.12.0 ; extra == 'computation'
-  - fsspec >=2022.11.0 ; extra == 'fss'
-  - s3fs >=2022.11.0 ; extra == 'aws'
-  - gcsfs >=2022.11.0 ; extra == 'gcp'
-  - pandas-gbq >=0.19.0 ; extra == 'gcp'
-  - odfpy >=1.4.1 ; extra == 'excel'
-  - openpyxl >=3.1.0 ; extra == 'excel'
-  - python-calamine >=0.1.7 ; extra == 'excel'
-  - pyxlsb >=1.0.10 ; extra == 'excel'
-  - xlrd >=2.0.1 ; extra == 'excel'
-  - xlsxwriter >=3.0.5 ; extra == 'excel'
-  - pyarrow >=10.0.1 ; extra == 'parquet'
-  - pyarrow >=10.0.1 ; extra == 'feather'
-  - tables >=3.8.0 ; extra == 'hdf5'
-  - pyreadstat >=1.2.0 ; extra == 'spss'
-  - sqlalchemy >=2.0.0 ; extra == 'postgresql'
-  - psycopg2 >=2.9.6 ; extra == 'postgresql'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'postgresql'
-  - sqlalchemy >=2.0.0 ; extra == 'mysql'
-  - pymysql >=1.0.2 ; extra == 'mysql'
-  - sqlalchemy >=2.0.0 ; extra == 'sql-other'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'sql-other'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'sql-other'
-  - beautifulsoup4 >=4.11.2 ; extra == 'html'
-  - html5lib >=1.1 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'xml'
-  - matplotlib >=3.6.3 ; extra == 'plot'
-  - jinja2 >=3.1.2 ; extra == 'output-formatting'
-  - tabulate >=0.9.0 ; extra == 'output-formatting'
-  - pyqt5 >=5.15.9 ; extra == 'clipboard'
-  - qtpy >=2.3.0 ; extra == 'clipboard'
-  - zstandard >=0.19.0 ; extra == 'compression'
-  - dataframe-api-compat >=0.1.7 ; extra == 'consortium-standard'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'all'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'all'
-  - beautifulsoup4 >=4.11.2 ; extra == 'all'
-  - bottleneck >=1.3.6 ; extra == 'all'
-  - dataframe-api-compat >=0.1.7 ; extra == 'all'
-  - fastparquet >=2022.12.0 ; extra == 'all'
-  - fsspec >=2022.11.0 ; extra == 'all'
-  - gcsfs >=2022.11.0 ; extra == 'all'
-  - html5lib >=1.1 ; extra == 'all'
-  - hypothesis >=6.46.1 ; extra == 'all'
-  - jinja2 >=3.1.2 ; extra == 'all'
-  - lxml >=4.9.2 ; extra == 'all'
-  - matplotlib >=3.6.3 ; extra == 'all'
-  - numba >=0.56.4 ; extra == 'all'
-  - numexpr >=2.8.4 ; extra == 'all'
-  - odfpy >=1.4.1 ; extra == 'all'
-  - openpyxl >=3.1.0 ; extra == 'all'
-  - pandas-gbq >=0.19.0 ; extra == 'all'
-  - psycopg2 >=2.9.6 ; extra == 'all'
-  - pyarrow >=10.0.1 ; extra == 'all'
-  - pymysql >=1.0.2 ; extra == 'all'
-  - pyqt5 >=5.15.9 ; extra == 'all'
-  - pyreadstat >=1.2.0 ; extra == 'all'
-  - pytest >=7.3.2 ; extra == 'all'
-  - pytest-xdist >=2.2.0 ; extra == 'all'
-  - python-calamine >=0.1.7 ; extra == 'all'
-  - pyxlsb >=1.0.10 ; extra == 'all'
-  - qtpy >=2.3.0 ; extra == 'all'
-  - scipy >=1.10.0 ; extra == 'all'
-  - s3fs >=2022.11.0 ; extra == 'all'
-  - sqlalchemy >=2.0.0 ; extra == 'all'
-  - tables >=3.8.0 ; extra == 'all'
-  - tabulate >=0.9.0 ; extra == 'all'
-  - xarray >=2022.12.0 ; extra == 'all'
-  - xlrd >=2.0.1 ; extra == 'all'
-  - xlsxwriter >=3.0.5 ; extra == 'all'
-  - zstandard >=0.19.0 ; extra == 'all'
-  requires_python: '>=3.9'
-- kind: pypi
-  name: pandas
-  version: 2.2.2
   url: https://files.pythonhosted.org/packages/fc/a5/4d82be566f069d7a9a702dcdf6f9106df0e0b042e738043c0cc7ddd7e3f6/pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee
   requires_dist:
-  - numpy >=1.22.4 ; python_version < '3.11'
-  - numpy >=1.23.2 ; python_version == '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - python-dateutil >=2.8.2
-  - pytz >=2020.1
-  - tzdata >=2022.7
-  - hypothesis >=6.46.1 ; extra == 'test'
-  - pytest >=7.3.2 ; extra == 'test'
-  - pytest-xdist >=2.2.0 ; extra == 'test'
-  - pyarrow >=10.0.1 ; extra == 'pyarrow'
-  - bottleneck >=1.3.6 ; extra == 'performance'
-  - numba >=0.56.4 ; extra == 'performance'
-  - numexpr >=2.8.4 ; extra == 'performance'
-  - scipy >=1.10.0 ; extra == 'computation'
-  - xarray >=2022.12.0 ; extra == 'computation'
-  - fsspec >=2022.11.0 ; extra == 'fss'
-  - s3fs >=2022.11.0 ; extra == 'aws'
-  - gcsfs >=2022.11.0 ; extra == 'gcp'
-  - pandas-gbq >=0.19.0 ; extra == 'gcp'
-  - odfpy >=1.4.1 ; extra == 'excel'
-  - openpyxl >=3.1.0 ; extra == 'excel'
-  - python-calamine >=0.1.7 ; extra == 'excel'
-  - pyxlsb >=1.0.10 ; extra == 'excel'
-  - xlrd >=2.0.1 ; extra == 'excel'
-  - xlsxwriter >=3.0.5 ; extra == 'excel'
-  - pyarrow >=10.0.1 ; extra == 'parquet'
-  - pyarrow >=10.0.1 ; extra == 'feather'
-  - tables >=3.8.0 ; extra == 'hdf5'
-  - pyreadstat >=1.2.0 ; extra == 'spss'
-  - sqlalchemy >=2.0.0 ; extra == 'postgresql'
-  - psycopg2 >=2.9.6 ; extra == 'postgresql'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'postgresql'
-  - sqlalchemy >=2.0.0 ; extra == 'mysql'
-  - pymysql >=1.0.2 ; extra == 'mysql'
-  - sqlalchemy >=2.0.0 ; extra == 'sql-other'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'sql-other'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'sql-other'
-  - beautifulsoup4 >=4.11.2 ; extra == 'html'
-  - html5lib >=1.1 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'xml'
-  - matplotlib >=3.6.3 ; extra == 'plot'
-  - jinja2 >=3.1.2 ; extra == 'output-formatting'
-  - tabulate >=0.9.0 ; extra == 'output-formatting'
-  - pyqt5 >=5.15.9 ; extra == 'clipboard'
-  - qtpy >=2.3.0 ; extra == 'clipboard'
-  - zstandard >=0.19.0 ; extra == 'compression'
-  - dataframe-api-compat >=0.1.7 ; extra == 'consortium-standard'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'all'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'all'
-  - beautifulsoup4 >=4.11.2 ; extra == 'all'
-  - bottleneck >=1.3.6 ; extra == 'all'
-  - dataframe-api-compat >=0.1.7 ; extra == 'all'
-  - fastparquet >=2022.12.0 ; extra == 'all'
-  - fsspec >=2022.11.0 ; extra == 'all'
-  - gcsfs >=2022.11.0 ; extra == 'all'
-  - html5lib >=1.1 ; extra == 'all'
-  - hypothesis >=6.46.1 ; extra == 'all'
-  - jinja2 >=3.1.2 ; extra == 'all'
-  - lxml >=4.9.2 ; extra == 'all'
-  - matplotlib >=3.6.3 ; extra == 'all'
-  - numba >=0.56.4 ; extra == 'all'
-  - numexpr >=2.8.4 ; extra == 'all'
-  - odfpy >=1.4.1 ; extra == 'all'
-  - openpyxl >=3.1.0 ; extra == 'all'
-  - pandas-gbq >=0.19.0 ; extra == 'all'
-  - psycopg2 >=2.9.6 ; extra == 'all'
-  - pyarrow >=10.0.1 ; extra == 'all'
-  - pymysql >=1.0.2 ; extra == 'all'
-  - pyqt5 >=5.15.9 ; extra == 'all'
-  - pyreadstat >=1.2.0 ; extra == 'all'
-  - pytest >=7.3.2 ; extra == 'all'
-  - pytest-xdist >=2.2.0 ; extra == 'all'
-  - python-calamine >=0.1.7 ; extra == 'all'
-  - pyxlsb >=1.0.10 ; extra == 'all'
-  - qtpy >=2.3.0 ; extra == 'all'
-  - scipy >=1.10.0 ; extra == 'all'
-  - s3fs >=2022.11.0 ; extra == 'all'
-  - sqlalchemy >=2.0.0 ; extra == 'all'
-  - tables >=3.8.0 ; extra == 'all'
-  - tabulate >=0.9.0 ; extra == 'all'
-  - xarray >=2022.12.0 ; extra == 'all'
-  - xlrd >=2.0.1 ; extra == 'all'
-  - xlsxwriter >=3.0.5 ; extra == 'all'
-  - zstandard >=0.19.0 ; extra == 'all'
+  - numpy>=1.22.4 ; python_version < '3.11'
+  - numpy>=1.23.2 ; python_version == '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - python-dateutil>=2.8.2
+  - pytz>=2020.1
+  - tzdata>=2022.7
+  - hypothesis>=6.46.1 ; extra == 'test'
+  - pytest>=7.3.2 ; extra == 'test'
+  - pytest-xdist>=2.2.0 ; extra == 'test'
+  - pyarrow>=10.0.1 ; extra == 'pyarrow'
+  - bottleneck>=1.3.6 ; extra == 'performance'
+  - numba>=0.56.4 ; extra == 'performance'
+  - numexpr>=2.8.4 ; extra == 'performance'
+  - scipy>=1.10.0 ; extra == 'computation'
+  - xarray>=2022.12.0 ; extra == 'computation'
+  - fsspec>=2022.11.0 ; extra == 'fss'
+  - s3fs>=2022.11.0 ; extra == 'aws'
+  - gcsfs>=2022.11.0 ; extra == 'gcp'
+  - pandas-gbq>=0.19.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.0 ; extra == 'excel'
+  - python-calamine>=0.1.7 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.0.5 ; extra == 'excel'
+  - pyarrow>=10.0.1 ; extra == 'parquet'
+  - pyarrow>=10.0.1 ; extra == 'feather'
+  - tables>=3.8.0 ; extra == 'hdf5'
+  - pyreadstat>=1.2.0 ; extra == 'spss'
+  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
+  - psycopg2>=2.9.6 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.0 ; extra == 'mysql'
+  - pymysql>=1.0.2 ; extra == 'mysql'
+  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.11.2 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'xml'
+  - matplotlib>=3.6.3 ; extra == 'plot'
+  - jinja2>=3.1.2 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.3.0 ; extra == 'clipboard'
+  - zstandard>=0.19.0 ; extra == 'compression'
+  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
+  - beautifulsoup4>=4.11.2 ; extra == 'all'
+  - bottleneck>=1.3.6 ; extra == 'all'
+  - dataframe-api-compat>=0.1.7 ; extra == 'all'
+  - fastparquet>=2022.12.0 ; extra == 'all'
+  - fsspec>=2022.11.0 ; extra == 'all'
+  - gcsfs>=2022.11.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.46.1 ; extra == 'all'
+  - jinja2>=3.1.2 ; extra == 'all'
+  - lxml>=4.9.2 ; extra == 'all'
+  - matplotlib>=3.6.3 ; extra == 'all'
+  - numba>=0.56.4 ; extra == 'all'
+  - numexpr>=2.8.4 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.0 ; extra == 'all'
+  - pandas-gbq>=0.19.0 ; extra == 'all'
+  - psycopg2>=2.9.6 ; extra == 'all'
+  - pyarrow>=10.0.1 ; extra == 'all'
+  - pymysql>=1.0.2 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.0 ; extra == 'all'
+  - pytest>=7.3.2 ; extra == 'all'
+  - pytest-xdist>=2.2.0 ; extra == 'all'
+  - python-calamine>=0.1.7 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.3.0 ; extra == 'all'
+  - scipy>=1.10.0 ; extra == 'all'
+  - s3fs>=2022.11.0 ; extra == 'all'
+  - sqlalchemy>=2.0.0 ; extra == 'all'
+  - tables>=3.8.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2022.12.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.0.5 ; extra == 'all'
+  - zstandard>=0.19.0 ; extra == 'all'
   requires_python: '>=3.9'
 - kind: pypi
   name: pandas
@@ -22486,91 +22394,91 @@ packages:
   url: https://files.pythonhosted.org/packages/ab/63/966db1321a0ad55df1d1fe51505d2cdae191b84c907974873817b0a6e849/pandas-2.2.2-cp311-cp311-win_amd64.whl
   sha256: 873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24
   requires_dist:
-  - numpy >=1.22.4 ; python_version < '3.11'
-  - numpy >=1.23.2 ; python_version == '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - python-dateutil >=2.8.2
-  - pytz >=2020.1
-  - tzdata >=2022.7
-  - hypothesis >=6.46.1 ; extra == 'test'
-  - pytest >=7.3.2 ; extra == 'test'
-  - pytest-xdist >=2.2.0 ; extra == 'test'
-  - pyarrow >=10.0.1 ; extra == 'pyarrow'
-  - bottleneck >=1.3.6 ; extra == 'performance'
-  - numba >=0.56.4 ; extra == 'performance'
-  - numexpr >=2.8.4 ; extra == 'performance'
-  - scipy >=1.10.0 ; extra == 'computation'
-  - xarray >=2022.12.0 ; extra == 'computation'
-  - fsspec >=2022.11.0 ; extra == 'fss'
-  - s3fs >=2022.11.0 ; extra == 'aws'
-  - gcsfs >=2022.11.0 ; extra == 'gcp'
-  - pandas-gbq >=0.19.0 ; extra == 'gcp'
-  - odfpy >=1.4.1 ; extra == 'excel'
-  - openpyxl >=3.1.0 ; extra == 'excel'
-  - python-calamine >=0.1.7 ; extra == 'excel'
-  - pyxlsb >=1.0.10 ; extra == 'excel'
-  - xlrd >=2.0.1 ; extra == 'excel'
-  - xlsxwriter >=3.0.5 ; extra == 'excel'
-  - pyarrow >=10.0.1 ; extra == 'parquet'
-  - pyarrow >=10.0.1 ; extra == 'feather'
-  - tables >=3.8.0 ; extra == 'hdf5'
-  - pyreadstat >=1.2.0 ; extra == 'spss'
-  - sqlalchemy >=2.0.0 ; extra == 'postgresql'
-  - psycopg2 >=2.9.6 ; extra == 'postgresql'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'postgresql'
-  - sqlalchemy >=2.0.0 ; extra == 'mysql'
-  - pymysql >=1.0.2 ; extra == 'mysql'
-  - sqlalchemy >=2.0.0 ; extra == 'sql-other'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'sql-other'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'sql-other'
-  - beautifulsoup4 >=4.11.2 ; extra == 'html'
-  - html5lib >=1.1 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'xml'
-  - matplotlib >=3.6.3 ; extra == 'plot'
-  - jinja2 >=3.1.2 ; extra == 'output-formatting'
-  - tabulate >=0.9.0 ; extra == 'output-formatting'
-  - pyqt5 >=5.15.9 ; extra == 'clipboard'
-  - qtpy >=2.3.0 ; extra == 'clipboard'
-  - zstandard >=0.19.0 ; extra == 'compression'
-  - dataframe-api-compat >=0.1.7 ; extra == 'consortium-standard'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'all'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'all'
-  - beautifulsoup4 >=4.11.2 ; extra == 'all'
-  - bottleneck >=1.3.6 ; extra == 'all'
-  - dataframe-api-compat >=0.1.7 ; extra == 'all'
-  - fastparquet >=2022.12.0 ; extra == 'all'
-  - fsspec >=2022.11.0 ; extra == 'all'
-  - gcsfs >=2022.11.0 ; extra == 'all'
-  - html5lib >=1.1 ; extra == 'all'
-  - hypothesis >=6.46.1 ; extra == 'all'
-  - jinja2 >=3.1.2 ; extra == 'all'
-  - lxml >=4.9.2 ; extra == 'all'
-  - matplotlib >=3.6.3 ; extra == 'all'
-  - numba >=0.56.4 ; extra == 'all'
-  - numexpr >=2.8.4 ; extra == 'all'
-  - odfpy >=1.4.1 ; extra == 'all'
-  - openpyxl >=3.1.0 ; extra == 'all'
-  - pandas-gbq >=0.19.0 ; extra == 'all'
-  - psycopg2 >=2.9.6 ; extra == 'all'
-  - pyarrow >=10.0.1 ; extra == 'all'
-  - pymysql >=1.0.2 ; extra == 'all'
-  - pyqt5 >=5.15.9 ; extra == 'all'
-  - pyreadstat >=1.2.0 ; extra == 'all'
-  - pytest >=7.3.2 ; extra == 'all'
-  - pytest-xdist >=2.2.0 ; extra == 'all'
-  - python-calamine >=0.1.7 ; extra == 'all'
-  - pyxlsb >=1.0.10 ; extra == 'all'
-  - qtpy >=2.3.0 ; extra == 'all'
-  - scipy >=1.10.0 ; extra == 'all'
-  - s3fs >=2022.11.0 ; extra == 'all'
-  - sqlalchemy >=2.0.0 ; extra == 'all'
-  - tables >=3.8.0 ; extra == 'all'
-  - tabulate >=0.9.0 ; extra == 'all'
-  - xarray >=2022.12.0 ; extra == 'all'
-  - xlrd >=2.0.1 ; extra == 'all'
-  - xlsxwriter >=3.0.5 ; extra == 'all'
-  - zstandard >=0.19.0 ; extra == 'all'
+  - numpy>=1.22.4 ; python_version < '3.11'
+  - numpy>=1.23.2 ; python_version == '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - python-dateutil>=2.8.2
+  - pytz>=2020.1
+  - tzdata>=2022.7
+  - hypothesis>=6.46.1 ; extra == 'test'
+  - pytest>=7.3.2 ; extra == 'test'
+  - pytest-xdist>=2.2.0 ; extra == 'test'
+  - pyarrow>=10.0.1 ; extra == 'pyarrow'
+  - bottleneck>=1.3.6 ; extra == 'performance'
+  - numba>=0.56.4 ; extra == 'performance'
+  - numexpr>=2.8.4 ; extra == 'performance'
+  - scipy>=1.10.0 ; extra == 'computation'
+  - xarray>=2022.12.0 ; extra == 'computation'
+  - fsspec>=2022.11.0 ; extra == 'fss'
+  - s3fs>=2022.11.0 ; extra == 'aws'
+  - gcsfs>=2022.11.0 ; extra == 'gcp'
+  - pandas-gbq>=0.19.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.0 ; extra == 'excel'
+  - python-calamine>=0.1.7 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.0.5 ; extra == 'excel'
+  - pyarrow>=10.0.1 ; extra == 'parquet'
+  - pyarrow>=10.0.1 ; extra == 'feather'
+  - tables>=3.8.0 ; extra == 'hdf5'
+  - pyreadstat>=1.2.0 ; extra == 'spss'
+  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
+  - psycopg2>=2.9.6 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.0 ; extra == 'mysql'
+  - pymysql>=1.0.2 ; extra == 'mysql'
+  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.11.2 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'xml'
+  - matplotlib>=3.6.3 ; extra == 'plot'
+  - jinja2>=3.1.2 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.3.0 ; extra == 'clipboard'
+  - zstandard>=0.19.0 ; extra == 'compression'
+  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
+  - beautifulsoup4>=4.11.2 ; extra == 'all'
+  - bottleneck>=1.3.6 ; extra == 'all'
+  - dataframe-api-compat>=0.1.7 ; extra == 'all'
+  - fastparquet>=2022.12.0 ; extra == 'all'
+  - fsspec>=2022.11.0 ; extra == 'all'
+  - gcsfs>=2022.11.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.46.1 ; extra == 'all'
+  - jinja2>=3.1.2 ; extra == 'all'
+  - lxml>=4.9.2 ; extra == 'all'
+  - matplotlib>=3.6.3 ; extra == 'all'
+  - numba>=0.56.4 ; extra == 'all'
+  - numexpr>=2.8.4 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.0 ; extra == 'all'
+  - pandas-gbq>=0.19.0 ; extra == 'all'
+  - psycopg2>=2.9.6 ; extra == 'all'
+  - pyarrow>=10.0.1 ; extra == 'all'
+  - pymysql>=1.0.2 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.0 ; extra == 'all'
+  - pytest>=7.3.2 ; extra == 'all'
+  - pytest-xdist>=2.2.0 ; extra == 'all'
+  - python-calamine>=0.1.7 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.3.0 ; extra == 'all'
+  - scipy>=1.10.0 ; extra == 'all'
+  - s3fs>=2022.11.0 ; extra == 'all'
+  - sqlalchemy>=2.0.0 ; extra == 'all'
+  - tables>=3.8.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2022.12.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.0.5 ; extra == 'all'
+  - zstandard>=0.19.0 ; extra == 'all'
   requires_python: '>=3.9'
 - kind: pypi
   name: pandas
@@ -22578,91 +22486,183 @@ packages:
   url: https://files.pythonhosted.org/packages/16/c6/75231fd47afd6b3f89011e7077f1a3958441264aca7ae9ff596e3276a5d0/pandas-2.2.2-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151
   requires_dist:
-  - numpy >=1.22.4 ; python_version < '3.11'
-  - numpy >=1.23.2 ; python_version == '3.11'
-  - numpy >=1.26.0 ; python_version >= '3.12'
-  - python-dateutil >=2.8.2
-  - pytz >=2020.1
-  - tzdata >=2022.7
-  - hypothesis >=6.46.1 ; extra == 'test'
-  - pytest >=7.3.2 ; extra == 'test'
-  - pytest-xdist >=2.2.0 ; extra == 'test'
-  - pyarrow >=10.0.1 ; extra == 'pyarrow'
-  - bottleneck >=1.3.6 ; extra == 'performance'
-  - numba >=0.56.4 ; extra == 'performance'
-  - numexpr >=2.8.4 ; extra == 'performance'
-  - scipy >=1.10.0 ; extra == 'computation'
-  - xarray >=2022.12.0 ; extra == 'computation'
-  - fsspec >=2022.11.0 ; extra == 'fss'
-  - s3fs >=2022.11.0 ; extra == 'aws'
-  - gcsfs >=2022.11.0 ; extra == 'gcp'
-  - pandas-gbq >=0.19.0 ; extra == 'gcp'
-  - odfpy >=1.4.1 ; extra == 'excel'
-  - openpyxl >=3.1.0 ; extra == 'excel'
-  - python-calamine >=0.1.7 ; extra == 'excel'
-  - pyxlsb >=1.0.10 ; extra == 'excel'
-  - xlrd >=2.0.1 ; extra == 'excel'
-  - xlsxwriter >=3.0.5 ; extra == 'excel'
-  - pyarrow >=10.0.1 ; extra == 'parquet'
-  - pyarrow >=10.0.1 ; extra == 'feather'
-  - tables >=3.8.0 ; extra == 'hdf5'
-  - pyreadstat >=1.2.0 ; extra == 'spss'
-  - sqlalchemy >=2.0.0 ; extra == 'postgresql'
-  - psycopg2 >=2.9.6 ; extra == 'postgresql'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'postgresql'
-  - sqlalchemy >=2.0.0 ; extra == 'mysql'
-  - pymysql >=1.0.2 ; extra == 'mysql'
-  - sqlalchemy >=2.0.0 ; extra == 'sql-other'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'sql-other'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'sql-other'
-  - beautifulsoup4 >=4.11.2 ; extra == 'html'
-  - html5lib >=1.1 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'html'
-  - lxml >=4.9.2 ; extra == 'xml'
-  - matplotlib >=3.6.3 ; extra == 'plot'
-  - jinja2 >=3.1.2 ; extra == 'output-formatting'
-  - tabulate >=0.9.0 ; extra == 'output-formatting'
-  - pyqt5 >=5.15.9 ; extra == 'clipboard'
-  - qtpy >=2.3.0 ; extra == 'clipboard'
-  - zstandard >=0.19.0 ; extra == 'compression'
-  - dataframe-api-compat >=0.1.7 ; extra == 'consortium-standard'
-  - adbc-driver-postgresql >=0.8.0 ; extra == 'all'
-  - adbc-driver-sqlite >=0.8.0 ; extra == 'all'
-  - beautifulsoup4 >=4.11.2 ; extra == 'all'
-  - bottleneck >=1.3.6 ; extra == 'all'
-  - dataframe-api-compat >=0.1.7 ; extra == 'all'
-  - fastparquet >=2022.12.0 ; extra == 'all'
-  - fsspec >=2022.11.0 ; extra == 'all'
-  - gcsfs >=2022.11.0 ; extra == 'all'
-  - html5lib >=1.1 ; extra == 'all'
-  - hypothesis >=6.46.1 ; extra == 'all'
-  - jinja2 >=3.1.2 ; extra == 'all'
-  - lxml >=4.9.2 ; extra == 'all'
-  - matplotlib >=3.6.3 ; extra == 'all'
-  - numba >=0.56.4 ; extra == 'all'
-  - numexpr >=2.8.4 ; extra == 'all'
-  - odfpy >=1.4.1 ; extra == 'all'
-  - openpyxl >=3.1.0 ; extra == 'all'
-  - pandas-gbq >=0.19.0 ; extra == 'all'
-  - psycopg2 >=2.9.6 ; extra == 'all'
-  - pyarrow >=10.0.1 ; extra == 'all'
-  - pymysql >=1.0.2 ; extra == 'all'
-  - pyqt5 >=5.15.9 ; extra == 'all'
-  - pyreadstat >=1.2.0 ; extra == 'all'
-  - pytest >=7.3.2 ; extra == 'all'
-  - pytest-xdist >=2.2.0 ; extra == 'all'
-  - python-calamine >=0.1.7 ; extra == 'all'
-  - pyxlsb >=1.0.10 ; extra == 'all'
-  - qtpy >=2.3.0 ; extra == 'all'
-  - scipy >=1.10.0 ; extra == 'all'
-  - s3fs >=2022.11.0 ; extra == 'all'
-  - sqlalchemy >=2.0.0 ; extra == 'all'
-  - tables >=3.8.0 ; extra == 'all'
-  - tabulate >=0.9.0 ; extra == 'all'
-  - xarray >=2022.12.0 ; extra == 'all'
-  - xlrd >=2.0.1 ; extra == 'all'
-  - xlsxwriter >=3.0.5 ; extra == 'all'
-  - zstandard >=0.19.0 ; extra == 'all'
+  - numpy>=1.22.4 ; python_version < '3.11'
+  - numpy>=1.23.2 ; python_version == '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - python-dateutil>=2.8.2
+  - pytz>=2020.1
+  - tzdata>=2022.7
+  - hypothesis>=6.46.1 ; extra == 'test'
+  - pytest>=7.3.2 ; extra == 'test'
+  - pytest-xdist>=2.2.0 ; extra == 'test'
+  - pyarrow>=10.0.1 ; extra == 'pyarrow'
+  - bottleneck>=1.3.6 ; extra == 'performance'
+  - numba>=0.56.4 ; extra == 'performance'
+  - numexpr>=2.8.4 ; extra == 'performance'
+  - scipy>=1.10.0 ; extra == 'computation'
+  - xarray>=2022.12.0 ; extra == 'computation'
+  - fsspec>=2022.11.0 ; extra == 'fss'
+  - s3fs>=2022.11.0 ; extra == 'aws'
+  - gcsfs>=2022.11.0 ; extra == 'gcp'
+  - pandas-gbq>=0.19.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.0 ; extra == 'excel'
+  - python-calamine>=0.1.7 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.0.5 ; extra == 'excel'
+  - pyarrow>=10.0.1 ; extra == 'parquet'
+  - pyarrow>=10.0.1 ; extra == 'feather'
+  - tables>=3.8.0 ; extra == 'hdf5'
+  - pyreadstat>=1.2.0 ; extra == 'spss'
+  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
+  - psycopg2>=2.9.6 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.0 ; extra == 'mysql'
+  - pymysql>=1.0.2 ; extra == 'mysql'
+  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.11.2 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'xml'
+  - matplotlib>=3.6.3 ; extra == 'plot'
+  - jinja2>=3.1.2 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.3.0 ; extra == 'clipboard'
+  - zstandard>=0.19.0 ; extra == 'compression'
+  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
+  - beautifulsoup4>=4.11.2 ; extra == 'all'
+  - bottleneck>=1.3.6 ; extra == 'all'
+  - dataframe-api-compat>=0.1.7 ; extra == 'all'
+  - fastparquet>=2022.12.0 ; extra == 'all'
+  - fsspec>=2022.11.0 ; extra == 'all'
+  - gcsfs>=2022.11.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.46.1 ; extra == 'all'
+  - jinja2>=3.1.2 ; extra == 'all'
+  - lxml>=4.9.2 ; extra == 'all'
+  - matplotlib>=3.6.3 ; extra == 'all'
+  - numba>=0.56.4 ; extra == 'all'
+  - numexpr>=2.8.4 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.0 ; extra == 'all'
+  - pandas-gbq>=0.19.0 ; extra == 'all'
+  - psycopg2>=2.9.6 ; extra == 'all'
+  - pyarrow>=10.0.1 ; extra == 'all'
+  - pymysql>=1.0.2 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.0 ; extra == 'all'
+  - pytest>=7.3.2 ; extra == 'all'
+  - pytest-xdist>=2.2.0 ; extra == 'all'
+  - python-calamine>=0.1.7 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.3.0 ; extra == 'all'
+  - scipy>=1.10.0 ; extra == 'all'
+  - s3fs>=2022.11.0 ; extra == 'all'
+  - sqlalchemy>=2.0.0 ; extra == 'all'
+  - tables>=3.8.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2022.12.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.0.5 ; extra == 'all'
+  - zstandard>=0.19.0 ; extra == 'all'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: pandas
+  version: 2.2.2
+  url: https://files.pythonhosted.org/packages/1b/70/61704497903d43043e288017cb2b82155c0d41e15f5c17807920877b45c2/pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288
+  requires_dist:
+  - numpy>=1.22.4 ; python_version < '3.11'
+  - numpy>=1.23.2 ; python_version == '3.11'
+  - numpy>=1.26.0 ; python_version >= '3.12'
+  - python-dateutil>=2.8.2
+  - pytz>=2020.1
+  - tzdata>=2022.7
+  - hypothesis>=6.46.1 ; extra == 'test'
+  - pytest>=7.3.2 ; extra == 'test'
+  - pytest-xdist>=2.2.0 ; extra == 'test'
+  - pyarrow>=10.0.1 ; extra == 'pyarrow'
+  - bottleneck>=1.3.6 ; extra == 'performance'
+  - numba>=0.56.4 ; extra == 'performance'
+  - numexpr>=2.8.4 ; extra == 'performance'
+  - scipy>=1.10.0 ; extra == 'computation'
+  - xarray>=2022.12.0 ; extra == 'computation'
+  - fsspec>=2022.11.0 ; extra == 'fss'
+  - s3fs>=2022.11.0 ; extra == 'aws'
+  - gcsfs>=2022.11.0 ; extra == 'gcp'
+  - pandas-gbq>=0.19.0 ; extra == 'gcp'
+  - odfpy>=1.4.1 ; extra == 'excel'
+  - openpyxl>=3.1.0 ; extra == 'excel'
+  - python-calamine>=0.1.7 ; extra == 'excel'
+  - pyxlsb>=1.0.10 ; extra == 'excel'
+  - xlrd>=2.0.1 ; extra == 'excel'
+  - xlsxwriter>=3.0.5 ; extra == 'excel'
+  - pyarrow>=10.0.1 ; extra == 'parquet'
+  - pyarrow>=10.0.1 ; extra == 'feather'
+  - tables>=3.8.0 ; extra == 'hdf5'
+  - pyreadstat>=1.2.0 ; extra == 'spss'
+  - sqlalchemy>=2.0.0 ; extra == 'postgresql'
+  - psycopg2>=2.9.6 ; extra == 'postgresql'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'postgresql'
+  - sqlalchemy>=2.0.0 ; extra == 'mysql'
+  - pymysql>=1.0.2 ; extra == 'mysql'
+  - sqlalchemy>=2.0.0 ; extra == 'sql-other'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'sql-other'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'sql-other'
+  - beautifulsoup4>=4.11.2 ; extra == 'html'
+  - html5lib>=1.1 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'html'
+  - lxml>=4.9.2 ; extra == 'xml'
+  - matplotlib>=3.6.3 ; extra == 'plot'
+  - jinja2>=3.1.2 ; extra == 'output-formatting'
+  - tabulate>=0.9.0 ; extra == 'output-formatting'
+  - pyqt5>=5.15.9 ; extra == 'clipboard'
+  - qtpy>=2.3.0 ; extra == 'clipboard'
+  - zstandard>=0.19.0 ; extra == 'compression'
+  - dataframe-api-compat>=0.1.7 ; extra == 'consortium-standard'
+  - adbc-driver-postgresql>=0.8.0 ; extra == 'all'
+  - adbc-driver-sqlite>=0.8.0 ; extra == 'all'
+  - beautifulsoup4>=4.11.2 ; extra == 'all'
+  - bottleneck>=1.3.6 ; extra == 'all'
+  - dataframe-api-compat>=0.1.7 ; extra == 'all'
+  - fastparquet>=2022.12.0 ; extra == 'all'
+  - fsspec>=2022.11.0 ; extra == 'all'
+  - gcsfs>=2022.11.0 ; extra == 'all'
+  - html5lib>=1.1 ; extra == 'all'
+  - hypothesis>=6.46.1 ; extra == 'all'
+  - jinja2>=3.1.2 ; extra == 'all'
+  - lxml>=4.9.2 ; extra == 'all'
+  - matplotlib>=3.6.3 ; extra == 'all'
+  - numba>=0.56.4 ; extra == 'all'
+  - numexpr>=2.8.4 ; extra == 'all'
+  - odfpy>=1.4.1 ; extra == 'all'
+  - openpyxl>=3.1.0 ; extra == 'all'
+  - pandas-gbq>=0.19.0 ; extra == 'all'
+  - psycopg2>=2.9.6 ; extra == 'all'
+  - pyarrow>=10.0.1 ; extra == 'all'
+  - pymysql>=1.0.2 ; extra == 'all'
+  - pyqt5>=5.15.9 ; extra == 'all'
+  - pyreadstat>=1.2.0 ; extra == 'all'
+  - pytest>=7.3.2 ; extra == 'all'
+  - pytest-xdist>=2.2.0 ; extra == 'all'
+  - python-calamine>=0.1.7 ; extra == 'all'
+  - pyxlsb>=1.0.10 ; extra == 'all'
+  - qtpy>=2.3.0 ; extra == 'all'
+  - scipy>=1.10.0 ; extra == 'all'
+  - s3fs>=2022.11.0 ; extra == 'all'
+  - sqlalchemy>=2.0.0 ; extra == 'all'
+  - tables>=3.8.0 ; extra == 'all'
+  - tabulate>=0.9.0 ; extra == 'all'
+  - xarray>=2022.12.0 ; extra == 'all'
+  - xlrd>=2.0.1 ; extra == 'all'
+  - xlsxwriter>=3.0.5 ; extra == 'all'
+  - zstandard>=0.19.0 ; extra == 'all'
   requires_python: '>=3.9'
 - kind: conda
   name: patchelf
@@ -22693,60 +22693,12 @@ packages:
 - kind: pypi
   name: pillow
   version: 10.0.0
-  url: https://files.pythonhosted.org/packages/b7/ad/71982d18fd28ed1f93c31b8648f980ebdbdbcf7d8c9c9b4af59290914ce9/Pillow-10.0.0-cp311-cp311-macosx_11_0_arm64.whl
-  sha256: d35e3c8d9b1268cbf5d3670285feb3528f6680420eafe35cccc686b73c1e330f
+  url: https://files.pythonhosted.org/packages/7a/54/f6a14d95cba8ff082c550d836c9e5c23f1641d2ac291c23efe0494219b8c/Pillow-10.0.0-cp311-cp311-macosx_10_10_x86_64.whl
+  sha256: 9fb218c8a12e51d7ead2a7c9e101a04982237d4855716af2e9499306728fb485
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - sphinx-inline-tabs ; extra == 'docs'
-  - sphinx-removed-in ; extra == 'docs'
-  - sphinxext-opengraph ; extra == 'docs'
-  - check-manifest ; extra == 'tests'
-  - coverage ; extra == 'tests'
-  - defusedxml ; extra == 'tests'
-  - markdown2 ; extra == 'tests'
-  - olefile ; extra == 'tests'
-  - packaging ; extra == 'tests'
-  - pyroma ; extra == 'tests'
-  - pytest ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  - pytest-timeout ; extra == 'tests'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: pillow
-  version: 10.0.0
-  url: https://files.pythonhosted.org/packages/66/d4/054e491f0880bf0119ee79cdc03264e01d5732e06c454da8c69b83a7c8f2/Pillow-10.0.0-cp311-cp311-win_amd64.whl
-  sha256: 3a82c40d706d9aa9734289740ce26460a11aeec2d9c79b7af87bb35f0073c12f
-  requires_dist:
-  - furo ; extra == 'docs'
-  - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - sphinx-inline-tabs ; extra == 'docs'
-  - sphinx-removed-in ; extra == 'docs'
-  - sphinxext-opengraph ; extra == 'docs'
-  - check-manifest ; extra == 'tests'
-  - coverage ; extra == 'tests'
-  - defusedxml ; extra == 'tests'
-  - markdown2 ; extra == 'tests'
-  - olefile ; extra == 'tests'
-  - packaging ; extra == 'tests'
-  - pyroma ; extra == 'tests'
-  - pytest ; extra == 'tests'
-  - pytest-cov ; extra == 'tests'
-  - pytest-timeout ; extra == 'tests'
-  requires_python: '>=3.8'
-- kind: pypi
-  name: pillow
-  version: 10.0.0
-  url: https://files.pythonhosted.org/packages/16/89/818fa238e37a47a29bb8495ca2cafdd514599a89f19ada7916348a74b5f9/Pillow-10.0.0-cp311-cp311-manylinux_2_28_x86_64.whl
-  sha256: cd25d2a9d2b36fcb318882481367956d2cf91329f6892fe5d385c346c0649629
-  requires_dist:
-  - furo ; extra == 'docs'
-  - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22770,7 +22722,7 @@ packages:
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22789,12 +22741,12 @@ packages:
 - kind: pypi
   name: pillow
   version: 10.0.0
-  url: https://files.pythonhosted.org/packages/7a/54/f6a14d95cba8ff082c550d836c9e5c23f1641d2ac291c23efe0494219b8c/Pillow-10.0.0-cp311-cp311-macosx_10_10_x86_64.whl
-  sha256: 9fb218c8a12e51d7ead2a7c9e101a04982237d4855716af2e9499306728fb485
+  url: https://files.pythonhosted.org/packages/16/89/818fa238e37a47a29bb8495ca2cafdd514599a89f19ada7916348a74b5f9/Pillow-10.0.0-cp311-cp311-manylinux_2_28_x86_64.whl
+  sha256: cd25d2a9d2b36fcb318882481367956d2cf91329f6892fe5d385c346c0649629
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22812,19 +22764,17 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: pillow
-  version: 10.3.0
-  url: https://files.pythonhosted.org/packages/e5/51/e4b35e394b4e5ca24983e50361a1db3d7da05b1758074f9c4f5b4be4b22a/pillow-10.3.0-cp311-cp311-macosx_10_10_x86_64.whl
-  sha256: 5f77cf66e96ae734717d341c145c5949c63180842a545c47a0ce7ae52ca83795
+  version: 10.0.0
+  url: https://files.pythonhosted.org/packages/b7/ad/71982d18fd28ed1f93c31b8648f980ebdbdbcf7d8c9c9b4af59290914ce9/Pillow-10.0.0-cp311-cp311-macosx_11_0_arm64.whl
+  sha256: d35e3c8d9b1268cbf5d3670285feb3528f6680420eafe35cccc686b73c1e330f
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
   - sphinxext-opengraph ; extra == 'docs'
-  - olefile ; extra == 'fpx'
-  - olefile ; extra == 'mic'
   - check-manifest ; extra == 'tests'
   - coverage ; extra == 'tests'
   - defusedxml ; extra == 'tests'
@@ -22835,8 +22785,30 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   - pytest-timeout ; extra == 'tests'
-  - typing-extensions ; python_version < '3.10' and extra == 'typing'
-  - defusedxml ; extra == 'xmp'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: pillow
+  version: 10.0.0
+  url: https://files.pythonhosted.org/packages/66/d4/054e491f0880bf0119ee79cdc03264e01d5732e06c454da8c69b83a7c8f2/Pillow-10.0.0-cp311-cp311-win_amd64.whl
+  sha256: 3a82c40d706d9aa9734289740ce26460a11aeec2d9c79b7af87bb35f0073c12f
+  requires_dist:
+  - furo ; extra == 'docs'
+  - olefile ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - sphinx-removed-in ; extra == 'docs'
+  - sphinxext-opengraph ; extra == 'docs'
+  - check-manifest ; extra == 'tests'
+  - coverage ; extra == 'tests'
+  - defusedxml ; extra == 'tests'
+  - markdown2 ; extra == 'tests'
+  - olefile ; extra == 'tests'
+  - packaging ; extra == 'tests'
+  - pyroma ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-timeout ; extra == 'tests'
   requires_python: '>=3.8'
 - kind: pypi
   name: pillow
@@ -22846,7 +22818,7 @@ packages:
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22874,7 +22846,7 @@ packages:
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22902,7 +22874,35 @@ packages:
   requires_dist:
   - furo ; extra == 'docs'
   - olefile ; extra == 'docs'
-  - sphinx >=2.4 ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - sphinx-inline-tabs ; extra == 'docs'
+  - sphinx-removed-in ; extra == 'docs'
+  - sphinxext-opengraph ; extra == 'docs'
+  - olefile ; extra == 'fpx'
+  - olefile ; extra == 'mic'
+  - check-manifest ; extra == 'tests'
+  - coverage ; extra == 'tests'
+  - defusedxml ; extra == 'tests'
+  - markdown2 ; extra == 'tests'
+  - olefile ; extra == 'tests'
+  - packaging ; extra == 'tests'
+  - pyroma ; extra == 'tests'
+  - pytest ; extra == 'tests'
+  - pytest-cov ; extra == 'tests'
+  - pytest-timeout ; extra == 'tests'
+  - typing-extensions ; python_version < '3.10' and extra == 'typing'
+  - defusedxml ; extra == 'xmp'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: pillow
+  version: 10.3.0
+  url: https://files.pythonhosted.org/packages/e5/51/e4b35e394b4e5ca24983e50361a1db3d7da05b1758074f9c4f5b4be4b22a/pillow-10.3.0-cp311-cp311-macosx_10_10_x86_64.whl
+  sha256: 5f77cf66e96ae734717d341c145c5949c63180842a545c47a0ce7ae52ca83795
+  requires_dist:
+  - furo ; extra == 'docs'
+  - olefile ; extra == 'docs'
+  - sphinx>=2.4 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - sphinx-inline-tabs ; extra == 'docs'
   - sphinx-removed-in ; extra == 'docs'
@@ -22974,16 +22974,33 @@ packages:
   url: https://files.pythonhosted.org/packages/b0/15/1691fa5aaddc0c4ea4901c26f6137c29d5f6673596fe960a0340e8c308e1/platformdirs-4.2.1-py3-none-any.whl
   sha256: 17d5a1161b3fd67b390023cb2d3b026bbd40abde6fdb052dfbd3a29c3ba22ee1
   requires_dist:
-  - furo >=2023.9.10 ; extra == 'docs'
-  - proselint >=0.13 ; extra == 'docs'
-  - sphinx-autodoc-typehints >=1.25.2 ; extra == 'docs'
-  - sphinx >=7.2.6 ; extra == 'docs'
-  - appdirs ==1.4.4 ; extra == 'test'
-  - covdefaults >=2.3 ; extra == 'test'
-  - pytest-cov >=4.1 ; extra == 'test'
-  - pytest-mock >=3.12 ; extra == 'test'
-  - pytest >=7.4.3 ; extra == 'test'
-  - mypy >=1.8 ; extra == 'type'
+  - furo>=2023.9.10 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  - pytest-mock>=3.12 ; extra == 'test'
+  - pytest>=7.4.3 ; extra == 'test'
+  - mypy>=1.8 ; extra == 'type'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: platformdirs
+  version: 4.2.2
+  url: https://files.pythonhosted.org/packages/68/13/2aa1f0e1364feb2c9ef45302f387ac0bd81484e9c9a4c5688a322fbdfd08/platformdirs-4.2.2-py3-none-any.whl
+  sha256: 2d7a1657e36a80ea911db832a8a6ece5ee53d8de21edd5cc5879af6530b1bfee
+  requires_dist:
+  - furo>=2023.9.10 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx-autodoc-typehints>=1.25.2 ; extra == 'docs'
+  - sphinx>=7.2.6 ; extra == 'docs'
+  - appdirs==1.4.4 ; extra == 'test'
+  - covdefaults>=2.3 ; extra == 'test'
+  - pytest-cov>=4.1 ; extra == 'test'
+  - pytest-mock>=3.12 ; extra == 'test'
+  - pytest>=7.4.3 ; extra == 'test'
+  - mypy>=1.8 ; extra == 'type'
   requires_python: '>=3.8'
 - kind: pypi
   name: plots
@@ -23112,8 +23129,8 @@ packages:
   url: https://files.pythonhosted.org/packages/ad/41/7361075f3a31dcd05a6a38cfd807a6eecbfb6dbfe420d922cd400fc03ac1/proto_plus-1.23.0-py3-none-any.whl
   sha256: a829c79e619e1cf632de091013a4173deed13a55f326ef84f05af6f50ff4c82c
   requires_dist:
-  - protobuf <5.0.0.dev0, >=3.19.0
-  - google-api-core[grpc] >=1.31.5 ; extra == 'testing'
+  - protobuf<5.0.0.dev0,>=3.19.0
+  - google-api-core[grpc]>=1.31.5 ; extra == 'testing'
   requires_python: '>=3.6'
 - kind: pypi
   name: protobuf
@@ -23130,8 +23147,8 @@ packages:
 - kind: pypi
   name: protobuf
   version: 4.25.3
-  url: https://files.pythonhosted.org/packages/ad/6e/1bed3b7c904cc178cb8ee8dbaf72934964452b3de95b7a63412591edb93c/protobuf-4.25.3-cp310-abi3-win_amd64.whl
-  sha256: 209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8
+  url: https://files.pythonhosted.org/packages/d8/82/aefe901174b5a618daee511ddd00342193c1b545e3cd6a2cd6df9ba452b5/protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl
+  sha256: e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019
   requires_python: '>=3.8'
 - kind: pypi
   name: protobuf
@@ -23142,21 +23159,9 @@ packages:
 - kind: pypi
   name: protobuf
   version: 4.25.3
-  url: https://files.pythonhosted.org/packages/d8/82/aefe901174b5a618daee511ddd00342193c1b545e3cd6a2cd6df9ba452b5/protobuf-4.25.3-cp37-abi3-manylinux2014_aarch64.whl
-  sha256: e7cb0ae90dd83727f0c0718634ed56837bfeeee29a5f82a7514c03ee1364c019
+  url: https://files.pythonhosted.org/packages/ad/6e/1bed3b7c904cc178cb8ee8dbaf72934964452b3de95b7a63412591edb93c/protobuf-4.25.3-cp310-abi3-win_amd64.whl
+  sha256: 209ba4cc916bab46f64e56b85b090607a676f66b473e6b762e6f1d9d591eb2e8
   requires_python: '>=3.8'
-- kind: pypi
-  name: psutil
-  version: 5.9.8
-  url: https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl
-  sha256: aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81
-  requires_dist:
-  - ipaddress ; python_version < '3.0' and extra == 'test'
-  - mock ; python_version < '3.0' and extra == 'test'
-  - enum34 ; python_version <= '3.4' and extra == 'test'
-  - pywin32 ; sys_platform == 'win32' and extra == 'test'
-  - wmi ; sys_platform == 'win32' and extra == 'test'
-  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
 - kind: pypi
   name: psutil
   version: 5.9.8
@@ -23186,6 +23191,18 @@ packages:
   version: 5.9.8
   url: https://files.pythonhosted.org/packages/05/33/2d74d588408caedd065c2497bdb5ef83ce6082db01289a1e1147f6639802/psutil-5.9.8-cp38-abi3-macosx_11_0_arm64.whl
   sha256: d16bbddf0693323b8c6123dd804100241da461e41d6e332fb0ba6058f630f8c8
+  requires_dist:
+  - ipaddress ; python_version < '3.0' and extra == 'test'
+  - mock ; python_version < '3.0' and extra == 'test'
+  - enum34 ; python_version <= '3.4' and extra == 'test'
+  - pywin32 ; sys_platform == 'win32' and extra == 'test'
+  - wmi ; sys_platform == 'win32' and extra == 'test'
+  requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*'
+- kind: pypi
+  name: psutil
+  version: 5.9.8
+  url: https://files.pythonhosted.org/packages/e7/e3/07ae864a636d70a8a6f58da27cb1179192f1140d5d1da10886ade9405797/psutil-5.9.8-cp36-abi3-macosx_10_9_x86_64.whl
+  sha256: aee678c8720623dc456fa20659af736241f575d79429a0e5e9cf88ae0605cc81
   requires_dist:
   - ipaddress ; python_version < '3.0' and extra == 'test'
   - mock ; python_version < '3.0' and extra == 'test'
@@ -23731,7 +23748,7 @@ packages:
   url: https://files.pythonhosted.org/packages/13/68/8906226b15ef38e71dc926c321d2fe99de8048e9098b5dfd38343011c886/pyasn1_modules-0.4.0-py3-none-any.whl
   sha256: be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b
   requires_dist:
-  - pyasn1 <0.7.0, >=0.4.6
+  - pyasn1<0.7.0,>=0.4.6
   requires_python: '>=3.8'
 - kind: pypi
   name: pycparser
@@ -23762,9 +23779,9 @@ packages:
   sha256: 126bdbae72087d8d038b113aab6b059b4553cb59348e3024bb1a1cae406ace9e
   requires_dist:
   - deprecated
-  - pyjwt[crypto] >=2.4.0
-  - pynacl >=1.4.0
-  - requests >=2.14.0
+  - pyjwt[crypto]>=2.4.0
+  - pynacl>=1.4.0
+  - requests>=2.14.0
   requires_python: '>=3.7'
 - kind: pypi
   name: pyglet
@@ -23778,7 +23795,7 @@ packages:
   url: https://files.pythonhosted.org/packages/38/d7/0b8e35cb3ff69dd981e358e72e0a5632f847d4bd61876be04518cb4e075a/pygltflib-1.16.2.tar.gz
   sha256: 4f9481f5841b0b8fb7b271b0414b394b503405260a6ee0cf2c330a5420d19b64
   requires_dist:
-  - dataclasses-json >=0.0.25
+  - dataclasses-json>=0.0.25
   - deprecated
   - dataclasses ; python_version >= '3.6' and python_version < '3.7'
   requires_python: '>=3.6'
@@ -23789,19 +23806,19 @@ packages:
   sha256: 59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320
   requires_dist:
   - typing-extensions ; python_version <= '3.7'
-  - cryptography >=3.4.0 ; extra == 'crypto'
-  - sphinx <5.0.0, >=4.5.0 ; extra == 'dev'
+  - cryptography>=3.4.0 ; extra == 'crypto'
+  - sphinx<5.0.0,>=4.5.0 ; extra == 'dev'
   - sphinx-rtd-theme ; extra == 'dev'
   - zope-interface ; extra == 'dev'
-  - cryptography >=3.4.0 ; extra == 'dev'
-  - pytest <7.0.0, >=6.0.0 ; extra == 'dev'
-  - coverage[toml] ==5.0.4 ; extra == 'dev'
+  - cryptography>=3.4.0 ; extra == 'dev'
+  - pytest<7.0.0,>=6.0.0 ; extra == 'dev'
+  - coverage[toml]==5.0.4 ; extra == 'dev'
   - pre-commit ; extra == 'dev'
-  - sphinx <5.0.0, >=4.5.0 ; extra == 'docs'
+  - sphinx<5.0.0,>=4.5.0 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
   - zope-interface ; extra == 'docs'
-  - pytest <7.0.0, >=6.0.0 ; extra == 'tests'
-  - coverage[toml] ==5.0.4 ; extra == 'tests'
+  - pytest<7.0.0,>=6.0.0 ; extra == 'tests'
+  - coverage[toml]==5.0.4 ; extra == 'tests'
   requires_python: '>=3.7'
 - kind: pypi
   name: pynacl
@@ -23809,35 +23826,11 @@ packages:
   url: https://files.pythonhosted.org/packages/ce/75/0b8ede18506041c0bf23ac4d8e2971b4161cd6ce630b177d0a08eb0d8857/PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl
   sha256: 401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1
   requires_dist:
-  - cffi >=1.4.1
-  - sphinx >=1.6.5 ; extra == 'docs'
+  - cffi>=1.4.1
+  - sphinx>=1.6.5 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
-  - pytest !=3.3.0, >=3.2.1 ; extra == 'tests'
-  - hypothesis >=3.27.0 ; extra == 'tests'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: pynacl
-  version: 1.5.0
-  url: https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl
-  sha256: 20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
-  requires_dist:
-  - cffi >=1.4.1
-  - sphinx >=1.6.5 ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - pytest !=3.3.0, >=3.2.1 ; extra == 'tests'
-  - hypothesis >=3.27.0 ; extra == 'tests'
-  requires_python: '>=3.6'
-- kind: pypi
-  name: pynacl
-  version: 1.5.0
-  url: https://files.pythonhosted.org/packages/ee/87/f1bb6a595f14a327e8285b9eb54d41fef76c585a0edef0a45f6fc95de125/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
-  sha256: 0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d
-  requires_dist:
-  - cffi >=1.4.1
-  - sphinx >=1.6.5 ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - pytest !=3.3.0, >=3.2.1 ; extra == 'tests'
-  - hypothesis >=3.27.0 ; extra == 'tests'
+  - pytest!=3.3.0,>=3.2.1 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
   requires_python: '>=3.6'
 - kind: pypi
   name: pynacl
@@ -23845,11 +23838,35 @@ packages:
   url: https://files.pythonhosted.org/packages/59/bb/fddf10acd09637327a97ef89d2a9d621328850a72f1fdc8c08bdf72e385f/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl
   sha256: 52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92
   requires_dist:
-  - cffi >=1.4.1
-  - sphinx >=1.6.5 ; extra == 'docs'
+  - cffi>=1.4.1
+  - sphinx>=1.6.5 ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
-  - pytest !=3.3.0, >=3.2.1 ; extra == 'tests'
-  - hypothesis >=3.27.0 ; extra == 'tests'
+  - pytest!=3.3.0,>=3.2.1 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: pynacl
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/ee/87/f1bb6a595f14a327e8285b9eb54d41fef76c585a0edef0a45f6fc95de125/PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl
+  sha256: 0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d
+  requires_dist:
+  - cffi>=1.4.1
+  - sphinx>=1.6.5 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - pytest!=3.3.0,>=3.2.1 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
+  requires_python: '>=3.6'
+- kind: pypi
+  name: pynacl
+  version: 1.5.0
+  url: https://files.pythonhosted.org/packages/5e/22/d3db169895faaf3e2eda892f005f433a62db2decbcfbc2f61e6517adfa87/PyNaCl-1.5.0-cp36-abi3-win_amd64.whl
+  sha256: 20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93
+  requires_dist:
+  - cffi>=1.4.1
+  - sphinx>=1.6.5 ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - pytest!=3.3.0,>=3.2.1 ; extra == 'tests'
+  - hypothesis>=3.27.0 ; extra == 'tests'
   requires_python: '>=3.6'
 - kind: pypi
   name: pynndescent
@@ -23857,31 +23874,31 @@ packages:
   url: https://files.pythonhosted.org/packages/bf/06/18c0e17eb245b7caeb861f2ff747adb0575500183b6ec4282d5350d29e9f/pynndescent-0.5.12-py3-none-any.whl
   sha256: 9023dc5fea520a4e84d0633ae735db97d2509da927bfa86c897e61f3315473c7
   requires_dist:
-  - scikit-learn >=0.18
-  - scipy >=1.0
-  - numba >=0.51.2
-  - llvmlite >=0.30
-  - joblib >=0.11
-  - importlib-metadata >=4.8.1 ; python_version < '3.8'
+  - scikit-learn>=0.18
+  - scipy>=1.0
+  - numba>=0.51.2
+  - llvmlite>=0.30
+  - joblib>=0.11
+  - importlib-metadata>=4.8.1 ; python_version < '3.8'
 - kind: pypi
   name: pyopengl
   version: 3.1.0
-  url: https://files.pythonhosted.org/packages/ce/33/ef0e3b40a3f4cbfcfb93511652673fb19d07bafac0611f01f6237d1978ed/PyOpenGL-3.1.0.zip
-  sha256: efa4e39a49b906ccbe66758812ca81ced13a6f26931ab2ba2dba2750c016c0d0
+  url: https://files.pythonhosted.org/packages/9c/1d/4544708aaa89f26c97cc09450bb333a23724a320923e74d73e028b3560f9/PyOpenGL-3.1.0.tar.gz
+  sha256: 9b47c5c3a094fa518ca88aeed35ae75834d53e4285512c61879f67a48c94ddaf
 - kind: pypi
   name: pyopf
   version: 1.1.1
   url: https://files.pythonhosted.org/packages/a8/26/b67fe94cb53c489c5ccaed118f257a5100e7775071515942c9f45d8cd40f/pyopf-1.1.1-py3-none-any.whl
   sha256: 10971881afcb7ed0dd373f7e88862fa8ad0f70fe4329f2ef5093c152e923831f
   requires_dist:
-  - argparse >=1.4.0
-  - numpy >=1.24.1
-  - pillow >=9.5.0
-  - pygltflib >=1.15.3
-  - python-dateutil >=2.8.2
-  - shapely >=2.0.1
-  - tqdm >=4.65.0
-  - simplejson >=18.3 ; extra == 'tests'
+  - argparse>=1.4.0
+  - numpy>=1.24.1
+  - pillow>=9.5.0
+  - pygltflib>=1.15.3
+  - python-dateutil>=2.8.2
+  - shapely>=2.0.1
+  - tqdm>=4.65.0
+  - simplejson>=18.3 ; extra == 'tests'
   requires_python: '>=3.10'
 - kind: pypi
   name: pyparsing
@@ -23903,8 +23920,8 @@ packages:
   - networkx
   - numpy
   - pillow
-  - pyglet >=1.4.10
-  - pyopengl ==3.1.0
+  - pyglet>=1.4.10
+  - pyopengl==3.1.0
   - scipy
   - six
   - trimesh
@@ -24262,7 +24279,7 @@ packages:
   url: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
   sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
   requires_dist:
-  - six >=1.5
+  - six>=1.5
   requires_python: '!=3.0.*,!=3.1.*,!=3.2.*,>=2.7'
 - kind: conda
   name: python_abi
@@ -24347,12 +24364,6 @@ packages:
 - kind: pypi
   name: pyyaml
   version: 6.0.1
-  url: https://files.pythonhosted.org/packages/ec/0d/26fb23e8863e0aeaac0c64e03fd27367ad2ae3f3cccf3798ee98ce160368/PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007
-  requires_python: '>=3.6'
-- kind: pypi
-  name: pyyaml
-  version: 6.0.1
   url: https://files.pythonhosted.org/packages/7b/5e/efd033ab7199a0b2044dab3b9f7a4f6670e6a52c089de572e928d2873b06/PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673
   requires_python: '>=3.6'
@@ -24369,16 +24380,21 @@ packages:
   sha256: f003ed9ad21d6a4713f0a9b5a7a0a79e08dd0f221aff4525a2be4c346ee60aab
   requires_python: '>=3.6'
 - kind: pypi
+  name: pyyaml
+  version: 6.0.1
+  url: https://files.pythonhosted.org/packages/ec/0d/26fb23e8863e0aeaac0c64e03fd27367ad2ae3f3cccf3798ee98ce160368/PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007
+  requires_python: '>=3.6'
+- kind: pypi
   name: raw-mesh
   version: 0.1.0
   path: examples/python/raw_mesh
-  sha256: 29d7482ea0dae8ceb7b95c4adeff04bd362cab0842f3f0a9572b2c42013c7656
+  sha256: 9006b1b7ca8bd9c90ba0bf0d7a00641b7dd13a6de76a2828f79ec5b853a4ef98
   requires_dist:
   - numpy
-  - pillow
-  - requests <3, >=2.31
+  - requests>=2.31,<3
   - rerun-sdk
-  - trimesh ==3.15.2
+  - trimesh==3.15.2
   editable: true
 - kind: conda
   name: rdma-core
@@ -24648,12 +24664,6 @@ packages:
 - kind: pypi
   name: regex
   version: 2024.5.10
-  url: https://files.pythonhosted.org/packages/6c/99/152009b8f39e38c03dafa07ffdbc1027981dc2249d42919ed54eaeb9450b/regex-2024.5.10-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 45cc13d398b6359a7708986386f72bd156ae781c3e83a68a6d4cee5af04b1ce9
-  requires_python: '>=3.8'
-- kind: pypi
-  name: regex
-  version: 2024.5.10
   url: https://files.pythonhosted.org/packages/a4/06/c5d4eb73c1f1335a2447b1de9411014e3bb12331c8c32eaa26a4ae318e54/regex-2024.5.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 7467ad8b0eac0b28e52679e972b9b234b3de0ea5cee12eb50091d2b68145fe36
   requires_python: '>=3.8'
@@ -24670,17 +24680,23 @@ packages:
   sha256: ad45f3bccfcb00868f2871dce02a755529838d2b86163ab8a246115e80cfb7d6
   requires_python: '>=3.8'
 - kind: pypi
+  name: regex
+  version: 2024.5.10
+  url: https://files.pythonhosted.org/packages/6c/99/152009b8f39e38c03dafa07ffdbc1027981dc2249d42919ed54eaeb9450b/regex-2024.5.10-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 45cc13d398b6359a7708986386f72bd156ae781c3e83a68a6d4cee5af04b1ce9
+  requires_python: '>=3.8'
+- kind: pypi
   name: requests
   version: 2.31.0
   url: https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl
   sha256: 58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f
   requires_dist:
-  - charset-normalizer <4, >=2
-  - idna <4, >=2.5
-  - urllib3 <3, >=1.21.1
-  - certifi >=2017.4.17
-  - pysocks !=1.5.7, >=1.5.6 ; extra == 'socks'
-  - chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'
+  - charset-normalizer<4,>=2
+  - idna<4,>=2.5
+  - urllib3<3,>=1.21.1
+  - certifi>=2017.4.17
+  - pysocks!=1.5.7,>=1.5.6 ; extra == 'socks'
+  - chardet<6,>=3.0.2 ; extra == 'use_chardet_on_py3'
   requires_python: '>=3.7'
 - kind: pypi
   name: rerun-sdk
@@ -24694,8 +24710,8 @@ packages:
   sha256: b2ef153b0bedd672c3e0ce89b7be1f64f4344b2b75d71748899faea270383fa2
   requires_dist:
   - numpy
-  - opencv-python >4.6
-  - requests <3, >=2.31
+  - opencv-python>4.6
+  - requests>=2.31,<3
   - rerun-sdk
   - tqdm
   editable: true
@@ -24766,7 +24782,7 @@ packages:
   url: https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl
   sha256: 90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7
   requires_dist:
-  - pyasn1 >=0.1.3
+  - pyasn1>=0.1.3
   requires_python: '>=3.6,<4'
 - kind: conda
   name: ruff
@@ -24948,74 +24964,34 @@ packages:
 - kind: pypi
   name: safetensors
   version: 0.4.3
-  url: https://files.pythonhosted.org/packages/9f/d9/1bd2c06c1e7aff0c6db4affff5c0b8d6b2fa421ee0d2de94408d43e6aa7c/safetensors-0.4.3-cp311-cp311-macosx_10_12_x86_64.whl
-  sha256: 22f3b5d65e440cec0de8edaa672efa888030802e11c09b3d6203bff60ebff05a
-  requires_dist:
-  - numpy >=1.21.6 ; extra == 'numpy'
-  - safetensors[numpy] ; extra == 'torch'
-  - torch >=1.10 ; extra == 'torch'
-  - safetensors[numpy] ; extra == 'tensorflow'
-  - tensorflow >=2.11.0 ; extra == 'tensorflow'
-  - safetensors[numpy] ; extra == 'pinned-tf'
-  - tensorflow ==2.11.0 ; extra == 'pinned-tf'
-  - safetensors[numpy] ; extra == 'jax'
-  - flax >=0.6.3 ; extra == 'jax'
-  - jax >=0.3.25 ; extra == 'jax'
-  - jaxlib >=0.3.25 ; extra == 'jax'
-  - mlx >=0.0.9 ; extra == 'mlx'
-  - safetensors[numpy] ; extra == 'paddlepaddle'
-  - paddlepaddle >=2.4.1 ; extra == 'paddlepaddle'
-  - black ==22.3 ; extra == 'quality'
-  - click ==8.0.4 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - flake8 >=3.8.3 ; extra == 'quality'
-  - safetensors[numpy] ; extra == 'testing'
-  - h5py >=3.7.0 ; extra == 'testing'
-  - huggingface-hub >=0.12.1 ; extra == 'testing'
-  - setuptools-rust >=1.5.2 ; extra == 'testing'
-  - pytest >=7.2.0 ; extra == 'testing'
-  - pytest-benchmark >=4.0.0 ; extra == 'testing'
-  - hypothesis >=6.70.2 ; extra == 'testing'
-  - safetensors[torch] ; extra == 'all'
-  - safetensors[numpy] ; extra == 'all'
-  - safetensors[pinned-tf] ; extra == 'all'
-  - safetensors[jax] ; extra == 'all'
-  - safetensors[paddlepaddle] ; extra == 'all'
-  - safetensors[quality] ; extra == 'all'
-  - safetensors[testing] ; extra == 'all'
-  - safetensors[all] ; extra == 'dev'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: safetensors
-  version: 0.4.3
   url: https://files.pythonhosted.org/packages/d5/85/1e7d2804cbf82204cde462d16f1cb0ff5814b03f559fb46ceaa6b7020db4/safetensors-0.4.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 0bf4f9d6323d9f86eef5567eabd88f070691cf031d4c0df27a40d3b4aaee755b
   requires_dist:
-  - numpy >=1.21.6 ; extra == 'numpy'
+  - numpy>=1.21.6 ; extra == 'numpy'
   - safetensors[numpy] ; extra == 'torch'
-  - torch >=1.10 ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
   - safetensors[numpy] ; extra == 'tensorflow'
-  - tensorflow >=2.11.0 ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
   - safetensors[numpy] ; extra == 'pinned-tf'
-  - tensorflow ==2.11.0 ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
   - safetensors[numpy] ; extra == 'jax'
-  - flax >=0.6.3 ; extra == 'jax'
-  - jax >=0.3.25 ; extra == 'jax'
-  - jaxlib >=0.3.25 ; extra == 'jax'
-  - mlx >=0.0.9 ; extra == 'mlx'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
   - safetensors[numpy] ; extra == 'paddlepaddle'
-  - paddlepaddle >=2.4.1 ; extra == 'paddlepaddle'
-  - black ==22.3 ; extra == 'quality'
-  - click ==8.0.4 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - flake8 >=3.8.3 ; extra == 'quality'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
   - safetensors[numpy] ; extra == 'testing'
-  - h5py >=3.7.0 ; extra == 'testing'
-  - huggingface-hub >=0.12.1 ; extra == 'testing'
-  - setuptools-rust >=1.5.2 ; extra == 'testing'
-  - pytest >=7.2.0 ; extra == 'testing'
-  - pytest-benchmark >=4.0.0 ; extra == 'testing'
-  - hypothesis >=6.70.2 ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
   - safetensors[torch] ; extra == 'all'
   - safetensors[numpy] ; extra == 'all'
   - safetensors[pinned-tf] ; extra == 'all'
@@ -25031,31 +25007,31 @@ packages:
   url: https://files.pythonhosted.org/packages/cb/f6/19f268662be898ff2a23ac06f8dd0d2956b2ecd204c96e1ee07ba292c119/safetensors-0.4.3-cp311-none-win_amd64.whl
   sha256: 840b7ac0eff5633e1d053cc9db12fdf56b566e9403b4950b2dc85393d9b88d67
   requires_dist:
-  - numpy >=1.21.6 ; extra == 'numpy'
+  - numpy>=1.21.6 ; extra == 'numpy'
   - safetensors[numpy] ; extra == 'torch'
-  - torch >=1.10 ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
   - safetensors[numpy] ; extra == 'tensorflow'
-  - tensorflow >=2.11.0 ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
   - safetensors[numpy] ; extra == 'pinned-tf'
-  - tensorflow ==2.11.0 ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
   - safetensors[numpy] ; extra == 'jax'
-  - flax >=0.6.3 ; extra == 'jax'
-  - jax >=0.3.25 ; extra == 'jax'
-  - jaxlib >=0.3.25 ; extra == 'jax'
-  - mlx >=0.0.9 ; extra == 'mlx'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
   - safetensors[numpy] ; extra == 'paddlepaddle'
-  - paddlepaddle >=2.4.1 ; extra == 'paddlepaddle'
-  - black ==22.3 ; extra == 'quality'
-  - click ==8.0.4 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - flake8 >=3.8.3 ; extra == 'quality'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
   - safetensors[numpy] ; extra == 'testing'
-  - h5py >=3.7.0 ; extra == 'testing'
-  - huggingface-hub >=0.12.1 ; extra == 'testing'
-  - setuptools-rust >=1.5.2 ; extra == 'testing'
-  - pytest >=7.2.0 ; extra == 'testing'
-  - pytest-benchmark >=4.0.0 ; extra == 'testing'
-  - hypothesis >=6.70.2 ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
   - safetensors[torch] ; extra == 'all'
   - safetensors[numpy] ; extra == 'all'
   - safetensors[pinned-tf] ; extra == 'all'
@@ -25071,31 +25047,71 @@ packages:
   url: https://files.pythonhosted.org/packages/82/61/d4812330b32600972e92ef09a59dc54f9ab8ae570fdca28d8bdfc5577756/safetensors-0.4.3-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 7c4fa560ebd4522adddb71dcd25d09bf211b5634003f015a4b815b7647d62ebe
   requires_dist:
-  - numpy >=1.21.6 ; extra == 'numpy'
+  - numpy>=1.21.6 ; extra == 'numpy'
   - safetensors[numpy] ; extra == 'torch'
-  - torch >=1.10 ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
   - safetensors[numpy] ; extra == 'tensorflow'
-  - tensorflow >=2.11.0 ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
   - safetensors[numpy] ; extra == 'pinned-tf'
-  - tensorflow ==2.11.0 ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
   - safetensors[numpy] ; extra == 'jax'
-  - flax >=0.6.3 ; extra == 'jax'
-  - jax >=0.3.25 ; extra == 'jax'
-  - jaxlib >=0.3.25 ; extra == 'jax'
-  - mlx >=0.0.9 ; extra == 'mlx'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
   - safetensors[numpy] ; extra == 'paddlepaddle'
-  - paddlepaddle >=2.4.1 ; extra == 'paddlepaddle'
-  - black ==22.3 ; extra == 'quality'
-  - click ==8.0.4 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - flake8 >=3.8.3 ; extra == 'quality'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
   - safetensors[numpy] ; extra == 'testing'
-  - h5py >=3.7.0 ; extra == 'testing'
-  - huggingface-hub >=0.12.1 ; extra == 'testing'
-  - setuptools-rust >=1.5.2 ; extra == 'testing'
-  - pytest >=7.2.0 ; extra == 'testing'
-  - pytest-benchmark >=4.0.0 ; extra == 'testing'
-  - hypothesis >=6.70.2 ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
+  - safetensors[torch] ; extra == 'all'
+  - safetensors[numpy] ; extra == 'all'
+  - safetensors[pinned-tf] ; extra == 'all'
+  - safetensors[jax] ; extra == 'all'
+  - safetensors[paddlepaddle] ; extra == 'all'
+  - safetensors[quality] ; extra == 'all'
+  - safetensors[testing] ; extra == 'all'
+  - safetensors[all] ; extra == 'dev'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: safetensors
+  version: 0.4.3
+  url: https://files.pythonhosted.org/packages/9f/d9/1bd2c06c1e7aff0c6db4affff5c0b8d6b2fa421ee0d2de94408d43e6aa7c/safetensors-0.4.3-cp311-cp311-macosx_10_12_x86_64.whl
+  sha256: 22f3b5d65e440cec0de8edaa672efa888030802e11c09b3d6203bff60ebff05a
+  requires_dist:
+  - numpy>=1.21.6 ; extra == 'numpy'
+  - safetensors[numpy] ; extra == 'torch'
+  - torch>=1.10 ; extra == 'torch'
+  - safetensors[numpy] ; extra == 'tensorflow'
+  - tensorflow>=2.11.0 ; extra == 'tensorflow'
+  - safetensors[numpy] ; extra == 'pinned-tf'
+  - tensorflow==2.11.0 ; extra == 'pinned-tf'
+  - safetensors[numpy] ; extra == 'jax'
+  - flax>=0.6.3 ; extra == 'jax'
+  - jax>=0.3.25 ; extra == 'jax'
+  - jaxlib>=0.3.25 ; extra == 'jax'
+  - mlx>=0.0.9 ; extra == 'mlx'
+  - safetensors[numpy] ; extra == 'paddlepaddle'
+  - paddlepaddle>=2.4.1 ; extra == 'paddlepaddle'
+  - black==22.3 ; extra == 'quality'
+  - click==8.0.4 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - flake8>=3.8.3 ; extra == 'quality'
+  - safetensors[numpy] ; extra == 'testing'
+  - h5py>=3.7.0 ; extra == 'testing'
+  - huggingface-hub>=0.12.1 ; extra == 'testing'
+  - setuptools-rust>=1.5.2 ; extra == 'testing'
+  - pytest>=7.2.0 ; extra == 'testing'
+  - pytest-benchmark>=4.0.0 ; extra == 'testing'
+  - hypothesis>=6.70.2 ; extra == 'testing'
   - safetensors[torch] ; extra == 'all'
   - safetensors[numpy] ; extra == 'all'
   - safetensors[pinned-tf] ; extra == 'all'
@@ -25108,133 +25124,66 @@ packages:
 - kind: pypi
   name: scikit-image
   version: 0.23.2
-  url: https://files.pythonhosted.org/packages/78/2b/5f985cf4cf59378f80dc212004a7692b7b49b2a3910c3584d70284db5b89/scikit_image-0.23.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: ee83fdb1843ee938eabdfeb9498623282935ea30aa20dffc5d5d16698efb4b2a
-  requires_dist:
-  - numpy >=1.23
-  - scipy >=1.9
-  - networkx >=2.8
-  - pillow >=9.1
-  - imageio >=2.33
-  - tifffile >=2022.8.12
-  - packaging >=21
-  - lazy-loader >=0.4
-  - meson-python >=0.15 ; extra == 'build'
-  - wheel ; extra == 'build'
-  - setuptools >=67 ; extra == 'build'
-  - packaging >=21 ; extra == 'build'
-  - ninja ; extra == 'build'
-  - cython >=3.0.4 ; extra == 'build'
-  - pythran ; extra == 'build'
-  - numpy >=2.0.0rc1 ; extra == 'build'
-  - spin ==0.8 ; extra == 'build'
-  - build ; extra == 'build'
-  - pooch >=1.6.0 ; extra == 'data'
-  - pre-commit ; extra == 'developer'
-  - ipython ; extra == 'developer'
-  - tomli ; python_version < '3.11' and extra == 'developer'
-  - sphinx >=7.3 ; extra == 'docs'
-  - sphinx-gallery >=0.14 ; extra == 'docs'
-  - numpydoc >=1.7 ; extra == 'docs'
-  - sphinx-copybutton ; extra == 'docs'
-  - pytest-runner ; extra == 'docs'
-  - matplotlib >=3.6 ; extra == 'docs'
-  - dask[array] >=2022.9.2 ; extra == 'docs'
-  - pandas >=1.5 ; extra == 'docs'
-  - seaborn >=0.11 ; extra == 'docs'
-  - pooch >=1.6 ; extra == 'docs'
-  - tifffile >=2022.8.12 ; extra == 'docs'
-  - myst-parser ; extra == 'docs'
-  - ipywidgets ; extra == 'docs'
-  - ipykernel ; extra == 'docs'
-  - plotly >=5.10 ; extra == 'docs'
-  - kaleido ; extra == 'docs'
-  - scikit-learn >=1.1 ; extra == 'docs'
-  - sphinx-design >=0.5 ; extra == 'docs'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'docs'
-  - pywavelets >=1.1.1 ; extra == 'docs'
-  - pytest-doctestplus ; extra == 'docs'
-  - simpleitk ; extra == 'optional'
-  - astropy >=5.0 ; extra == 'optional'
-  - cloudpickle >=0.2.1 ; extra == 'optional'
-  - dask[array] >=2021.1.0 ; extra == 'optional'
-  - matplotlib >=3.6 ; extra == 'optional'
-  - pooch >=1.6.0 ; extra == 'optional'
-  - pyamg ; extra == 'optional'
-  - pywavelets >=1.1.1 ; extra == 'optional'
-  - scikit-learn >=1.1 ; extra == 'optional'
-  - asv ; extra == 'test'
-  - numpydoc >=1.7 ; extra == 'test'
-  - pooch >=1.6.0 ; extra == 'test'
-  - pytest >=7.0 ; extra == 'test'
-  - pytest-cov >=2.11.0 ; extra == 'test'
-  - pytest-localserver ; extra == 'test'
-  - pytest-faulthandler ; extra == 'test'
-  - pytest-doctestplus ; extra == 'test'
-  requires_python: '>=3.10'
-- kind: pypi
-  name: scikit-image
-  version: 0.23.2
   url: https://files.pythonhosted.org/packages/0a/40/2c57864acd77c168b96cb6e4e62651b9c98733962793293991ef55e2982c/scikit_image-0.23.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: fce619a6d84fe40c1208fa579b646e93ce13ef0afc3652a23e9782b2c183291a
   requires_dist:
-  - numpy >=1.23
-  - scipy >=1.9
-  - networkx >=2.8
-  - pillow >=9.1
-  - imageio >=2.33
-  - tifffile >=2022.8.12
-  - packaging >=21
-  - lazy-loader >=0.4
-  - meson-python >=0.15 ; extra == 'build'
+  - numpy>=1.23
+  - scipy>=1.9
+  - networkx>=2.8
+  - pillow>=9.1
+  - imageio>=2.33
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.15 ; extra == 'build'
   - wheel ; extra == 'build'
-  - setuptools >=67 ; extra == 'build'
-  - packaging >=21 ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
   - ninja ; extra == 'build'
-  - cython >=3.0.4 ; extra == 'build'
+  - cython>=3.0.4 ; extra == 'build'
   - pythran ; extra == 'build'
-  - numpy >=2.0.0rc1 ; extra == 'build'
-  - spin ==0.8 ; extra == 'build'
+  - numpy>=2.0.0rc1 ; extra == 'build'
+  - spin==0.8 ; extra == 'build'
   - build ; extra == 'build'
-  - pooch >=1.6.0 ; extra == 'data'
+  - pooch>=1.6.0 ; extra == 'data'
   - pre-commit ; extra == 'developer'
   - ipython ; extra == 'developer'
   - tomli ; python_version < '3.11' and extra == 'developer'
-  - sphinx >=7.3 ; extra == 'docs'
-  - sphinx-gallery >=0.14 ; extra == 'docs'
-  - numpydoc >=1.7 ; extra == 'docs'
+  - sphinx>=7.3 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - pytest-runner ; extra == 'docs'
-  - matplotlib >=3.6 ; extra == 'docs'
-  - dask[array] >=2022.9.2 ; extra == 'docs'
-  - pandas >=1.5 ; extra == 'docs'
-  - seaborn >=0.11 ; extra == 'docs'
-  - pooch >=1.6 ; extra == 'docs'
-  - tifffile >=2022.8.12 ; extra == 'docs'
+  - matplotlib>=3.6 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   - ipywidgets ; extra == 'docs'
   - ipykernel ; extra == 'docs'
-  - plotly >=5.10 ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
   - kaleido ; extra == 'docs'
-  - scikit-learn >=1.1 ; extra == 'docs'
-  - sphinx-design >=0.5 ; extra == 'docs'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'docs'
-  - pywavelets >=1.1.1 ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
   - pytest-doctestplus ; extra == 'docs'
   - simpleitk ; extra == 'optional'
-  - astropy >=5.0 ; extra == 'optional'
-  - cloudpickle >=0.2.1 ; extra == 'optional'
-  - dask[array] >=2021.1.0 ; extra == 'optional'
-  - matplotlib >=3.6 ; extra == 'optional'
-  - pooch >=1.6.0 ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.6 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
   - pyamg ; extra == 'optional'
-  - pywavelets >=1.1.1 ; extra == 'optional'
-  - scikit-learn >=1.1 ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
   - asv ; extra == 'test'
-  - numpydoc >=1.7 ; extra == 'test'
-  - pooch >=1.6.0 ; extra == 'test'
-  - pytest >=7.0 ; extra == 'test'
-  - pytest-cov >=2.11.0 ; extra == 'test'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
   - pytest-localserver ; extra == 'test'
   - pytest-faulthandler ; extra == 'test'
   - pytest-doctestplus ; extra == 'test'
@@ -25245,63 +25194,63 @@ packages:
   url: https://files.pythonhosted.org/packages/eb/ab/8791ce3063e6d4ac7f8efe3c993fd2e911c9e08f4c7dd05b603eaa2493b2/scikit_image-0.23.2-cp311-cp311-win_amd64.whl
   sha256: ee65669aa586e110346f567ed5c92d1bd63799a19e951cb83da3f54b0caf7c52
   requires_dist:
-  - numpy >=1.23
-  - scipy >=1.9
-  - networkx >=2.8
-  - pillow >=9.1
-  - imageio >=2.33
-  - tifffile >=2022.8.12
-  - packaging >=21
-  - lazy-loader >=0.4
-  - meson-python >=0.15 ; extra == 'build'
+  - numpy>=1.23
+  - scipy>=1.9
+  - networkx>=2.8
+  - pillow>=9.1
+  - imageio>=2.33
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.15 ; extra == 'build'
   - wheel ; extra == 'build'
-  - setuptools >=67 ; extra == 'build'
-  - packaging >=21 ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
   - ninja ; extra == 'build'
-  - cython >=3.0.4 ; extra == 'build'
+  - cython>=3.0.4 ; extra == 'build'
   - pythran ; extra == 'build'
-  - numpy >=2.0.0rc1 ; extra == 'build'
-  - spin ==0.8 ; extra == 'build'
+  - numpy>=2.0.0rc1 ; extra == 'build'
+  - spin==0.8 ; extra == 'build'
   - build ; extra == 'build'
-  - pooch >=1.6.0 ; extra == 'data'
+  - pooch>=1.6.0 ; extra == 'data'
   - pre-commit ; extra == 'developer'
   - ipython ; extra == 'developer'
   - tomli ; python_version < '3.11' and extra == 'developer'
-  - sphinx >=7.3 ; extra == 'docs'
-  - sphinx-gallery >=0.14 ; extra == 'docs'
-  - numpydoc >=1.7 ; extra == 'docs'
+  - sphinx>=7.3 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - pytest-runner ; extra == 'docs'
-  - matplotlib >=3.6 ; extra == 'docs'
-  - dask[array] >=2022.9.2 ; extra == 'docs'
-  - pandas >=1.5 ; extra == 'docs'
-  - seaborn >=0.11 ; extra == 'docs'
-  - pooch >=1.6 ; extra == 'docs'
-  - tifffile >=2022.8.12 ; extra == 'docs'
+  - matplotlib>=3.6 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   - ipywidgets ; extra == 'docs'
   - ipykernel ; extra == 'docs'
-  - plotly >=5.10 ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
   - kaleido ; extra == 'docs'
-  - scikit-learn >=1.1 ; extra == 'docs'
-  - sphinx-design >=0.5 ; extra == 'docs'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'docs'
-  - pywavelets >=1.1.1 ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
   - pytest-doctestplus ; extra == 'docs'
   - simpleitk ; extra == 'optional'
-  - astropy >=5.0 ; extra == 'optional'
-  - cloudpickle >=0.2.1 ; extra == 'optional'
-  - dask[array] >=2021.1.0 ; extra == 'optional'
-  - matplotlib >=3.6 ; extra == 'optional'
-  - pooch >=1.6.0 ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.6 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
   - pyamg ; extra == 'optional'
-  - pywavelets >=1.1.1 ; extra == 'optional'
-  - scikit-learn >=1.1 ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
   - asv ; extra == 'test'
-  - numpydoc >=1.7 ; extra == 'test'
-  - pooch >=1.6.0 ; extra == 'test'
-  - pytest >=7.0 ; extra == 'test'
-  - pytest-cov >=2.11.0 ; extra == 'test'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
   - pytest-localserver ; extra == 'test'
   - pytest-faulthandler ; extra == 'test'
   - pytest-doctestplus ; extra == 'test'
@@ -25312,63 +25261,130 @@ packages:
   url: https://files.pythonhosted.org/packages/b9/cf/9e5828fa29791bf7ac5c3fad3637ebb02f237a1c3de8233bd6a33c2c4aac/scikit_image-0.23.2-cp311-cp311-macosx_12_0_arm64.whl
   sha256: a158f50d3df4867bbd1c698520ede8bc493e430ad83f54ac1f0d8f57b328779b
   requires_dist:
-  - numpy >=1.23
-  - scipy >=1.9
-  - networkx >=2.8
-  - pillow >=9.1
-  - imageio >=2.33
-  - tifffile >=2022.8.12
-  - packaging >=21
-  - lazy-loader >=0.4
-  - meson-python >=0.15 ; extra == 'build'
+  - numpy>=1.23
+  - scipy>=1.9
+  - networkx>=2.8
+  - pillow>=9.1
+  - imageio>=2.33
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.15 ; extra == 'build'
   - wheel ; extra == 'build'
-  - setuptools >=67 ; extra == 'build'
-  - packaging >=21 ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
   - ninja ; extra == 'build'
-  - cython >=3.0.4 ; extra == 'build'
+  - cython>=3.0.4 ; extra == 'build'
   - pythran ; extra == 'build'
-  - numpy >=2.0.0rc1 ; extra == 'build'
-  - spin ==0.8 ; extra == 'build'
+  - numpy>=2.0.0rc1 ; extra == 'build'
+  - spin==0.8 ; extra == 'build'
   - build ; extra == 'build'
-  - pooch >=1.6.0 ; extra == 'data'
+  - pooch>=1.6.0 ; extra == 'data'
   - pre-commit ; extra == 'developer'
   - ipython ; extra == 'developer'
   - tomli ; python_version < '3.11' and extra == 'developer'
-  - sphinx >=7.3 ; extra == 'docs'
-  - sphinx-gallery >=0.14 ; extra == 'docs'
-  - numpydoc >=1.7 ; extra == 'docs'
+  - sphinx>=7.3 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
   - sphinx-copybutton ; extra == 'docs'
   - pytest-runner ; extra == 'docs'
-  - matplotlib >=3.6 ; extra == 'docs'
-  - dask[array] >=2022.9.2 ; extra == 'docs'
-  - pandas >=1.5 ; extra == 'docs'
-  - seaborn >=0.11 ; extra == 'docs'
-  - pooch >=1.6 ; extra == 'docs'
-  - tifffile >=2022.8.12 ; extra == 'docs'
+  - matplotlib>=3.6 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
   - myst-parser ; extra == 'docs'
   - ipywidgets ; extra == 'docs'
   - ipykernel ; extra == 'docs'
-  - plotly >=5.10 ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
   - kaleido ; extra == 'docs'
-  - scikit-learn >=1.1 ; extra == 'docs'
-  - sphinx-design >=0.5 ; extra == 'docs'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'docs'
-  - pywavelets >=1.1.1 ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
   - pytest-doctestplus ; extra == 'docs'
   - simpleitk ; extra == 'optional'
-  - astropy >=5.0 ; extra == 'optional'
-  - cloudpickle >=0.2.1 ; extra == 'optional'
-  - dask[array] >=2021.1.0 ; extra == 'optional'
-  - matplotlib >=3.6 ; extra == 'optional'
-  - pooch >=1.6.0 ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.6 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
   - pyamg ; extra == 'optional'
-  - pywavelets >=1.1.1 ; extra == 'optional'
-  - scikit-learn >=1.1 ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
   - asv ; extra == 'test'
-  - numpydoc >=1.7 ; extra == 'test'
-  - pooch >=1.6.0 ; extra == 'test'
-  - pytest >=7.0 ; extra == 'test'
-  - pytest-cov >=2.11.0 ; extra == 'test'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
+  - pytest-localserver ; extra == 'test'
+  - pytest-faulthandler ; extra == 'test'
+  - pytest-doctestplus ; extra == 'test'
+  requires_python: '>=3.10'
+- kind: pypi
+  name: scikit-image
+  version: 0.23.2
+  url: https://files.pythonhosted.org/packages/78/2b/5f985cf4cf59378f80dc212004a7692b7b49b2a3910c3584d70284db5b89/scikit_image-0.23.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: ee83fdb1843ee938eabdfeb9498623282935ea30aa20dffc5d5d16698efb4b2a
+  requires_dist:
+  - numpy>=1.23
+  - scipy>=1.9
+  - networkx>=2.8
+  - pillow>=9.1
+  - imageio>=2.33
+  - tifffile>=2022.8.12
+  - packaging>=21
+  - lazy-loader>=0.4
+  - meson-python>=0.15 ; extra == 'build'
+  - wheel ; extra == 'build'
+  - setuptools>=67 ; extra == 'build'
+  - packaging>=21 ; extra == 'build'
+  - ninja ; extra == 'build'
+  - cython>=3.0.4 ; extra == 'build'
+  - pythran ; extra == 'build'
+  - numpy>=2.0.0rc1 ; extra == 'build'
+  - spin==0.8 ; extra == 'build'
+  - build ; extra == 'build'
+  - pooch>=1.6.0 ; extra == 'data'
+  - pre-commit ; extra == 'developer'
+  - ipython ; extra == 'developer'
+  - tomli ; python_version < '3.11' and extra == 'developer'
+  - sphinx>=7.3 ; extra == 'docs'
+  - sphinx-gallery>=0.14 ; extra == 'docs'
+  - numpydoc>=1.7 ; extra == 'docs'
+  - sphinx-copybutton ; extra == 'docs'
+  - pytest-runner ; extra == 'docs'
+  - matplotlib>=3.6 ; extra == 'docs'
+  - dask[array]>=2022.9.2 ; extra == 'docs'
+  - pandas>=1.5 ; extra == 'docs'
+  - seaborn>=0.11 ; extra == 'docs'
+  - pooch>=1.6 ; extra == 'docs'
+  - tifffile>=2022.8.12 ; extra == 'docs'
+  - myst-parser ; extra == 'docs'
+  - ipywidgets ; extra == 'docs'
+  - ipykernel ; extra == 'docs'
+  - plotly>=5.10 ; extra == 'docs'
+  - kaleido ; extra == 'docs'
+  - scikit-learn>=1.1 ; extra == 'docs'
+  - sphinx-design>=0.5 ; extra == 'docs'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'docs'
+  - pywavelets>=1.1.1 ; extra == 'docs'
+  - pytest-doctestplus ; extra == 'docs'
+  - simpleitk ; extra == 'optional'
+  - astropy>=5.0 ; extra == 'optional'
+  - cloudpickle>=0.2.1 ; extra == 'optional'
+  - dask[array]>=2021.1.0 ; extra == 'optional'
+  - matplotlib>=3.6 ; extra == 'optional'
+  - pooch>=1.6.0 ; extra == 'optional'
+  - pyamg ; extra == 'optional'
+  - pywavelets>=1.1.1 ; extra == 'optional'
+  - scikit-learn>=1.1 ; extra == 'optional'
+  - asv ; extra == 'test'
+  - numpydoc>=1.7 ; extra == 'test'
+  - pooch>=1.6.0 ; extra == 'test'
+  - pytest>=7.0 ; extra == 'test'
+  - pytest-cov>=2.11.0 ; extra == 'test'
   - pytest-localserver ; extra == 'test'
   - pytest-faulthandler ; extra == 'test'
   - pytest-doctestplus ; extra == 'test'
@@ -25376,96 +25392,49 @@ packages:
 - kind: pypi
   name: scikit-learn
   version: 1.4.2
-  url: https://files.pythonhosted.org/packages/59/11/63de36e6933b03490fdfe5cbc9b5a68870a1281d8e705a23b33076dc82fb/scikit_learn-1.4.2-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 45dee87ac5309bb82e3ea633955030df9bbcb8d2cdb30383c6cd483691c546cc
-  requires_dist:
-  - numpy >=1.19.5
-  - scipy >=1.6.0
-  - joblib >=1.2.0
-  - threadpoolctl >=2.0.0
-  - matplotlib >=3.3.4 ; extra == 'benchmark'
-  - pandas >=1.1.5 ; extra == 'benchmark'
-  - memory-profiler >=0.57.0 ; extra == 'benchmark'
-  - matplotlib >=3.3.4 ; extra == 'docs'
-  - scikit-image >=0.17.2 ; extra == 'docs'
-  - pandas >=1.1.5 ; extra == 'docs'
-  - seaborn >=0.9.0 ; extra == 'docs'
-  - memory-profiler >=0.57.0 ; extra == 'docs'
-  - sphinx >=6.0.0 ; extra == 'docs'
-  - sphinx-copybutton >=0.5.2 ; extra == 'docs'
-  - sphinx-gallery >=0.15.0 ; extra == 'docs'
-  - numpydoc >=1.2.0 ; extra == 'docs'
-  - pillow >=7.1.2 ; extra == 'docs'
-  - pooch >=1.6.0 ; extra == 'docs'
-  - sphinx-prompt >=1.3.0 ; extra == 'docs'
-  - sphinxext-opengraph >=0.4.2 ; extra == 'docs'
-  - plotly >=5.14.0 ; extra == 'docs'
-  - matplotlib >=3.3.4 ; extra == 'examples'
-  - scikit-image >=0.17.2 ; extra == 'examples'
-  - pandas >=1.1.5 ; extra == 'examples'
-  - seaborn >=0.9.0 ; extra == 'examples'
-  - pooch >=1.6.0 ; extra == 'examples'
-  - plotly >=5.14.0 ; extra == 'examples'
-  - matplotlib >=3.3.4 ; extra == 'tests'
-  - scikit-image >=0.17.2 ; extra == 'tests'
-  - pandas >=1.1.5 ; extra == 'tests'
-  - pytest >=7.1.2 ; extra == 'tests'
-  - pytest-cov >=2.9.0 ; extra == 'tests'
-  - ruff >=0.0.272 ; extra == 'tests'
-  - black >=23.3.0 ; extra == 'tests'
-  - mypy >=1.3 ; extra == 'tests'
-  - pyamg >=4.0.0 ; extra == 'tests'
-  - polars >=0.19.12 ; extra == 'tests'
-  - pyarrow >=12.0.0 ; extra == 'tests'
-  - numpydoc >=1.2.0 ; extra == 'tests'
-  - pooch >=1.6.0 ; extra == 'tests'
-  requires_python: '>=3.9'
-- kind: pypi
-  name: scikit-learn
-  version: 1.4.2
   url: https://files.pythonhosted.org/packages/4e/53/14405a47292b59235d811a2af8634aba188ccfd1a38ef4b8042f3447d79a/scikit_learn-1.4.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 44c62f2b124848a28fd695db5bc4da019287abf390bfce602ddc8aa1ec186aae
   requires_dist:
-  - numpy >=1.19.5
-  - scipy >=1.6.0
-  - joblib >=1.2.0
-  - threadpoolctl >=2.0.0
-  - matplotlib >=3.3.4 ; extra == 'benchmark'
-  - pandas >=1.1.5 ; extra == 'benchmark'
-  - memory-profiler >=0.57.0 ; extra == 'benchmark'
-  - matplotlib >=3.3.4 ; extra == 'docs'
-  - scikit-image >=0.17.2 ; extra == 'docs'
-  - pandas >=1.1.5 ; extra == 'docs'
-  - seaborn >=0.9.0 ; extra == 'docs'
-  - memory-profiler >=0.57.0 ; extra == 'docs'
-  - sphinx >=6.0.0 ; extra == 'docs'
-  - sphinx-copybutton >=0.5.2 ; extra == 'docs'
-  - sphinx-gallery >=0.15.0 ; extra == 'docs'
-  - numpydoc >=1.2.0 ; extra == 'docs'
-  - pillow >=7.1.2 ; extra == 'docs'
-  - pooch >=1.6.0 ; extra == 'docs'
-  - sphinx-prompt >=1.3.0 ; extra == 'docs'
-  - sphinxext-opengraph >=0.4.2 ; extra == 'docs'
-  - plotly >=5.14.0 ; extra == 'docs'
-  - matplotlib >=3.3.4 ; extra == 'examples'
-  - scikit-image >=0.17.2 ; extra == 'examples'
-  - pandas >=1.1.5 ; extra == 'examples'
-  - seaborn >=0.9.0 ; extra == 'examples'
-  - pooch >=1.6.0 ; extra == 'examples'
-  - plotly >=5.14.0 ; extra == 'examples'
-  - matplotlib >=3.3.4 ; extra == 'tests'
-  - scikit-image >=0.17.2 ; extra == 'tests'
-  - pandas >=1.1.5 ; extra == 'tests'
-  - pytest >=7.1.2 ; extra == 'tests'
-  - pytest-cov >=2.9.0 ; extra == 'tests'
-  - ruff >=0.0.272 ; extra == 'tests'
-  - black >=23.3.0 ; extra == 'tests'
-  - mypy >=1.3 ; extra == 'tests'
-  - pyamg >=4.0.0 ; extra == 'tests'
-  - polars >=0.19.12 ; extra == 'tests'
-  - pyarrow >=12.0.0 ; extra == 'tests'
-  - numpydoc >=1.2.0 ; extra == 'tests'
-  - pooch >=1.6.0 ; extra == 'tests'
+  - numpy>=1.19.5
+  - scipy>=1.6.0
+  - joblib>=1.2.0
+  - threadpoolctl>=2.0.0
+  - matplotlib>=3.3.4 ; extra == 'benchmark'
+  - pandas>=1.1.5 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.3.4 ; extra == 'docs'
+  - scikit-image>=0.17.2 ; extra == 'docs'
+  - pandas>=1.1.5 ; extra == 'docs'
+  - seaborn>=0.9.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=6.0.0 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.15.0 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=7.1.2 ; extra == 'docs'
+  - pooch>=1.6.0 ; extra == 'docs'
+  - sphinx-prompt>=1.3.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.4.2 ; extra == 'docs'
+  - plotly>=5.14.0 ; extra == 'docs'
+  - matplotlib>=3.3.4 ; extra == 'examples'
+  - scikit-image>=0.17.2 ; extra == 'examples'
+  - pandas>=1.1.5 ; extra == 'examples'
+  - seaborn>=0.9.0 ; extra == 'examples'
+  - pooch>=1.6.0 ; extra == 'examples'
+  - plotly>=5.14.0 ; extra == 'examples'
+  - matplotlib>=3.3.4 ; extra == 'tests'
+  - scikit-image>=0.17.2 ; extra == 'tests'
+  - pandas>=1.1.5 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.0.272 ; extra == 'tests'
+  - black>=23.3.0 ; extra == 'tests'
+  - mypy>=1.3 ; extra == 'tests'
+  - pyamg>=4.0.0 ; extra == 'tests'
+  - polars>=0.19.12 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.6.0 ; extra == 'tests'
   requires_python: '>=3.9'
 - kind: pypi
   name: scikit-learn
@@ -25473,46 +25442,46 @@ packages:
   url: https://files.pythonhosted.org/packages/79/3d/02d5d3ed359498fec3abdf65407d3c07e3b8765af17464969055aaec5171/scikit_learn-1.4.2-cp311-cp311-win_amd64.whl
   sha256: 5cd7b524115499b18b63f0c96f4224eb885564937a0b3477531b2b63ce331904
   requires_dist:
-  - numpy >=1.19.5
-  - scipy >=1.6.0
-  - joblib >=1.2.0
-  - threadpoolctl >=2.0.0
-  - matplotlib >=3.3.4 ; extra == 'benchmark'
-  - pandas >=1.1.5 ; extra == 'benchmark'
-  - memory-profiler >=0.57.0 ; extra == 'benchmark'
-  - matplotlib >=3.3.4 ; extra == 'docs'
-  - scikit-image >=0.17.2 ; extra == 'docs'
-  - pandas >=1.1.5 ; extra == 'docs'
-  - seaborn >=0.9.0 ; extra == 'docs'
-  - memory-profiler >=0.57.0 ; extra == 'docs'
-  - sphinx >=6.0.0 ; extra == 'docs'
-  - sphinx-copybutton >=0.5.2 ; extra == 'docs'
-  - sphinx-gallery >=0.15.0 ; extra == 'docs'
-  - numpydoc >=1.2.0 ; extra == 'docs'
-  - pillow >=7.1.2 ; extra == 'docs'
-  - pooch >=1.6.0 ; extra == 'docs'
-  - sphinx-prompt >=1.3.0 ; extra == 'docs'
-  - sphinxext-opengraph >=0.4.2 ; extra == 'docs'
-  - plotly >=5.14.0 ; extra == 'docs'
-  - matplotlib >=3.3.4 ; extra == 'examples'
-  - scikit-image >=0.17.2 ; extra == 'examples'
-  - pandas >=1.1.5 ; extra == 'examples'
-  - seaborn >=0.9.0 ; extra == 'examples'
-  - pooch >=1.6.0 ; extra == 'examples'
-  - plotly >=5.14.0 ; extra == 'examples'
-  - matplotlib >=3.3.4 ; extra == 'tests'
-  - scikit-image >=0.17.2 ; extra == 'tests'
-  - pandas >=1.1.5 ; extra == 'tests'
-  - pytest >=7.1.2 ; extra == 'tests'
-  - pytest-cov >=2.9.0 ; extra == 'tests'
-  - ruff >=0.0.272 ; extra == 'tests'
-  - black >=23.3.0 ; extra == 'tests'
-  - mypy >=1.3 ; extra == 'tests'
-  - pyamg >=4.0.0 ; extra == 'tests'
-  - polars >=0.19.12 ; extra == 'tests'
-  - pyarrow >=12.0.0 ; extra == 'tests'
-  - numpydoc >=1.2.0 ; extra == 'tests'
-  - pooch >=1.6.0 ; extra == 'tests'
+  - numpy>=1.19.5
+  - scipy>=1.6.0
+  - joblib>=1.2.0
+  - threadpoolctl>=2.0.0
+  - matplotlib>=3.3.4 ; extra == 'benchmark'
+  - pandas>=1.1.5 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.3.4 ; extra == 'docs'
+  - scikit-image>=0.17.2 ; extra == 'docs'
+  - pandas>=1.1.5 ; extra == 'docs'
+  - seaborn>=0.9.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=6.0.0 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.15.0 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=7.1.2 ; extra == 'docs'
+  - pooch>=1.6.0 ; extra == 'docs'
+  - sphinx-prompt>=1.3.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.4.2 ; extra == 'docs'
+  - plotly>=5.14.0 ; extra == 'docs'
+  - matplotlib>=3.3.4 ; extra == 'examples'
+  - scikit-image>=0.17.2 ; extra == 'examples'
+  - pandas>=1.1.5 ; extra == 'examples'
+  - seaborn>=0.9.0 ; extra == 'examples'
+  - pooch>=1.6.0 ; extra == 'examples'
+  - plotly>=5.14.0 ; extra == 'examples'
+  - matplotlib>=3.3.4 ; extra == 'tests'
+  - scikit-image>=0.17.2 ; extra == 'tests'
+  - pandas>=1.1.5 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.0.272 ; extra == 'tests'
+  - black>=23.3.0 ; extra == 'tests'
+  - mypy>=1.3 ; extra == 'tests'
+  - pyamg>=4.0.0 ; extra == 'tests'
+  - polars>=0.19.12 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.6.0 ; extra == 'tests'
   requires_python: '>=3.9'
 - kind: pypi
   name: scikit-learn
@@ -25520,85 +25489,93 @@ packages:
   url: https://files.pythonhosted.org/packages/f2/30/1299e84d2ba3bc735baf17cebbf5b9d55144243c41b3ec6559ce3cf61e23/scikit_learn-1.4.2-cp311-cp311-macosx_12_0_arm64.whl
   sha256: 1d0b25d9c651fd050555aadd57431b53d4cf664e749069da77f3d52c5ad14b3b
   requires_dist:
-  - numpy >=1.19.5
-  - scipy >=1.6.0
-  - joblib >=1.2.0
-  - threadpoolctl >=2.0.0
-  - matplotlib >=3.3.4 ; extra == 'benchmark'
-  - pandas >=1.1.5 ; extra == 'benchmark'
-  - memory-profiler >=0.57.0 ; extra == 'benchmark'
-  - matplotlib >=3.3.4 ; extra == 'docs'
-  - scikit-image >=0.17.2 ; extra == 'docs'
-  - pandas >=1.1.5 ; extra == 'docs'
-  - seaborn >=0.9.0 ; extra == 'docs'
-  - memory-profiler >=0.57.0 ; extra == 'docs'
-  - sphinx >=6.0.0 ; extra == 'docs'
-  - sphinx-copybutton >=0.5.2 ; extra == 'docs'
-  - sphinx-gallery >=0.15.0 ; extra == 'docs'
-  - numpydoc >=1.2.0 ; extra == 'docs'
-  - pillow >=7.1.2 ; extra == 'docs'
-  - pooch >=1.6.0 ; extra == 'docs'
-  - sphinx-prompt >=1.3.0 ; extra == 'docs'
-  - sphinxext-opengraph >=0.4.2 ; extra == 'docs'
-  - plotly >=5.14.0 ; extra == 'docs'
-  - matplotlib >=3.3.4 ; extra == 'examples'
-  - scikit-image >=0.17.2 ; extra == 'examples'
-  - pandas >=1.1.5 ; extra == 'examples'
-  - seaborn >=0.9.0 ; extra == 'examples'
-  - pooch >=1.6.0 ; extra == 'examples'
-  - plotly >=5.14.0 ; extra == 'examples'
-  - matplotlib >=3.3.4 ; extra == 'tests'
-  - scikit-image >=0.17.2 ; extra == 'tests'
-  - pandas >=1.1.5 ; extra == 'tests'
-  - pytest >=7.1.2 ; extra == 'tests'
-  - pytest-cov >=2.9.0 ; extra == 'tests'
-  - ruff >=0.0.272 ; extra == 'tests'
-  - black >=23.3.0 ; extra == 'tests'
-  - mypy >=1.3 ; extra == 'tests'
-  - pyamg >=4.0.0 ; extra == 'tests'
-  - polars >=0.19.12 ; extra == 'tests'
-  - pyarrow >=12.0.0 ; extra == 'tests'
-  - numpydoc >=1.2.0 ; extra == 'tests'
-  - pooch >=1.6.0 ; extra == 'tests'
+  - numpy>=1.19.5
+  - scipy>=1.6.0
+  - joblib>=1.2.0
+  - threadpoolctl>=2.0.0
+  - matplotlib>=3.3.4 ; extra == 'benchmark'
+  - pandas>=1.1.5 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.3.4 ; extra == 'docs'
+  - scikit-image>=0.17.2 ; extra == 'docs'
+  - pandas>=1.1.5 ; extra == 'docs'
+  - seaborn>=0.9.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=6.0.0 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.15.0 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=7.1.2 ; extra == 'docs'
+  - pooch>=1.6.0 ; extra == 'docs'
+  - sphinx-prompt>=1.3.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.4.2 ; extra == 'docs'
+  - plotly>=5.14.0 ; extra == 'docs'
+  - matplotlib>=3.3.4 ; extra == 'examples'
+  - scikit-image>=0.17.2 ; extra == 'examples'
+  - pandas>=1.1.5 ; extra == 'examples'
+  - seaborn>=0.9.0 ; extra == 'examples'
+  - pooch>=1.6.0 ; extra == 'examples'
+  - plotly>=5.14.0 ; extra == 'examples'
+  - matplotlib>=3.3.4 ; extra == 'tests'
+  - scikit-image>=0.17.2 ; extra == 'tests'
+  - pandas>=1.1.5 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.0.272 ; extra == 'tests'
+  - black>=23.3.0 ; extra == 'tests'
+  - mypy>=1.3 ; extra == 'tests'
+  - pyamg>=4.0.0 ; extra == 'tests'
+  - polars>=0.19.12 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.6.0 ; extra == 'tests'
   requires_python: '>=3.9'
 - kind: pypi
-  name: scipy
-  version: 1.13.0
-  url: https://files.pythonhosted.org/packages/be/e3/236639c51636ec7e678f2aa608fe89acb9d02ef64e1fe1d8eb40373bc62b/scipy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 0fbcf8abaf5aa2dc8d6400566c1a727aed338b5fe880cde64907596a89d576fa
+  name: scikit-learn
+  version: 1.4.2
+  url: https://files.pythonhosted.org/packages/59/11/63de36e6933b03490fdfe5cbc9b5a68870a1281d8e705a23b33076dc82fb/scikit_learn-1.4.2-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 45dee87ac5309bb82e3ea633955030df9bbcb8d2cdb30383c6cd483691c546cc
   requires_dist:
-  - numpy <2.3, >=1.22.4
-  - pytest ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  - pytest-timeout ; extra == 'test'
-  - pytest-xdist ; extra == 'test'
-  - asv ; extra == 'test'
-  - mpmath ; extra == 'test'
-  - gmpy2 ; extra == 'test'
-  - threadpoolctl ; extra == 'test'
-  - scikit-umfpack ; extra == 'test'
-  - pooch ; extra == 'test'
-  - hypothesis >=6.30 ; extra == 'test'
-  - array-api-strict ; extra == 'test'
-  - sphinx >=5.0.0 ; extra == 'doc'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'doc'
-  - sphinx-design >=0.4.0 ; extra == 'doc'
-  - matplotlib >=3.5 ; extra == 'doc'
-  - numpydoc ; extra == 'doc'
-  - jupytext ; extra == 'doc'
-  - myst-nb ; extra == 'doc'
-  - pooch ; extra == 'doc'
-  - jupyterlite-sphinx >=0.12.0 ; extra == 'doc'
-  - jupyterlite-pyodide-kernel ; extra == 'doc'
-  - mypy ; extra == 'dev'
-  - typing-extensions ; extra == 'dev'
-  - types-psutil ; extra == 'dev'
-  - pycodestyle ; extra == 'dev'
-  - ruff ; extra == 'dev'
-  - cython-lint >=0.12.2 ; extra == 'dev'
-  - rich-click ; extra == 'dev'
-  - doit >=0.36.0 ; extra == 'dev'
-  - pydevtool ; extra == 'dev'
+  - numpy>=1.19.5
+  - scipy>=1.6.0
+  - joblib>=1.2.0
+  - threadpoolctl>=2.0.0
+  - matplotlib>=3.3.4 ; extra == 'benchmark'
+  - pandas>=1.1.5 ; extra == 'benchmark'
+  - memory-profiler>=0.57.0 ; extra == 'benchmark'
+  - matplotlib>=3.3.4 ; extra == 'docs'
+  - scikit-image>=0.17.2 ; extra == 'docs'
+  - pandas>=1.1.5 ; extra == 'docs'
+  - seaborn>=0.9.0 ; extra == 'docs'
+  - memory-profiler>=0.57.0 ; extra == 'docs'
+  - sphinx>=6.0.0 ; extra == 'docs'
+  - sphinx-copybutton>=0.5.2 ; extra == 'docs'
+  - sphinx-gallery>=0.15.0 ; extra == 'docs'
+  - numpydoc>=1.2.0 ; extra == 'docs'
+  - pillow>=7.1.2 ; extra == 'docs'
+  - pooch>=1.6.0 ; extra == 'docs'
+  - sphinx-prompt>=1.3.0 ; extra == 'docs'
+  - sphinxext-opengraph>=0.4.2 ; extra == 'docs'
+  - plotly>=5.14.0 ; extra == 'docs'
+  - matplotlib>=3.3.4 ; extra == 'examples'
+  - scikit-image>=0.17.2 ; extra == 'examples'
+  - pandas>=1.1.5 ; extra == 'examples'
+  - seaborn>=0.9.0 ; extra == 'examples'
+  - pooch>=1.6.0 ; extra == 'examples'
+  - plotly>=5.14.0 ; extra == 'examples'
+  - matplotlib>=3.3.4 ; extra == 'tests'
+  - scikit-image>=0.17.2 ; extra == 'tests'
+  - pandas>=1.1.5 ; extra == 'tests'
+  - pytest>=7.1.2 ; extra == 'tests'
+  - pytest-cov>=2.9.0 ; extra == 'tests'
+  - ruff>=0.0.272 ; extra == 'tests'
+  - black>=23.3.0 ; extra == 'tests'
+  - mypy>=1.3 ; extra == 'tests'
+  - pyamg>=4.0.0 ; extra == 'tests'
+  - polars>=0.19.12 ; extra == 'tests'
+  - pyarrow>=12.0.0 ; extra == 'tests'
+  - numpydoc>=1.2.0 ; extra == 'tests'
+  - pooch>=1.6.0 ; extra == 'tests'
   requires_python: '>=3.9'
 - kind: pypi
   name: scipy
@@ -25606,7 +25583,7 @@ packages:
   url: https://files.pythonhosted.org/packages/e8/fb/e5955e2ddbdf2baee461eb53ec8d0adedd20a6dfc5510ef8d5e7e44ba461/scipy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 9ff7dad5d24a8045d836671e082a490848e8639cabb3dbdacb29f943a678683d
   requires_dist:
-  - numpy <2.3, >=1.22.4
+  - numpy<2.3,>=1.22.4
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
@@ -25617,26 +25594,26 @@ packages:
   - threadpoolctl ; extra == 'test'
   - scikit-umfpack ; extra == 'test'
   - pooch ; extra == 'test'
-  - hypothesis >=6.30 ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
   - array-api-strict ; extra == 'test'
-  - sphinx >=5.0.0 ; extra == 'doc'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'doc'
-  - sphinx-design >=0.4.0 ; extra == 'doc'
-  - matplotlib >=3.5 ; extra == 'doc'
+  - sphinx>=5.0.0 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
   - numpydoc ; extra == 'doc'
   - jupytext ; extra == 'doc'
   - myst-nb ; extra == 'doc'
   - pooch ; extra == 'doc'
-  - jupyterlite-sphinx >=0.12.0 ; extra == 'doc'
+  - jupyterlite-sphinx>=0.12.0 ; extra == 'doc'
   - jupyterlite-pyodide-kernel ; extra == 'doc'
   - mypy ; extra == 'dev'
   - typing-extensions ; extra == 'dev'
   - types-psutil ; extra == 'dev'
   - pycodestyle ; extra == 'dev'
   - ruff ; extra == 'dev'
-  - cython-lint >=0.12.2 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
   - rich-click ; extra == 'dev'
-  - doit >=0.36.0 ; extra == 'dev'
+  - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.9'
 - kind: pypi
@@ -25645,7 +25622,7 @@ packages:
   url: https://files.pythonhosted.org/packages/d4/a1/d4adf25b6d2bef8d0ad1682829dcfcba97f3f96bb5b6f137bc3e41003cc7/scipy-1.13.0-cp311-cp311-win_amd64.whl
   sha256: a2f471de4d01200718b2b8927f7d76b5d9bde18047ea0fa8bd15c5ba3f26a1d6
   requires_dist:
-  - numpy <2.3, >=1.22.4
+  - numpy<2.3,>=1.22.4
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
@@ -25656,26 +25633,26 @@ packages:
   - threadpoolctl ; extra == 'test'
   - scikit-umfpack ; extra == 'test'
   - pooch ; extra == 'test'
-  - hypothesis >=6.30 ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
   - array-api-strict ; extra == 'test'
-  - sphinx >=5.0.0 ; extra == 'doc'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'doc'
-  - sphinx-design >=0.4.0 ; extra == 'doc'
-  - matplotlib >=3.5 ; extra == 'doc'
+  - sphinx>=5.0.0 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
   - numpydoc ; extra == 'doc'
   - jupytext ; extra == 'doc'
   - myst-nb ; extra == 'doc'
   - pooch ; extra == 'doc'
-  - jupyterlite-sphinx >=0.12.0 ; extra == 'doc'
+  - jupyterlite-sphinx>=0.12.0 ; extra == 'doc'
   - jupyterlite-pyodide-kernel ; extra == 'doc'
   - mypy ; extra == 'dev'
   - typing-extensions ; extra == 'dev'
   - types-psutil ; extra == 'dev'
   - pycodestyle ; extra == 'dev'
   - ruff ; extra == 'dev'
-  - cython-lint >=0.12.2 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
   - rich-click ; extra == 'dev'
-  - doit >=0.36.0 ; extra == 'dev'
+  - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.9'
 - kind: pypi
@@ -25684,7 +25661,7 @@ packages:
   url: https://files.pythonhosted.org/packages/51/b6/188c8974d747b2998d672040c5b62a635a72240c515dc4577a28e1dedc80/scipy-1.13.0-cp311-cp311-macosx_12_0_arm64.whl
   sha256: 5e4a756355522eb60fcd61f8372ac2549073c8788f6114449b37e9e8104f15a5
   requires_dist:
-  - numpy <2.3, >=1.22.4
+  - numpy<2.3,>=1.22.4
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   - pytest-timeout ; extra == 'test'
@@ -25695,26 +25672,65 @@ packages:
   - threadpoolctl ; extra == 'test'
   - scikit-umfpack ; extra == 'test'
   - pooch ; extra == 'test'
-  - hypothesis >=6.30 ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
   - array-api-strict ; extra == 'test'
-  - sphinx >=5.0.0 ; extra == 'doc'
-  - pydata-sphinx-theme >=0.15.2 ; extra == 'doc'
-  - sphinx-design >=0.4.0 ; extra == 'doc'
-  - matplotlib >=3.5 ; extra == 'doc'
+  - sphinx>=5.0.0 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
   - numpydoc ; extra == 'doc'
   - jupytext ; extra == 'doc'
   - myst-nb ; extra == 'doc'
   - pooch ; extra == 'doc'
-  - jupyterlite-sphinx >=0.12.0 ; extra == 'doc'
+  - jupyterlite-sphinx>=0.12.0 ; extra == 'doc'
   - jupyterlite-pyodide-kernel ; extra == 'doc'
   - mypy ; extra == 'dev'
   - typing-extensions ; extra == 'dev'
   - types-psutil ; extra == 'dev'
   - pycodestyle ; extra == 'dev'
   - ruff ; extra == 'dev'
-  - cython-lint >=0.12.2 ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
   - rich-click ; extra == 'dev'
-  - doit >=0.36.0 ; extra == 'dev'
+  - doit>=0.36.0 ; extra == 'dev'
+  - pydevtool ; extra == 'dev'
+  requires_python: '>=3.9'
+- kind: pypi
+  name: scipy
+  version: 1.13.0
+  url: https://files.pythonhosted.org/packages/be/e3/236639c51636ec7e678f2aa608fe89acb9d02ef64e1fe1d8eb40373bc62b/scipy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 0fbcf8abaf5aa2dc8d6400566c1a727aed338b5fe880cde64907596a89d576fa
+  requires_dist:
+  - numpy<2.3,>=1.22.4
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - pytest-timeout ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - asv ; extra == 'test'
+  - mpmath ; extra == 'test'
+  - gmpy2 ; extra == 'test'
+  - threadpoolctl ; extra == 'test'
+  - scikit-umfpack ; extra == 'test'
+  - pooch ; extra == 'test'
+  - hypothesis>=6.30 ; extra == 'test'
+  - array-api-strict ; extra == 'test'
+  - sphinx>=5.0.0 ; extra == 'doc'
+  - pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+  - sphinx-design>=0.4.0 ; extra == 'doc'
+  - matplotlib>=3.5 ; extra == 'doc'
+  - numpydoc ; extra == 'doc'
+  - jupytext ; extra == 'doc'
+  - myst-nb ; extra == 'doc'
+  - pooch ; extra == 'doc'
+  - jupyterlite-sphinx>=0.12.0 ; extra == 'doc'
+  - jupyterlite-pyodide-kernel ; extra == 'doc'
+  - mypy ; extra == 'dev'
+  - typing-extensions ; extra == 'dev'
+  - types-psutil ; extra == 'dev'
+  - pycodestyle ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - cython-lint>=0.12.2 ; extra == 'dev'
+  - rich-click ; extra == 'dev'
+  - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.9'
 - kind: pypi
@@ -25737,12 +25753,12 @@ packages:
   path: examples/python/segment_anything_model
   sha256: 85bc241bedf212c63a39d0251a9dcc0fb3a435087a024d4eafd7f49342a75926
   requires_dist:
+  - segment-anything @ git+https://github.com/facebookresearch/segment-anything.git
   - numpy
   - opencv-python
-  - requests <3, >=2.31
+  - requests>=2.31,<3
   - rerun-sdk
-  - segment-anything @ git+https://github.com/facebookresearch/segment-anything.git
-  - torch ==2.2.2
+  - torch==2.2.2
   - torchvision
   - tqdm
   editable: true
@@ -25821,26 +25837,11 @@ packages:
 - kind: pypi
   name: shapely
   version: 2.0.4
-  url: https://files.pythonhosted.org/packages/93/fd/b205661ed60294a344406fb04227042fcede9501e81ee1e7018e9159455a/shapely-2.0.4-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 7d56ce3e2a6a556b59a288771cf9d091470116867e578bebced8bfc4147fbfd7
-  requires_dist:
-  - numpy <3, >=1.14
-  - numpydoc ==1.1.* ; extra == 'docs'
-  - matplotlib ; extra == 'docs'
-  - sphinx ; extra == 'docs'
-  - sphinx-book-theme ; extra == 'docs'
-  - sphinx-remove-toctrees ; extra == 'docs'
-  - pytest ; extra == 'test'
-  - pytest-cov ; extra == 'test'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: shapely
-  version: 2.0.4
   url: https://files.pythonhosted.org/packages/d5/fb/bcf6a8164ed307c99f1a8fabe5acd86ac99a33f52530a3ca84b0936f95bd/shapely-2.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: 4310b5494271e18580d61022c0857eb85d30510d88606fa3b8314790df7f367d
   requires_dist:
-  - numpy <3, >=1.14
-  - numpydoc ==1.1.* ; extra == 'docs'
+  - numpy<3,>=1.14
+  - numpydoc==1.1.* ; extra == 'docs'
   - matplotlib ; extra == 'docs'
   - sphinx ; extra == 'docs'
   - sphinx-book-theme ; extra == 'docs'
@@ -25854,8 +25855,8 @@ packages:
   url: https://files.pythonhosted.org/packages/6a/5c/3330f499ca860f0b92db4ceaebd7090096a83c1ea3ae7d8d4c6111761b82/shapely-2.0.4-cp311-cp311-win_amd64.whl
   sha256: c52ed79f683f721b69a10fb9e3d940a468203f5054927215586c5d49a072de8d
   requires_dist:
-  - numpy <3, >=1.14
-  - numpydoc ==1.1.* ; extra == 'docs'
+  - numpy<3,>=1.14
+  - numpydoc==1.1.* ; extra == 'docs'
   - matplotlib ; extra == 'docs'
   - sphinx ; extra == 'docs'
   - sphinx-book-theme ; extra == 'docs'
@@ -25869,8 +25870,23 @@ packages:
   url: https://files.pythonhosted.org/packages/2a/fb/e3f72b10a90e26bb1a92a38b3f30f3074ebac6d532f87848ac09c3e8a73b/shapely-2.0.4-cp311-cp311-macosx_11_0_arm64.whl
   sha256: 58b0ecc505bbe49a99551eea3f2e8a9b3b24b3edd2a4de1ac0dc17bc75c9ec07
   requires_dist:
-  - numpy <3, >=1.14
-  - numpydoc ==1.1.* ; extra == 'docs'
+  - numpy<3,>=1.14
+  - numpydoc==1.1.* ; extra == 'docs'
+  - matplotlib ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-book-theme ; extra == 'docs'
+  - sphinx-remove-toctrees ; extra == 'docs'
+  - pytest ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: shapely
+  version: 2.0.4
+  url: https://files.pythonhosted.org/packages/93/fd/b205661ed60294a344406fb04227042fcede9501e81ee1e7018e9159455a/shapely-2.0.4-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 7d56ce3e2a6a556b59a288771cf9d091470116867e578bebced8bfc4147fbfd7
+  requires_dist:
+  - numpy<3,>=1.14
+  - numpydoc==1.1.* ; extra == 'docs'
   - matplotlib ; extra == 'docs'
   - sphinx ; extra == 'docs'
   - sphinx-book-theme ; extra == 'docs'
@@ -25894,10 +25910,10 @@ packages:
   requires_dist:
   - mesh-to-sdf @ git+https://github.com/marian42/mesh_to_sdf.git
   - numpy
-  - requests <3, >=2.31
+  - requests>=2.31,<3
   - rerun-sdk
-  - scikit-learn >=1.1.3
-  - trimesh ==3.15.2
+  - scikit-learn>=1.1.3
+  - trimesh==3.15.2
   editable: true
 - kind: conda
   name: sigtool
@@ -26108,19 +26124,10 @@ packages:
 - kind: pypi
   name: sounddevice
   version: 0.4.6
-  url: https://files.pythonhosted.org/packages/24/5a/c0b9066fcaf783054b3f35254938dcba2d8cf02576ebdc56b6b4e85661f2/sounddevice-0.4.6-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl
-  sha256: 8b0b806c205dd3e3cd5a97262b2482624fd21db7d47083b887090148a08051c8
-  requires_dist:
-  - cffi >=1.0
-  - numpy ; extra == 'numpy'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: sounddevice
-  version: 0.4.6
   url: https://files.pythonhosted.org/packages/d7/d5/f0a0aba169f23657c7af3f0c878db7413a9a3b113026fc759862a697c611/sounddevice-0.4.6-py3-none-any.whl
   sha256: 5de768ba6fe56ad2b5aaa2eea794b76b73e427961c95acad2ee2ed7f866a4b20
   requires_dist:
-  - cffi >=1.0
+  - cffi>=1.0
   - numpy ; extra == 'numpy'
   requires_python: '>=3.7'
 - kind: pypi
@@ -26129,7 +26136,16 @@ packages:
   url: https://files.pythonhosted.org/packages/39/ae/5e84220bfca4256e4ca2a62a174636089ab6ff671b5f9ddd7e8238587acd/sounddevice-0.4.6-py3-none-win_amd64.whl
   sha256: 7830d4f8f8570f2e5552942f81d96999c5fcd9a0b682d6fc5d5c5529df23be2c
   requires_dist:
-  - cffi >=1.0
+  - cffi>=1.0
+  - numpy ; extra == 'numpy'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: sounddevice
+  version: 0.4.6
+  url: https://files.pythonhosted.org/packages/24/5a/c0b9066fcaf783054b3f35254938dcba2d8cf02576ebdc56b6b4e85661f2/sounddevice-0.4.6-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl
+  sha256: 8b0b806c205dd3e3cd5a97262b2482624fd21db7d47083b887090148a08051c8
+  requires_dist:
+  - cffi>=1.0
   - numpy ; extra == 'numpy'
   requires_python: '>=3.7'
 - kind: pypi
@@ -26157,9 +26173,9 @@ packages:
   path: examples/python/structure_from_motion
   sha256: b20b79aa7bb2b4225b37d3cb28872a70dc7e9ab2ca9ab138b90d60fc8d7b4c15
   requires_dist:
+  - opencv-python>4.6
   - numpy
-  - opencv-python >4.6
-  - requests <3, >=2.31
+  - requests>=2.31,<3
   - rerun-sdk
   - tqdm
   editable: true
@@ -26169,7 +26185,7 @@ packages:
   url: https://files.pythonhosted.org/packages/d2/05/e6600db80270777c4a64238a98d442f0fd07cc8915be2a1c16da7f2b9e74/sympy-1.12-py3-none-any.whl
   sha256: c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5
   requires_dist:
-  - mpmath >=0.19
+  - mpmath>=0.19
   requires_python: '>=3.8'
 - kind: conda
   name: sysroot_linux-64
@@ -26360,7 +26376,7 @@ packages:
   sha256: 4154f091aa24d4e75bfad9ab2d5424a68c70e67b8220188066dc61946d4551bd
   requires_dist:
   - numpy
-  - imagecodecs >=2023.8.12 ; extra == 'all'
+  - imagecodecs>=2023.8.12 ; extra == 'all'
   - matplotlib ; extra == 'all'
   - defusedxml ; extra == 'all'
   - lxml ; extra == 'all'
@@ -26373,7 +26389,7 @@ packages:
   url: https://files.pythonhosted.org/packages/76/aa/4b54f6047c442883243f68f6f9e3a0ab77aaae4b3e6e51a98b371e73dd77/timm-0.9.11-py3-none-any.whl
   sha256: 02bba56786633ff46b55ee0ce3b991fa85375556844e500ad18e6b12921dc3da
   requires_dist:
-  - torch >=1.7
+  - torch>=1.7
   - torchvision
   - pyyaml
   - huggingface-hub
@@ -26527,33 +26543,15 @@ packages:
 - kind: pypi
   name: tokenizers
   version: 0.19.1
-  url: https://files.pythonhosted.org/packages/c8/d6/6e1d728d765eb4102767f071bf7f6439ab10d7f4a975c9217db65715207a/tokenizers-0.19.1-cp311-cp311-macosx_10_12_x86_64.whl
-  sha256: 5c88d1481f1882c2e53e6bb06491e474e420d9ac7bdff172610c4f9ad3898059
-  requires_dist:
-  - huggingface-hub >=0.16.4, <1.0
-  - pytest ; extra == 'testing'
-  - requests ; extra == 'testing'
-  - numpy ; extra == 'testing'
-  - datasets ; extra == 'testing'
-  - black ==22.3 ; extra == 'testing'
-  - ruff ; extra == 'testing'
-  - sphinx ; extra == 'docs'
-  - sphinx-rtd-theme ; extra == 'docs'
-  - setuptools-rust ; extra == 'docs'
-  - tokenizers[testing] ; extra == 'dev'
-  requires_python: '>=3.7'
-- kind: pypi
-  name: tokenizers
-  version: 0.19.1
   url: https://files.pythonhosted.org/packages/a7/03/fb50fc03f86016b227a967c8d474f90230c885c0d18f78acdfda7a96ce56/tokenizers-0.19.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   sha256: d16ff18907f4909dca9b076b9c2d899114dd6abceeb074eca0c93e2353f943aa
   requires_dist:
-  - huggingface-hub >=0.16.4, <1.0
+  - huggingface-hub>=0.16.4,<1.0
   - pytest ; extra == 'testing'
   - requests ; extra == 'testing'
   - numpy ; extra == 'testing'
   - datasets ; extra == 'testing'
-  - black ==22.3 ; extra == 'testing'
+  - black==22.3 ; extra == 'testing'
   - ruff ; extra == 'testing'
   - sphinx ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
@@ -26566,12 +26564,12 @@ packages:
   url: https://files.pythonhosted.org/packages/65/8e/6d7d72b28f22c422cff8beae10ac3c2e4376b9be721ef8167b7eecd1da62/tokenizers-0.19.1-cp311-none-win_amd64.whl
   sha256: ad57d59341710b94a7d9dbea13f5c1e7d76fd8d9bcd944a7a6ab0b0da6e0cc66
   requires_dist:
-  - huggingface-hub >=0.16.4, <1.0
+  - huggingface-hub>=0.16.4,<1.0
   - pytest ; extra == 'testing'
   - requests ; extra == 'testing'
   - numpy ; extra == 'testing'
   - datasets ; extra == 'testing'
-  - black ==22.3 ; extra == 'testing'
+  - black==22.3 ; extra == 'testing'
   - ruff ; extra == 'testing'
   - sphinx ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
@@ -26584,12 +26582,30 @@ packages:
   url: https://files.pythonhosted.org/packages/90/79/d17a0f491d10817cd30f1121a07aa09c8e97a81114b116e473baf1577f09/tokenizers-0.19.1-cp311-cp311-macosx_11_0_arm64.whl
   sha256: ddf672ed719b4ed82b51499100f5417d7d9f6fb05a65e232249268f35de5ed14
   requires_dist:
-  - huggingface-hub >=0.16.4, <1.0
+  - huggingface-hub>=0.16.4,<1.0
   - pytest ; extra == 'testing'
   - requests ; extra == 'testing'
   - numpy ; extra == 'testing'
   - datasets ; extra == 'testing'
-  - black ==22.3 ; extra == 'testing'
+  - black==22.3 ; extra == 'testing'
+  - ruff ; extra == 'testing'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  - setuptools-rust ; extra == 'docs'
+  - tokenizers[testing] ; extra == 'dev'
+  requires_python: '>=3.7'
+- kind: pypi
+  name: tokenizers
+  version: 0.19.1
+  url: https://files.pythonhosted.org/packages/c8/d6/6e1d728d765eb4102767f071bf7f6439ab10d7f4a975c9217db65715207a/tokenizers-0.19.1-cp311-cp311-macosx_10_12_x86_64.whl
+  sha256: 5c88d1481f1882c2e53e6bb06491e474e420d9ac7bdff172610c4f9ad3898059
+  requires_dist:
+  - huggingface-hub>=0.16.4,<1.0
+  - pytest ; extra == 'testing'
+  - requests ; extra == 'testing'
+  - numpy ; extra == 'testing'
+  - datasets ; extra == 'testing'
+  - black==22.3 ; extra == 'testing'
   - ruff ; extra == 'testing'
   - sphinx ; extra == 'docs'
   - sphinx-rtd-theme ; extra == 'docs'
@@ -26637,56 +26653,56 @@ packages:
 - kind: pypi
   name: torch
   version: 2.2.2
-  url: https://files.pythonhosted.org/packages/02/af/81abea3d73fddfde26afd1ce52a4ddfa389cd2b684c89d6c4d0d5d8d0dfa/torch-2.2.2-cp311-cp311-manylinux2014_aarch64.whl
-  sha256: 32827fa1fbe5da8851686256b4cd94cc7b11be962862c2293811c94eea9457bf
+  url: https://files.pythonhosted.org/packages/3f/14/e105b8ef6d324e789c1589e95cb0ab63f3e07c2216d68b1178b7c21b7d2a/torch-2.2.2-cp311-none-macosx_10_9_x86_64.whl
+  sha256: 95b9b44f3bcebd8b6cd8d37ec802048c872d9c567ba52c894bba90863a439059
   requires_dist:
   - filelock
-  - typing-extensions >=4.8.0
+  - typing-extensions>=4.8.0
   - sympy
   - networkx
   - jinja2
   - fsspec
-  - nvidia-cuda-nvrtc-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-runtime-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-cupti-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cudnn-cu12 ==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cublas-cu12 ==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cufft-cu12 ==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-curand-cu12 ==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusolver-cu12 ==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusparse-cu12 ==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nccl-cu12 ==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nvtx-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - triton ==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
-  - opt-einsum >=3.3 ; extra == 'opt-einsum'
-  - optree >=0.9.1 ; extra == 'optree'
+  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cudnn-cu12==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cublas-cu12==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cufft-cu12==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-curand-cu12==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusolver-cu12==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusparse-cu12==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nccl-cu12==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nvtx-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - triton==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - optree>=0.9.1 ; extra == 'optree'
   requires_python: '>=3.8.0'
 - kind: pypi
   name: torch
   version: 2.2.2
-  url: https://files.pythonhosted.org/packages/5c/01/5ab75f138bf32d7a69df61e4997e24eccad87cc009f5fb7e2a31af8a4036/torch-2.2.2-cp311-cp311-win_amd64.whl
-  sha256: f9ef0a648310435511e76905f9b89612e45ef2c8b023bee294f5e6f7e73a3e7c
+  url: https://files.pythonhosted.org/packages/02/af/81abea3d73fddfde26afd1ce52a4ddfa389cd2b684c89d6c4d0d5d8d0dfa/torch-2.2.2-cp311-cp311-manylinux2014_aarch64.whl
+  sha256: 32827fa1fbe5da8851686256b4cd94cc7b11be962862c2293811c94eea9457bf
   requires_dist:
   - filelock
-  - typing-extensions >=4.8.0
+  - typing-extensions>=4.8.0
   - sympy
   - networkx
   - jinja2
   - fsspec
-  - nvidia-cuda-nvrtc-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-runtime-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-cupti-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cudnn-cu12 ==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cublas-cu12 ==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cufft-cu12 ==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-curand-cu12 ==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusolver-cu12 ==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusparse-cu12 ==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nccl-cu12 ==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nvtx-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - triton ==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
-  - opt-einsum >=3.3 ; extra == 'opt-einsum'
-  - optree >=0.9.1 ; extra == 'optree'
+  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cudnn-cu12==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cublas-cu12==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cufft-cu12==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-curand-cu12==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusolver-cu12==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusparse-cu12==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nccl-cu12==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nvtx-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - triton==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - optree>=0.9.1 ; extra == 'optree'
   requires_python: '>=3.8.0'
 - kind: pypi
   name: torch
@@ -26695,25 +26711,52 @@ packages:
   sha256: ad4c03b786e074f46606f4151c0a1e3740268bcf29fbd2fdf6666d66341c1dcb
   requires_dist:
   - filelock
-  - typing-extensions >=4.8.0
+  - typing-extensions>=4.8.0
   - sympy
   - networkx
   - jinja2
   - fsspec
-  - nvidia-cuda-nvrtc-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-runtime-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-cupti-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cudnn-cu12 ==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cublas-cu12 ==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cufft-cu12 ==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-curand-cu12 ==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusolver-cu12 ==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusparse-cu12 ==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nccl-cu12 ==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nvtx-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - triton ==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
-  - opt-einsum >=3.3 ; extra == 'opt-einsum'
-  - optree >=0.9.1 ; extra == 'optree'
+  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cudnn-cu12==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cublas-cu12==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cufft-cu12==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-curand-cu12==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusolver-cu12==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusparse-cu12==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nccl-cu12==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nvtx-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - triton==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - optree>=0.9.1 ; extra == 'optree'
+  requires_python: '>=3.8.0'
+- kind: pypi
+  name: torch
+  version: 2.2.2
+  url: https://files.pythonhosted.org/packages/5c/01/5ab75f138bf32d7a69df61e4997e24eccad87cc009f5fb7e2a31af8a4036/torch-2.2.2-cp311-cp311-win_amd64.whl
+  sha256: f9ef0a648310435511e76905f9b89612e45ef2c8b023bee294f5e6f7e73a3e7c
+  requires_dist:
+  - filelock
+  - typing-extensions>=4.8.0
+  - sympy
+  - networkx
+  - jinja2
+  - fsspec
+  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cudnn-cu12==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cublas-cu12==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cufft-cu12==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-curand-cu12==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusolver-cu12==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusparse-cu12==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nccl-cu12==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nvtx-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - triton==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - optree>=0.9.1 ; extra == 'optree'
   requires_python: '>=3.8.0'
 - kind: pypi
   name: torch
@@ -26722,64 +26765,26 @@ packages:
   sha256: 49aa4126ede714c5aeef7ae92969b4b0bbe67f19665106463c39f22e0a1860d1
   requires_dist:
   - filelock
-  - typing-extensions >=4.8.0
+  - typing-extensions>=4.8.0
   - sympy
   - networkx
   - jinja2
   - fsspec
-  - nvidia-cuda-nvrtc-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-runtime-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-cupti-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cudnn-cu12 ==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cublas-cu12 ==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cufft-cu12 ==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-curand-cu12 ==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusolver-cu12 ==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusparse-cu12 ==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nccl-cu12 ==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nvtx-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - triton ==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
-  - opt-einsum >=3.3 ; extra == 'opt-einsum'
-  - optree >=0.9.1 ; extra == 'optree'
+  - nvidia-cuda-nvrtc-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-runtime-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cuda-cupti-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cudnn-cu12==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cublas-cu12==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cufft-cu12==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-curand-cu12==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusolver-cu12==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-cusparse-cu12==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nccl-cu12==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - nvidia-nvtx-cu12==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
+  - triton==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
+  - opt-einsum>=3.3 ; extra == 'opt-einsum'
+  - optree>=0.9.1 ; extra == 'optree'
   requires_python: '>=3.8.0'
-- kind: pypi
-  name: torch
-  version: 2.2.2
-  url: https://files.pythonhosted.org/packages/3f/14/e105b8ef6d324e789c1589e95cb0ab63f3e07c2216d68b1178b7c21b7d2a/torch-2.2.2-cp311-none-macosx_10_9_x86_64.whl
-  sha256: 95b9b44f3bcebd8b6cd8d37ec802048c872d9c567ba52c894bba90863a439059
-  requires_dist:
-  - filelock
-  - typing-extensions >=4.8.0
-  - sympy
-  - networkx
-  - jinja2
-  - fsspec
-  - nvidia-cuda-nvrtc-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-runtime-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cuda-cupti-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cudnn-cu12 ==8.9.2.26 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cublas-cu12 ==12.1.3.1 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cufft-cu12 ==11.0.2.54 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-curand-cu12 ==10.3.2.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusolver-cu12 ==11.4.5.107 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-cusparse-cu12 ==12.1.0.106 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nccl-cu12 ==2.19.3 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - nvidia-nvtx-cu12 ==12.1.105 ; platform_system == 'Linux' and platform_machine == 'x86_64'
-  - triton ==2.2.0 ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version < '3.12'
-  - opt-einsum >=3.3 ; extra == 'opt-einsum'
-  - optree >=0.9.1 ; extra == 'optree'
-  requires_python: '>=3.8.0'
-- kind: pypi
-  name: torchvision
-  version: 0.17.2
-  url: https://files.pythonhosted.org/packages/46/95/179dd1bf8fd6bd689f0907f4baed557d2b12d2cf3d7ed1a8ecefe0a63d83/torchvision-0.17.2-cp311-cp311-macosx_10_13_x86_64.whl
-  sha256: 9b83e55ee7d0a1704f52b9c0ac87388e7a6d1d98a6bde7b0b35f9ab54d7bda54
-  requires_dist:
-  - numpy
-  - torch ==2.2.2
-  - pillow !=8.3.*, >=5.3.0
-  - scipy ; extra == 'scipy'
-  requires_python: '>=3.8'
 - kind: pypi
   name: torchvision
   version: 0.17.2
@@ -26787,8 +26792,8 @@ packages:
   sha256: 3bbc24b7713e8f22766992562547d8b4b10001208d372fe599255af84bfd1a69
   requires_dist:
   - numpy
-  - torch ==2.2.2
-  - pillow !=8.3.*, >=5.3.0
+  - torch==2.2.2
+  - pillow!=8.3.*,>=5.3.0
   - scipy ; extra == 'scipy'
   requires_python: '>=3.8'
 - kind: pypi
@@ -26798,8 +26803,8 @@ packages:
   sha256: 6835897df852fad1015e6a106c167c83848114cbcc7d86112384a973404e4431
   requires_dist:
   - numpy
-  - torch ==2.2.2
-  - pillow !=8.3.*, >=5.3.0
+  - torch==2.2.2
+  - pillow!=8.3.*,>=5.3.0
   - scipy ; extra == 'scipy'
   requires_python: '>=3.8'
 - kind: pypi
@@ -26809,8 +26814,19 @@ packages:
   sha256: e031004a1bc432c980a7bd642f6c189a3efc316e423fc30b5569837166a4e28d
   requires_dist:
   - numpy
-  - torch ==2.2.2
-  - pillow !=8.3.*, >=5.3.0
+  - torch==2.2.2
+  - pillow!=8.3.*,>=5.3.0
+  - scipy ; extra == 'scipy'
+  requires_python: '>=3.8'
+- kind: pypi
+  name: torchvision
+  version: 0.17.2
+  url: https://files.pythonhosted.org/packages/46/95/179dd1bf8fd6bd689f0907f4baed557d2b12d2cf3d7ed1a8ecefe0a63d83/torchvision-0.17.2-cp311-cp311-macosx_10_13_x86_64.whl
+  sha256: 9b83e55ee7d0a1704f52b9c0ac87388e7a6d1d98a6bde7b0b35f9ab54d7bda54
+  requires_dist:
+  - numpy
+  - torch==2.2.2
+  - pillow!=8.3.*,>=5.3.0
   - scipy ; extra == 'scipy'
   requires_python: '>=3.8'
 - kind: pypi
@@ -26820,11 +26836,11 @@ packages:
   sha256: b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644
   requires_dist:
   - colorama ; platform_system == 'Windows'
-  - pytest >=6 ; extra == 'dev'
+  - pytest>=6 ; extra == 'dev'
   - pytest-cov ; extra == 'dev'
   - pytest-timeout ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
-  - ipywidgets >=6 ; extra == 'notebook'
+  - ipywidgets>=6 ; extra == 'notebook'
   - slack-sdk ; extra == 'slack'
   - requests ; extra == 'telegram'
   requires_python: '>=3.7'
@@ -26852,308 +26868,308 @@ packages:
   sha256: 71cb94301ec211a2e1d4b8c8d18dcfaa902dfa00a089dceca167a8aa265d6f2d
   requires_dist:
   - filelock
-  - huggingface-hub <1.0, >=0.19.3
-  - numpy >=1.17
-  - packaging >=20.0
-  - pyyaml >=5.1
-  - regex !=2019.12.17
+  - huggingface-hub<1.0,>=0.19.3
+  - numpy>=1.17
+  - packaging>=20.0
+  - pyyaml>=5.1
+  - regex!=2019.12.17
   - requests
-  - tokenizers <0.20, >=0.19
-  - safetensors >=0.4.1
-  - tqdm >=4.27
-  - accelerate >=0.21.0 ; extra == 'accelerate'
+  - tokenizers<0.20,>=0.19
+  - safetensors>=0.4.1
+  - tqdm>=4.27
+  - accelerate>=0.21.0 ; extra == 'accelerate'
   - diffusers ; extra == 'agents'
-  - accelerate >=0.21.0 ; extra == 'agents'
-  - datasets !=2.5.0 ; extra == 'agents'
+  - accelerate>=0.21.0 ; extra == 'agents'
+  - datasets!=2.5.0 ; extra == 'agents'
   - torch ; extra == 'agents'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'agents'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'agents'
   - opencv-python ; extra == 'agents'
-  - pillow <=15.0, >=10.0.1 ; extra == 'agents'
-  - tensorflow <2.16, >=2.6 ; extra == 'all'
+  - pillow<=15.0,>=10.0.1 ; extra == 'agents'
+  - tensorflow<2.16,>=2.6 ; extra == 'all'
   - onnxconverter-common ; extra == 'all'
   - tf2onnx ; extra == 'all'
-  - tensorflow-text <2.16 ; extra == 'all'
-  - keras-nlp >=0.3.1 ; extra == 'all'
+  - tensorflow-text<2.16 ; extra == 'all'
+  - keras-nlp>=0.3.1 ; extra == 'all'
   - torch ; extra == 'all'
-  - accelerate >=0.21.0 ; extra == 'all'
-  - jax <=0.4.13, >=0.4.1 ; extra == 'all'
-  - jaxlib <=0.4.13, >=0.4.1 ; extra == 'all'
-  - flax <=0.7.0, >=0.4.1 ; extra == 'all'
-  - optax <=0.1.4, >=0.0.8 ; extra == 'all'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'all'
+  - accelerate>=0.21.0 ; extra == 'all'
+  - jax<=0.4.13,>=0.4.1 ; extra == 'all'
+  - jaxlib<=0.4.13,>=0.4.1 ; extra == 'all'
+  - flax<=0.7.0,>=0.4.1 ; extra == 'all'
+  - optax<=0.1.4,>=0.0.8 ; extra == 'all'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'all'
   - protobuf ; extra == 'all'
-  - tokenizers <0.20, >=0.19 ; extra == 'all'
+  - tokenizers<0.20,>=0.19 ; extra == 'all'
   - torchaudio ; extra == 'all'
   - librosa ; extra == 'all'
-  - pyctcdecode >=0.4.0 ; extra == 'all'
+  - pyctcdecode>=0.4.0 ; extra == 'all'
   - phonemizer ; extra == 'all'
   - kenlm ; extra == 'all'
-  - pillow <=15.0, >=10.0.1 ; extra == 'all'
+  - pillow<=15.0,>=10.0.1 ; extra == 'all'
   - optuna ; extra == 'all'
-  - ray[tune] >=2.7.0 ; extra == 'all'
+  - ray[tune]>=2.7.0 ; extra == 'all'
   - sigopt ; extra == 'all'
   - timm ; extra == 'all'
   - torchvision ; extra == 'all'
-  - codecarbon ==1.2.0 ; extra == 'all'
-  - decord ==0.6.0 ; extra == 'all'
-  - av ==9.2.0 ; extra == 'all'
+  - codecarbon==1.2.0 ; extra == 'all'
+  - decord==0.6.0 ; extra == 'all'
+  - av==9.2.0 ; extra == 'all'
   - librosa ; extra == 'audio'
-  - pyctcdecode >=0.4.0 ; extra == 'audio'
+  - pyctcdecode>=0.4.0 ; extra == 'audio'
   - phonemizer ; extra == 'audio'
   - kenlm ; extra == 'audio'
-  - codecarbon ==1.2.0 ; extra == 'codecarbon'
-  - deepspeed >=0.9.3 ; extra == 'deepspeed'
-  - accelerate >=0.21.0 ; extra == 'deepspeed'
-  - deepspeed >=0.9.3 ; extra == 'deepspeed-testing'
-  - accelerate >=0.21.0 ; extra == 'deepspeed-testing'
-  - pytest <8.0.0, >=7.2.0 ; extra == 'deepspeed-testing'
+  - codecarbon==1.2.0 ; extra == 'codecarbon'
+  - deepspeed>=0.9.3 ; extra == 'deepspeed'
+  - accelerate>=0.21.0 ; extra == 'deepspeed'
+  - deepspeed>=0.9.3 ; extra == 'deepspeed-testing'
+  - accelerate>=0.21.0 ; extra == 'deepspeed-testing'
+  - pytest<8.0.0,>=7.2.0 ; extra == 'deepspeed-testing'
   - pytest-xdist ; extra == 'deepspeed-testing'
   - timeout-decorator ; extra == 'deepspeed-testing'
   - parameterized ; extra == 'deepspeed-testing'
   - psutil ; extra == 'deepspeed-testing'
-  - datasets !=2.5.0 ; extra == 'deepspeed-testing'
-  - dill <0.3.5 ; extra == 'deepspeed-testing'
-  - evaluate >=0.2.0 ; extra == 'deepspeed-testing'
+  - datasets!=2.5.0 ; extra == 'deepspeed-testing'
+  - dill<0.3.5 ; extra == 'deepspeed-testing'
+  - evaluate>=0.2.0 ; extra == 'deepspeed-testing'
   - pytest-timeout ; extra == 'deepspeed-testing'
-  - ruff ==0.1.5 ; extra == 'deepspeed-testing'
-  - sacrebleu <2.0.0, >=1.4.12 ; extra == 'deepspeed-testing'
-  - rouge-score !=0.0.7, !=0.0.8, !=0.1, !=0.1.1 ; extra == 'deepspeed-testing'
+  - ruff==0.1.5 ; extra == 'deepspeed-testing'
+  - sacrebleu<2.0.0,>=1.4.12 ; extra == 'deepspeed-testing'
+  - rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1 ; extra == 'deepspeed-testing'
   - nltk ; extra == 'deepspeed-testing'
-  - gitpython <3.1.19 ; extra == 'deepspeed-testing'
-  - hf-doc-builder >=0.3.0 ; extra == 'deepspeed-testing'
+  - gitpython<3.1.19 ; extra == 'deepspeed-testing'
+  - hf-doc-builder>=0.3.0 ; extra == 'deepspeed-testing'
   - protobuf ; extra == 'deepspeed-testing'
   - sacremoses ; extra == 'deepspeed-testing'
   - rjieba ; extra == 'deepspeed-testing'
   - beautifulsoup4 ; extra == 'deepspeed-testing'
   - tensorboard ; extra == 'deepspeed-testing'
   - pydantic ; extra == 'deepspeed-testing'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'deepspeed-testing'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'deepspeed-testing'
   - faiss-cpu ; extra == 'deepspeed-testing'
-  - cookiecutter ==1.7.3 ; extra == 'deepspeed-testing'
+  - cookiecutter==1.7.3 ; extra == 'deepspeed-testing'
   - optuna ; extra == 'deepspeed-testing'
-  - tensorflow <2.16, >=2.6 ; extra == 'dev'
+  - tensorflow<2.16,>=2.6 ; extra == 'dev'
   - onnxconverter-common ; extra == 'dev'
   - tf2onnx ; extra == 'dev'
-  - tensorflow-text <2.16 ; extra == 'dev'
-  - keras-nlp >=0.3.1 ; extra == 'dev'
+  - tensorflow-text<2.16 ; extra == 'dev'
+  - keras-nlp>=0.3.1 ; extra == 'dev'
   - torch ; extra == 'dev'
-  - accelerate >=0.21.0 ; extra == 'dev'
-  - jax <=0.4.13, >=0.4.1 ; extra == 'dev'
-  - jaxlib <=0.4.13, >=0.4.1 ; extra == 'dev'
-  - flax <=0.7.0, >=0.4.1 ; extra == 'dev'
-  - optax <=0.1.4, >=0.0.8 ; extra == 'dev'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'dev'
+  - accelerate>=0.21.0 ; extra == 'dev'
+  - jax<=0.4.13,>=0.4.1 ; extra == 'dev'
+  - jaxlib<=0.4.13,>=0.4.1 ; extra == 'dev'
+  - flax<=0.7.0,>=0.4.1 ; extra == 'dev'
+  - optax<=0.1.4,>=0.0.8 ; extra == 'dev'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'dev'
   - protobuf ; extra == 'dev'
-  - tokenizers <0.20, >=0.19 ; extra == 'dev'
+  - tokenizers<0.20,>=0.19 ; extra == 'dev'
   - torchaudio ; extra == 'dev'
   - librosa ; extra == 'dev'
-  - pyctcdecode >=0.4.0 ; extra == 'dev'
+  - pyctcdecode>=0.4.0 ; extra == 'dev'
   - phonemizer ; extra == 'dev'
   - kenlm ; extra == 'dev'
-  - pillow <=15.0, >=10.0.1 ; extra == 'dev'
+  - pillow<=15.0,>=10.0.1 ; extra == 'dev'
   - optuna ; extra == 'dev'
-  - ray[tune] >=2.7.0 ; extra == 'dev'
+  - ray[tune]>=2.7.0 ; extra == 'dev'
   - sigopt ; extra == 'dev'
   - timm ; extra == 'dev'
   - torchvision ; extra == 'dev'
-  - codecarbon ==1.2.0 ; extra == 'dev'
-  - decord ==0.6.0 ; extra == 'dev'
-  - av ==9.2.0 ; extra == 'dev'
-  - pytest <8.0.0, >=7.2.0 ; extra == 'dev'
+  - codecarbon==1.2.0 ; extra == 'dev'
+  - decord==0.6.0 ; extra == 'dev'
+  - av==9.2.0 ; extra == 'dev'
+  - pytest<8.0.0,>=7.2.0 ; extra == 'dev'
   - pytest-xdist ; extra == 'dev'
   - timeout-decorator ; extra == 'dev'
   - parameterized ; extra == 'dev'
   - psutil ; extra == 'dev'
-  - datasets !=2.5.0 ; extra == 'dev'
-  - dill <0.3.5 ; extra == 'dev'
-  - evaluate >=0.2.0 ; extra == 'dev'
+  - datasets!=2.5.0 ; extra == 'dev'
+  - dill<0.3.5 ; extra == 'dev'
+  - evaluate>=0.2.0 ; extra == 'dev'
   - pytest-timeout ; extra == 'dev'
-  - ruff ==0.1.5 ; extra == 'dev'
-  - sacrebleu <2.0.0, >=1.4.12 ; extra == 'dev'
-  - rouge-score !=0.0.7, !=0.0.8, !=0.1, !=0.1.1 ; extra == 'dev'
+  - ruff==0.1.5 ; extra == 'dev'
+  - sacrebleu<2.0.0,>=1.4.12 ; extra == 'dev'
+  - rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1 ; extra == 'dev'
   - nltk ; extra == 'dev'
-  - gitpython <3.1.19 ; extra == 'dev'
-  - hf-doc-builder >=0.3.0 ; extra == 'dev'
+  - gitpython<3.1.19 ; extra == 'dev'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev'
   - sacremoses ; extra == 'dev'
   - rjieba ; extra == 'dev'
   - beautifulsoup4 ; extra == 'dev'
   - tensorboard ; extra == 'dev'
   - pydantic ; extra == 'dev'
   - faiss-cpu ; extra == 'dev'
-  - cookiecutter ==1.7.3 ; extra == 'dev'
-  - isort >=5.5.4 ; extra == 'dev'
-  - urllib3 <2.0.0 ; extra == 'dev'
-  - fugashi >=1.0 ; extra == 'dev'
-  - ipadic <2.0, >=1.0.0 ; extra == 'dev'
-  - unidic-lite >=1.0.7 ; extra == 'dev'
-  - unidic >=1.0.2 ; extra == 'dev'
-  - sudachipy >=0.6.6 ; extra == 'dev'
-  - sudachidict-core >=20220729 ; extra == 'dev'
-  - rhoknp <1.3.1, >=1.1.0 ; extra == 'dev'
+  - cookiecutter==1.7.3 ; extra == 'dev'
+  - isort>=5.5.4 ; extra == 'dev'
+  - urllib3<2.0.0 ; extra == 'dev'
+  - fugashi>=1.0 ; extra == 'dev'
+  - ipadic<2.0,>=1.0.0 ; extra == 'dev'
+  - unidic-lite>=1.0.7 ; extra == 'dev'
+  - unidic>=1.0.2 ; extra == 'dev'
+  - sudachipy>=0.6.6 ; extra == 'dev'
+  - sudachidict-core>=20220729 ; extra == 'dev'
+  - rhoknp<1.3.1,>=1.1.0 ; extra == 'dev'
   - hf-doc-builder ; extra == 'dev'
   - scikit-learn ; extra == 'dev'
-  - pytest <8.0.0, >=7.2.0 ; extra == 'dev-tensorflow'
+  - pytest<8.0.0,>=7.2.0 ; extra == 'dev-tensorflow'
   - pytest-xdist ; extra == 'dev-tensorflow'
   - timeout-decorator ; extra == 'dev-tensorflow'
   - parameterized ; extra == 'dev-tensorflow'
   - psutil ; extra == 'dev-tensorflow'
-  - datasets !=2.5.0 ; extra == 'dev-tensorflow'
-  - dill <0.3.5 ; extra == 'dev-tensorflow'
-  - evaluate >=0.2.0 ; extra == 'dev-tensorflow'
+  - datasets!=2.5.0 ; extra == 'dev-tensorflow'
+  - dill<0.3.5 ; extra == 'dev-tensorflow'
+  - evaluate>=0.2.0 ; extra == 'dev-tensorflow'
   - pytest-timeout ; extra == 'dev-tensorflow'
-  - ruff ==0.1.5 ; extra == 'dev-tensorflow'
-  - sacrebleu <2.0.0, >=1.4.12 ; extra == 'dev-tensorflow'
-  - rouge-score !=0.0.7, !=0.0.8, !=0.1, !=0.1.1 ; extra == 'dev-tensorflow'
+  - ruff==0.1.5 ; extra == 'dev-tensorflow'
+  - sacrebleu<2.0.0,>=1.4.12 ; extra == 'dev-tensorflow'
+  - rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1 ; extra == 'dev-tensorflow'
   - nltk ; extra == 'dev-tensorflow'
-  - gitpython <3.1.19 ; extra == 'dev-tensorflow'
-  - hf-doc-builder >=0.3.0 ; extra == 'dev-tensorflow'
+  - gitpython<3.1.19 ; extra == 'dev-tensorflow'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev-tensorflow'
   - protobuf ; extra == 'dev-tensorflow'
   - sacremoses ; extra == 'dev-tensorflow'
   - rjieba ; extra == 'dev-tensorflow'
   - beautifulsoup4 ; extra == 'dev-tensorflow'
   - tensorboard ; extra == 'dev-tensorflow'
   - pydantic ; extra == 'dev-tensorflow'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'dev-tensorflow'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'dev-tensorflow'
   - faiss-cpu ; extra == 'dev-tensorflow'
-  - cookiecutter ==1.7.3 ; extra == 'dev-tensorflow'
-  - tensorflow <2.16, >=2.6 ; extra == 'dev-tensorflow'
+  - cookiecutter==1.7.3 ; extra == 'dev-tensorflow'
+  - tensorflow<2.16,>=2.6 ; extra == 'dev-tensorflow'
   - onnxconverter-common ; extra == 'dev-tensorflow'
   - tf2onnx ; extra == 'dev-tensorflow'
-  - tensorflow-text <2.16 ; extra == 'dev-tensorflow'
-  - keras-nlp >=0.3.1 ; extra == 'dev-tensorflow'
-  - tokenizers <0.20, >=0.19 ; extra == 'dev-tensorflow'
-  - pillow <=15.0, >=10.0.1 ; extra == 'dev-tensorflow'
-  - isort >=5.5.4 ; extra == 'dev-tensorflow'
-  - urllib3 <2.0.0 ; extra == 'dev-tensorflow'
+  - tensorflow-text<2.16 ; extra == 'dev-tensorflow'
+  - keras-nlp>=0.3.1 ; extra == 'dev-tensorflow'
+  - tokenizers<0.20,>=0.19 ; extra == 'dev-tensorflow'
+  - pillow<=15.0,>=10.0.1 ; extra == 'dev-tensorflow'
+  - isort>=5.5.4 ; extra == 'dev-tensorflow'
+  - urllib3<2.0.0 ; extra == 'dev-tensorflow'
   - hf-doc-builder ; extra == 'dev-tensorflow'
   - scikit-learn ; extra == 'dev-tensorflow'
-  - onnxruntime >=1.4.0 ; extra == 'dev-tensorflow'
-  - onnxruntime-tools >=1.4.2 ; extra == 'dev-tensorflow'
+  - onnxruntime>=1.4.0 ; extra == 'dev-tensorflow'
+  - onnxruntime-tools>=1.4.2 ; extra == 'dev-tensorflow'
   - librosa ; extra == 'dev-tensorflow'
-  - pyctcdecode >=0.4.0 ; extra == 'dev-tensorflow'
+  - pyctcdecode>=0.4.0 ; extra == 'dev-tensorflow'
   - phonemizer ; extra == 'dev-tensorflow'
   - kenlm ; extra == 'dev-tensorflow'
-  - pytest <8.0.0, >=7.2.0 ; extra == 'dev-torch'
+  - pytest<8.0.0,>=7.2.0 ; extra == 'dev-torch'
   - pytest-xdist ; extra == 'dev-torch'
   - timeout-decorator ; extra == 'dev-torch'
   - parameterized ; extra == 'dev-torch'
   - psutil ; extra == 'dev-torch'
-  - datasets !=2.5.0 ; extra == 'dev-torch'
-  - dill <0.3.5 ; extra == 'dev-torch'
-  - evaluate >=0.2.0 ; extra == 'dev-torch'
+  - datasets!=2.5.0 ; extra == 'dev-torch'
+  - dill<0.3.5 ; extra == 'dev-torch'
+  - evaluate>=0.2.0 ; extra == 'dev-torch'
   - pytest-timeout ; extra == 'dev-torch'
-  - ruff ==0.1.5 ; extra == 'dev-torch'
-  - sacrebleu <2.0.0, >=1.4.12 ; extra == 'dev-torch'
-  - rouge-score !=0.0.7, !=0.0.8, !=0.1, !=0.1.1 ; extra == 'dev-torch'
+  - ruff==0.1.5 ; extra == 'dev-torch'
+  - sacrebleu<2.0.0,>=1.4.12 ; extra == 'dev-torch'
+  - rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1 ; extra == 'dev-torch'
   - nltk ; extra == 'dev-torch'
-  - gitpython <3.1.19 ; extra == 'dev-torch'
-  - hf-doc-builder >=0.3.0 ; extra == 'dev-torch'
+  - gitpython<3.1.19 ; extra == 'dev-torch'
+  - hf-doc-builder>=0.3.0 ; extra == 'dev-torch'
   - protobuf ; extra == 'dev-torch'
   - sacremoses ; extra == 'dev-torch'
   - rjieba ; extra == 'dev-torch'
   - beautifulsoup4 ; extra == 'dev-torch'
   - tensorboard ; extra == 'dev-torch'
   - pydantic ; extra == 'dev-torch'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'dev-torch'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'dev-torch'
   - faiss-cpu ; extra == 'dev-torch'
-  - cookiecutter ==1.7.3 ; extra == 'dev-torch'
+  - cookiecutter==1.7.3 ; extra == 'dev-torch'
   - torch ; extra == 'dev-torch'
-  - accelerate >=0.21.0 ; extra == 'dev-torch'
-  - tokenizers <0.20, >=0.19 ; extra == 'dev-torch'
+  - accelerate>=0.21.0 ; extra == 'dev-torch'
+  - tokenizers<0.20,>=0.19 ; extra == 'dev-torch'
   - torchaudio ; extra == 'dev-torch'
   - librosa ; extra == 'dev-torch'
-  - pyctcdecode >=0.4.0 ; extra == 'dev-torch'
+  - pyctcdecode>=0.4.0 ; extra == 'dev-torch'
   - phonemizer ; extra == 'dev-torch'
   - kenlm ; extra == 'dev-torch'
-  - pillow <=15.0, >=10.0.1 ; extra == 'dev-torch'
+  - pillow<=15.0,>=10.0.1 ; extra == 'dev-torch'
   - optuna ; extra == 'dev-torch'
-  - ray[tune] >=2.7.0 ; extra == 'dev-torch'
+  - ray[tune]>=2.7.0 ; extra == 'dev-torch'
   - sigopt ; extra == 'dev-torch'
   - timm ; extra == 'dev-torch'
   - torchvision ; extra == 'dev-torch'
-  - codecarbon ==1.2.0 ; extra == 'dev-torch'
-  - isort >=5.5.4 ; extra == 'dev-torch'
-  - urllib3 <2.0.0 ; extra == 'dev-torch'
-  - fugashi >=1.0 ; extra == 'dev-torch'
-  - ipadic <2.0, >=1.0.0 ; extra == 'dev-torch'
-  - unidic-lite >=1.0.7 ; extra == 'dev-torch'
-  - unidic >=1.0.2 ; extra == 'dev-torch'
-  - sudachipy >=0.6.6 ; extra == 'dev-torch'
-  - sudachidict-core >=20220729 ; extra == 'dev-torch'
-  - rhoknp <1.3.1, >=1.1.0 ; extra == 'dev-torch'
+  - codecarbon==1.2.0 ; extra == 'dev-torch'
+  - isort>=5.5.4 ; extra == 'dev-torch'
+  - urllib3<2.0.0 ; extra == 'dev-torch'
+  - fugashi>=1.0 ; extra == 'dev-torch'
+  - ipadic<2.0,>=1.0.0 ; extra == 'dev-torch'
+  - unidic-lite>=1.0.7 ; extra == 'dev-torch'
+  - unidic>=1.0.2 ; extra == 'dev-torch'
+  - sudachipy>=0.6.6 ; extra == 'dev-torch'
+  - sudachidict-core>=20220729 ; extra == 'dev-torch'
+  - rhoknp<1.3.1,>=1.1.0 ; extra == 'dev-torch'
   - hf-doc-builder ; extra == 'dev-torch'
   - scikit-learn ; extra == 'dev-torch'
-  - onnxruntime >=1.4.0 ; extra == 'dev-torch'
-  - onnxruntime-tools >=1.4.2 ; extra == 'dev-torch'
-  - tensorflow <2.16, >=2.6 ; extra == 'docs'
+  - onnxruntime>=1.4.0 ; extra == 'dev-torch'
+  - onnxruntime-tools>=1.4.2 ; extra == 'dev-torch'
+  - tensorflow<2.16,>=2.6 ; extra == 'docs'
   - onnxconverter-common ; extra == 'docs'
   - tf2onnx ; extra == 'docs'
-  - tensorflow-text <2.16 ; extra == 'docs'
-  - keras-nlp >=0.3.1 ; extra == 'docs'
+  - tensorflow-text<2.16 ; extra == 'docs'
+  - keras-nlp>=0.3.1 ; extra == 'docs'
   - torch ; extra == 'docs'
-  - accelerate >=0.21.0 ; extra == 'docs'
-  - jax <=0.4.13, >=0.4.1 ; extra == 'docs'
-  - jaxlib <=0.4.13, >=0.4.1 ; extra == 'docs'
-  - flax <=0.7.0, >=0.4.1 ; extra == 'docs'
-  - optax <=0.1.4, >=0.0.8 ; extra == 'docs'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'docs'
+  - accelerate>=0.21.0 ; extra == 'docs'
+  - jax<=0.4.13,>=0.4.1 ; extra == 'docs'
+  - jaxlib<=0.4.13,>=0.4.1 ; extra == 'docs'
+  - flax<=0.7.0,>=0.4.1 ; extra == 'docs'
+  - optax<=0.1.4,>=0.0.8 ; extra == 'docs'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'docs'
   - protobuf ; extra == 'docs'
-  - tokenizers <0.20, >=0.19 ; extra == 'docs'
+  - tokenizers<0.20,>=0.19 ; extra == 'docs'
   - torchaudio ; extra == 'docs'
   - librosa ; extra == 'docs'
-  - pyctcdecode >=0.4.0 ; extra == 'docs'
+  - pyctcdecode>=0.4.0 ; extra == 'docs'
   - phonemizer ; extra == 'docs'
   - kenlm ; extra == 'docs'
-  - pillow <=15.0, >=10.0.1 ; extra == 'docs'
+  - pillow<=15.0,>=10.0.1 ; extra == 'docs'
   - optuna ; extra == 'docs'
-  - ray[tune] >=2.7.0 ; extra == 'docs'
+  - ray[tune]>=2.7.0 ; extra == 'docs'
   - sigopt ; extra == 'docs'
   - timm ; extra == 'docs'
   - torchvision ; extra == 'docs'
-  - codecarbon ==1.2.0 ; extra == 'docs'
-  - decord ==0.6.0 ; extra == 'docs'
-  - av ==9.2.0 ; extra == 'docs'
+  - codecarbon==1.2.0 ; extra == 'docs'
+  - decord==0.6.0 ; extra == 'docs'
+  - av==9.2.0 ; extra == 'docs'
   - hf-doc-builder ; extra == 'docs'
   - hf-doc-builder ; extra == 'docs_specific'
-  - jax <=0.4.13, >=0.4.1 ; extra == 'flax'
-  - jaxlib <=0.4.13, >=0.4.1 ; extra == 'flax'
-  - flax <=0.7.0, >=0.4.1 ; extra == 'flax'
-  - optax <=0.1.4, >=0.0.8 ; extra == 'flax'
+  - jax<=0.4.13,>=0.4.1 ; extra == 'flax'
+  - jaxlib<=0.4.13,>=0.4.1 ; extra == 'flax'
+  - flax<=0.7.0,>=0.4.1 ; extra == 'flax'
+  - optax<=0.1.4,>=0.0.8 ; extra == 'flax'
   - librosa ; extra == 'flax-speech'
-  - pyctcdecode >=0.4.0 ; extra == 'flax-speech'
+  - pyctcdecode>=0.4.0 ; extra == 'flax-speech'
   - phonemizer ; extra == 'flax-speech'
   - kenlm ; extra == 'flax-speech'
   - ftfy ; extra == 'ftfy'
   - optuna ; extra == 'integrations'
-  - ray[tune] >=2.7.0 ; extra == 'integrations'
+  - ray[tune]>=2.7.0 ; extra == 'integrations'
   - sigopt ; extra == 'integrations'
-  - fugashi >=1.0 ; extra == 'ja'
-  - ipadic <2.0, >=1.0.0 ; extra == 'ja'
-  - unidic-lite >=1.0.7 ; extra == 'ja'
-  - unidic >=1.0.2 ; extra == 'ja'
-  - sudachipy >=0.6.6 ; extra == 'ja'
-  - sudachidict-core >=20220729 ; extra == 'ja'
-  - rhoknp <1.3.1, >=1.1.0 ; extra == 'ja'
-  - cookiecutter ==1.7.3 ; extra == 'modelcreation'
-  - natten <0.15.0, >=0.14.6 ; extra == 'natten'
+  - fugashi>=1.0 ; extra == 'ja'
+  - ipadic<2.0,>=1.0.0 ; extra == 'ja'
+  - unidic-lite>=1.0.7 ; extra == 'ja'
+  - unidic>=1.0.2 ; extra == 'ja'
+  - sudachipy>=0.6.6 ; extra == 'ja'
+  - sudachidict-core>=20220729 ; extra == 'ja'
+  - rhoknp<1.3.1,>=1.1.0 ; extra == 'ja'
+  - cookiecutter==1.7.3 ; extra == 'modelcreation'
+  - natten<0.15.0,>=0.14.6 ; extra == 'natten'
   - onnxconverter-common ; extra == 'onnx'
   - tf2onnx ; extra == 'onnx'
-  - onnxruntime >=1.4.0 ; extra == 'onnx'
-  - onnxruntime-tools >=1.4.2 ; extra == 'onnx'
-  - onnxruntime >=1.4.0 ; extra == 'onnxruntime'
-  - onnxruntime-tools >=1.4.2 ; extra == 'onnxruntime'
+  - onnxruntime>=1.4.0 ; extra == 'onnx'
+  - onnxruntime-tools>=1.4.2 ; extra == 'onnx'
+  - onnxruntime>=1.4.0 ; extra == 'onnxruntime'
+  - onnxruntime-tools>=1.4.2 ; extra == 'onnxruntime'
   - optuna ; extra == 'optuna'
-  - datasets !=2.5.0 ; extra == 'quality'
-  - isort >=5.5.4 ; extra == 'quality'
-  - ruff ==0.1.5 ; extra == 'quality'
-  - gitpython <3.1.19 ; extra == 'quality'
-  - hf-doc-builder >=0.3.0 ; extra == 'quality'
-  - urllib3 <2.0.0 ; extra == 'quality'
-  - ray[tune] >=2.7.0 ; extra == 'ray'
+  - datasets!=2.5.0 ; extra == 'quality'
+  - isort>=5.5.4 ; extra == 'quality'
+  - ruff==0.1.5 ; extra == 'quality'
+  - gitpython<3.1.19 ; extra == 'quality'
+  - hf-doc-builder>=0.3.0 ; extra == 'quality'
+  - urllib3<2.0.0 ; extra == 'quality'
+  - ray[tune]>=2.7.0 ; extra == 'ray'
   - faiss-cpu ; extra == 'retrieval'
-  - datasets !=2.5.0 ; extra == 'retrieval'
-  - sagemaker >=2.31.0 ; extra == 'sagemaker'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'sentencepiece'
+  - datasets!=2.5.0 ; extra == 'retrieval'
+  - sagemaker>=2.31.0 ; extra == 'sagemaker'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'sentencepiece'
   - protobuf ; extra == 'sentencepiece'
   - pydantic ; extra == 'serving'
   - uvicorn ; extra == 'serving'
@@ -27163,73 +27179,73 @@ packages:
   - scikit-learn ; extra == 'sklearn'
   - torchaudio ; extra == 'speech'
   - librosa ; extra == 'speech'
-  - pyctcdecode >=0.4.0 ; extra == 'speech'
+  - pyctcdecode>=0.4.0 ; extra == 'speech'
   - phonemizer ; extra == 'speech'
   - kenlm ; extra == 'speech'
-  - pytest <8.0.0, >=7.2.0 ; extra == 'testing'
+  - pytest<8.0.0,>=7.2.0 ; extra == 'testing'
   - pytest-xdist ; extra == 'testing'
   - timeout-decorator ; extra == 'testing'
   - parameterized ; extra == 'testing'
   - psutil ; extra == 'testing'
-  - datasets !=2.5.0 ; extra == 'testing'
-  - dill <0.3.5 ; extra == 'testing'
-  - evaluate >=0.2.0 ; extra == 'testing'
+  - datasets!=2.5.0 ; extra == 'testing'
+  - dill<0.3.5 ; extra == 'testing'
+  - evaluate>=0.2.0 ; extra == 'testing'
   - pytest-timeout ; extra == 'testing'
-  - ruff ==0.1.5 ; extra == 'testing'
-  - sacrebleu <2.0.0, >=1.4.12 ; extra == 'testing'
-  - rouge-score !=0.0.7, !=0.0.8, !=0.1, !=0.1.1 ; extra == 'testing'
+  - ruff==0.1.5 ; extra == 'testing'
+  - sacrebleu<2.0.0,>=1.4.12 ; extra == 'testing'
+  - rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1 ; extra == 'testing'
   - nltk ; extra == 'testing'
-  - gitpython <3.1.19 ; extra == 'testing'
-  - hf-doc-builder >=0.3.0 ; extra == 'testing'
+  - gitpython<3.1.19 ; extra == 'testing'
+  - hf-doc-builder>=0.3.0 ; extra == 'testing'
   - protobuf ; extra == 'testing'
   - sacremoses ; extra == 'testing'
   - rjieba ; extra == 'testing'
   - beautifulsoup4 ; extra == 'testing'
   - tensorboard ; extra == 'testing'
   - pydantic ; extra == 'testing'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'testing'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'testing'
   - faiss-cpu ; extra == 'testing'
-  - cookiecutter ==1.7.3 ; extra == 'testing'
-  - tensorflow <2.16, >=2.6 ; extra == 'tf'
+  - cookiecutter==1.7.3 ; extra == 'testing'
+  - tensorflow<2.16,>=2.6 ; extra == 'tf'
   - onnxconverter-common ; extra == 'tf'
   - tf2onnx ; extra == 'tf'
-  - tensorflow-text <2.16 ; extra == 'tf'
-  - keras-nlp >=0.3.1 ; extra == 'tf'
-  - tensorflow-cpu <2.16, >=2.6 ; extra == 'tf-cpu'
+  - tensorflow-text<2.16 ; extra == 'tf'
+  - keras-nlp>=0.3.1 ; extra == 'tf'
+  - tensorflow-cpu<2.16,>=2.6 ; extra == 'tf-cpu'
   - onnxconverter-common ; extra == 'tf-cpu'
   - tf2onnx ; extra == 'tf-cpu'
-  - tensorflow-text <2.16 ; extra == 'tf-cpu'
-  - keras-nlp >=0.3.1 ; extra == 'tf-cpu'
+  - tensorflow-text<2.16 ; extra == 'tf-cpu'
+  - keras-nlp>=0.3.1 ; extra == 'tf-cpu'
   - librosa ; extra == 'tf-speech'
-  - pyctcdecode >=0.4.0 ; extra == 'tf-speech'
+  - pyctcdecode>=0.4.0 ; extra == 'tf-speech'
   - phonemizer ; extra == 'tf-speech'
   - kenlm ; extra == 'tf-speech'
   - timm ; extra == 'timm'
-  - tokenizers <0.20, >=0.19 ; extra == 'tokenizers'
+  - tokenizers<0.20,>=0.19 ; extra == 'tokenizers'
   - torch ; extra == 'torch'
-  - accelerate >=0.21.0 ; extra == 'torch'
+  - accelerate>=0.21.0 ; extra == 'torch'
   - torchaudio ; extra == 'torch-speech'
   - librosa ; extra == 'torch-speech'
-  - pyctcdecode >=0.4.0 ; extra == 'torch-speech'
+  - pyctcdecode>=0.4.0 ; extra == 'torch-speech'
   - phonemizer ; extra == 'torch-speech'
   - kenlm ; extra == 'torch-speech'
   - torchvision ; extra == 'torch-vision'
-  - pillow <=15.0, >=10.0.1 ; extra == 'torch-vision'
+  - pillow<=15.0,>=10.0.1 ; extra == 'torch-vision'
   - filelock ; extra == 'torchhub'
-  - huggingface-hub <1.0, >=0.19.3 ; extra == 'torchhub'
+  - huggingface-hub<1.0,>=0.19.3 ; extra == 'torchhub'
   - importlib-metadata ; extra == 'torchhub'
-  - numpy >=1.17 ; extra == 'torchhub'
-  - packaging >=20.0 ; extra == 'torchhub'
+  - numpy>=1.17 ; extra == 'torchhub'
+  - packaging>=20.0 ; extra == 'torchhub'
   - protobuf ; extra == 'torchhub'
-  - regex !=2019.12.17 ; extra == 'torchhub'
+  - regex!=2019.12.17 ; extra == 'torchhub'
   - requests ; extra == 'torchhub'
-  - sentencepiece !=0.1.92, >=0.1.91 ; extra == 'torchhub'
+  - sentencepiece!=0.1.92,>=0.1.91 ; extra == 'torchhub'
   - torch ; extra == 'torchhub'
-  - tokenizers <0.20, >=0.19 ; extra == 'torchhub'
-  - tqdm >=4.27 ; extra == 'torchhub'
-  - decord ==0.6.0 ; extra == 'video'
-  - av ==9.2.0 ; extra == 'video'
-  - pillow <=15.0, >=10.0.1 ; extra == 'vision'
+  - tokenizers<0.20,>=0.19 ; extra == 'torchhub'
+  - tqdm>=4.27 ; extra == 'torchhub'
+  - decord==0.6.0 ; extra == 'video'
+  - av==9.2.0 ; extra == 'video'
+  - pillow<=15.0,>=10.0.1 ; extra == 'vision'
   requires_python: '>=3.8.0'
 - kind: pypi
   name: trimesh
@@ -27292,14 +27308,14 @@ packages:
   sha256: da58a152bddb62cafa9a857dd2bc1f886dbf9f9c90a2b5da82157cd2b34392b0
   requires_dist:
   - filelock
-  - cmake >=3.20 ; extra == 'build'
+  - cmake>=3.20 ; extra == 'build'
   - lit ; extra == 'build'
   - autopep8 ; extra == 'tests'
   - flake8 ; extra == 'tests'
   - isort ; extra == 'tests'
   - numpy ; extra == 'tests'
   - pytest ; extra == 'tests'
-  - scipy >=1.7.1 ; extra == 'tests'
+  - scipy>=1.7.1 ; extra == 'tests'
   - torch ; extra == 'tests'
   - matplotlib ; extra == 'tutorials'
   - pandas ; extra == 'tutorials'
@@ -27316,7 +27332,7 @@ packages:
   url: https://files.pythonhosted.org/packages/8b/ea/91b718b8c0b88e4f61cdd61357cc4a1f8767b32be691fb388299003a3ae3/types_requests-2.31.0.20240406-py3-none-any.whl
   sha256: 6216cdac377c6b9a040ac1c0404f7284bd13199c0e1bb235f4324627e8898cf5
   requires_dist:
-  - urllib3 >=2
+  - urllib3>=2
   requires_python: '>=3.8'
 - kind: pypi
   name: typing-extensions
@@ -27330,9 +27346,9 @@ packages:
   url: https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl
   sha256: 9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f
   requires_dist:
-  - mypy-extensions >=0.3.0
-  - typing-extensions >=3.7.4
-  - typing >=3.7.4 ; python_version < '3.5'
+  - mypy-extensions>=0.3.0
+  - typing-extensions>=3.7.4
+  - typing>=3.7.4 ; python_version < '3.5'
 - kind: conda
   name: typing_extensions
   version: 4.8.0
@@ -27736,13 +27752,13 @@ packages:
   url: https://files.pythonhosted.org/packages/d1/1b/46802a050b1c55d10c4f59fc6afd2b45ac9b4f62b2e12092d3f599286f14/umap_learn-0.5.6-py3-none-any.whl
   sha256: 881cc0c2ee845b790bf0455aa1664f9f68b838d9d0fe12a1291b85c5a559c913
   requires_dist:
-  - numpy >=1.17
-  - scipy >=1.3.1
-  - scikit-learn >=0.22
-  - numba >=0.51.2
-  - pynndescent >=0.5
+  - numpy>=1.17
+  - scipy>=1.3.1
+  - scikit-learn>=0.22
+  - numba>=0.51.2
+  - pynndescent>=0.5
   - tqdm
-  - tensorflow >=2.1 ; extra == 'parametric_umap'
+  - tensorflow>=2.1 ; extra == 'parametric_umap'
   - pandas ; extra == 'plot'
   - matplotlib ; extra == 'plot'
   - datashader ; extra == 'plot'
@@ -27751,18 +27767,18 @@ packages:
   - colorcet ; extra == 'plot'
   - seaborn ; extra == 'plot'
   - scikit-image ; extra == 'plot'
-  - tbb >=2019.0 ; extra == 'tbb'
+  - tbb>=2019.0 ; extra == 'tbb'
 - kind: pypi
   name: urllib3
   version: 2.2.1
   url: https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl
   sha256: 450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
   requires_dist:
-  - brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
-  - brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
-  - h2 <5, >=4 ; extra == 'h2'
-  - pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'
-  - zstandard >=0.18.0 ; extra == 'zstd'
+  - brotli>=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - h2<5,>=4 ; extra == 'h2'
+  - pysocks!=1.5.7,<2.0,>=1.5.6 ; extra == 'socks'
+  - zstandard>=0.18.0 ; extra == 'zstd'
   requires_python: '>=3.8'
 - kind: conda
   name: vc
@@ -27842,29 +27858,29 @@ packages:
   url: https://files.pythonhosted.org/packages/ca/28/19728b052c52b588fa117e80561d4b6e872664f4df73628d58593218becd/virtualenv-20.26.1-py3-none-any.whl
   sha256: 7aa9982a728ae5892558bff6a2839c00b9ed145523ece2274fad6f414690ae75
   requires_dist:
-  - distlib <1, >=0.3.7
-  - filelock <4, >=3.12.2
-  - importlib-metadata >=6.6 ; python_version < '3.8'
-  - platformdirs <5, >=3.9.1
-  - furo >=2023.7.26 ; extra == 'docs'
-  - proselint >=0.13 ; extra == 'docs'
-  - sphinx !=7.3, >=7.1.2 ; extra == 'docs'
-  - sphinx-argparse >=0.4 ; extra == 'docs'
-  - sphinxcontrib-towncrier >=0.2.1a0 ; extra == 'docs'
-  - towncrier >=23.6 ; extra == 'docs'
-  - covdefaults >=2.3 ; extra == 'test'
-  - coverage-enable-subprocess >=1 ; extra == 'test'
-  - coverage >=7.2.7 ; extra == 'test'
-  - flaky >=3.7 ; extra == 'test'
-  - packaging >=23.1 ; extra == 'test'
-  - pytest-env >=0.8.2 ; extra == 'test'
-  - pytest-freezer >=0.4.8 ; platform_python_implementation == 'PyPy' and extra == 'test'
-  - pytest-mock >=3.11.1 ; extra == 'test'
-  - pytest-randomly >=3.12 ; extra == 'test'
-  - pytest-timeout >=2.1 ; extra == 'test'
-  - pytest >=7.4 ; extra == 'test'
-  - setuptools >=68 ; extra == 'test'
-  - time-machine >=2.10 ; platform_python_implementation == 'CPython' and extra == 'test'
+  - distlib<1,>=0.3.7
+  - filelock<4,>=3.12.2
+  - importlib-metadata>=6.6 ; python_version < '3.8'
+  - platformdirs<5,>=3.9.1
+  - furo>=2023.7.26 ; extra == 'docs'
+  - proselint>=0.13 ; extra == 'docs'
+  - sphinx!=7.3,>=7.1.2 ; extra == 'docs'
+  - sphinx-argparse>=0.4 ; extra == 'docs'
+  - sphinxcontrib-towncrier>=0.2.1a0 ; extra == 'docs'
+  - towncrier>=23.6 ; extra == 'docs'
+  - covdefaults>=2.3 ; extra == 'test'
+  - coverage-enable-subprocess>=1 ; extra == 'test'
+  - coverage>=7.2.7 ; extra == 'test'
+  - flaky>=3.7 ; extra == 'test'
+  - packaging>=23.1 ; extra == 'test'
+  - pytest-env>=0.8.2 ; extra == 'test'
+  - pytest-freezer>=0.4.8 ; platform_python_implementation == 'PyPy' and extra == 'test'
+  - pytest-mock>=3.11.1 ; extra == 'test'
+  - pytest-randomly>=3.12 ; extra == 'test'
+  - pytest-timeout>=2.1 ; extra == 'test'
+  - pytest>=7.4 ; extra == 'test'
+  - setuptools>=68 ; extra == 'test'
+  - time-machine>=2.10 ; platform_python_implementation == 'CPython' and extra == 'test'
   requires_python: '>=3.7'
 - kind: conda
   name: vs2015_runtime
@@ -27972,20 +27988,8 @@ packages:
 - kind: pypi
   name: wrapt
   version: 1.16.0
-  url: https://files.pythonhosted.org/packages/0f/16/ea627d7817394db04518f62934a5de59874b587b792300991b3c347ff5e0/wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl
-  sha256: 75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d
-  requires_python: '>=3.6'
-- kind: pypi
-  name: wrapt
-  version: 1.16.0
-  url: https://files.pythonhosted.org/packages/cf/c3/0084351951d9579ae83a3d9e38c140371e4c6b038136909235079f2e6e78/wrapt-1.16.0-cp311-cp311-win_amd64.whl
-  sha256: aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89
-  requires_python: '>=3.6'
-- kind: pypi
-  name: wrapt
-  version: 1.16.0
-  url: https://files.pythonhosted.org/packages/6e/52/2da48b35193e39ac53cfb141467d9f259851522d0e8c87153f0ba4205fb1/wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-  sha256: 72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1
+  url: https://files.pythonhosted.org/packages/fd/03/c188ac517f402775b90d6f312955a5e53b866c964b32119f2ed76315697e/wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl
+  sha256: 1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09
   requires_python: '>=3.6'
 - kind: pypi
   name: wrapt
@@ -27996,8 +28000,20 @@ packages:
 - kind: pypi
   name: wrapt
   version: 1.16.0
-  url: https://files.pythonhosted.org/packages/fd/03/c188ac517f402775b90d6f312955a5e53b866c964b32119f2ed76315697e/wrapt-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl
-  sha256: 1a5db485fe2de4403f13fafdc231b0dbae5eca4359232d2efc79025527375b09
+  url: https://files.pythonhosted.org/packages/6e/52/2da48b35193e39ac53cfb141467d9f259851522d0e8c87153f0ba4205fb1/wrapt-1.16.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+  sha256: 72554a23c78a8e7aa02abbd699d129eead8b147a23c56e08d08dfc29cfdddca1
+  requires_python: '>=3.6'
+- kind: pypi
+  name: wrapt
+  version: 1.16.0
+  url: https://files.pythonhosted.org/packages/0f/16/ea627d7817394db04518f62934a5de59874b587b792300991b3c347ff5e0/wrapt-1.16.0-cp311-cp311-macosx_11_0_arm64.whl
+  sha256: 75ea7d0ee2a15733684badb16de6794894ed9c55aa5e9903260922f0482e687d
+  requires_python: '>=3.6'
+- kind: pypi
+  name: wrapt
+  version: 1.16.0
+  url: https://files.pythonhosted.org/packages/cf/c3/0084351951d9579ae83a3d9e38c140371e4c6b038136909235079f2e6e78/wrapt-1.16.0-cp311-cp311-win_amd64.whl
+  sha256: aefbc4cb0a54f91af643660a0a150ce2c090d3652cf4052a5397fb2de549cd89
   requires_python: '>=3.6'
 - kind: conda
   name: xz
@@ -28169,37 +28185,37 @@ packages:
   url: https://files.pythonhosted.org/packages/d5/b5/70bb98ee38ce532ee29fab76fb668382291fe6e1aa69a8c1ac7e6bc108e7/yfinance-0.2.38-py2.py3-none-any.whl
   sha256: 07525cf84414272723a3e2b9d4c0a2898ddb60cc0828aa190de26664fac6f676
   requires_dist:
-  - pandas >=1.3.0
-  - numpy >=1.16.5
-  - requests >=2.31
-  - multitasking >=0.0.7
-  - lxml >=4.9.1
-  - appdirs >=1.4.4
-  - pytz >=2022.5
-  - frozendict >=2.3.4
-  - peewee >=3.16.2
-  - beautifulsoup4 >=4.11.1
-  - html5lib >=1.1
-  - requests-cache >=1.0 ; extra == 'nospam'
-  - requests-ratelimiter >=0.3.1 ; extra == 'nospam'
-  - scipy >=1.6.3 ; extra == 'repair'
+  - pandas>=1.3.0
+  - numpy>=1.16.5
+  - requests>=2.31
+  - multitasking>=0.0.7
+  - lxml>=4.9.1
+  - appdirs>=1.4.4
+  - pytz>=2022.5
+  - frozendict>=2.3.4
+  - peewee>=3.16.2
+  - beautifulsoup4>=4.11.1
+  - html5lib>=1.1
+  - requests-cache>=1.0 ; extra == 'nospam'
+  - requests-ratelimiter>=0.3.1 ; extra == 'nospam'
+  - scipy>=1.6.3 ; extra == 'repair'
 - kind: pypi
   name: zipp
   version: 3.18.1
   url: https://files.pythonhosted.org/packages/c2/0a/ba9d0ee9536d3ef73a3448e931776e658b36f128d344e175bc32b092a8bf/zipp-3.18.1-py3-none-any.whl
   sha256: 206f5a15f2af3dbaee80769fb7dc6f249695e940acca08dfb2a4769fe61e538b
   requires_dist:
-  - sphinx >=3.5 ; extra == 'docs'
-  - jaraco-packaging >=9.3 ; extra == 'docs'
-  - rst-linker >=1.9 ; extra == 'docs'
+  - sphinx>=3.5 ; extra == 'docs'
+  - jaraco-packaging>=9.3 ; extra == 'docs'
+  - rst-linker>=1.9 ; extra == 'docs'
   - furo ; extra == 'docs'
   - sphinx-lint ; extra == 'docs'
-  - jaraco-tidelift >=1.4 ; extra == 'docs'
-  - pytest >=6 ; extra == 'testing'
-  - pytest-checkdocs >=2.4 ; extra == 'testing'
+  - jaraco-tidelift>=1.4 ; extra == 'docs'
+  - pytest>=6 ; extra == 'testing'
+  - pytest-checkdocs>=2.4 ; extra == 'testing'
   - pytest-cov ; extra == 'testing'
-  - pytest-enabler >=2.2 ; extra == 'testing'
-  - pytest-ruff >=0.2.1 ; extra == 'testing'
+  - pytest-enabler>=2.2 ; extra == 'testing'
+  - pytest-ruff>=0.2.1 ; extra == 'testing'
   - jaraco-itertools ; extra == 'testing'
   - jaraco-functools ; extra == 'testing'
   - more-itertools ; extra == 'testing'

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_test_wheels.yml`
   "attrs>=23.1.0",
   "numpy>=1.23,<2",
-  "pillow>=10.3.0",         # Used for JPEG encoding
+  "pillow>=8.0.0",          # Used for JPEG encoding. 8.0.0 added the `format` arguments to `Image.open`
   "pyarrow>=14.0.2",
   "typing_extensions>=4.5", # Used for PEP-702 deprecated decorator
 ]

--- a/rerun_py/pyproject.toml
+++ b/rerun_py/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
   # Must match list in `.github/workflows/reusable_test_wheels.yml`
   "attrs>=23.1.0",
   "numpy>=1.23,<2",
-  "pillow",                 # Used for JPEG encoding
+  "pillow>=10.3.0",         # Used for JPEG encoding
   "pyarrow>=14.0.2",
   "typing_extensions>=4.5", # Used for PEP-702 deprecated decorator
 ]


### PR DESCRIPTION
### What
A user reported that

``` py
rr.log("foo", rr.Image(img).compress(jpeg_quality=95))
```

caused this warning:

> RerunWarning: Image compression: TypeError(open() got an unexpected keyword argument 'formats')

I suspect this line:

https://github.com/rerun-io/rerun/blob/3805781ee53dec571bfef0b0c44d95e61fc690ca/rerun_py/rerun_sdk/rerun/_image.py#L203

Which indicate a version mismatch of pillow.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6327?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6327?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6327)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.