### PR TITLE
Preserve component order in codegened component list

### DIFF
--- a/crates/re_types/src/archetypes/arrows2d.rs
+++ b/crates/re_types/src/archetypes/arrows2d.rs
@@ -108,18 +108,18 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Arrows2DIndicator".into(),
             "rerun.components.Position2D".into(),
+            "rerun.components.Arrows2DIndicator".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Radius".into(),
+            "rerun.components.Color".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -127,12 +127,12 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Vector2D".into(),
-            "rerun.components.Arrows2DIndicator".into(),
             "rerun.components.Position2D".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.Color".into(),
+            "rerun.components.Arrows2DIndicator".into(),
             "rerun.components.Radius".into(),
+            "rerun.components.Color".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/arrows3d.rs
+++ b/crates/re_types/src/archetypes/arrows3d.rs
@@ -121,18 +121,18 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Arrows3DIndicator".into(),
             "rerun.components.Position3D".into(),
+            "rerun.components.Arrows3DIndicator".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Radius".into(),
+            "rerun.components.Color".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -140,12 +140,12 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Vector3D".into(),
-            "rerun.components.Arrows3DIndicator".into(),
             "rerun.components.Position3D".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.Color".into(),
+            "rerun.components.Arrows3DIndicator".into(),
             "rerun.components.Radius".into(),
+            "rerun.components.Color".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/asset3d.rs
+++ b/crates/re_types/src/archetypes/asset3d.rs
@@ -100,8 +100,8 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Asset3DIndicator".into(),
             "rerun.components.MediaType".into(),
+            "rerun.components.Asset3DIndicator".into(),
         ]
     });
 
@@ -112,8 +112,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Blob".into(),
-            "rerun.components.Asset3DIndicator".into(),
             "rerun.components.MediaType".into(),
+            "rerun.components.Asset3DIndicator".into(),
             "rerun.components.OutOfTreeTransform3D".into(),
         ]
     });

--- a/crates/re_types/src/archetypes/boxes2d.rs
+++ b/crates/re_types/src/archetypes/boxes2d.rs
@@ -108,19 +108,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Boxes2DIndicator".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Position2D".into(),
+            "rerun.components.Color".into(),
+            "rerun.components.Boxes2DIndicator".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
             "rerun.components.Radius".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -128,13 +128,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.HalfSizes2D".into(),
-            "rerun.components.Boxes2DIndicator".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Position2D".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
+            "rerun.components.Color".into(),
+            "rerun.components.Boxes2DIndicator".into(),
             "rerun.components.Radius".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/boxes3d.rs
+++ b/crates/re_types/src/archetypes/boxes3d.rs
@@ -119,19 +119,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Boxes3DIndicator".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Position3D".into(),
             "rerun.components.Rotation3D".into(),
+            "rerun.components.Color".into(),
+            "rerun.components.Boxes3DIndicator".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
             "rerun.components.Radius".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -139,13 +139,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.HalfSizes3D".into(),
-            "rerun.components.Boxes3DIndicator".into(),
-            "rerun.components.Color".into(),
             "rerun.components.Position3D".into(),
             "rerun.components.Rotation3D".into(),
-            "rerun.components.ClassId".into(),
+            "rerun.components.Color".into(),
+            "rerun.components.Boxes3DIndicator".into(),
             "rerun.components.Radius".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/re_types/src/archetypes/line_strips2d.rs
@@ -109,18 +109,18 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.LineStrips2DIndicator".into(),
-            "rerun.components.Radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -128,12 +128,12 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.LineStrip2D".into(),
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.LineStrips2DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/re_types/src/archetypes/line_strips3d.rs
@@ -108,17 +108,17 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.LineStrips3DIndicator".into(),
-            "rerun.components.Radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -126,11 +126,11 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.LineStrip3D".into(),
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.LineStrips3DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.ClassId".into(),
             "rerun.components.Text".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/mesh3d.rs
+++ b/crates/re_types/src/archetypes/mesh3d.rs
@@ -120,20 +120,20 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Mesh3DIndicator".into(),
             "rerun.components.TriangleIndices".into(),
             "rerun.components.Vector3D".into(),
