### PR TITLE
Fix broken example source links in Viewer example list

### DIFF
--- a/crates/re_dev_tools/src/build_examples/example.rs
+++ b/crates/re_dev_tools/src/build_examples/example.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use anyhow::Context;
 
 pub struct Example {
+    /// Name of the folder it's stored in.
     pub name: String,
     pub title: String,
     pub dir: PathBuf,

--- a/crates/re_dev_tools/src/build_examples/manifest.rs
+++ b/crates/re_dev_tools/src/build_examples/manifest.rs
@@ -85,9 +85,8 @@ impl ManifestEntry {
                 height: example.thumbnail_dimensions[1],
             },
             source_url: format!(
-                "{base_source_url}/examples/{}/{name}/{}",
+                "{base_source_url}/examples/{}/{name}",
                 example.language.examples_dir().to_string_lossy(),
-                example.script_path.to_string_lossy(),
             ),
             name,
         }


### PR DESCRIPTION
### What

* Fixes #6425 

Tested using `cargo run -p re_dev_tools -- build-examples manifest --channel nightly test.json` and then trying a few links inside the manifest

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6451?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6451?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6451)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.