### PR TITLE
fix incorrect roundtrips.py test exception

### DIFF
--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -43,7 +43,7 @@ opt_out = {
     "space_view_blueprint": ["cpp", "py", "rust"],
     "space_view_contents": ["cpp", "py", "rust"],
     "viewport_blueprint": ["cpp", "py", "rust"],
-    "visual_bounds": ["cpp", "py", "rust"],
+    "visual_bounds2d": ["cpp", "py", "rust"],
 }
 
 


### PR DESCRIPTION
### What

trivial oversight in #6333 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6340?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6340?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6340)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.