### PR TITLE
Use nicer colors for the `Spatial2DView` snippet

### DIFF
--- a/crates/re_types/definitions/rerun/blueprint/views/spatial2d.fbs
+++ b/crates/re_types/definitions/rerun/blueprint/views/spatial2d.fbs
@@ -4,7 +4,7 @@ namespace rerun.blueprint.views;
 
 /// For viewing spatial 2D data.
 ///
-/// \example views/spatial2d title="Use a blueprint to customize a Spatial2DView." image="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/1200w.png"
+/// \example views/spatial2d title="Use a blueprint to customize a Spatial2DView." image="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/1200w.png"
 table Spatial2DView (
     "attr.docs.unreleased",
     "attr.rerun.view_identifier": "2D"

--- a/docs/content/reference/types/views/spatial2d_view.md
+++ b/docs/content/reference/types/views/spatial2d_view.md
@@ -33,11 +33,11 @@ If a timeline is specified more than once, the first entry will be used.
 snippet: views/spatial2d
 
 <picture data-inline-viewer="snippets/spatial2d">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/1200w.png">
-  <img src="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/full.png">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/1200w.png">
+  <img src="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/full.png">
 </picture>
 
 

--- a/docs/snippets/all/views/spatial2d.py
+++ b/docs/snippets/all/views/spatial2d.py
@@ -11,10 +11,10 @@ n = 150
 angle = np.linspace(0, 10 * np.pi, n)
 spiral_radius = np.linspace(0.0, 3.0, n) ** 2
 positions = np.column_stack((np.cos(angle) * spiral_radius, np.sin(angle) * spiral_radius))
-r = np.linspace(255, 255, n).astype(int)
-g = np.linspace(255, 0, n).astype(int)
-b = np.linspace(0, 255, n).astype(int)
-colors = np.dstack((r, g, b))[0]
+r = np.linspace(255, 255, n)
+g = np.linspace(255, 0, n)
+b = np.linspace(0, 255, n)
+colors = np.dstack((r, g, b))[0].astype(int)
 radii = np.linspace(0.01, 0.7, n)
 
 rr.log("points", rr.Points2D(positions, colors=colors, radii=radii))

--- a/docs/snippets/all/views/spatial2d.py
+++ b/docs/snippets/all/views/spatial2d.py
@@ -11,10 +11,7 @@ n = 150
 angle = np.linspace(0, 10 * np.pi, n)
 spiral_radius = np.linspace(0.0, 3.0, n) ** 2
 positions = np.column_stack((np.cos(angle) * spiral_radius, np.sin(angle) * spiral_radius))
-r = np.linspace(255, 255, n)
-g = np.linspace(255, 0, n)
-b = np.linspace(0, 255, n)
-colors = np.dstack((r, g, b))[0].astype(int)
+colors = np.dstack((np.linspace(255, 255, n), np.linspace(255, 0, n), np.linspace(0, 255, n)))[0].astype(int)
 radii = np.linspace(0.01, 0.7, n)
 
 rr.log("points", rr.Points2D(positions, colors=colors, radii=radii))

--- a/docs/snippets/all/views/spatial2d.py
+++ b/docs/snippets/all/views/spatial2d.py
@@ -7,21 +7,25 @@ import rerun.blueprint as rrb
 rr.init("rerun_example_spatial_2d", spawn=True)
 
 # Create a spiral of points:
-theta = np.linspace(0, 10 * np.pi, 300)
-radius = np.linspace(0, 10, 300)
-positions = np.column_stack((np.cos(theta) * radius, np.sin(theta) * radius))
-colors = np.random.randint(0, 255, size=(len(theta), 3))
+n = 150
+angle = np.linspace(0, 10 * np.pi, n)
+spiral_radius = np.linspace(0.0, 3.0, n) ** 2
+positions = np.column_stack((np.cos(angle) * spiral_radius, np.sin(angle) * spiral_radius))
+r = np.linspace(255, 255, n).astype(int)
+g = np.linspace(255, 0, n).astype(int)
+b = np.linspace(0, 255, n).astype(int)
+colors = np.dstack((r, g, b))[0]
+radii = np.linspace(0.01, 0.7, n)
 
-rr.log("points", rr.Points2D(positions, colors=colors, radii=0.1))
-rr.log("box", rr.Boxes2D(half_sizes=[3, 3], colors=0))
+rr.log("points", rr.Points2D(positions, colors=colors, radii=radii))
 
 # Create a Spatial2D view to display the points.
 blueprint = rrb.Blueprint(
     rrb.Spatial2DView(
         origin="/",
         name="2D Scene",
-        # Set the background color to light blue.
-        background=[100, 149, 237],
+        # Set the background color
+        background=[105, 20, 105],
         # Note that this range is smaller than the range of the points,
         # so some points will not be visible.
         visual_bounds=rrb.VisualBounds2D(x_range=[-5, 5], y_range=[-5, 5]),

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -35,10 +35,7 @@ class Spatial2DView(SpaceView):
     angle = np.linspace(0, 10 * np.pi, n)
     spiral_radius = np.linspace(0.0, 3.0, n) ** 2
     positions = np.column_stack((np.cos(angle) * spiral_radius, np.sin(angle) * spiral_radius))
-    r = np.linspace(255, 255, n).astype(int)
-    g = np.linspace(255, 0, n).astype(int)
-    b = np.linspace(0, 255, n).astype(int)
-    colors = np.dstack((r, g, b))[0]
+    colors = np.dstack((np.linspace(255, 255, n), np.linspace(255, 0, n), np.linspace(0, 255, n)))[0].astype(int)
     radii = np.linspace(0.01, 0.7, n)
 
     rr.log("points", rr.Points2D(positions, colors=colors, radii=radii))

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -31,21 +31,25 @@ class Spatial2DView(SpaceView):
     rr.init("rerun_example_spatial_2d", spawn=True)
 
     # Create a spiral of points:
-    theta = np.linspace(0, 10 * np.pi, 300)
-    radius = np.linspace(0, 10, 300)
-    positions = np.column_stack((np.cos(theta) * radius, np.sin(theta) * radius))
-    colors = np.random.randint(0, 255, size=(len(theta), 3))
+    n = 150
+    angle = np.linspace(0, 10 * np.pi, n)
+    spiral_radius = np.linspace(0.0, 3.0, n) ** 2
+    positions = np.column_stack((np.cos(angle) * spiral_radius, np.sin(angle) * spiral_radius))
+    r = np.linspace(255, 255, n).astype(int)
+    g = np.linspace(255, 0, n).astype(int)
+    b = np.linspace(0, 255, n).astype(int)
+    colors = np.dstack((r, g, b))[0]
+    radii = np.linspace(0.01, 0.7, n)
 
-    rr.log("points", rr.Points2D(positions, colors=colors, radii=0.1))
-    rr.log("box", rr.Boxes2D(half_sizes=[3, 3], colors=0))
+    rr.log("points", rr.Points2D(positions, colors=colors, radii=radii))
 
     # Create a Spatial2D view to display the points.
     blueprint = rrb.Blueprint(
         rrb.Spatial2DView(
             origin="/",
             name="2D Scene",
-            # Set the background color to light blue.
-            background=[100, 149, 237],
+            # Set the background color
+            background=[105, 20, 105],
             # Note that this range is smaller than the range of the points,
             # so some points will not be visible.
             visual_bounds=rrb.VisualBounds2D(x_range=[-5, 5], y_range=[-5, 5]),
@@ -57,11 +61,11 @@ class Spatial2DView(SpaceView):
     ```
     <center>
     <picture>
-      <source media="(max-width: 480px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/480w.png">
-      <source media="(max-width: 768px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/768w.png">
-      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/1024w.png">
-      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/1200w.png">
-      <img src="https://static.rerun.io/spatial2d/074c0822870325d6502c9f51c165c1181a20e83f/full.png" width="640">
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/1200w.png">
+      <img src="https://static.rerun.io/Spatial2DVIew/824a075e0c50ea4110eb6ddd60257f087cb2264d/full.png" width="640">
     </picture>
     </center>
 


### PR DESCRIPTION
### What
![image](https://github.com/rerun-io/rerun/assets/1148717/ca53012b-ff94-4874-ae80-65361b665894)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6351?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6351?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6351)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.