### PR TITLE
Fix wasm clippy ci, reenable wasm ci, improve rust_checks

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -104,7 +104,7 @@ jobs:
           pixi-version: v0.20.0
 
       - name: Rust checks & tests
-        run: pixi run rs-check --skip-check-individual-crates
+        run: pixi run rs-check --skip individual_crates
 
   misc-rerun-lints:
     name: Rerun lints

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'pr' }}
-        run: pixi run rs-check --skip-check-individual-crates --skip-wasm-checks --skip-test
+        run: pixi run rs-check --skip-check-individual-crates --skip-test
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'main' }}

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'pr' }}
-        run: pixi run rs-check --skip-check-individual-crates --skip-test
+        run: pixi run rs-check --skip individual_crates tests
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'main' }}
-        run: pixi run rs-check --skip-check-individual-crates
+        run: pixi run rs-check --skip individual_crates
 
       - name: Rust all checks & tests
         if: ${{ inputs.CHANNEL == 'nightly' }}

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -57,7 +57,6 @@ impl WebHandle {
             default_theme: eframe::Theme::Dark,
             wgpu_options: crate::wgpu_options(app_options.render_backend.clone()),
             depth_buffer: 0,
-            ..Default::default()
         };
 
         self.runner

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -1,6 +1,24 @@
 #!/usr/bin/env python3
 
-"""Run various rust checks for CI."""
+"""
+Run various rust checks for CI.
+
+You can run the script via pixi which will make sure that the web build is around and up-to-date:
+    pixi run rs-check
+
+Alternatively you can also run it directly via python:
+    python3 scripts/ci/rust_checks.py
+
+To run only a specific test you can use the `--only` argument:
+    pixi run rs-check --only wasm
+
+To run all tests except a few specific ones you can use the `--skip` argument:
+    pixi run rs-check --skip wasm docs
+
+To see a list of all available tests you can use the `--help` argument:
+    pixi run rs-check --help
+
+"""
 
 from __future__ import annotations
 

--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -62,104 +62,52 @@ def package_name_from_cargo_toml(cargo_toml_path: str) -> str:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run Rust checks and tests")
+    checks = [
+        ("base_checks", base_checks),
+        ("sdk_variations", sdk_variations),
+        ("cargo_deny", cargo_deny),
+        ("wasm", wasm),
+        ("individual_examples", individual_examples),
+        ("individual_crates", individual_crates),
+        ("docs", docs),
+        ("tests", tests),
+    ]
+    check_names = [check[0] for check in checks]
+
+    parser = argparse.ArgumentParser(description="Run Rust checks and tests.")
     parser.add_argument(
-        "--skip-check-individual-crates",
-        help="If true, don't check individual crates in /crates/.",
-        action="store_true",
+        "--skip",
+        help="Skip all specified given checks but runs everything else.",
+        nargs="+",
+        type=str,
+        choices=check_names,
     )
     parser.add_argument(
-        "--skip-check-individual-examples",
-        help="If true, don't check individual examples in /examples/rust/.",
-        action="store_true",
+        "--only",
+        help="Runs only the specified checks (ignores --skip argument).",
+        nargs="+",
+        type=str,
+        choices=check_names,
     )
-    parser.add_argument("--skip-wasm-checks", help="If true, don't run explicit wasm32 checks.", action="store_true")
-    parser.add_argument("--skip-docs", help="If true, don't run doc generation.", action="store_true")
-    parser.add_argument("--skip-tests", help="If true, don't run tests.", action="store_true")
-    parser.add_argument("--skip-cargo-deny", help="If true, don't run cargo deny.", action="store_true")
     args = parser.parse_args()
+
+    enabled_check_names = []
+    if args.only is not None:
+        enabled_check_names = args.only
+    else:
+        enabled_check_names = [check[0] for check in checks if check[0] not in (args.skip or [])]
+    print("Enabled checks:")
+    for check in enabled_check_names:
+        print(f" - {check}")
 
     # ----------------------
 
-    # NOTE: a lot of these jobs use very little CPU, but we csannot parallelize them because they all take a lock on the `target` directory.
+    # NOTE: a lot of these jobs use very little CPU, but we cannot parallelize them because they all take a lock on the `target` directory.
 
