### PR TITLE
Disable flush_blocking in Sender on wasm

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -50,7 +50,7 @@ disallowed-methods = [
 
   # There are many things that aren't allowed on wasm,
   # but we cannot disable them all here (because of e.g. https://github.com/rust-lang/rust-clippy/issues/10406)
-  # so we do that in `clipppy_wasm.toml` instead.
+  # so we do that in `clippy_wasm.toml` instead.
 ]
 
 # https://rust-lang.github.io/rust-clippy/master/index.html#disallowed_names

--- a/crates/re_smart_channel/src/sender.rs
+++ b/crates/re_smart_channel/src/sender.rs
@@ -61,6 +61,7 @@ impl<T: Send> Sender<T> {
     }
 
     /// Blocks until all previously sent messages have been received.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn flush_blocking(&self) -> Result<(), SendError<()>> {
         let (tx, rx) = std::sync::mpsc::sync_channel(0); // oneshot
         self.tx

--- a/crates/re_smart_channel/src/sender.rs
+++ b/crates/re_smart_channel/src/sender.rs
@@ -61,6 +61,9 @@ impl<T: Send> Sender<T> {
     }
 
     /// Blocks until all previously sent messages have been received.
+    ///
+    /// Note: This is only implemented for non-wasm targets since we cannot make
+    /// blocking calls on web.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn flush_blocking(&self) -> Result<(), SendError<()>> {
         let (tx, rx) = std::sync::mpsc::sync_channel(0); // oneshot


### PR DESCRIPTION
### What
This avoids a lint related to using blocking `recv()` on wasm buids.

This method was added as part of https://github.com/rerun-io/rerun/pull/6335 but is not actually needed by the viewer, only the SDK, which we don't build on wasm yet.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6339?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6339?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6339)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.