### PR TITLE
Quick fix for `check_all_components_ui.py`

### DIFF
--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -128,7 +128,6 @@ ALL_COMPONENTS: dict[str, TestCase] = {
     "Position3DBatch": TestCase(batch=[(0, 3, 4), (1, 4, 5), (2, 5, 6)]),
     "RadiusBatch": TestCase(batch=[4.5, 5, 6, 7]),
     "Range1DBatch": TestCase((0, 5)),
-    "Range2DBatch": TestCase(rr.datatypes.Range2D(x_range=(0, 5), y_range=(0, 5))),
     "ResolutionBatch": TestCase((1920, 1080)),
     "Rotation3DBatch": TestCase(
         alternatives=[

--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -147,7 +147,7 @@ ALL_COMPONENTS: dict[str, TestCase] = {
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4), dtype=np.uint8)),
             rr.datatypes.TensorData(
                 array=np.random.randint(0, 255, (5, 3, 6, 4), dtype=np.uint8),
-                dim_names=[None, "hello", None, "world", None],
+                dim_names=[None, "hello", None, "world"],
             ),
             rr.datatypes.TensorData(array=np.random.randint(0, 255, (5, 3, 6, 4, 3), dtype=np.uint8)),
         ]


### PR DESCRIPTION
### What

Fixes two issues with `check_all_components_ui.py`
- an array one item too long (would fail with `strict=True`)
- removes `VisualBounds2D`, formerly `Range2D`, now moved to blueprint components

Much needed follow-up: #6344 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6345?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6345?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6345)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.