### PR TITLE
Fix error when logging segmentation image

### DIFF
--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -146,26 +146,29 @@ pub fn tensor_ui(
                         |ui| {
                             ui.set_min_size(preview_size);
 
-                            show_image_preview(
+                            match show_image_preview(
                                 ctx.render_ctx,
                                 ctx.re_ui,
                                 ui,
                                 texture.clone(),
                                 &debug_name,
                                 preview_size,
-                            )
-                            .on_hover_ui(|ui| {
-                                // Show larger image on hover.
-                                let preview_size = Vec2::splat(400.0);
-                                show_image_preview(
-                                    ctx.render_ctx,
-                                    ctx.re_ui,
-                                    ui,
-                                    texture.clone(),
-                                    &debug_name,
-                                    preview_size,
-                                );
-                            });
+                            ) {
+                                Ok(response) => response.on_hover_ui(|ui| {
+                                    // Show larger image on hover.
+                                    let preview_size = Vec2::splat(400.0);
+                                    show_image_preview(
+                                        ctx.render_ctx,
+                                        ctx.re_ui,
+                                        ui,
+                                        texture.clone(),
+                                        &debug_name,
+                                        preview_size,
+                                    )
+                                    .ok();
+                                }),
+                                Err((response, err)) => response.on_hover_text(err.to_string()),
+                            }
                         },
                     );
                 }
