### PR TITLE
Fix rerun.io deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,14 +296,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RERUN_BOT_TOKEN }}
           ref: ${{ needs.version.outputs.release-commit }}
-          # `secrets.GITHUB_TOKEN` is used here so that the `git push … doc-latest`
-          # below can trigger a workflow run of the `on_push_docs.yml` workflow
-          # https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update latest branch
         run: |
+          git config --global user.name "rerun-bot"
+          git config --global user.email "bot@rerun.io"
           git fetch
           git checkout ${{ github.ref_name }}
           git push --force origin refs/heads/${{ github.ref_name }}:refs/heads/latest


### PR DESCRIPTION
### What

When an example had no entrypoint, the `entrypoint_path` function would panic. This would cause the search index build to fail. It turns out we aren't using `script_path` anywhere anymore, so it has been removed.

The `release` workflow should now be able to trigger the `Push Docs` workflow by pushing to `docs-latest`, which redeploys the website. Previously it used `GITHUB_TOKEN`, which cannot trigger other workflows. It now uses a personal access token instead.

As a bandaid fix, I manually updated `RELEASE_VERSION` on `rerun.io` to `0.16.1`. After merging this PR, we don't need to do a cherry-pick to `docs-latest` or a patch release, it can just wait until the next time we do a proper release.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6476?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6476?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6476)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.