### PR TITLE
Introduce a generic query helper that handles overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,10 +4843,8 @@ version = "0.17.0-alpha.3"
 dependencies = [
  "ahash",
  "egui",
- "parking_lot",
  "re_data_store",
  "re_entity_db",
- "re_log",
  "re_log_types",
  "re_query",
  "re_tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4846,6 +4846,7 @@ dependencies = [
  "parking_lot",
  "re_data_store",
  "re_entity_db",
+ "re_log",
  "re_log_types",
  "re_query",
  "re_tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,8 +4843,11 @@ version = "0.17.0-alpha.3"
 dependencies = [
  "ahash",
  "egui",
+ "parking_lot",
  "re_data_store",
  "re_entity_db",
+ "re_log_types",
+ "re_query",
  "re_tracing",
  "re_types_core",
  "re_ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4843,6 +4843,7 @@ version = "0.17.0-alpha.3"
 dependencies = [
  "ahash",
  "egui",
+ "nohash-hasher",
  "re_data_store",
  "re_entity_db",
  "re_log_types",

--- a/crates/re_query/src/range/results.rs
+++ b/crates/re_query/src/range/results.rs
@@ -33,7 +33,7 @@ pub struct RangeResults {
 
 impl RangeResults {
     #[inline]
-    pub(crate) fn new(query: RangeQuery) -> Self {
+    pub fn new(query: RangeQuery) -> Self {
         Self {
             query,
             components: Default::default(),

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -24,6 +24,8 @@ default = []
 [dependencies]
 re_data_store.workspace = true
 re_entity_db.workspace = true
+re_log_types.workspace = true
+re_query.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 re_ui.workspace = true
@@ -32,3 +34,4 @@ re_viewport_blueprint.workspace = true
 
 ahash.workspace = true
 egui.workspace = true
+parking_lot.workspace = true

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -24,6 +24,7 @@ default = []
 [dependencies]
 re_data_store.workspace = true
 re_entity_db.workspace = true
+re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
 re_tracing.workspace = true

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -24,7 +24,6 @@ default = []
 [dependencies]
 re_data_store.workspace = true
 re_entity_db.workspace = true
-re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
 re_tracing.workspace = true
@@ -35,4 +34,3 @@ re_viewport_blueprint.workspace = true
 
 ahash.workspace = true
 egui.workspace = true
-parking_lot.workspace = true

--- a/crates/re_space_view/Cargo.toml
+++ b/crates/re_space_view/Cargo.toml
@@ -34,3 +34,4 @@ re_viewport_blueprint.workspace = true
 
 ahash.workspace = true
 egui.workspace = true
+nohash-hasher.workspace = true

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -6,11 +6,13 @@ pub mod controls;
 
 mod heuristics;
 mod query;
+mod results_ext;
 mod screenshot;
 mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
 pub use query::range_with_overrides;
+pub use results_ext::RangeResultsExt;
 pub use screenshot::ScreenshotMode;
 pub use view_property_ui::view_property_ui;
 

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -11,7 +11,7 @@ mod screenshot;
 mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
-pub use query::range_with_overrides;
+pub use query::{range_with_overrides, HybridResults};
 pub use results_ext::RangeResultsExt;
 pub use screenshot::ScreenshotMode;
 pub use view_property_ui::view_property_ui;

--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -5,10 +5,12 @@
 pub mod controls;
 
 mod heuristics;
+mod query;
 mod screenshot;
 mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
+pub use query::range_with_overrides;
 pub use screenshot::ScreenshotMode;
 pub use view_property_ui::view_property_ui;
 

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -1,8 +1,9 @@
+use nohash_hasher::IntSet;
 use re_data_store::RangeQuery;
 use re_types_core::ComponentName;
 
 use re_query::{LatestAtResults, RangeResults};
-use re_viewer_context::{external::nohash_hasher::IntSet, ViewerContext};
+use re_viewer_context::ViewerContext;
 
 // ---
 

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -2,7 +2,7 @@ use re_data_store::RangeQuery;
 use re_types_core::ComponentName;
 
 use re_query::{LatestAtResults, RangeResults};
-use re_viewer_context::{external::nohash_hasher::IntSet, ViewQuery, ViewerContext};
+use re_viewer_context::{external::nohash_hasher::IntSet, ViewerContext};
 
 // ---
 

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -38,33 +38,38 @@ pub fn range_with_overrides(
                 .resolved_component_overrides
                 .get(component_name)
             {
-                match override_value.store_kind {
+                let component_override_result = match override_value.store_kind {
                     re_log_types::StoreKind::Recording => {
-                        todo!("Implement recording query");
+                        // TODO(jleibs): This probably is not right, but this code path is not used
+                        // currently. This may want to use range_query instead depending on how
+                        // component override data-references are resolved.
+                        ctx.store_context.blueprint.query_caches().latest_at(
+                            ctx.store_context.blueprint.store(),
+                            &ctx.current_query(),
+                            &override_value.path,
+                            [*component_name],
+                        )
                     }
                     re_log_types::StoreKind::Blueprint => {
-                        let component_override_result =
-                            ctx.store_context.blueprint.query_caches().latest_at(
-                                ctx.store_context.blueprint.store(),
-                                ctx.blueprint_query,
-                                &override_value.path,
-                                [*component_name],
-                            );
-
-                        // If we successfully find a non-empty override, add it to our results.
-
-                        // TODO(jleibs): it seems like value could still be null/empty if the override
-                        // has been cleared. It seems like something is preventing that from happening
-                        // but I don't fully understand what.
-                        //
-                        // This is extra tricky since the promise hasn't been resolved yet so we can't
-                        // actually look at the data.
-                        if let Some(value) =
-                            component_override_result.components.get(component_name)
-                        {
-                            overrides.add(*component_name, value.clone());
-                        }
+                        ctx.store_context.blueprint.query_caches().latest_at(
+                            ctx.store_context.blueprint.store(),
+                            ctx.blueprint_query,
+                            &override_value.path,
+                            [*component_name],
+                        )
                     }
+                };
+
+                // If we successfully find a non-empty override, add it to our results.
+
+                // TODO(jleibs): it seems like value could still be null/empty if the override
+                // has been cleared. It seems like something is preventing that from happening
+                // but I don't fully understand what.
+                //
+                // This is extra tricky since the promise hasn't been resolved yet so we can't
+                // actually look at the data.
+                if let Some(value) = component_override_result.components.get(component_name) {
+                    overrides.add(*component_name, value.clone());
                 }
             }
         }

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -1,0 +1,32 @@
+use re_data_store::RangeQuery;
+use re_types_core::ComponentName;
+
+use re_query::RangeResults;
+use re_viewer_context::{ViewQuery, ViewerContext};
+
+// ---
+
+/// Queries for the given `component_names` using range semantics.
+///
+/// See [`RangeResults`] for more information about how to handle the results.
+///
+/// This is a cached API -- data will be lazily cached upon access.
+pub fn range_with_overrides(
+    ctx: &ViewerContext<'_>,
+    view_query: &ViewQuery<'_>,
+    annotations: &re_viewer_context::Annotations,
+    range_query: &RangeQuery,
+    data_result: &re_viewer_context::DataResult,
+    component_names: impl IntoIterator<Item = ComponentName>,
+) -> RangeResults {
+    re_tracing::profile_function!(data_result.entity_path.to_string());
+
+    let results = ctx.recording().query_caches().range(
+        ctx.recording_store(),
+        range_query,
+        &data_result.entity_path,
+        component_names,
+    );
+
+    results
+}

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -19,7 +19,7 @@ pub struct HybridResults {
 /// This is a cached API -- data will be lazily cached upon access.
 pub fn range_with_overrides(
     ctx: &ViewerContext<'_>,
-    _annotations: &re_viewer_context::Annotations,
+    _annotations: Option<&re_viewer_context::Annotations>,
     range_query: &RangeQuery,
     data_result: &re_viewer_context::DataResult,
     component_names: impl IntoIterator<Item = ComponentName>,

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -19,8 +19,7 @@ pub struct HybridResults {
 /// This is a cached API -- data will be lazily cached upon access.
 pub fn range_with_overrides(
     ctx: &ViewerContext<'_>,
-    view_query: &ViewQuery<'_>,
-    annotations: &re_viewer_context::Annotations,
+    _annotations: &re_viewer_context::Annotations,
     range_query: &RangeQuery,
     data_result: &re_viewer_context::DataResult,
     component_names: impl IntoIterator<Item = ComponentName>,

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -7,16 +7,21 @@ use re_viewer_context::{external::nohash_hasher::IntSet, ViewerContext};
 // ---
 
 /// Wrapper that contains the results of a range query with possible overrides.
+///
+/// Although overrides are never temporal, when accessed via the [`crate::RangeResultsExt`] trait
+/// they will be merged into the results appropriately.
 pub struct HybridResults {
     pub(crate) overrides: LatestAtResults,
     pub(crate) results: RangeResults,
 }
 
-/// Queries for the given `component_names` using range semantics.
+/// Queries for the given `component_names` using range semantics with override support.
 ///
-/// See [`RangeResults`] for more information about how to handle the results.
+/// If the `DataResult` contains a specified override from the blueprint, that values
+/// will be used instead of the range query.
 ///
-/// This is a cached API -- data will be lazily cached upon access.
+/// Data should be accessed via the [`crate::RangeResultsExt`] trait which is implemented for
+/// [`HybridResults`].
 pub fn range_with_overrides(
     ctx: &ViewerContext<'_>,
     _annotations: Option<&re_viewer_context::Annotations>,

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -1,6 +1,6 @@
 use re_log_types::{RowId, TimeInt};
 use re_query::{LatestAtResults, PromiseResolver, PromiseResult, RangeData, RangeResults, Results};
-use re_types::Component;
+use re_types_core::Component;
 
 // ---
 

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -2,6 +2,8 @@ use re_log_types::{RowId, TimeInt};
 use re_query::{LatestAtResults, PromiseResolver, PromiseResult, RangeData, RangeResults, Results};
 use re_types_core::Component;
 
+use crate::query::HybridResults;
+
 // ---
 
 /// Extension traits to abstract query result handling for all spatial space views.
@@ -135,5 +137,69 @@ impl RangeResultsExt for LatestAtResults {
         }
 
         Ok(data)
+    }
+}
+
+impl RangeResultsExt for HybridResults {
+    #[inline]
+    fn get_dense<'a, C: Component>(
+        &'a self,
+        resolver: &PromiseResolver,
+    ) -> Option<re_query::Result<RangeData<'a, C>>> {
+        let component_name = C::name();
+
+        if self.overrides.contains(component_name) {
+            let results = self.overrides.get(C::name())?;
+            let data =
+                RangeData::from_latest_at(resolver, results, Some((TimeInt::STATIC, RowId::ZERO)));
+
+            // TODO(#5607): what should happen if the promise is still pending?
+            let (front_status, back_status) = data.status();
+            match front_status {
+                PromiseResult::Error(err) => {
+                    return Some(Err(re_query::QueryError::Other(err.into())))
+                }
+                PromiseResult::Pending | PromiseResult::Ready(_) => {}
+            }
+            match back_status {
+                PromiseResult::Error(err) => {
+                    return Some(Err(re_query::QueryError::Other(err.into())))
+                }
+                PromiseResult::Pending | PromiseResult::Ready(_) => {}
+            }
+
+            Some(Ok(data))
+        } else {
+            self.results.get_dense(resolver)
+        }
+    }
+
+    #[inline]
+    fn get_or_empty_dense<'a, C: Component>(
+        &'a self,
+        resolver: &PromiseResolver,
+    ) -> re_query::Result<RangeData<'a, C>> {
+        let component_name = C::name();
+
+        if self.overrides.contains(component_name) {
+            let results = self.overrides.get_or_empty(C::name());
+            let data =
+                RangeData::from_latest_at(resolver, results, Some((TimeInt::STATIC, RowId::ZERO)));
+
+            // TODO(#5607): what should happen if the promise is still pending?
+            let (front_status, back_status) = data.status();
+            match front_status {
+                PromiseResult::Error(err) => return Err(re_query::QueryError::Other(err.into())),
+                PromiseResult::Pending | PromiseResult::Ready(_) => {}
+            }
+            match back_status {
+                PromiseResult::Error(err) => return Err(re_query::QueryError::Other(err.into())),
+                PromiseResult::Pending | PromiseResult::Ready(_) => {}
+            }
+
+            Ok(data)
+        } else {
+            self.results.get_or_empty_dense(resolver)
+        }
     }
 }

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -150,6 +150,7 @@ impl RangeResultsExt for HybridResults {
 
         if self.overrides.contains(component_name) {
             let results = self.overrides.get(C::name())?;
+            // Because this is an override we always re-index the data as static
             let data =
                 RangeData::from_latest_at(resolver, results, Some((TimeInt::STATIC, RowId::ZERO)));
 
@@ -183,6 +184,7 @@ impl RangeResultsExt for HybridResults {
 
         if self.overrides.contains(component_name) {
             let results = self.overrides.get_or_empty(C::name());
+            // Because this is an override we always re-index the data as static
             let data =
                 RangeData::from_latest_at(resolver, results, Some((TimeInt::STATIC, RowId::ZERO)));
 

--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -227,7 +227,7 @@ impl VisualizerSystem for Arrows2DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -230,7 +230,7 @@ impl VisualizerSystem for Arrows3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -149,7 +149,7 @@ impl VisualizerSystem for Asset3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -223,7 +223,7 @@ impl VisualizerSystem for Boxes2DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -214,7 +214,7 @@ impl VisualizerSystem for Boxes3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -877,7 +877,7 @@ impl ImageVisualizer {
             |ctx, entity_path, entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -212,7 +212,7 @@ impl VisualizerSystem for Lines2DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -221,7 +221,7 @@ impl VisualizerSystem for Lines3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -180,7 +180,7 @@ impl VisualizerSystem for Mesh3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -13,7 +13,6 @@ mod lines3d;
 mod meshes;
 mod points2d;
 mod points3d;
-mod results_ext;
 mod spatial_view_visualizer;
 mod transform3d_arrows;
 
@@ -21,8 +20,6 @@ pub use cameras::CamerasVisualizer;
 pub use images::{ImageVisualizer, ViewerImage};
 pub use spatial_view_visualizer::SpatialViewVisualizerData;
 pub use transform3d_arrows::{add_axis_arrows, Transform3DArrowsVisualizer};
-
-pub(crate) use self::results_ext::RangeResultsExt;
 
 // ---
 

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -230,7 +230,7 @@ impl VisualizerSystem for Points2DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -221,7 +221,7 @@ impl VisualizerSystem for Points3DVisualizer {
             |ctx, entity_path, _entity_props, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 
-                use crate::visualizers::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt as _;
 
                 let resolver = ctx.recording().resolver();
 

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -213,7 +213,6 @@ impl SeriesLineSystem {
 
             let results = range_with_overrides(
                 ctx,
-                view_query,
                 annotations,
                 &query,
                 data_result,

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -8,7 +8,7 @@ use re_types::{
     Archetype as _, ComponentNameSet, Loggable,
 };
 use re_viewer_context::{
-    AnnotationMap, DefaultColor, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
+    AnnotationMap, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
     TypedComponentFallbackProvider, ViewQuery, ViewerContext, VisualizerQueryInfo,
     VisualizerSystem,
 };
@@ -224,7 +224,12 @@ impl SeriesLineSystem {
                 ],
             );
 
-            let all_scalars = results.get_or_empty_dense::<Scalar>(resolver)?;
+            // If we have no scalars, we can't do anything.
+            let Some(all_scalars) = results.get_dense::<Scalar>(resolver) else {
+                return Ok(());
+            };
+
+            let all_scalars = all_scalars?;
 
             let all_scalars_entry_range = all_scalars.entry_range();
 

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -113,7 +113,7 @@ impl SeriesLineSystem {
                 .map(|data_result| -> Result<Vec<PlotSeries>, QueryError> {
                     let annotations = self.annotation_map.find(&data_result.entity_path);
                     let mut series = vec![];
-                    load_series(
+                    self.load_series(
                         ctx,
                         query,
                         plot_bounds,
@@ -129,139 +129,152 @@ impl SeriesLineSystem {
                 self.all_series.append(&mut one_series?);
             }
         } else {
+            let mut series = vec![];
             for data_result in data_results {
                 let annotations = self.annotation_map.find(&data_result.entity_path);
-                load_series(
+
+                self.load_series(
                     ctx,
                     query,
                     plot_bounds,
                     time_per_pixel,
                     &annotations,
                     data_result,
-                    &mut self.all_series,
+                    &mut series,
                 )?;
             }
+            self.all_series = series;
         }
 
         Ok(())
     }
-}
 
-fn load_series(
-    ctx: &ViewerContext<'_>,
-    view_query: &ViewQuery<'_>,
-    plot_bounds: Option<egui_plot::PlotBounds>,
-    time_per_pixel: f64,
-    annotations: &re_viewer_context::Annotations,
-    data_result: &re_viewer_context::DataResult,
-    all_series: &mut Vec<PlotSeries>,
-) -> Result<(), QueryError> {
-    re_tracing::profile_function!();
+    #[allow(clippy::too_many_arguments)]
+    fn load_series(
+        &self,
+        ctx: &ViewerContext<'_>,
+        view_query: &ViewQuery<'_>,
+        plot_bounds: Option<egui_plot::PlotBounds>,
+        time_per_pixel: f64,
+        annotations: &re_viewer_context::Annotations,
+        data_result: &re_viewer_context::DataResult,
+        all_series: &mut Vec<PlotSeries>,
+    ) -> Result<(), QueryError> {
+        re_tracing::profile_function!();
 
-    let resolver = ctx.recording().resolver();
+        let resolver = ctx.recording().resolver();
 
-    let annotation_info = annotations
-        .resolved_class_description(None)
-        .annotation_info();
-    let default_color = DefaultColor::EntityPath(&data_result.entity_path);
-    let override_color = data_result
-        .lookup_override::<Color>(ctx)
-        .map(|c| c.to_array());
-    let override_series_name = data_result.lookup_override::<Name>(ctx).map(|t| t.0);
-    let override_stroke_width = data_result.lookup_override::<StrokeWidth>(ctx).map(|r| r.0);
+        let query_ctx = QueryContext {
+            viewer_ctx: ctx,
+            archetype_name: Some(SeriesLine::name()),
+            query: &ctx.current_query(),
+            target_entity_path: &data_result.entity_path,
+        };
 
-    // All the default values for a `PlotPoint`, accounting for both overrides and default
-    // values.
-    let default_point = PlotPoint {
-        time: 0,
-        value: 0.0,
-        attrs: PlotPointAttrs {
-            label: None,
-            color: annotation_info.color(override_color, default_color),
-            marker_size: override_stroke_width.unwrap_or(DEFAULT_STROKE_WIDTH),
-            kind: PlotSeriesKind::Continuous,
-        },
-    };
+        let fallback_color =
+            re_viewer_context::TypedComponentFallbackProvider::<Color>::fallback_for(
+                self, &query_ctx,
+            );
 
-    let mut points;
+        let fallback_stroke =
+            re_viewer_context::TypedComponentFallbackProvider::<StrokeWidth>::fallback_for(
+                self, &query_ctx,
+            );
 
-    let time_range = determine_time_range(
-        view_query.latest_at,
-        data_result,
-        plot_bounds,
-        ctx.app_options.experimental_plot_query_clamping,
-    );
-    {
-        re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
+        // All the default values for a `PlotPoint`, accounting for both overrides and default
+        // values.
+        let default_point = PlotPoint {
+            time: 0,
+            value: 0.0,
+            attrs: PlotPointAttrs {
+                label: None,
+                color: fallback_color.into(),
+                marker_size: fallback_stroke.into(),
+                kind: PlotSeriesKind::Continuous,
+            },
+        };
 
-        let entity_path = &data_result.entity_path;
-        let query = re_data_store::RangeQuery::new(view_query.timeline, time_range);
+        let mut points;
+        let mut series_name = Default::default();
 
-        let results = range_with_overrides(
-            ctx,
-            view_query,
-            annotations,
-            &query,
+        let time_range = determine_time_range(
+            view_query.latest_at,
             data_result,
-            [Scalar::name(), Color::name(), StrokeWidth::name()],
+            plot_bounds,
+            ctx.app_options.experimental_plot_query_clamping,
         );
+        {
+            use re_space_view::RangeResultsExt as _;
 
-        let all_scalars = results
-            .get_required(Scalar::name())?
-            .to_dense::<Scalar>(resolver);
-        let all_scalars_entry_range = all_scalars.entry_range();
+            re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
 
-        if !matches!(
-            all_scalars.status(),
-            (PromiseResult::Ready(()), PromiseResult::Ready(()))
-        ) {
-            // TODO(#5607): what should happen if the promise is still pending?
-        }
+            let entity_path = &data_result.entity_path;
+            let query = re_data_store::RangeQuery::new(view_query.timeline, time_range);
 
-        // Allocate all points.
-        points = all_scalars
-            .range_indices(all_scalars_entry_range.clone())
-            .map(|(data_time, _)| PlotPoint {
-                time: data_time.as_i64(),
-                ..default_point.clone()
-            })
-            .collect_vec();
+            let results = range_with_overrides(
+                ctx,
+                view_query,
+                annotations,
+                &query,
+                data_result,
+                [
+                    Scalar::name(),
+                    Color::name(),
+                    StrokeWidth::name(),
+                    Name::name(),
+                ],
+            );
 
-        if cfg!(debug_assertions) {
-            for ps in points.windows(2) {
-                assert!(
+            let all_scalars = results.get_or_empty_dense::<Scalar>(resolver)?;
+
+            let all_scalars_entry_range = all_scalars.entry_range();
+
+            if !matches!(
+                all_scalars.status(),
+                (PromiseResult::Ready(()), PromiseResult::Ready(()))
+            ) {
+                // TODO(#5607): what should happen if the promise is still pending?
+            }
+
+            // Allocate all points.
+            points = all_scalars
+                .range_indices(all_scalars_entry_range.clone())
+                .map(|(data_time, _)| PlotPoint {
+                    time: data_time.as_i64(),
+                    ..default_point.clone()
+                })
+                .collect_vec();
+
+            if cfg!(debug_assertions) {
+                for ps in points.windows(2) {
+                    assert!(
                     ps[0].time <= ps[1].time,
                     "scalars should be sorted already when extracted from the cache, got p0 at {} and p1 at {}\n{:?}",
                     ps[0].time, ps[1].time,
                     points.iter().map(|p| p.time).collect_vec(),
                 );
+                }
             }
-        }
 
-        // Fill in values.
-        for (i, scalars) in all_scalars
-            .range_data(all_scalars_entry_range.clone())
-            .enumerate()
-        {
-            if scalars.len() > 1 {
-                re_log::warn_once!(
-                    "found a scalar batch in {entity_path:?} -- those have no effect"
-                );
-            } else if scalars.is_empty() {
-                points[i].attrs.kind = PlotSeriesKind::Clear;
-            } else {
-                points[i].value = scalars.first().map_or(0.0, |s| s.0);
+            // Fill in values.
+            for (i, scalars) in all_scalars
+                .range_data(all_scalars_entry_range.clone())
+                .enumerate()
+            {
+                if scalars.len() > 1 {
+                    re_log::warn_once!(
+                        "found a scalar batch in {entity_path:?} -- those have no effect"
+                    );
+                } else if scalars.is_empty() {
+                    points[i].attrs.kind = PlotSeriesKind::Clear;
+                } else {
+                    points[i].value = scalars.first().map_or(0.0, |s| s.0);
+                }
             }
-        }
 
-        // Make it as clear as possible to the optimizer that some parameters
-        // go completely unused as soon as overrides have been defined.
-
-        // Fill in colors -- if available _and_ not overridden.
-        if override_color.is_none() {
-            if let Some(all_colors) = results.get(Color::name()) {
-                let all_colors = all_colors.to_dense::<Color>(resolver);
-
+            // Fill in colors.
+            // TODO(jleibs): Handle Err values.
+            if let Ok(all_colors) = results.get_or_empty_dense::<Color>(resolver) {
                 if !matches!(
                     all_colors.status(),
                     (PromiseResult::Ready(()), PromiseResult::Ready(()))
@@ -293,13 +306,10 @@ fn load_series(
                     }
                 }
             }
-        }
 
-        // Fill in stroke widths -- if available _and_ not overridden.
-        if override_stroke_width.is_none() {
-            if let Some(all_stroke_widths) = results.get(StrokeWidth::name()) {
-                let all_stroke_widths = all_stroke_widths.to_dense::<StrokeWidth>(resolver);
-
+            // Fill in stroke widths
+            // TODO(jleibs): Handle Err values.
+            if let Ok(all_stroke_widths) = results.get_or_empty_dense::<StrokeWidth>(resolver) {
                 if !matches!(
                     all_stroke_widths.status(),
                     (PromiseResult::Ready(()), PromiseResult::Ready(()))
@@ -323,31 +333,36 @@ fn load_series(
                     }
                 }
             }
+
+            // Extract the series name
+            // TODO(jleibs): Handle Err values.
+            if let Ok(all_series_name) = results.get_or_empty_dense::<Name>(resolver) {
+                if !matches!(
+                    all_series_name.status(),
+                    (PromiseResult::Ready(()), PromiseResult::Ready(()))
+                ) {
+                    // TODO(#5607): what should happen if the promise is still pending?
+                }
+
+                series_name = all_series_name
+                    .range_data(all_scalars_entry_range.clone())
+                    .next()
+                    .and_then(|name| name.first())
+                    .map(|name| name.0.clone());
+            }
+
+            // Now convert the `PlotPoints` into `Vec<PlotSeries>`
+            points_to_series(
+                data_result,
+                time_per_pixel,
+                points,
+                ctx.recording_store(),
+                view_query,
+                series_name,
+                all_series,
+            );
         }
+
+        Ok(())
     }
-
-    // Check for an explicit label if any.
-    // We're using a separate latest-at query for this since the semantics for labels changing over time are a
-    // a bit unclear.
-    // Sidestepping the cache here shouldn't be a problem since we do so only once per entity.
-    let series_name = if let Some(override_name) = override_series_name {
-        Some(override_name)
-    } else {
-        // TODO(#5607): what should happen if the promise is still pending?
-        ctx.recording()
-            .latest_at_component::<Name>(&data_result.entity_path, &ctx.current_query())
-            .map(|name| name.value.0)
-    };
-
-    // Now convert the `PlotPoints` into `Vec<PlotSeries>`
-    points_to_series(
-        data_result,
-        time_per_pixel,
-        points,
-        ctx.recording_store(),
-        view_query,
-        series_name,
-        all_series,
-    );
-    Ok(())
 }

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -140,7 +140,7 @@ impl SeriesPointSystem {
                     color: fallback_color.into(),
                     marker_size: fallback_size.into(),
                     kind: PlotSeriesKind::Scatter(ScatterAttrs {
-                        marker: fallback_shape.into(),
+                        marker: fallback_shape,
                     }),
                 },
             };


### PR DESCRIPTION
### What

Rather than need to explicitly check for each possible override, we want this to happen automatically without the visualizer needing to be aware.

This builds out an initial helper and proof-of-concept just for range query and updates the time_series view to use it. Has feature parity with the previous design.

Note: Some indentation changed. Recommend: https://github.com/rerun-io/rerun/pull/6474/files?diff=split&w=1

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6474?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6474?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6474)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.