+            "rerun.components.Mesh3DIndicator".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
             "rerun.components.Color".into(),
+            "rerun.components.Texcoord2D".into(),
             "rerun.components.Material".into(),
             "rerun.components.TensorData".into(),
-            "rerun.components.Texcoord2D".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 
@@ -141,14 +141,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Position3D".into(),
-            "rerun.components.Mesh3DIndicator".into(),
             "rerun.components.TriangleIndices".into(),
             "rerun.components.Vector3D".into(),
-            "rerun.components.ClassId".into(),
+            "rerun.components.Mesh3DIndicator".into(),
             "rerun.components.Color".into(),
+            "rerun.components.Texcoord2D".into(),
             "rerun.components.Material".into(),
             "rerun.components.TensorData".into(),
-            "rerun.components.Texcoord2D".into(),
+            "rerun.components.ClassId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/pinhole.rs
+++ b/crates/re_types/src/archetypes/pinhole.rs
@@ -152,8 +152,8 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PinholeIndicator".into(),
             "rerun.components.Resolution".into(),
+            "rerun.components.PinholeIndicator".into(),
         ]
     });
 
@@ -164,8 +164,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.PinholeProjection".into(),
-            "rerun.components.PinholeIndicator".into(),
             "rerun.components.Resolution".into(),
+            "rerun.components.PinholeIndicator".into(),
             "rerun.components.ViewCoordinates".into(),
         ]
     });

--- a/crates/re_types/src/archetypes/points2d.rs
+++ b/crates/re_types/src/archetypes/points2d.rs
@@ -122,19 +122,19 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.Points2DIndicator".into(),
-            "rerun.components.Radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.KeypointId".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
+            "rerun.components.KeypointId".into(),
         ]
     });
 
@@ -142,13 +142,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Position2D".into(),
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.Points2DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.KeypointId".into(),
             "rerun.components.Text".into(),
+            "rerun.components.DrawOrder".into(),
+            "rerun.components.ClassId".into(),
+            "rerun.components.KeypointId".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/points3d.rs
+++ b/crates/re_types/src/archetypes/points3d.rs
@@ -115,18 +115,18 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.Points3DIndicator".into(),
-            "rerun.components.Radius".into(),
         ]
     });
 
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Text".into(),
             "rerun.components.ClassId".into(),
             "rerun.components.KeypointId".into(),
-            "rerun.components.Text".into(),
         ]
     });
 
@@ -134,12 +134,12 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Position3D".into(),
+            "rerun.components.Radius".into(),
             "rerun.components.Color".into(),
             "rerun.components.Points3DIndicator".into(),
-            "rerun.components.Radius".into(),
+            "rerun.components.Text".into(),
             "rerun.components.ClassId".into(),
             "rerun.components.KeypointId".into(),
-            "rerun.components.Text".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/series_line.rs
+++ b/crates/re_types/src/archetypes/series_line.rs
@@ -113,8 +113,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Color".into(),
-            "rerun.components.Name".into(),
             "rerun.components.StrokeWidth".into(),
+            "rerun.components.Name".into(),
         ]
     });
 
@@ -123,8 +123,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
         [
             "rerun.components.SeriesLineIndicator".into(),
             "rerun.components.Color".into(),
-            "rerun.components.Name".into(),
             "rerun.components.StrokeWidth".into(),
+            "rerun.components.Name".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/series_point.rs
+++ b/crates/re_types/src/archetypes/series_point.rs
@@ -123,8 +123,8 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
         [
             "rerun.components.Color".into(),
             "rerun.components.MarkerShape".into(),
-            "rerun.components.MarkerSize".into(),
             "rerun.components.Name".into(),
+            "rerun.components.MarkerSize".into(),
         ]
     });
 
@@ -134,8 +134,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
             "rerun.components.SeriesPointIndicator".into(),
             "rerun.components.Color".into(),
             "rerun.components.MarkerShape".into(),
