### PR TITLE
`list_item2` migration (part 1): ensure background is painted on rounded pixels

### DIFF
--- a/crates/re_ui/src/list_item2/list_item.rs
+++ b/crates/re_ui/src/list_item2/list_item.rs
@@ -307,11 +307,20 @@ impl<'a> ListItem<'a> {
             };
             content.ui(re_ui, ui, &content_ctx);
 
+            // Ensure the background highlight is drawn over round pixel coordinates. Otherwise,
+            // there could be artifact between consecutive highlighted items when drawn on
+            // fractional pixels.
+            let bg_rect_to_paint = ui.painter().round_rect_to_pixels(bg_rect);
+
             // Draw background on interaction.
             if drag_target {
                 ui.painter().set(
                     background_frame,
-                    Shape::rect_stroke(bg_rect, 0.0, (1.0, ui.visuals().selection.bg_fill)),
+                    Shape::rect_stroke(
+                        bg_rect_to_paint,
+                        0.0,
+                        (1.0, ui.visuals().selection.bg_fill),
+                    ),
                 );
             } else {
                 let bg_fill = if !response.hovered() && ui.rect_contains_pointer(bg_rect) {
@@ -329,8 +338,10 @@ impl<'a> ListItem<'a> {
                 };
 
                 if let Some(bg_fill) = bg_fill {
-                    ui.painter()
-                        .set(background_frame, Shape::rect_filled(bg_rect, 0.0, bg_fill));
+                    ui.painter().set(
+                        background_frame,
+                        Shape::rect_filled(bg_rect_to_paint, 0.0, bg_fill),
+                    );
                 }
             }
         }


### PR DESCRIPTION
### What

This PR fixes a visual glitch with `ui.cursor()` is on an uneven pixel (which apparently can happen in the streams tree). The background is now alway painted on rounded pixels.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
