### PR TITLE
Make sure all log messages are sent when using `.serve()`

### DIFF
--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -94,7 +94,7 @@ impl Drop for WebViewerSink {
             // For small scripts that execute fast we run the risk of finishing
             // before the browser has a chance to connect.
             // Let's give it a little more time:
-            re_log::debug!("Sleeping a short while to give the browser time to connect…");
+            re_log::info!("Sleeping a short while to give the browser time to connect…");
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }
 

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -70,6 +70,19 @@ impl WebViewerSink {
     }
 }
 
+impl crate::sink::LogSink for WebViewerSink {
+    fn send(&self, msg: LogMsg) {
+        if let Err(err) = self.sender.send(msg) {
+            re_log::error_once!("Failed to send log message to web server: {err}");
+        }
+    }
+
+    #[inline]
+    fn flush_blocking(&self) {}
+}
+
+// ----------------------------------------------------------------------------
+
 /// Helper to spawn an instance of the [`WebViewerServer`].
 /// This serves the HTTP+Wasm+JS files that make up the web-viewer.
 ///
@@ -99,17 +112,6 @@ pub fn host_web_viewer(
     }
 
     Ok(web_server)
-}
-
-impl crate::sink::LogSink for WebViewerSink {
-    fn send(&self, msg: LogMsg) {
-        if let Err(err) = self.sender.send(msg) {
-            re_log::error_once!("Failed to send log message to web server: {err}");
-        }
-    }
-
-    #[inline]
-    fn flush_blocking(&self) {}
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -78,7 +78,11 @@ impl crate::sink::LogSink for WebViewerSink {
     }
 
     #[inline]
-    fn flush_blocking(&self) {}
+    fn flush_blocking(&self) {
+        if let Err(err) = self.sender.flush_blocking() {
+            re_log::error_once!("Failed to flush: {err}");
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -94,6 +94,7 @@ impl Drop for WebViewerSink {
             // For small scripts that execute fast we run the risk of finishing
             // before the browser has a chance to connect.
             // Let's give it a little more time:
+            re_log::debug!("Sleeping a short while to give the browser time to connect…");
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }
 

--- a/crates/re_sdk/src/web_viewer.rs
+++ b/crates/re_sdk/src/web_viewer.rs
@@ -96,6 +96,10 @@ impl Drop for WebViewerSink {
             // Let's give it a little more time:
             std::thread::sleep(std::time::Duration::from_millis(1000));
         }
+
+        if self.rerun_server.num_accepted_clients() == 0 {
+            re_log::info!("Shutting down without any clients ever having connected. Consider sleeping to give them more time to connect");
+        }
     }
 }
 

--- a/crates/re_smart_channel/src/sender.rs
+++ b/crates/re_smart_channel/src/sender.rs
@@ -37,7 +37,7 @@ impl<T: Send> Sender<T> {
         )
         .map_err(|SendError(msg)| match msg {
             SmartMessagePayload::Msg(msg) => SendError(msg),
-            SmartMessagePayload::Quit(_) => unreachable!(),
+            SmartMessagePayload::Flush { .. } | SmartMessagePayload::Quit(_) => unreachable!(),
         })
     }
 

