### PR TITLE
Respect the RERUN_STRICT environment variable if not specified in rr.init

### DIFF
--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -233,9 +233,10 @@ def init(
     init_logging
         Should we initialize the logging for this application?
     strict
-        If `True`, an exceptions is raised on use error (wrong parameter types, etc.).
-        If `False`, errors are logged as warnings instead. This is the default.
-        If unset, this can also be overridden using the RERUN_STRICT environment variables.
+        If `True`, an exception is raised on use error (wrong parameter types, etc.).
+        If `False`, errors are logged as warnings instead.
+        If unset, this can alternatively be overridden using the RERUN_STRICT environment variable.
+        If not otherwise specified, the default behavior will be equivalent to `False`.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, the new blueprint won't become active until the user

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -166,7 +166,7 @@ def init(
     spawn: bool = False,
     init_logging: bool = True,
     default_enabled: bool = True,
-    strict: bool = False,
+    strict: bool | None = None,
     default_blueprint: BlueprintLike | None = None,
 ) -> None:
     """
@@ -234,7 +234,8 @@ def init(
         Should we initialize the logging for this application?
     strict
         If `True`, an exceptions is raised on use error (wrong parameter types, etc.).
-        If `False`, errors are logged as warnings instead.
+        If `False`, errors are logged as warnings instead. This is the default.
+        If unset, this can also be overridden using the RERUN_STRICT environment variables.
     default_blueprint
         Optionally set a default blueprint to use for this application. If the application
         already has an active blueprint, the new blueprint won't become active until the user
@@ -248,7 +249,8 @@ def init(
         random.seed(0)
         np.random.seed(0)
 
-    set_strict_mode(strict)
+    if strict is not None:
+        set_strict_mode(strict)
 
     # Always check whether we are a forked child when calling init. This should have happened
     # via `_register_on_fork` but it's worth being conservative.

--- a/rerun_py/tests/unit/test_exceptions.py
+++ b/rerun_py/tests/unit/test_exceptions.py
@@ -56,7 +56,7 @@ def expected_warnings(warnings: Any, mem: Any, starting_msgs: int, count: int, e
 def test_stack_tracking() -> None:
     # Force flushing so we can count the messages
     os.environ["RERUN_FLUSH_NUM_ROWS"] = "0"
-    rr.init("rerun_example_strict_mode", spawn=False)
+    rr.init("rerun_example_strict_mode", strict=False, spawn=False)
 
     mem = rr.memory_recording()
     with pytest.warns(RerunWarning) as warnings:
@@ -117,17 +117,24 @@ def test_stack_tracking() -> None:
 
 
 def test_strict_mode() -> None:
-    # We can disable strict on just this function
+    rr.set_strict_mode(False)
+
+    # Confirm strict mode is off
+    with pytest.warns(RerunWarning):
+        assert outer() == 42
+
+    # We can enable strict on just this function
     with pytest.raises(ValueError):
         outer(strict=True)
 
     with pytest.raises(ValueError):
         uses_context(strict=True)
 
-    # We can disable strict mode globally
+    # We can enable strict mode globally
     rr.set_strict_mode(True)
     with pytest.raises(ValueError):
         outer()
+
     # Clear the global strict mode again
     rr.set_strict_mode(False)
 


### PR DESCRIPTION
### What
Any time we used `rr.init()` such as in our example scripts, we were forcing strict to be False in a way that would not be overridden by the RERUN_STRICT environment variable.

We now only set strict if it's passed in as an arg.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6341?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6341?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6341)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.