-            "rerun.components.MarkerSize".into(),
             "rerun.components.Name".into(),
+            "rerun.components.MarkerSize".into(),
         ]
     });
 

--- a/crates/re_types/src/archetypes/text_log.rs
+++ b/crates/re_types/src/archetypes/text_log.rs
@@ -96,8 +96,8 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.TextLogIndicator".into(),
             "rerun.components.TextLogLevel".into(),
+            "rerun.components.TextLogIndicator".into(),
         ]
     });
 
@@ -108,8 +108,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Text".into(),
-            "rerun.components.TextLogIndicator".into(),
             "rerun.components.TextLogLevel".into(),
+            "rerun.components.TextLogIndicator".into(),
             "rerun.components.Color".into(),
         ]
     });

--- a/crates/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -56,8 +56,8 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.LockRangeDuringZoom".into(),
             "rerun.components.Range1D".into(),
+            "rerun.blueprint.components.LockRangeDuringZoom".into(),
         ]
     });
 
@@ -65,8 +65,8 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.blueprint.components.ScalarAxisIndicator".into(),
-            "rerun.blueprint.components.LockRangeDuringZoom".into(),
             "rerun.components.Range1D".into(),
+            "rerun.blueprint.components.LockRangeDuringZoom".into(),
         ]
     });
 

--- a/crates/re_types/src/blueprint/archetypes/space_view_blueprint.rs
+++ b/crates/re_types/src/blueprint/archetypes/space_view_blueprint.rs
@@ -75,9 +75,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
+            "rerun.components.Name".into(),
             "rerun.blueprint.components.SpaceViewOrigin".into(),
             "rerun.blueprint.components.Visible".into(),
-            "rerun.components.Name".into(),
         ]
     });
 
@@ -86,9 +86,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
         [
             "rerun.blueprint.components.SpaceViewClass".into(),
             "rerun.blueprint.components.SpaceViewBlueprintIndicator".into(),
+            "rerun.components.Name".into(),
             "rerun.blueprint.components.SpaceViewOrigin".into(),
             "rerun.blueprint.components.Visible".into(),
-            "rerun.components.Name".into(),
         ]
     });
 

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -106,6 +106,14 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 22usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -116,17 +124,9 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 22usize]> =
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
             "rerun.testing.components.AffixFuzzer19".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer20".into(),
             "rerun.testing.components.AffixFuzzer21".into(),
             "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 
@@ -140,6 +140,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 23usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -150,17 +158,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 23usize]> =
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
             "rerun.testing.components.AffixFuzzer19".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer20".into(),
             "rerun.testing.components.AffixFuzzer21".into(),
             "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer1Indicator".into(),
         ]
     });

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -97,6 +97,14 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -106,15 +114,7 @@ static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 
@@ -128,6 +128,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 20usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -137,15 +145,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 20usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
             "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer2Indicator".into(),
         ]
     });

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -100,6 +100,14 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -109,14 +117,6 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 
@@ -125,6 +125,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
         [
             "rerun.testing.components.AffixFuzzer3Indicator".into(),
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -134,14 +142,6 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 

--- a/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -100,6 +100,14 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -109,14 +117,6 @@ static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 
@@ -125,6 +125,14 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
         [
             "rerun.testing.components.AffixFuzzer4Indicator".into(),
             "rerun.testing.components.AffixFuzzer1".into(),
+            "rerun.testing.components.AffixFuzzer2".into(),
+            "rerun.testing.components.AffixFuzzer3".into(),
+            "rerun.testing.components.AffixFuzzer4".into(),
+            "rerun.testing.components.AffixFuzzer5".into(),
+            "rerun.testing.components.AffixFuzzer6".into(),
+            "rerun.testing.components.AffixFuzzer7".into(),
+            "rerun.testing.components.AffixFuzzer8".into(),
+            "rerun.testing.components.AffixFuzzer9".into(),
             "rerun.testing.components.AffixFuzzer10".into(),
             "rerun.testing.components.AffixFuzzer11".into(),
             "rerun.testing.components.AffixFuzzer12".into(),
@@ -134,14 +142,6 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
             "rerun.testing.components.AffixFuzzer16".into(),
             "rerun.testing.components.AffixFuzzer17".into(),
             "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
         ]
     });
 

