### PR TITLE
Quiet the 'not a mono-batch' log spam when selecting keypoint with a batch class-id

### DIFF
--- a/crates/re_data_ui/src/annotation_context.rs
+++ b/crates/re_data_ui/src/annotation_context.rs
@@ -94,9 +94,13 @@ fn annotation_info(
     keypoint_id: KeypointId,
 ) -> Option<AnnotationInfo> {
     // TODO(#5607): what should happen if the promise is still pending?
+
+    // TODO(#6358): this needs to use the index of the keypoint to look up the correct
+    // class_id. For now we use `latest_at_component_quiet` to avoid the warning spam.
     let class_id = ctx
         .recording()
-        .latest_at_component::<re_types::components::ClassId>(entity_path, query)?;
+        .latest_at_component_quiet::<re_types::components::ClassId>(entity_path, query)?;
+
     let annotations = crate::annotations(ctx, query, entity_path);
     let class = annotations.resolved_class_description(Some(class_id.value));
     class.keypoint_map?.get(&keypoint_id).cloned()


### PR DESCRIPTION
### What
- Partially mitigates: https://github.com/rerun-io/rerun/issues/6358

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6359?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6359?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6359)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.