### PR TITLE
Add another helper for `latest_at_with_overrides` and use it for all spatial visualizers

### DIFF
--- a/crates/re_space_view/src/lib.rs
+++ b/crates/re_space_view/src/lib.rs
@@ -11,7 +11,7 @@ mod screenshot;
 mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
-pub use query::{range_with_overrides, HybridResults};
+pub use query::{latest_at_with_overrides, range_with_overrides, HybridResults};
 pub use results_ext::RangeResultsExt;
 pub use screenshot::ScreenshotMode;
 pub use view_property_ui::view_property_ui;

--- a/crates/re_space_view/src/query.rs
+++ b/crates/re_space_view/src/query.rs
@@ -9,13 +9,13 @@ use re_viewer_context::ViewerContext;
 
 #[derive(Debug)]
 pub enum HybridResults {
-    LatestAt(LatestAtQuery, LatestAtResults),
+    LatestAt(LatestAtQuery, HybridLatestAtResults),
     Range(RangeQuery, HybridRangeResults),
 }
 
-impl From<(LatestAtQuery, LatestAtResults)> for HybridResults {
+impl From<(LatestAtQuery, HybridLatestAtResults)> for HybridResults {
     #[inline]
-    fn from((query, results): (LatestAtQuery, LatestAtResults)) -> Self {
+    fn from((query, results): (LatestAtQuery, HybridLatestAtResults)) -> Self {
         Self::LatestAt(query, results)
     }
 }
@@ -55,12 +55,75 @@ pub fn range_with_overrides(
 
     let mut component_set = component_names.into_iter().collect::<IntSet<_>>();
 
+    let overrides = query_overrides(ctx, data_result, component_set.iter());
+
+    // No need to query for components that have overrides.
+    component_set.retain(|component| !overrides.components.contains_key(component));
+
+    let results = ctx.recording().query_caches().range(
+        ctx.recording_store(),
+        range_query,
+        &data_result.entity_path,
+        component_set,
+    );
+
+    HybridRangeResults { overrides, results }
+}
+
+/// Wrapper that contains the results of a latest-at query with possible overrides.
+///
+/// Although overrides are never temporal, when accessed via the [`crate::RangeResultsExt`] trait
+/// they will be merged into the results appropriately.
+#[derive(Debug)]
+pub struct HybridLatestAtResults {
+    pub(crate) overrides: LatestAtResults,
+    pub(crate) results: LatestAtResults,
+}
+
+/// Queries for the given `component_names` using latest-at semantics with override support.
+///
+/// If the `DataResult` contains a specified override from the blueprint, that values
+/// will be used instead of the latest-at query.
+///
+/// Data should be accessed via the [`crate::RangeResultsExt`] trait which is implemented for
+/// [`HybridResults`].
+pub fn latest_at_with_overrides(
+    ctx: &ViewerContext<'_>,
+    _annotations: Option<&re_viewer_context::Annotations>,
+    latest_at_query: &LatestAtQuery,
+    data_result: &re_viewer_context::DataResult,
+    component_names: impl IntoIterator<Item = ComponentName>,
+) -> HybridLatestAtResults {
+    re_tracing::profile_function!(data_result.entity_path.to_string());
+
+    let mut component_set = component_names.into_iter().collect::<IntSet<_>>();
+
+    let overrides = query_overrides(ctx, data_result, component_set.iter());
+
+    // No need to query for components that have overrides.
+    component_set.retain(|component| !overrides.components.contains_key(component));
+
+    let results = ctx.recording().query_caches().latest_at(
+        ctx.recording_store(),
+        latest_at_query,
+        &data_result.entity_path,
+        component_set,
+    );
+
+    HybridLatestAtResults { overrides, results }
+}
+
+fn query_overrides<'a>(
+    ctx: &ViewerContext<'_>,
+    data_result: &re_viewer_context::DataResult,
+    component_names: impl Iterator<Item = &'a ComponentName>,
+) -> LatestAtResults {
     // First see if any components have overrides.
     let mut overrides = LatestAtResults::default();
 
     if let Some(prop_overrides) = &data_result.property_overrides {
         // TODO(jleibs): partitioning overrides by path
-        for component_name in &component_set {
+        for component_name in component_names {
             if let Some(override_value) = prop_overrides
                 .resolved_component_overrides
                 .get(component_name)
@@ -101,16 +164,5 @@ pub fn range_with_overrides(
             }
         }
     }
-
-    // No need to query for components that have overrides.
-    component_set.retain(|component| !overrides.components.contains_key(component));
-
-    let results = ctx.recording().query_caches().range(
-        ctx.recording_store(),
-        range_query,
-        &data_result.entity_path,
-        component_set,
-    );
-
-    HybridRangeResults { overrides, results }
+    overrides
 }

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -2,7 +2,7 @@ use re_log_types::{RowId, TimeInt};
 use re_query::{LatestAtResults, PromiseResolver, PromiseResult, RangeData, RangeResults, Results};
 use re_types_core::Component;
 
-use crate::query::HybridResults;
+use crate::{query::HybridRangeResults, HybridResults};
 
 // ---
 
@@ -140,7 +140,7 @@ impl RangeResultsExt for LatestAtResults {
     }
 }
 
-impl RangeResultsExt for HybridResults {
+impl RangeResultsExt for HybridRangeResults {
     #[inline]
     fn get_dense<'a, C: Component>(
         &'a self,
@@ -202,6 +202,28 @@ impl RangeResultsExt for HybridResults {
             Ok(data)
         } else {
             self.results.get_or_empty_dense(resolver)
+        }
+    }
+}
+
+impl RangeResultsExt for HybridResults {
+    fn get_dense<'a, C: Component>(
+        &'a self,
+        resolver: &PromiseResolver,
+    ) -> Option<re_query::Result<RangeData<'a, C>>> {
+        match self {
+            Self::LatestAt(_, results) => results.get_dense(resolver),
+            Self::Range(_, results) => results.get_dense(resolver),
+        }
+    }
+
+    fn get_or_empty_dense<'a, C: Component>(
+        &'a self,
+        resolver: &PromiseResolver,
+    ) -> re_query::Result<RangeData<'a, C>> {
+        match self {
+            Self::LatestAt(_, results) => results.get_or_empty_dense(resolver),
+            Self::Range(_, results) => results.get_or_empty_dense(resolver),
         }
     }
 }

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -1,6 +1,6 @@
 use itertools::Either;
 use re_data_store::{LatestAtQuery, RangeQuery};
