### PR TITLE
Smooth scrolling in 2D space views

### DIFF
--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -80,12 +80,7 @@ fn ui_from_scene(
 
         let mut pan_delta_in_ui = response.drag_delta();
         if response.hovered() {
-            // NOTE: we use `raw_scroll` instead of `smooth_scroll_delta` to avoid the
-            // added latency of smoothing, which is really annoying on Mac trackpads.
-            // The smoothing is only useful for users with discreet scroll wheels,
-            // and they are likely to pan with dragging instead.
-            // TODO(egui#4401): https://github.com/emilk/egui/issues/4401
-            pan_delta_in_ui += response.ctx.input(|i| i.raw_scroll_delta);
+            pan_delta_in_ui += response.ctx.input(|i| i.smooth_scroll_delta);
         }
         if pan_delta_in_ui != Vec2::ZERO {
             *visual_bounds =


### PR DESCRIPTION
When scrolling with a discreet mouse wheel, the scrolling is now smoothed.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6422?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6422?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6422)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.