### PR TITLE
Fix welcome screen header jumping during load

### DIFF
--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -251,35 +251,6 @@ impl ExampleSection {
             .examples
             .get_or_insert_with(|| load_manifest(ui.ctx(), self.manifest_url.clone()));
 
-        let Some(examples) = examples.ready_mut() else {
-            // Still waiting for example to load
-
-            header_ui(ui); // Always show the header
-
-            ui.separator();
-
-            ui.spinner(); // Placeholder for the examples
-            return;
-        };
-
-        let examples = match examples {
-            Ok(examples) => examples,
-            Err(err) => {
-                // Examples failed to load.
-
-                header_ui(ui); // Always show the header
-
-                re_log::warn_once!("Failed to load examples: {err}");
-
-                return;
-            }
-        };
-
-        if examples.is_empty() {
-            ui.label("No examples found.");
-            return;
-        }
-
         // vertical spacing isn't homogeneous so it's handled manually
         let grid_spacing = egui::vec2(COLUMN_HSPACE, 0.0);
         let column_count = (((ui.available_width() + grid_spacing.x)
@@ -302,6 +273,29 @@ impl ExampleSection {
 
             ui.vertical(|ui| {
                 header_ui(ui);
+
+                let Some(examples) = examples.ready_mut() else {
+                    // Still waiting for example to load
+                    ui.separator();
+
+                    ui.spinner(); // Placeholder for the examples
+                    return;
+                };
+
+                let examples = match examples {
+                    Ok(examples) => examples,
+                    Err(err) => {
+                        // Examples failed to load.
+                        re_log::warn_once!("Failed to load examples: {err}");
+
+                        return;
+                    }
+                };
+
+                if examples.is_empty() {
+                    ui.label("No examples found.");
+                    return;
+                }
 
                 ui.add(egui::Label::new(
                     egui::RichText::new("View example recordings")


### PR DESCRIPTION
### What
The centering was wrong until the examples has finished loading, leading to it jumping, especially on slow internet connections.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
