### PR TITLE
Fix: docs-latest push workflow not triggered by release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,7 @@ jobs:
           ref: ${{ needs.version.outputs.release-commit }}
           # `secrets.GITHUB_TOKEN` is used here so that the `git push ... doc-latest`
           # below can trigger a workflow run of the `on_push_docs.yml` workflow
+          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update latest branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.version.outputs.release-commit }}
+          # `secrets.GITHUB_TOKEN` is used here so that the `git push ... doc-latest`
+          # below can trigger a workflow run of the `on_push_docs.yml` workflow
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update latest branch
         run: |


### PR DESCRIPTION
### What

`release.yml` contains a bit of code that force-pushes the release branch into `docs-latest`, which should then trigger a redeploy of `rerun.io` together with updated env vars, e.g. `RELEASE_VERSION` set to the newly released version. That did not happen because the default `GITHUB_TOKEN` generated by GHA _cannot_ be used to trigger other workflows: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
