### PR TITLE
Fix clearing mesh3d causing a warning

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -68,7 +68,7 @@ impl Mesh3DVisualizer {
             let outline_mask_ids = ent_context.highlight.index_outline_mask(Instance::ALL);
 
             // Skip over empty meshes.
-            // Note that we can deal with zero normals/colors/texcoords/indicies just fine (we generate them),
+            // Note that we can deal with zero normals/colors/texcoords/indices just fine (we generate them),
             // but re_renderer insists on having at a non-zero vertex list.
             if data.vertex_positions.is_empty() {
                 continue;

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -67,6 +67,13 @@ impl Mesh3DVisualizer {
             let picking_instance_hash = re_entity_db::InstancePathHash::entity_all(entity_path);
             let outline_mask_ids = ent_context.highlight.index_outline_mask(Instance::ALL);
 
+            // Skip over empty meshes.
+            // Note that we can deal with zero normals/colors/texcoords/indicies just fine (we generate them),
+            // but re_renderer insists on having at a non-zero vertex list.
+            if data.vertex_positions.is_empty() {
+                continue;
+            }
+
             let mesh = ctx.cache.entry(|c: &mut MeshCache| {
                 let key = MeshCacheKey {
                     versioned_instance_path_hash: picking_instance_hash.versioned(primary_row_id),


### PR DESCRIPTION
### What

* Fixes #6355

... and improve re_renderers internal error messaging a little bit.
Guess we could react to re_renderer's errors directly instead of doing a separate check, but I found it cleaner 🤷 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6361?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6361?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6361)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.