### PR TITLE
Move sort out of inner loop to fix perf regression on updating range cache

### DIFF
--- a/crates/re_query/src/range/query.rs
+++ b/crates/re_query/src/range/query.rs
@@ -242,6 +242,9 @@ impl RangeCache {
                 per_data_time
                     .promises_front
                     .push(((data_time, row_id), Promise::new(cell)));
+            }
+            {
+                re_tracing::profile_scope!("sort front");
                 per_data_time
                     .promises_front
                     .sort_by_key(|(index, _)| *index);
@@ -267,6 +270,9 @@ impl RangeCache {
                 per_data_time
                     .promises_back
                     .push(((data_time, row_id), Promise::new(cell)));
+            }
+            {
+                re_tracing::profile_scope!("sort back");
                 per_data_time.promises_back.sort_by_key(|(index, _)| *index);
             }
         }


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/6336

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6338?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6338?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6338)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.