### PR TITLE
Improve welcome screen for small screens

### DIFF
--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -264,7 +264,9 @@ impl TimePanel {
     ) {
         ui.spacing_mut().item_spacing.x = 18.0; // from figma
 
-        if ui.max_rect().width() < 600.0 {
+        let has_any_data_on_timeline = entity_db.has_any_data_on_timeline(time_ctrl.timeline());
+
+        if ui.max_rect().width() < 600.0 && has_any_data_on_timeline {
             // Responsive ui for narrow screens, e.g. mobile. Split the controls into two rows.
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
@@ -273,7 +275,7 @@ impl TimePanel {
                     self.time_control_ui
                         .play_pause_ui(time_ctrl, re_ui, times_per_timeline, ui);
 
-                    if entity_db.has_any_data_on_timeline(time_ctrl.timeline()) {
+                    if has_any_data_on_timeline {
                         self.time_control_ui.playback_speed_ui(time_ctrl, ui);
                         self.time_control_ui.fps_ui(time_ctrl, ui);
                     }
@@ -296,7 +298,7 @@ impl TimePanel {
             self.time_control_ui
                 .timeline_selector_ui(time_ctrl, times_per_timeline, ui);
 
-            if entity_db.has_any_data_on_timeline(time_ctrl.timeline()) {
+            if has_any_data_on_timeline {
                 self.time_control_ui.playback_speed_ui(time_ctrl, ui);
                 self.time_control_ui.fps_ui(time_ctrl, ui);
             }

--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -4,10 +4,10 @@ use re_log_types::{DataRow, EntityPath, RowId};
 use re_types::blueprint::components::PanelState;
 use re_viewer_context::{CommandSender, StoreContext, SystemCommand, SystemCommandSender};
 
-pub const TOP_PANEL_PATH: &str = "top_panel";
-pub const BLUEPRINT_PANEL_PATH: &str = "blueprint_panel";
-pub const SELECTION_PANEL_PATH: &str = "selection_panel";
-pub const TIME_PANEL_PATH: &str = "time_panel";
+const TOP_PANEL_PATH: &str = "top_panel";
+const BLUEPRINT_PANEL_PATH: &str = "blueprint_panel";
+const SELECTION_PANEL_PATH: &str = "selection_panel";
+const TIME_PANEL_PATH: &str = "time_panel";
 
 /// Blueprint for top-level application
 pub struct AppBlueprint<'a> {

--- a/crates/re_viewer/src/app_blueprint.rs
+++ b/crates/re_viewer/src/app_blueprint.rs
@@ -98,9 +98,10 @@ impl<'a> AppBlueprint<'a> {
 }
 
 pub fn setup_welcome_screen_blueprint(welcome_screen_blueprint: &mut EntityDb) {
+    // Most things are hidden in the welcome screen:
     for (panel_name, value) in [
         (TOP_PANEL_PATH, PanelState::Expanded),
-        (BLUEPRINT_PANEL_PATH, PanelState::Expanded),
+        (BLUEPRINT_PANEL_PATH, PanelState::Hidden),
         (SELECTION_PANEL_PATH, PanelState::Hidden),
         (TIME_PANEL_PATH, PanelState::Hidden),
     ] {

--- a/crates/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -34,7 +34,8 @@ pub(super) const MIN_COLUMN_WIDTH: f32 = 250.0;
 const MAX_COLUMN_WIDTH: f32 = 337.0;
 const MAX_COLUMN_COUNT: usize = 3;
 const COLUMN_HSPACE: f32 = 20.0;
-const TITLE_TO_GRID_VSPACE: f32 = 32.0;
+const AFTER_HEADER_VSPACE: f32 = 48.0;
+const TITLE_TO_GRID_VSPACE: f32 = 24.0;
 const ROW_VSPACE: f32 = 20.0;
 const THUMBNAIL_RADIUS: f32 = 12.0;
 
@@ -273,6 +274,8 @@ impl ExampleSection {
 
             ui.vertical(|ui| {
                 header_ui(ui);
+
+                ui.add_space(AFTER_HEADER_VSPACE);
 
                 let Some(examples) = examples.ready_mut() else {
                     // Still waiting for example to load

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -65,7 +65,5 @@ pub(super) fn welcome_section_ui(ui: &mut egui::Ui) {
                 new_tab: true,
             });
         }
-
-        ui.add_space(83.0);
     });
 }

--- a/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
+++ b/crates/re_viewer/src/ui/welcome_screen/welcome_section.rs
@@ -1,7 +1,7 @@
 use egui::Ui;
 
 pub(super) const DOCS_URL: &str = "https://www.rerun.io/docs";
-pub(super) const WELCOME_SCREEN_TITLE: &str = "Visualize Multimodal Data";
+pub(super) const WELCOME_SCREEN_TITLE: &str = "Visualize multimodal data";
 pub(super) const WELCOME_SCREEN_BULLET_TEXT: &[&str] = &[
     "Log data with the Rerun SDK in C++, Python, or Rust",
     "Visualize and explore live or recorded data",


### PR DESCRIPTION
Makes the welcome screen use more of the available space.

Important for small screens, mobile, or embedded web viewers.

### What
* Hide blueprint panel
* Reduce vertical space
* Fix title casing

#### Before (0.16 viewer)
<img width="861" alt="Screenshot 2024-05-23 at 15 14 14" src="https://github.com/rerun-io/rerun/assets/1148717/67c7aef1-817b-48fb-922c-234c9fe91d62">


#### After
<img width="861" alt="Screenshot 2024-05-23 at 15 14 24" src="https://github.com/rerun-io/rerun/assets/1148717/1b28716e-627a-4f3f-a659-62657ee82ba3">


#### Mobile
![IMG_7872](https://github.com/rerun-io/rerun/assets/1148717/f4ba5a95-0c6e-43f0-aadd-b17f768ebaec)



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6421?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6421?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6421)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.