@@ -215,14 +218,17 @@ pub fn tensor_ui(
                         .available_size()
                         .min(texture_size(texture))
                         .min(egui::vec2(150.0, 300.0));
-                    let response = show_image_preview(
+                    let response = match show_image_preview(
                         ctx.render_ctx,
                         ctx.re_ui,
                         ui,
                         texture.clone(),
                         &debug_name,
                         preview_size,
-                    );
+                    ) {
+                        Ok(response) => response,
+                        Err((response, err)) => response.on_hover_text(err.to_string()),
+                    };
 
                     if let Some(pointer_pos) = ui.ctx().pointer_latest_pos() {
                         let image_rect = response.rect;
@@ -279,6 +285,8 @@ fn texture_size(colormapped_texture: &ColormappedTexture) -> Vec2 {
 ///
 /// Extremely small images will be stretched on their thin axis to make them visible.
 /// This does not preserve aspect ratio, but we only stretch it to a very thin size, so it is fine.
+///
+/// Returns error if the image could not be rendered.
 fn show_image_preview(
     render_ctx: &re_renderer::RenderContext,
     re_ui: &ReUi,
@@ -286,7 +294,7 @@ fn show_image_preview(
     colormapped_texture: ColormappedTexture,
     debug_name: &str,
     desired_size: egui::Vec2,
-) -> egui::Response {
+) -> Result<egui::Response, (egui::Response, anyhow::Error)> {
     const MIN_SIZE: f32 = 2.0;
 
     let texture_size = texture_size(&colormapped_texture);
@@ -309,10 +317,17 @@ fn show_image_preview(
         egui::TextureOptions::LINEAR,
         debug_name,
     ) {
-        let label_response = ui.label(re_ui.error_text(err.to_string()));
-        response.union(label_response)
+        let color = ui.visuals().error_fg_color;
+        painter.text(
+            response.rect.left_top(),
+            egui::Align2::LEFT_TOP,
+            "🚫",
+            egui::FontId::default(),
+            color,
+        );
+        Err((response, err))
     } else {
-        response
+        Ok(response)
     }
 }
 

--- a/crates/re_data_ui/src/image.rs
+++ b/crates/re_data_ui/src/image.rs
@@ -6,7 +6,6 @@ use re_renderer::renderer::ColormappedTexture;
 use re_types::components::{ClassId, DepthMeter};
 use re_types::datatypes::{TensorBuffer, TensorData, TensorDimension};
 use re_types::tensor_data::{DecodedTensor, TensorDataMeaning, TensorElement};
-use re_ui::ReUi;
 use re_viewer_context::{
     gpu_bridge, Annotations, TensorDecodeCache, TensorStats, TensorStatsCache, UiLayout,
     ViewerContext,
@@ -148,7 +147,6 @@ pub fn tensor_ui(
 
                             match show_image_preview(
                                 ctx.render_ctx,
-                                ctx.re_ui,
                                 ui,
                                 texture.clone(),
                                 &debug_name,
@@ -159,7 +157,6 @@ pub fn tensor_ui(
                                     let preview_size = Vec2::splat(400.0);
                                     show_image_preview(
                                         ctx.render_ctx,
-                                        ctx.re_ui,
                                         ui,
                                         texture.clone(),
                                         &debug_name,
@@ -220,7 +217,6 @@ pub fn tensor_ui(
                         .min(egui::vec2(150.0, 300.0));
                     let response = match show_image_preview(
                         ctx.render_ctx,
-                        ctx.re_ui,
                         ui,
                         texture.clone(),
                         &debug_name,
@@ -289,7 +285,6 @@ fn texture_size(colormapped_texture: &ColormappedTexture) -> Vec2 {
 /// Returns error if the image could not be rendered.
 fn show_image_preview(
     render_ctx: &re_renderer::RenderContext,
-    re_ui: &ReUi,
     ui: &mut egui::Ui,
     colormapped_texture: ColormappedTexture,
     debug_name: &str,

--- a/crates/re_renderer/src/renderer/rectangles.rs
+++ b/crates/re_renderer/src/renderer/rectangles.rs
@@ -210,7 +210,7 @@ pub enum RectangleError {
     #[error("Texture format not supported: {0:?} - use float or integer textures instead.")]
     TextureFormatNotSupported(wgpu::TextureFormat),
 
-    #[error("Color mapping is being applied to a four-component RGBA texture")]
+    #[error("Color mapping cannot be applied to a four-component RGBA image, but only to a single-component image.")]
     ColormappingRgbaTexture,
 
     #[error("Only 1 and 4 component textures are supported, got {0} components")]

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -560,12 +560,14 @@ impl ImageVisualizer {
         let tensor_stats = ctx
             .cache
             .entry(|c: &mut TensorStatsCache| c.entry(tensor_data_row_id, tensor));
-        let depth_texture = re_viewer_context::gpu_bridge::depth_tensor_to_gpu(
+        let depth_texture = re_viewer_context::gpu_bridge::tensor_to_gpu(
             ctx.render_ctx,
             &debug_name,
             tensor_data_row_id,
             tensor,
+            TensorDataMeaning::Depth,
             &tensor_stats,
+            &ent_context.annotations,
         )?;
 
         let depth_from_world_scale = *properties.depth_from_world_scale;

--- a/crates/re_types/src/tensor_data.rs
+++ b/crates/re_types/src/tensor_data.rs
@@ -418,7 +418,7 @@ impl DecodedTensor {
 
 // Backwards comparabillity shim
 // TODO(jleibs): fully express this in terms of indicator components
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TensorDataMeaning {
     /// Default behavior: guess based on shape
     Unknown,

--- a/crates/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/mod.rs
@@ -6,10 +6,7 @@ mod tensor_to_gpu;
 
 pub use colormap::colormap_dropdown_button_ui;
 pub use re_renderer_callback::new_renderer_callback;
-pub use tensor_to_gpu::{
-    class_id_tensor_to_gpu, color_tensor_to_gpu, depth_tensor_to_gpu, tensor_to_gpu,
-    texture_height_width_channels,
-};
+pub use tensor_to_gpu::{tensor_to_gpu, texture_height_width_channels};
 
 use crate::TensorStats;
 

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -27,6 +27,7 @@ use super::{get_or_create_texture, try_get_or_create_texture};
 
 // ----------------------------------------------------------------------------
 
+#[derive(Copy, Clone)]
 enum TextureKeyUsage {
     AnnotationContextColormap,
     TensorData(TensorDataMeaning),
@@ -37,15 +38,17 @@ enum TextureKeyUsage {
 /// Several textures may be created from the same row.
 /// This makes sure that they all get different keys!
 fn generate_texture_key(row_id: RowId, usage: TextureKeyUsage) -> u64 {
-    hash(row_id)
-        ^ hash(match usage {
+    hash((
+        row_id,
+        match usage {
             TextureKeyUsage::TensorData(meaning) => match meaning {
                 TensorDataMeaning::Unknown => 0x12345678,
                 TensorDataMeaning::ClassId => 0x23456789,
                 TensorDataMeaning::Depth => 0x34567890,
             },
             TextureKeyUsage::AnnotationContextColormap => 0x45678901,
-        })
+        },
+    ))
 }
 
 /// Set up tensor for rendering on the GPU.

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -27,7 +27,7 @@ use super::{get_or_create_texture, try_get_or_create_texture};
 
 // ----------------------------------------------------------------------------
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Hash)]
 enum TextureKeyUsage {
     AnnotationContextColormap,
     TensorData(TensorDataMeaning),
@@ -38,17 +38,7 @@ enum TextureKeyUsage {
 /// Several textures may be created from the same row.
 /// This makes sure that they all get different keys!
 fn generate_texture_key(row_id: RowId, usage: TextureKeyUsage) -> u64 {
-    hash((
-        row_id,
-        match usage {
-            TextureKeyUsage::TensorData(meaning) => match meaning {
-                TensorDataMeaning::Unknown => 0x12345678,
-                TensorDataMeaning::ClassId => 0x23456789,
-                TensorDataMeaning::Depth => 0x34567890,
-            },
-            TextureKeyUsage::AnnotationContextColormap => 0x45678901,
-        },
-    ))
+    hash((row_id, usage))
 }
 
 /// Set up tensor for rendering on the GPU.


### PR DESCRIPTION
### What

* Fixes #6443
    * the problem was that we use row ids for hashing texture manager entries. Instead, we need to use a combination of texture meaning + row id, because the same row may give rise to several textures! 
* Fixes this also for any other combination of textures on the same row (e.g. depth + regular)
* Fixes bad error message display

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6449?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6449?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6449)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.