### PR TITLE
Move case conversions to new crate `re_case`

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,11 +88,11 @@ Of course, this will only take us so far. In the future we plan on caching queri
 Here is an overview of the crates included in the project:
 
 <picture>
-  <img src="https://static.rerun.io/architecture/3b77eee59cfef76b8312f66a637cf28edbd0f6ac/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/architecture/3b77eee59cfef76b8312f66a637cf28edbd0f6ac/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/architecture/3b77eee59cfef76b8312f66a637cf28edbd0f6ac/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/architecture/3b77eee59cfef76b8312f66a637cf28edbd0f6ac/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/architecture/3b77eee59cfef76b8312f66a637cf28edbd0f6ac/1200w.png">
+  <img src="https://static.rerun.io/crates/710562417756943b47657d3260622b5effe392f7/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/710562417756943b47657d3260622b5effe392f7/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/710562417756943b47657d3260622b5effe392f7/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/710562417756943b47657d3260622b5effe392f7/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/710562417756943b47657d3260622b5effe392f7/1200w.png">
 </picture>
 
 
@@ -203,6 +203,7 @@ Update instructions:
 | Crate              | Description                                                                          |
 |--------------------|--------------------------------------------------------------------------------------|
 | re_analytics       | Rerun's analytics SDK                                                                |
+| re_case            | Case conversions, the way Rerun likes them                                           |
 | re_log             | Helpers for setting up and doing text logging in the Rerun crates.                   |
 | re_error           | Helpers for handling errors.                                                         |
 | re_format          | Miscellaneous tools to format and parse numbers, durations, etc.                     |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4274,6 +4274,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_case"