--- a/crates/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
@@ -103,13 +103,13 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.ActiveTab".into(),
-            "rerun.blueprint.components.ColumnShare".into(),
-            "rerun.blueprint.components.GridColumns".into(),
-            "rerun.blueprint.components.IncludedContent".into(),
-            "rerun.blueprint.components.RowShare".into(),
-            "rerun.blueprint.components.Visible".into(),
             "rerun.components.Name".into(),
+            "rerun.blueprint.components.IncludedContent".into(),
+            "rerun.blueprint.components.ColumnShare".into(),
+            "rerun.blueprint.components.RowShare".into(),
+            "rerun.blueprint.components.ActiveTab".into(),
+            "rerun.blueprint.components.Visible".into(),
+            "rerun.blueprint.components.GridColumns".into(),
         ]
     });
 
@@ -118,13 +118,13 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
         [
             "rerun.blueprint.components.ContainerKind".into(),
             "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
-            "rerun.blueprint.components.ActiveTab".into(),
-            "rerun.blueprint.components.ColumnShare".into(),
-            "rerun.blueprint.components.GridColumns".into(),
-            "rerun.blueprint.components.IncludedContent".into(),
-            "rerun.blueprint.components.RowShare".into(),
-            "rerun.blueprint.components.Visible".into(),
             "rerun.components.Name".into(),
+            "rerun.blueprint.components.IncludedContent".into(),
+            "rerun.blueprint.components.ColumnShare".into(),
+            "rerun.blueprint.components.RowShare".into(),
+            "rerun.blueprint.components.ActiveTab".into(),
+            "rerun.blueprint.components.Visible".into(),
+            "rerun.blueprint.components.GridColumns".into(),
         ]
     });
 

--- a/crates/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
@@ -83,10 +83,10 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
 static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.AutoLayout".into(),
-            "rerun.blueprint.components.AutoSpaceViews".into(),
             "rerun.blueprint.components.RootContainer".into(),
             "rerun.blueprint.components.SpaceViewMaximized".into(),
+            "rerun.blueprint.components.AutoLayout".into(),
+            "rerun.blueprint.components.AutoSpaceViews".into(),
             "rerun.blueprint.components.ViewerRecommendationHash".into(),
         ]
     });
@@ -95,10 +95,10 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
-            "rerun.blueprint.components.AutoLayout".into(),
-            "rerun.blueprint.components.AutoSpaceViews".into(),
             "rerun.blueprint.components.RootContainer".into(),
             "rerun.blueprint.components.SpaceViewMaximized".into(),
+            "rerun.blueprint.components.AutoLayout".into(),
+            "rerun.blueprint.components.AutoSpaceViews".into(),
             "rerun.blueprint.components.ViewerRecommendationHash".into(),
         ]
     });

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use anyhow::Context as _;
 use camino::{Utf8Path, Utf8PathBuf};
@@ -1210,7 +1210,8 @@ fn quote_trait_impls_from_obj(
             ) -> (usize, TokenStream) {
                 let components = iter_archetype_components(obj, attr)
                     .chain(extras)
-                    .collect::<BTreeSet<_>>();
+                    // Do *not* sort again, we want to preserve the order given by the datatype definition
+                    .collect::<Vec<_>>();
 
                 let num_components = components.len();
                 let quoted_components = quote!(#(#components.into(),)*);


### PR DESCRIPTION
### What

... at least within required/recommended/requried blocks.
This fixes an ordering issue in (upcoming) generic ui, but has no effect on existing ones yet, making this part of
* #6237

(pictures from a not pr'ed branch)

Before:
<img width="384" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/5ce9af88-4a9a-4a74-b2bc-0d3d794dc70e">

After:
<img width="382" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/983eccc9-0773-4c85-b64d-c6705aad3cb4">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6468?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6468?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6468)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.