-use re_entity_db::{EntityDb, EntityProperties};
+use re_entity_db::EntityProperties;
 use re_log_types::{EntityPath, TimeInt, Timeline};
 use re_query::Results;
 use re_renderer::DepthOffset;
@@ -40,14 +40,16 @@ pub fn clamped<T>(values: &[T], clamped_len: usize) -> impl Iterator<Item = &T> 
 // --- Cached APIs ---
 
 pub fn query_archetype_with_history<A: Archetype>(
-    entity_db: &EntityDb,
+    ctx: &ViewerContext<'_>,
     timeline: &Timeline,
     timeline_cursor: TimeInt,
     query_range: &QueryRange,
-    entity_path: &EntityPath,
+    data_result: &re_viewer_context::DataResult,
 ) -> Results {
+    let entity_db = ctx.recording();
     let store = entity_db.store();
     let caches = entity_db.query_caches();
+    let entity_path = &data_result.entity_path;
 
     match query_range {
         QueryRange::TimeRange(time_range) => {
@@ -135,11 +137,11 @@ where
         };
 
         let results = query_archetype_with_history::<A>(
-            ctx.recording(),
+            ctx,
             &query.timeline,
             query.latest_at,
             data_result.query_range(),
-            &data_result.entity_path,
+            data_result,
         );
 
         // NOTE: We used to compute the number of primitives across the entire scene here, but that

--- a/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
+++ b/crates/re_space_view_spatial/src/visualizers/entity_iterator.rs
@@ -2,8 +2,8 @@ use itertools::Either;
 use re_data_store::{LatestAtQuery, RangeQuery};
 use re_entity_db::EntityProperties;
 use re_log_types::{EntityPath, TimeInt, Timeline};
-use re_query::Results;
 use re_renderer::DepthOffset;
+use re_space_view::{range_with_overrides, HybridResults};
 use re_types::Archetype;
 use re_viewer_context::{
     IdentifiedViewSystem, QueryRange, SpaceViewClass, SpaceViewSystemExecutionError,
@@ -45,7 +45,7 @@ pub fn query_archetype_with_history<A: Archetype>(
     timeline_cursor: TimeInt,
     query_range: &QueryRange,
     data_result: &re_viewer_context::DataResult,
-) -> Results {
+) -> HybridResults {
     let entity_db = ctx.recording();
     let store = entity_db.store();
     let caches = entity_db.query_caches();
@@ -60,10 +60,11 @@ pub fn query_archetype_with_history<A: Archetype>(
                     timeline_cursor,
                 ),
             );
-            let results = caches.range(
-                store,
+            let results = range_with_overrides(
+                ctx,
+                None,
                 &range_query,
-                entity_path,
+                data_result,
                 A::all_components().iter().copied(),
             );
             (range_query, results).into()
@@ -99,7 +100,7 @@ where
         &EntityPath,
         &EntityProperties,
         &SpatialSceneEntityContext<'_>,
-        &Results,
+        &HybridResults,
     ) -> Result<(), SpaceViewSystemExecutionError>,
 {
     let transforms = view_ctx.get::<TransformContext>()?;


### PR DESCRIPTION
### What
- Builds on top of: https://github.com/rerun-io/rerun/pull/6474
- part of #6435

This extends the work in the base PR by introducing a latest-at variant of the query supporting overrides.

Since spatial archetypes all bottom out in `query_archetype_with_history`, they end up with generic support for component overrides in cases where they aren't bottoming out in an alternative pathway.



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6475?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6475?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6475)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.