### PR TITLE
Revert making web_viewer a default feature of rerun_py

### DIFF
--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -15,7 +15,7 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 
 
 [features]
-default = ["extension-module", "web_viewer"]
+default = ["extension-module"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.


### PR DESCRIPTION
### What

In https://github.com/rerun-io/rerun/pull/6335 `web_viewer` became a default feature of `rerun_py`.
This caused a bunch of issues for development:
* `pixi run py-build` builds with default features and doesn't build new wasm blobs, meaning that the build either fails or picks up outdated
* currently contributor ci doesn't build the web builder during its wheel test job causing failures

_Q: Are we sure that wheel publish would still include the web_viewer?_
A: Yes. We test this prior to release. This works because we use the `pypi` feature of `build_and_upload_wheels.py`. This script also ensures that the wasm blobs are built.

_Q: Why does the non-contributor ci build the wasm blobs?_
A: It doesn't! Again, we use `build_and_upload_wheels.py` there which builds with `--no-default-features`. However, that script can't be used on the contributor ci since that would spill the GCS secrets (upload on that script is not optional right now).


=> Alternative solutions:
* do `--no-default-features` on `pixi run py-build` and on the contributor ci (potentially by using and adjusting `build_and_upload_wheels.py`
* make `pixi run py-build` slower by making it depend on the web build 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6370?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6370?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6370)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.