### PR TITLE
Fix re_sdk_comms isolated compilation

### DIFF
--- a/crates/re_sdk_comms/src/lib.rs
+++ b/crates/re_sdk_comms/src/lib.rs
@@ -37,6 +37,7 @@ pub enum ConnectionError {
     SendError(#[from] std::io::Error),
 
     #[error(transparent)]
+    #[cfg(feature = "server")]
     DecodeError(#[from] re_log_encoding::decoder::DecodeError),
 
     #[error("The receiving end of the channel was closed")]


### PR DESCRIPTION
* [x] fixes nightly ci 🤞 
* [x] confirm re_sdk_comms actually has a `server` feature https://github.com/rerun-io/rerun/blob/main/crates/re_sdk_comms/Cargo.toml#L27

made sure that both `cargo clippy -p re_sdk_comms --no-default-features` `cargo clippy -p re_sdk_comms --all-features` work