### PR TITLE
Fix not being able to set time series y axis ranges from ui

### DIFF
--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -706,7 +706,7 @@ fn axis_ui(
                     });
 
                     if !auto_range {
-                        let range_edit = y_range
+                        let mut range_edit = y_range
                             .unwrap_or_else(|| y_range.unwrap_or(state.saved_y_axis_range.into()));
 
                         ui.horizontal(|ui| {
@@ -718,13 +718,13 @@ fn axis_ui(
                             let speed = ((prev_max - prev_min) * 0.01).at_least(0.001);
                             ui.label("Min");
                             ui.add(
-                                egui::DragValue::new(&mut range_edit.start())
+                                egui::DragValue::new(range_edit.start_mut())
                                     .speed(speed)
                                     .clamp_range(std::f64::MIN..=prev_max),
                             );
                             ui.label("Max");
                             ui.add(
-                                egui::DragValue::new(&mut range_edit.end())
+                                egui::DragValue::new(range_edit.end_mut())
                                     .speed(speed)
                                     .clamp_range(prev_min..=std::f64::MAX),
                             );

--- a/crates/re_types/src/components/range1d_ext.rs
+++ b/crates/re_types/src/components/range1d_ext.rs
@@ -21,6 +21,18 @@ impl Range1D {
     pub fn end(&self) -> f64 {
         self.0 .0[1]
     }
+
+    /// The start of the range.
+    #[inline]
+    pub fn start_mut(&mut self) -> &mut f64 {
+        &mut self.0 .0[0]
+    }
+
+    /// The end of the range.
+    #[inline]
+    pub fn end_mut(&mut self) -> &mut f64 {
+        &mut self.0 .0[1]
+    }
 }
 
 impl From<Range1D> for emath::Rangef {


### PR DESCRIPTION
### What

* Fixes #6383

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6384?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6384?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6384)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.