### PR TITLE
Drop rerun_cpp_sdk-{tag}-multiplatform.zip in favor of rerun_cpp_sdk.zip

### DIFF
--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -129,7 +129,12 @@ def fetch_binary_assets(
             if blob is not None and blob.name is not None:
                 name = blob.name.split("/")[-1]
                 print(f"Found Rerun cross-platform bundle: {name}")
-                assets[f"rerun_cpp_sdk-{tag}-multiplatform.zip"] = blob
+                # ATTENTION: Renaming this file has tremendous ripple effects:
+                # Not only is this the convenient short name we use examples,
+                # we also rely on https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip
+                # to always give you the latest stable version of the Rerun SDK.
+                # -> The name should *not* contain the version number.
+                assets[f"rerun_cpp_sdk.zip"] = blob
             else:
                 all_found = False
                 print("Rerun cross-platform bundle not found")

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -129,6 +129,10 @@ def fetch_binary_assets(
             if blob is not None and blob.name is not None:
                 name = blob.name.split("/")[-1]
                 print(f"Found Rerun cross-platform bundle: {name}")
+                assets[f"rerun_cpp_sdk-{tag}-multiplatform.zip"] = blob
+
+                # Upload again as rerun_cpp_sdk.zip for convenience.
+                #
                 # ATTENTION: Renaming this file has tremendous ripple effects:
                 # Not only is this the convenient short name we use examples,
                 # we also rely on https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip

--- a/scripts/ci/sync_release_assets.py
+++ b/scripts/ci/sync_release_assets.py
@@ -134,7 +134,7 @@ def fetch_binary_assets(
                 # Upload again as rerun_cpp_sdk.zip for convenience.
                 #
                 # ATTENTION: Renaming this file has tremendous ripple effects:
-                # Not only is this the convenient short name we use examples,
+                # Not only is this the convenient short name we use in examples,
                 # we also rely on https://github.com/rerun-io/rerun/releases/latest/download/rerun_cpp_sdk.zip
                 # to always give you the latest stable version of the Rerun SDK.
                 # -> The name should *not* contain the version number.


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/6364

Previously we had _both_ `rerun_cpp_sdk-{tag}-multiplatform.zip` and `rerun_cpp_sdk.zip`. Between 0.15 and 0.16 we removed the later from automation which meant that we had to upload it manually. This brings back `rerun_cpp_sdk.zip` ~but instead drops the redundant multiplatform one. We could upload with both names but seems confusing to me.~ and keeps the old one since it has the advantage of knowing what you're dealing with by just looking at the file + you can more easily download different versions into the same folder without any conflicts

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6373?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6373?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6373)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.