--- a/crates/re_viewer/src/app.rs
+++ b/crates/re_viewer/src/app.rs
@@ -971,6 +971,12 @@ impl App {
         while let Some((channel_source, msg)) = self.rx.try_recv() {
             let msg = match msg.payload {
                 re_smart_channel::SmartMessagePayload::Msg(msg) => msg,
+
+                re_smart_channel::SmartMessagePayload::Flush { on_flush_done } => {
+                    on_flush_done();
+                    continue;
+                }
+
                 re_smart_channel::SmartMessagePayload::Quit(err) => {
                     if let Some(err) = err {
                         let log_msg =

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -346,6 +346,11 @@ impl ReceiveSetBroadcaster {
 
                     inner.history.push(msg);
                 }
+
+                re_smart_channel::SmartMessagePayload::Flush { on_flush_done } => {
+                    (on_flush_done)();
+                }
+
                 re_smart_channel::SmartMessagePayload::Quit(err) => {
                     if let Some(err) = err {
                         re_log::warn!("Sender {} has left unexpectedly: {err}", msg.source);

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -166,6 +166,11 @@ impl RerunServer {
         server_url(&self.local_addr)
     }
 
+    /// Total count; never decreasing.
+    pub fn num_accepted_clients(&self) -> u64 {
+        self.num_accepted_clients.load(Ordering::Relaxed)
+    }
+
     fn listen_thread_func(
         poller: &Poller,
         listener_socket: &TcpListener,

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -9,7 +9,10 @@
 use std::{
     collections::VecDeque,
     net::{TcpListener, TcpStream},
-    sync::{atomic::AtomicBool, Arc},
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
 };
 
 use parking_lot::Mutex;
@@ -86,6 +89,9 @@ pub struct RerunServer {
     listener_join_handle: Option<std::thread::JoinHandle<()>>,
     poller: Arc<Poller>,
     shutdown_flag: Arc<AtomicBool>,
+
+    /// Total count; never decreasing.
+    num_accepted_clients: Arc<AtomicU64>,
 }
 
 impl RerunServer {
@@ -120,10 +126,12 @@ impl RerunServer {
 
         let poller = Arc::new(Poller::new()?);
         let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let num_accepted_clients = Arc::new(AtomicU64::new(0));
 
         let local_addr = listener_socket.local_addr()?;
         let poller_copy = poller.clone();
         let shutdown_flag_copy = shutdown_flag.clone();
+        let num_clients_copy = num_accepted_clients.clone();
 
         let listener_join_handle = std::thread::Builder::new()
             .name("rerun_ws_server: listener".to_owned())
@@ -133,6 +141,7 @@ impl RerunServer {
                     &listener_socket,
                     &ReceiveSetBroadcaster::new(rerun_rx, server_memory_limit),
                     &shutdown_flag,
+                    &num_accepted_clients,
                 );
             })?;
 
@@ -141,6 +150,7 @@ impl RerunServer {
             poller: poller_copy,
             listener_join_handle: Some(listener_join_handle),
             shutdown_flag: shutdown_flag_copy,
+            num_accepted_clients: num_clients_copy,
         };
 
         re_log::info!(
@@ -161,6 +171,7 @@ impl RerunServer {
         listener_socket: &TcpListener,
         message_broadcaster: &ReceiveSetBroadcaster,
         shutdown_flag: &AtomicBool,
+        num_accepted_clients: &AtomicU64,
     ) {
         // Each socket in `poll::Poller` needs a "name".
         // Doesn't matter much what we're using here, as long as it's not used for something else
@@ -190,6 +201,7 @@ impl RerunServer {
                         message_broadcaster,
                         poller,
                         listener_poll_key,
+                        num_accepted_clients,
                     );
                 }
             }
@@ -201,6 +213,7 @@ impl RerunServer {
         message_broadcaster: &ReceiveSetBroadcaster,
         poller: &Poller,
         listener_poll_key: usize,
+        num_accepted_clients: &AtomicU64,
     ) {
         match listener_socket.accept() {
             Ok((tcp_stream, _)) => {
@@ -214,6 +227,7 @@ impl RerunServer {
                 match tungstenite::accept(tcp_stream) {
                     Ok(ws_stream) => {
                         message_broadcaster.add_client(ws_stream);
+                        num_accepted_clients.fetch_add(1, Ordering::Relaxed);
                     }
                     Err(err) => {
                         re_log::warn!("Error accepting WebSocket connection: {err}");
@@ -251,7 +265,11 @@ impl RerunServer {
 
 impl Drop for RerunServer {
     fn drop(&mut self) {
-        re_log::info!("Shutting down Rerun server on {}", self.server_url());
+        let num_accepted_clients = self.num_accepted_clients.load(Ordering::Relaxed);
+        re_log::info!(
+            "Shutting down Rerun server on {} after serving {num_accepted_clients} client(s)",
+            self.server_url()
+        );
         self.stop_listener();
     }
 }

--- a/crates/re_ws_comms/src/server.rs
+++ b/crates/re_ws_comms/src/server.rs
@@ -353,7 +353,7 @@ impl ReceiveSetBroadcaster {
                 }
 
                 re_smart_channel::SmartMessagePayload::Flush { on_flush_done } => {
-                    (on_flush_done)();
+                    on_flush_done();
                 }
 
                 re_smart_channel::SmartMessagePayload::Quit(err) => {

--- a/crates/rerun/src/run.rs
+++ b/crates/rerun/src/run.rs
@@ -830,6 +830,11 @@ fn assert_receive_into_entity_db(
                         mut_db.add(&msg)?;
                         num_messages += 1;
                     }
+
+                    re_smart_channel::SmartMessagePayload::Flush { on_flush_done } => {
+                        on_flush_done();
+                    }
+
                     SmartMessagePayload::Quit(err) => {
                         if let Some(err) = err {
                             anyhow::bail!("data source has disconnected unexpectedly: {err}")

--- a/pixi.toml
+++ b/pixi.toml
@@ -147,7 +147,7 @@ py-lint = "mypy --install-types --non-interactive --no-warn-unused-ignore"
 # - RERUN_ALLOW_MISSING_BIN is needed to allow maturin to run without the `rerun` binary being part of the rerun-sdk
 #   package.
 py-build = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
-  "rerun-build", # We need to build rerun-cli since it it bundled in the python package.
+  "rerun-build", # We need to build rerun-cli since it is bundled in the python package.
 ] }
 
 # Python example utilities

--- a/pixi.toml
+++ b/pixi.toml
@@ -147,7 +147,7 @@ py-lint = "mypy --install-types --non-interactive --no-warn-unused-ignore"
 # - RERUN_ALLOW_MISSING_BIN is needed to allow maturin to run without the `rerun` binary being part of the rerun-sdk
 #   package.
 py-build = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
-  "rerun-build",
+  "rerun-build", # We need to build rerun-cli since it it bundled in the python package.
 ] }
 
 # Python example utilities

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -15,7 +15,7 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 
 
 [features]
-default = ["extension-module"]
+default = ["extension-module", "web_viewer"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
@@ -23,15 +23,15 @@ pypi = ["extension-module", "web_viewer"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
-## must make it an opt-in feature.
+## must make it an optional feature.
 ## * <https://pyo3.rs/latest/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>
 ## * <https://pyo3.rs/main/building-and-distribution#building-python-extension-modules>
 extension-module = ["pyo3/extension-module"]
 
 ## Support serving a web viewer over HTTP with `serve()`.
 ##
-## Enabling this adds quite a bit to the compile time and binary size,
-## since it requires compiling and bundling the viewer as wasm.
+## Enabling this adds quite a bit to the binary size,
+## since it requires bundling the viewer as wasm.
 web_viewer = [
   "re_sdk/web_viewer",
   "dep:re_web_viewer_server",


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6286

See commit messages for details

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6335?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6335?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6335)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.