### PR TITLE
Reduce height of top and bottom panels

### DIFF
--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -336,6 +336,14 @@ impl EntityDb {
         &self.times_per_timeline
     }
 
+    pub fn has_any_data_on_timeline(&self, timeline: &Timeline) -> bool {
+        if let Some(times) = self.times_per_timeline.get(timeline) {
+            !times.is_empty()
+        } else {
+            false
+        }
+    }
+
     /// Histogram of all events on the timeeline, of all entities.
     pub fn time_histogram(&self, timeline: &Timeline) -> Option<&crate::TimeHistogram> {
         self.tree().subtree.time_histogram.get(timeline)

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -270,8 +270,11 @@ impl TimePanel {
                     let times_per_timeline = entity_db.times_per_timeline();
                     self.time_control_ui
                         .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
-                    self.time_control_ui.playback_speed_ui(time_ctrl, ui);
-                    self.time_control_ui.fps_ui(time_ctrl, ui);
+
+                    if entity_db.has_any_data_on_timeline(time_ctrl.timeline()) {
+                        self.time_control_ui.playback_speed_ui(time_ctrl, ui);
+                        self.time_control_ui.fps_ui(time_ctrl, ui);
+                    }
                 });
                 ui.horizontal(|ui| {
                     self.time_control_ui.timeline_selector_ui(
@@ -290,8 +293,11 @@ impl TimePanel {
                 .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
             self.time_control_ui
                 .timeline_selector_ui(time_ctrl, times_per_timeline, ui);
-            self.time_control_ui.playback_speed_ui(time_ctrl, ui);
-            self.time_control_ui.fps_ui(time_ctrl, ui);
+
+            if entity_db.has_any_data_on_timeline(time_ctrl.timeline()) {
+                self.time_control_ui.playback_speed_ui(time_ctrl, ui);
+                self.time_control_ui.fps_ui(time_ctrl, ui);
+            }
 
             collapsed_time_marker_and_time(ui, ctx, entity_db, time_ctrl);
         }
@@ -952,7 +958,13 @@ fn collapsed_time_marker_and_time(
     entity_db: &re_entity_db::EntityDb,
     time_ctrl: &mut TimeControl,
 ) {
-    let space_needed_for_current_time = match time_ctrl.timeline().typ() {
+    let timeline = time_ctrl.timeline();
+
+    if !entity_db.has_any_data_on_timeline(timeline) {
+        return;
+    }
+
+    let space_needed_for_current_time = match timeline.typ() {
         re_data_store::TimeType::Time => 220.0,
         re_data_store::TimeType::Sequence => 100.0,
     };

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -980,7 +980,7 @@ fn collapsed_time_marker_and_time(
             painter.hline(
                 time_range_rect.x_range(),
                 time_range_rect.center().y,
-                ui.visuals().widgets.inactive.fg_stroke,
+                ui.visuals().widgets.noninteractive.fg_stroke,
             );
             time_marker_ui(
                 &time_ranges_ui,

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -154,7 +154,7 @@ impl TimePanel {
         // etc.)
         let screen_header_height = ui.cursor().top();
 
-        let top_bar_height = 28.0;
+        let top_bar_height = re_ui::ReUi::top_bar_height();
         let margin = ctx.re_ui.bottom_panel_margin();
         let mut panel_frame = ctx.re_ui.bottom_panel_frame();
 

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -204,8 +204,8 @@ impl TimePanel {
                     ui.vertical(|ui| {
                         // Add back the margin we removed from the panel:
                         let mut top_row_frame = egui::Frame::default();
-                        top_row_frame.inner_margin.right = margin.x;
-                        top_row_frame.inner_margin.bottom = margin.y;
+                        top_row_frame.inner_margin.right = margin.right;
+                        top_row_frame.inner_margin.bottom = margin.bottom;
                         let top_row_rect = top_row_frame
                             .show(ui, |ui| {
                                 ui.horizontal(|ui| {
@@ -228,7 +228,7 @@ impl TimePanel {
 
                         // Add extra margin on the left which was intentionally missing on the controls.
                         let mut streams_frame = egui::Frame::default();
-                        streams_frame.inner_margin.left = margin.x;
+                        streams_frame.inner_margin.left = margin.left;
                         streams_frame.show(ui, |ui| {
                             self.expanded_ui(
                                 ctx,

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -407,7 +407,7 @@ impl ReUi {
         }
 
         let button_size = Vec2::splat(22.0);
-        let icon_size = Self::small_icon_size(); // centered inside the button
+        let icon_size = Vec2::splat(12.0); // centered inside the button
         let rounding = 6.0;
 
         let (rect, response) = ui.allocate_exact_size(button_size, egui::Sense::click());

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -185,7 +185,7 @@ impl ReUi {
 
     /// Height of the top-most bar.
     pub fn top_bar_height() -> f32 {
-        44.0 // from figma 2022-02-03
+        28.0 // Don't waste vertical space, especially important for embedded web viewers
     }
 
     /// Height of the title row in the blueprint view and selection view,

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -406,7 +406,7 @@ impl ReUi {
             visuals.widgets.open.expansion = 0.0;
         }
 
-        let button_size = Vec2::splat(28.0);
+        let button_size = Vec2::splat(22.0);
         let icon_size = Self::small_icon_size(); // centered inside the button
         let rounding = 6.0;
 

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -216,8 +216,8 @@ impl ReUi {
     }
 
     #[allow(clippy::unused_self)]
-    pub fn bottom_panel_margin(&self) -> egui::Vec2 {
-        egui::Vec2::splat(8.0)
+    pub fn bottom_panel_margin(&self) -> egui::Margin {
+        Self::top_bar_margin()
     }
 
     /// For the streams view (time panel)
@@ -230,10 +230,7 @@ impl ReUi {
 
         let mut frame = egui::Frame {
             fill: self.design_tokens.bottom_bar_color,
-            inner_margin: egui::Margin::symmetric(
-                margin.x + margin_offset,
-                margin.y + margin_offset,
-            ),
+            inner_margin: margin + margin_offset,
             outer_margin: egui::Margin {
                 left: -margin_offset,
                 right: -margin_offset,

--- a/crates/re_ui/src/lib.rs
+++ b/crates/re_ui/src/lib.rs
@@ -807,7 +807,8 @@ impl ReUi {
 
         let openness = state.openness(ui.ctx());
 
-        let header_size = egui::vec2(ui.available_width(), 28.0);
+        let height = Self::list_item_height();
+        let header_size = egui::vec2(ui.available_width(), height);
 
         // Draw custom header.
         ui.allocate_ui_with_layout(


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/5589


#### Before
<img width="969" alt="Screenshot 2024-05-21 at 19 58 17" src="https://github.com/rerun-io/rerun/assets/1148717/0a552fa8-5e1f-4e3b-860a-e5ed9919112e">
<img width="969" alt="Screenshot 2024-05-21 at 19 58 13" src="https://github.com/rerun-io/rerun/assets/1148717/8618cfd4-166f-44db-995d-09382968e5e9">

#### After
<img width="969" alt="Screenshot 2024-05-21 at 19 57 32" src="https://github.com/rerun-io/rerun/assets/1148717/66bbcff5-2be1-45f3-8475-0056255ee877">
<img width="969" alt="Screenshot 2024-05-21 at 19 57 27" src="https://github.com/rerun-io/rerun/assets/1148717/49ee2109-e187-4285-8270-24c66ff9d313">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6397?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6397?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6397)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.