### PR TITLE
Fix broken drag and drop

### DIFF
--- a/crates/re_ui/src/list_item.rs
+++ b/crates/re_ui/src/list_item.rs
@@ -440,12 +440,15 @@ impl<'a> ListItem<'a> {
         let bg_rect =
             egui::Rect::from_x_y_ranges(crate::full_span::get_full_span(ui), rect.y_range());
 
-        // we want to be able to select/hover the item across its full span, so we sense that and
-        // update the response accordingly.
+        // we want to be able to select/hover/drag the item across its full span, so we sense that
+        // and update the response accordingly.
         let full_span_response = ui.interact(bg_rect, response.id.with("full_span_check"), sense);
         response.clicked = full_span_response.clicked;
         response.contains_pointer = full_span_response.contains_pointer;
         response.hovered = full_span_response.hovered;
+        response.drag_started = full_span_response.drag_started;
+        response.dragged = full_span_response.dragged;
+        response.drag_stopped = full_span_response.drag_stopped;
 
         // override_hover should not affect the returned response
         let mut style_response = response.clone();


### PR DESCRIPTION
### What

Fix drag and drop which was broken by #6305. Rather ugly patch, but legacy list item will be removed altogether very soon.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
