### PR TITLE
Fix width/height/channel extraction logic

### DIFF
--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -875,11 +875,18 @@ fn test_image_height_width_channels() {
         // h=1, w=1, RGB:
         (vec![1, 1, 3], Some([1, 1, 3])),
         (vec![1, 1, 1, 3], Some([1, 1, 3])),
-        (vec![1, 1, 3, 1], Some([1, 1, 3])),
         //
         // h=1, w=3, Mono:
         (vec![1, 3, 1], Some([1, 3, 1])),
         (vec![1, 3, 1, 1], Some([1, 3, 1])),
+        //
+        // Ambiguous cases.
+        //
+        // This could validly be RGB or Mono. This is here to show how the current implementation
+        // behaves, not to suggest that it is a commitment to preserving this behavior going forward.
+        // If you need to change this test, it's ok but we should still communicate the subtle change
+        // in behavior.
+        (vec![1, 1, 3, 1], Some([1, 1, 3])),
     ];
 
     for (shape, expected_hwc) in test_cases {

--- a/crates/re_types/src/datatypes/tensor_data_ext.rs
+++ b/crates/re_types/src/datatypes/tensor_data_ext.rs
@@ -878,15 +878,15 @@ fn test_image_height_width_channels() {
         //
         // h=1, w=3, Mono:
         (vec![1, 3, 1], Some([1, 3, 1])),
-        (vec![1, 3, 1, 1], Some([1, 3, 1])),
         //
         // Ambiguous cases.
         //
-        // This could validly be RGB or Mono. This is here to show how the current implementation
-        // behaves, not to suggest that it is a commitment to preserving this behavior going forward.
+        // These are here to show how the current implementation behaves, not to suggest that it is a
+        // commitment to preserving this behavior going forward.
         // If you need to change this test, it's ok but we should still communicate the subtle change
         // in behavior.
-        (vec![1, 1, 3, 1], Some([1, 1, 3])),
+        (vec![1, 1, 3, 1], Some([1, 1, 3])), // Could be [1, 3, 1]
+        (vec![1, 3, 1, 1], Some([1, 3, 1])), // Could be [3, 1, 1]
     ];
 
     for (shape, expected_hwc) in test_cases {


### PR DESCRIPTION
- Fixes #6357

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6360?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6360?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6360)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.