### PR TITLE
Improve styling of list item's collapsing triangle

### DIFF
--- a/crates/re_ui/src/list_item/list_item.rs
+++ b/crates/re_ui/src/list_item/list_item.rs
@@ -288,7 +288,12 @@ impl<'a> ListItem<'a> {
                     id.unwrap_or(ui.id()).with("collapsing_triangle"),
                     egui::Sense::click(),
                 );
-                ReUi::paint_collapsing_triangle(ui, openness, triangle_rect.center(), &visuals);
+                ReUi::paint_collapsing_triangle(
+                    ui,
+                    openness,
+                    triangle_rect.center(),
+                    ui.style().interact(&triangle_response),
+                );
                 collapse_response = Some(triangle_response);
             }
 


### PR DESCRIPTION
### What

- Part of  #6418

Before:

![collapse-ui](https://github.com/rerun-io/rerun/assets/1148717/5bd9f55a-69a0-4d27-8393-26b8b376cf5d)

After:

![Export-1716534172555](https://github.com/rerun-io/rerun/assets/49431240/bc915eb9-9c45-4295-91f7-3ec889e957bc)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6426?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6426?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6426)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.