+version = "0.17.0-alpha.3"
+dependencies = [
+ "convert_case",
+]
+
+[[package]]
 name = "re_chunk"
 version = "0.17.0-alpha.3"
 dependencies = [
@@ -5118,7 +5125,6 @@ dependencies = [
  "anyhow",
  "camino",
  "clang-format",
- "convert_case",
  "flatbuffers",
  "indent",
  "itertools 0.13.0",
@@ -5128,6 +5134,7 @@ dependencies = [
  "rayon",
  "re_arrow2",
  "re_build_tools",
+ "re_case",
  "re_error",
  "re_log",
  "re_tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ re_analytics = { path = "crates/re_analytics", version = "=0.17.0-alpha.3", defa
 re_blueprint_tree = { path = "crates/re_blueprint_tree", version = "=0.17.0-alpha.3", default-features = false }
 re_build_info = { path = "crates/re_build_info", version = "=0.17.0-alpha.3", default-features = false }
 re_build_tools = { path = "crates/re_build_tools", version = "=0.17.0-alpha.3", default-features = false }
+re_case = { path = "crates/re_case", version = "=0.17.0-alpha.3", default-features = false }
 re_chunk = { path = "crates/re_chunk", version = "=0.17.0-alpha.3", default-features = false }
 re_context_menu = { path = "crates/re_context_menu", version = "=0.17.0-alpha.3", default-features = false }
 re_crash_handler = { path = "crates/re_crash_handler", version = "=0.17.0-alpha.3", default-features = false }

--- a/crates/re_case/Cargo.toml
+++ b/crates/re_case/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "re_case"
+authors.workspace = true
+description = "Case conversions, the way Rerun likes them"
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+
+[features]
+default = []
+
+
+[dependencies]
+convert_case.workspace = true

--- a/crates/re_case/README.md
+++ b/crates/re_case/README.md
@@ -1,0 +1,10 @@
+# re_case
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_case.svg)](https://crates.io/crates/re_case?speculative-link)
+[![Documentation](https://docs.rs/re_case/badge.svg)](https://docs.rs/re_case?speculative-link)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Case conversions, the way Rerun likes them.

--- a/crates/re_case/src/lib.rs
+++ b/crates/re_case/src/lib.rs
@@ -1,4 +1,4 @@
-// ---
+//! Case conversions, the way Rerun likes them.
 
 /// Converts a snake or pascal case input into a snake case output.
 ///

--- a/crates/re_types_builder/Cargo.toml
+++ b/crates/re_types_builder/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 
 [dependencies]
 re_build_tools.workspace = true
+re_case.workspace = true
 re_error.workspace = true
 re_log = { workspace = true, features = ["setup"] }
 re_tracing = { workspace = true, features = ["server"] }
@@ -31,7 +32,6 @@ anyhow.workspace = true
 arrow2.workspace = true
 camino.workspace = true
 clang-format.workspace = true
-convert_case.workspace = true
 flatbuffers.workspace = true
 indent.workspace = true
 itertools.workspace = true

--- a/crates/re_types_builder/src/codegen/cpp/includes.rs
+++ b/crates/re_types_builder/src/codegen/cpp/includes.rs
@@ -65,7 +65,7 @@ impl Includes {
             }
         };
 
-        let typname = crate::to_snake_case(typname);
+        let typname = re_case::to_snake_case(typname);
 
         if is_testing_fqname(&self.fqname) == is_testing_fqname(included_fqname) {
             // If the type is in the same library, we use a relative path.

--- a/crates/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/re_types_builder/src/codegen/docs/mod.rs
@@ -565,7 +565,7 @@ fn write_archetype_fields(
         {
             page.push_str(&format!(
                 "* [{view_name}](../views/{}.md)",
-                crate::to_snake_case(view_name)
+                re_case::to_snake_case(view_name)
             ));
             if let Some(explanation) = explanation {
                 page.push_str(&format!(" ({explanation})"));

--- a/crates/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/re_types_builder/src/codegen/rust/api.rs
@@ -596,7 +596,7 @@ fn quote_union(
     let quoted_custom_clause = quote_meta_clause_from_obj(obj, ATTR_RUST_CUSTOM_CLAUSE, "");
 
     let quoted_fields = fields.iter().map(|obj_field| {
-        let name = format_ident!("{}", crate::to_pascal_case(&obj_field.name));
+        let name = format_ident!("{}", re_case::to_pascal_case(&obj_field.name));
 
         let quoted_doc = quote_field_docs(reporter, obj_field);
         let quoted_type = quote_field_type_from_object_field(obj_field);
@@ -625,7 +625,7 @@ fn quote_union(
         quote!()
     } else {
         let quoted_matches = fields.iter().map(|obj_field| {
-            let name = format_ident!("{}", crate::to_pascal_case(&obj_field.name));
+            let name = format_ident!("{}", re_case::to_pascal_case(&obj_field.name));
 
             if obj_field.typ == Type::Unit {
                 quote!(Self::#name => 0)
@@ -1087,7 +1087,7 @@ fn quote_trait_impls_from_obj(
         fqname, name, kind, ..
     } = obj;
 
-    let display_name = crate::to_human_case(name);
+    let display_name = re_case::to_human_case(name);
     let name = format_ident!("{name}");
 
     match kind {
@@ -1351,7 +1351,7 @@ fn quote_trait_impls_from_obj(
                 .is_attr_set(ATTR_RUST_GENERATE_FIELD_INFO)
             {
                 let field_infos = obj.fields.iter().map(|field| {
-                    let display_name = crate::to_human_case(&field.name);
+                    let display_name = re_case::to_human_case(&field.name);
                     let documentation = field
                         .docs
                         .lines_with_tag_matching(|tag| tag.is_empty())

--- a/crates/re_types_builder/src/lib.rs
+++ b/crates/re_types_builder/src/lib.rs
@@ -104,7 +104,7 @@
 #![allow(clippy::unwrap_used)]
 
 // NOTE: Official generated code from flatbuffers; ignore _everything_.
-mod casing;
+
 #[allow(
     warnings,
     unused,
@@ -116,8 +116,6 @@ mod casing;
     clippy::all
 )]
 mod reflection;
-
-use casing::{to_human_case, to_pascal_case, to_snake_case};
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/crates/re_types_builder/src/objects.rs
+++ b/crates/re_types_builder/src/objects.rs
@@ -546,7 +546,7 @@ impl Object {
 
     /// The `snake_case` name of the object, e.g. `translation_and_mat3x3`.
     pub fn snake_case_name(&self) -> String {
-        crate::to_snake_case(&self.name)
+        re_case::to_snake_case(&self.name)
     }
 
     /// Returns true if this object is part of testing and not to be used in the production SDK.
@@ -807,12 +807,12 @@ impl ObjectField {
 
     /// The `snake_case` name of the field, e.g. `translation_and_mat3x3`.
     pub fn snake_case_name(&self) -> String {
-        crate::to_snake_case(&self.name)
+        re_case::to_snake_case(&self.name)
     }
 
     /// The `PascalCase` name of the field, e.g. `TranslationAndMat3x3`.
     pub fn pascal_case_name(&self) -> String {
-        crate::to_pascal_case(&self.name)
+        re_case::to_pascal_case(&self.name)
     }
 
     /// Returns true if this object is part of testing and not to be used in the production SDK.


### PR DESCRIPTION
Because I want to use it to get a snake_case url from a `ComponentName`


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6478?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6478?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6478)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.