-    timings = []
+    timings: list[Timing] = []
 
-    # First check with --locked to make sure Cargo.lock is up to date.
-    timings.append(run_cargo("check", "--locked --all-features"))
-
-    timings.append(run_cargo("fmt", "--all -- --check"))
-
-    timings.append(run_cargo("clippy", "--all-targets --all-features -- --deny warnings"))
-
-    # Check a few important permutations of the feature flags for our `rerun` library:
-    timings.append(run_cargo("check", "-p rerun --no-default-features"))
-    timings.append(run_cargo("check", "-p rerun --no-default-features --features sdk"))
-
-    # Cargo deny
-    if not args.skip_cargo_deny:
-        # Note: running just `cargo deny check` without a `--target` can result in
-        # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
-        # Installing is quite quick if it's already installed.
-        timings.append(run_cargo("install", "--locked cargo-deny"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target aarch64-apple-darwin check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-gnu check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-msvc check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target i686-unknown-linux-gnu check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target wasm32-unknown-unknown check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-apple-darwin check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-gnu check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-msvc check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-gnu check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-musl check"))
-        timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-redox check"))
-
-    if not args.skip_wasm_checks:
-        # Check viewer for wasm32
-        timings.append(
-            run_cargo(
-                "clippy",
-                "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
-                clippy_conf="scripts/clippy_wasm",  # Use ./scripts/clippy_wasm/clippy.toml
-            )
-        )
-        # Check re_renderer examples for wasm32.
-        timings.append(
-            run_cargo("check", "--target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples")
-        )
-
-    # Since features are additive, check examples & crates individually unless opted out.
-    if not args.skip_check_individual_examples:
-        for cargo_toml_path in glob("./examples/rust/**/Cargo.toml", recursive=True):
-            package_name = package_name_from_cargo_toml(cargo_toml_path)
-            timings.append(run_cargo("check", f"--no-default-features -p {package_name}"))
-            timings.append(run_cargo("check", f"--all-features -p {package_name}"))
-
-    if not args.skip_check_individual_crates:
-        for cargo_toml_path in glob("./crates/**/Cargo.toml", recursive=True):
-            package_name = package_name_from_cargo_toml(cargo_toml_path)
-            timings.append(run_cargo("check", f"--no-default-features -p {package_name}"))
-            timings.append(run_cargo("check", f"--all-features -p {package_name}"))
-
-    # Doc tests
-    if not args.skip_docs:
-        # Full doc build takes prohibitively long (over 17min as of writing), so we skip it:
-        # timings.append(run_cargo("doc", "--all-features"))
-
-        # These take around 3m40s each on CI, but very useful for catching broken doclinks:
-        timings.append(run_cargo("doc", "--no-deps --all-features --workspace"))
-        timings.append(run_cargo("doc", "--document-private-items --no-deps --all-features --workspace"))
-
-    if not args.skip_tests:
-        # We first use `--no-run` to measure the time of compiling vs actually running
-
-        # Just a normal `cargo test` should always work:
-        timings.append(run_cargo("test", "--all-targets --no-run"))
-        timings.append(run_cargo("test", "--all-targets"))
-
-        # Full test of everything:
-        timings.append(run_cargo("test", "--all-targets --all-features --no-run"))
-        timings.append(run_cargo("test", "--all-targets --all-features"))
+    for enabled_check_name in enabled_check_names:
+        checks[check_names.index(enabled_check_name)][1](timings)
 
     # Print timings overview
     print("-----------------")
@@ -167,6 +115,87 @@ def main() -> None:
     timings.sort(key=lambda timing: timing.duration, reverse=True)
     for timing in timings:
         print(f"{timing.duration:.2f}s \t {timing.command}")
+
+
+def base_checks(timings: list[Timing]) -> None:
+    # First check with --locked to make sure Cargo.lock is up to date.
+    timings.append(run_cargo("check", "--locked --all-features"))
+    timings.append(run_cargo("fmt", "--all -- --check"))
+    timings.append(run_cargo("clippy", "--all-targets --all-features -- --deny warnings"))
+
+
+def sdk_variations(timings: list[Timing]) -> None:
+    # Check a few important permutations of the feature flags for our `rerun` library:
+    timings.append(run_cargo("check", "-p rerun --no-default-features"))
+    timings.append(run_cargo("check", "-p rerun --no-default-features --features sdk"))
+
+
+def cargo_deny(timings: list[Timing]) -> None:
+    # Note: running just `cargo deny check` without a `--target` can result in
+    # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
+    # Installing is quite quick if it's already installed.
+    timings.append(run_cargo("install", "--locked cargo-deny"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target aarch64-apple-darwin check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-gnu check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-msvc check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target i686-unknown-linux-gnu check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target wasm32-unknown-unknown check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-apple-darwin check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-gnu check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-pc-windows-msvc check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-gnu check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-linux-musl check"))
+    timings.append(run_cargo("deny", "--all-features --log-level error --target x86_64-unknown-redox check"))
+
+
+def wasm(timings: list[Timing]) -> None:
+    # Check viewer for wasm32
+    timings.append(
+        run_cargo(
+            "clippy",
+            "--all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings",
+            clippy_conf="scripts/clippy_wasm",  # Use ./scripts/clippy_wasm/clippy.toml
+        )
+    )
+    # Check re_renderer examples for wasm32.
+    timings.append(
+        run_cargo("check", "--target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples")
+    )
+
+
+def individual_examples(timings: list[Timing]) -> None:
+    for cargo_toml_path in glob("./examples/rust/**/Cargo.toml", recursive=True):
+        package_name = package_name_from_cargo_toml(cargo_toml_path)
+        timings.append(run_cargo("check", f"--no-default-features -p {package_name}"))
+        timings.append(run_cargo("check", f"--all-features -p {package_name}"))
+
+
+def individual_crates(timings: list[Timing]) -> None:
+    for cargo_toml_path in glob("./crates/**/Cargo.toml", recursive=True):
+        package_name = package_name_from_cargo_toml(cargo_toml_path)
+        timings.append(run_cargo("check", f"--no-default-features -p {package_name}"))
+        timings.append(run_cargo("check", f"--all-features -p {package_name}"))
+
+
+def docs(timings: list[Timing]) -> None:
+    # Full doc build takes prohibitively long (over 17min as of writing), so we skip it:
+    # timings.append(run_cargo("doc", "--all-features"))
+
+    # These take around 3m40s each on CI, but very useful for catching broken doclinks:
+    timings.append(run_cargo("doc", "--no-deps --all-features --workspace"))
+    timings.append(run_cargo("doc", "--document-private-items --no-deps --all-features --workspace"))
+
+
+def tests(timings: list[Timing]) -> None:
+    # We first use `--no-run` to measure the time of compiling vs actually running
+
+    # Just a normal `cargo test` should always work:
+    timings.append(run_cargo("test", "--all-targets --no-run"))
+    timings.append(run_cargo("test", "--all-targets"))
+
+    # Full test of everything:
+    timings.append(run_cargo("test", "--all-targets --all-features --no-run"))
+    timings.append(run_cargo("test", "--all-targets --all-features"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What

Rust checks makes is now easier to run locally. E.g. this regression can now be tested with
`pixi run rs-check --only wasm`. Which gives the following output:
```
Enabled checks:
 - wasm
> cargo clippy --quiet --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings
> cargo check --quiet --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
-----------------
Timings:
0.37s 	 cargo clippy --quiet --all-features --target wasm32-unknown-unknown --target-dir target_wasm -p re_viewer -- --deny warnings
0.33s 	 cargo check --quiet --target wasm32-unknown-unknown --target-dir target_wasm -p re_renderer --examples
```


`pixi run rs-check --help`:
```
usage: rust_checks.py [-h] [--skip {base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} [{base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} ...]]
                      [--only {base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} [{base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} ...]]

Run Rust checks and tests.

options:
  -h, --help            show this help message and exit
  --skip {base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} [{base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} ...]
                        Skip all specified given checks but runs everything else.
  --only {base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} [{base_checks,sdk_variations,cargo_deny,wasm,individual_examples,individual_crates,docs,tests} ...]
                        Runs only the specified checks (ignores --skip argument).
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6452?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6452?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6452)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.