### PR TITLE
View property querying with fallbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5343,6 +5343,7 @@ dependencies = [
  "re_viewer_context",
  "slotmap",
  "smallvec",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/re_selection_panel/src/override_ui.rs
+++ b/crates/re_selection_panel/src/override_ui.rs
@@ -15,6 +15,7 @@ use re_viewport_blueprint::SpaceViewBlueprint;
 pub fn override_ui(
     ctx: &ViewerContext<'_>,
     space_view: &SpaceViewBlueprint,
+    view_state: &dyn re_viewer_context::SpaceViewState,
     instance_path: &InstancePath,
     ui: &mut egui::Ui,
 ) {
@@ -80,6 +81,7 @@ pub fn override_ui(
         &component_to_vis,
         &active_overrides,
         &data_result,
+        view_state,
     );
 
     let Some(overrides) = data_result.property_overrides else {
@@ -137,6 +139,7 @@ pub fn override_ui(
                             target_entity_path: entity_path_overridden,
                             archetype_name: None,
                             query: &query,
+                            view_state,
                         },
                         ui,
                         UiLayout::List,
@@ -184,6 +187,7 @@ pub fn add_new_override(
     component_to_vis: &BTreeMap<ComponentName, ViewSystemIdentifier>,
     active_overrides: &BTreeSet<ComponentName>,
     data_result: &DataResult,
+    view_state: &dyn re_viewer_context::SpaceViewState,
 ) {
     let remaining_components = component_to_vis
         .keys()
@@ -204,6 +208,7 @@ pub fn add_new_override(
                     target_entity_path: &data_result.entity_path,
                     archetype_name: None,
                     query,
+                    view_state,
                 };
 
                 // Present the option to add new components for each component that doesn't

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -162,24 +162,34 @@ impl SelectionPanel {
                 }
 
                 // Special override section for space-view-entities
-                if let Item::DataResult(space_view_id, instance_path) = item {
-                    if let Some(space_view) = blueprint.space_views.get(space_view_id) {
+                if let Item::DataResult(view_id, instance_path) = item {
+                    if let Some(view) = blueprint.space_views.get(view_id) {
                         // TODO(jleibs): Overrides still require special handling inside the visualizers.
                         // For now, only show the override section for TimeSeries until support is implemented
                         // generically.
-                        if *space_view.class_identifier() == TimeSeriesSpaceView::identifier()
+                        if *view.class_identifier() == TimeSeriesSpaceView::identifier()
                             || ctx.app_options.experimental_visualizer_selection
                         {
                             ctx.re_ui
                                 .large_collapsing_header(ui, "Visualizers", true, |ui| {
-                                    override_visualizer_ui(ctx, space_view, instance_path, ui);
+                                    override_visualizer_ui(ctx, view, instance_path, ui);
                                 });
+
+                            let view_state = view_states
+                                .view_state_mut(
+                                    ctx.space_view_class_registry,
+                                    *view_id,
+                                    view.class_identifier(),
+                                )
+                                .view_state
+                                .as_ref();
+
                             ctx.re_ui.large_collapsing_header(
                                 ui,
                                 "Component Overrides",
                                 true,
                                 |ui| {
-                                    override_ui(ctx, space_view, instance_path, ui);
+                                    override_ui(ctx, view, view_state, instance_path, ui);
                                 },
                             );
                         }

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -12,6 +12,7 @@ pub fn view_property_ui<A: Archetype>(
     ui: &mut egui::Ui,
     space_view_id: SpaceViewId,
     fallback_provider: &dyn ComponentFallbackProvider,
+    view_state: &dyn re_viewer_context::SpaceViewState,
 ) {
     let blueprint_db = ctx.store_context.blueprint;
     let blueprint_query = ctx.blueprint_query;
@@ -22,6 +23,7 @@ pub fn view_property_ui<A: Archetype>(
         target_entity_path: &blueprint_path,
         archetype_name: Some(A::name()),
         query: blueprint_query,
+        view_state,
     };
 
     let component_names = A::all_components();

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -187,7 +187,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                      (and readability) in such situations as it prevents overdraw.",
                 );
 
-            view_property_ui::<PlotLegend>(ctx, ui, space_view_id, self);
+            view_property_ui::<PlotLegend>(ctx, ui, space_view_id, self, state);
             axis_ui(ctx, space_view_id, ui, state);
         });
 

--- a/crates/re_viewer_context/src/component_fallbacks.rs
+++ b/crates/re_viewer_context/src/component_fallbacks.rs
@@ -41,6 +41,10 @@ pub enum ComponentFallbackError {
     /// Meaning, that this is an unknown component or something went wrong with the placeholder registration.
     #[error("Missing placeholder for component. Was the component's default registered with the viewer?")]
     MissingPlaceholderValue,
+
+    /// Not directly returned by the fallback provider, but useful when serializing a fallback value.
+    #[error("Fallback value turned up to be empty when we expected a value.")]
+    UnexpectedEmptyFallback,
 }
 
 /// Provides fallback values for components, implemented typically by [`crate::SpaceViewClass`] and [`crate::VisualizerSystem`].

--- a/crates/re_viewer_context/src/component_fallbacks.rs
+++ b/crates/re_viewer_context/src/component_fallbacks.rs
@@ -31,14 +31,16 @@ impl<T: re_types::ComponentBatch> From<T> for ComponentFallbackProviderResult {
     }
 }
 
-/// Result for a fallback request.
+/// Error type for a fallback request.
+#[derive(thiserror::Error, Debug)]
 pub enum ComponentFallbackError {
     /// The fallback provider is not able to handle the given component _and_ there was no placeholder value.
     ///
     /// This should never happen, since all components should have a placeholder value
     /// registered in [`crate::ViewerContext::component_placeholders`].
     /// Meaning, that this is an unknown component or something went wrong with the placeholder registration.
-    MissingBaseFallback,
+    #[error("Missing placeholder for component. Was the component's default registered with the viewer?")]
+    MissingPlaceholderValue,
 }
 
 /// Provides fallback values for components, implemented typically by [`crate::SpaceViewClass`] and [`crate::VisualizerSystem`].
@@ -79,8 +81,8 @@ pub trait ComponentFallbackProvider {
         }
 
         match ctx.viewer_ctx.component_placeholders.get(&component) {
-            Some(fallback) => Ok(fallback.clone()),
-            None => Err(ComponentFallbackError::MissingBaseFallback),
+            Some(placeholder) => Ok(placeholder.clone()),
+            None => Err(ComponentFallbackError::MissingPlaceholderValue),
         }
     }
 }

--- a/crates/re_viewer_context/src/query_context.rs
+++ b/crates/re_viewer_context/src/query_context.rs
@@ -5,7 +5,7 @@ use smallvec::SmallVec;
 
 use re_log_types::{EntityPath, EntityPathHash};
 
-use crate::{DataResult, SpaceViewId, ViewerContext};
+use crate::{DataResult, SpaceViewId, SpaceViewState, ViewerContext};
 
 slotmap::new_key_type! {
     /// Identifier for a [`DataResultNode`]
@@ -34,7 +34,9 @@ pub struct QueryContext<'a> {
     // TODO(andreas): Can we make this a `ViewQuery` instead?
     // pub query: &'a ViewQuery<'a>,
     pub query: &'a re_data_store::LatestAtQuery,
-    // pub view_state: &'a dyn SpaceViewState, // TODO(andreas): Need this, but don't know yet how to patch through everywhere.
+
+    /// The view state of the view in which the query is executed.
+    pub view_state: &'a dyn SpaceViewState,
 }
 
 /// The result of executing a single data query

--- a/crates/re_viewer_context/src/space_view/mod.rs
+++ b/crates/re_viewer_context/src/space_view/mod.rs
@@ -64,6 +64,9 @@ pub enum SpaceViewSystemExecutionError {
 
     #[error("No render context error.")]
     NoRenderContextError,
+
+    #[error(transparent)]
+    ComponentFallbackError(#[from] crate::ComponentFallbackError),
 }
 
 // Convenience conversions for some re_renderer error types since these are so frequent.

--- a/crates/re_viewer_context/src/viewer_context.rs
+++ b/crates/re_viewer_context/src/viewer_context.rs
@@ -92,6 +92,12 @@ impl<'a> ViewerContext<'a> {
         self.store_context.recording.store()
     }
 
+    /// The active blueprint.
+    #[inline]
+    pub fn blueprint_db(&self) -> &re_entity_db::EntityDb {
+        self.store_context.blueprint
+    }
+
     /// The `StoreId` of the active recording.
     #[inline]
     pub fn recording_id(&self) -> &re_log_types::StoreId {

--- a/crates/re_viewport_blueprint/Cargo.toml
+++ b/crates/re_viewport_blueprint/Cargo.toml
@@ -39,3 +39,4 @@ once_cell.workspace = true
 parking_lot.workspace = true
 slotmap.workspace = true
 smallvec.workspace = true
+thiserror.workspace = true

--- a/crates/re_viewport_blueprint/src/lib.rs
+++ b/crates/re_viewport_blueprint/src/lib.rs
@@ -17,7 +17,7 @@ pub use space_view_contents::SpaceViewContents;
 pub use tree_actions::TreeAction;
 pub use view_properties::{
     edit_blueprint_component, entity_path_for_view_property, query_view_property,
-    query_view_property_or_default, view_property,
+    query_view_property_or_default, view_property, ViewProperty,
 };
 pub use viewport_blueprint::ViewportBlueprint;
 

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -4,42 +4,13 @@ use re_entity_db::{
     EntityDb,
 };
 use re_log_types::EntityPath;
-use re_types::Archetype;
-use re_viewer_context::{external::re_entity_db::EntityTree, SpaceViewId, ViewerContext};
+use re_types::{external::arrow2, Archetype, ArchetypeName, ComponentName};
+use re_viewer_context::{
+    external::re_entity_db::EntityTree, ComponentFallbackError, ComponentFallbackProvider,
+    QueryContext, SpaceViewId, SpaceViewSystemExecutionError, ViewerContext,
+};
 
-pub fn entity_path_for_view_property<T: Archetype>(
-    space_view_id: SpaceViewId,
-    _blueprint_entity_tree: &EntityTree,
-) -> EntityPath {
-    // TODO(andreas,jleibs):
-    // We want to search the subtree for occurrences of the property archetype here.
-    // Only if none is found we make up a new (standardized) path.
-    // There's some nuances to figure out what happens when we find the archetype several times.
-    // Also, we need to specify what it means to "find" the archetype (likely just matching the indicator?).
-    let space_view_blueprint_path = space_view_id.as_entity_path();
-
-    // Use short_name instead of full_name since full_name has dots and looks too much like an indicator component.
-    space_view_blueprint_path.join(&EntityPath::from_single_string(T::name().short_name()))
-}
-
-/// Return the archetype value for the given space view, or `None` if it doesn't exist.
-pub fn view_property<A: re_types::Archetype>(
-    ctx: &re_viewer_context::ViewerContext<'_>,
-    space_view_id: re_viewer_context::SpaceViewId,
-) -> Option<A>
-where
-    LatestAtResults: ToArchetype<A>,
-{
-    let blueprint_db = ctx.store_context.blueprint;
-    let blueprint_query = ctx.blueprint_query;
-    let path = entity_path_for_view_property::<A>(space_view_id, blueprint_db.tree());
-    blueprint_db
-        .latest_at_archetype(&path, blueprint_query)
-        .ok()
-        .flatten()
-        .map(|(_index, value)| value)
-}
-
+// TODO(andreas): Replace all usages with `ViewProperty`.
 /// Returns `Ok(None)` if any of the required components are missing.
 pub fn query_view_property<A: Archetype>(
     space_view_id: SpaceViewId,
@@ -58,6 +29,193 @@ where
     )
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum ViewPropertyQueryError {
+    #[error(transparent)]
+    SerializationError(#[from] re_types::DeserializationError),
+
+    #[error(transparent)]
+    ComponentFallbackError(#[from] ComponentFallbackError),
+}
+
+impl From<ViewPropertyQueryError> for SpaceViewSystemExecutionError {
+    fn from(val: ViewPropertyQueryError) -> Self {
+        match val {
+            ViewPropertyQueryError::SerializationError(err) => err.into(),
+            ViewPropertyQueryError::ComponentFallbackError(err) => err.into(),
+        }
+    }
+}
+
+/// Utility for querying view properties.
+pub struct ViewProperty<'a> {
+    blueprint_store_path: EntityPath,
+    archetype_name: ArchetypeName,
+    query_results: LatestAtResults,
+    viewer_ctx: &'a ViewerContext<'a>,
+}
+
+impl<'a> ViewProperty<'a> {
+    /// Query a specific view property for a given view.
+    pub fn from_archetype<A: Archetype>(
+        viewer_ctx: &'a ViewerContext<'a>,
+        view_id: SpaceViewId,
+    ) -> Self {
+        Self::from_archetype_impl(viewer_ctx, view_id, A::name(), A::all_components().as_ref())
+    }
+
+    fn from_archetype_impl(
+        viewer_ctx: &'a ViewerContext<'a>,
+        space_view_id: SpaceViewId,
+        archetype_name: ArchetypeName,
+        component_names: &[ComponentName],
+    ) -> Self {
+        let blueprint_db = viewer_ctx.blueprint_db();
+
+        let blueprint_store_path = entity_path_for_view_property_from_archetype_name(
+            space_view_id,
+            blueprint_db.tree(),
+            archetype_name,
+        );
+
+        let query_results = blueprint_db.latest_at(
+            viewer_ctx.blueprint_query,
+            &blueprint_store_path,
+            component_names.iter().copied(),
+        );
+
+        ViewProperty {
+            blueprint_store_path,
+            archetype_name,
+            query_results,
+
+            viewer_ctx,
+        }
+    }
+
+    /// Get the value of a specific component or its fallback if the component is not present.
+    // TODO(andreas): Unfortunately we can't use TypedComponentFallbackProvider here because it may not be implemented for all components of interest.
+    // This sadly means that there's a bit of unnecessary back and forth between arrow array and untyped that could be avoided otherwise.
+    pub fn component_or_fallback<C: re_types::Component + Default>(
+        &self,
+        fallback_provider: &dyn ComponentFallbackProvider,
+        view_state: &'a dyn re_viewer_context::SpaceViewState,
+    ) -> Result<C, ViewPropertyQueryError> {
+        self.component_array_or_fallback::<C>(fallback_provider, view_state)?
+            .into_iter()
+            .next()
+            .ok_or(ComponentFallbackError::UnexpectedEmptyFallback.into())
+    }
+
+    /// Get the value of a specific component or its fallback if the component is not present.
+    pub fn component_array_or_fallback<C: re_types::Component + Default>(
+        &self,
+        fallback_provider: &dyn ComponentFallbackProvider,
+        view_state: &'a dyn re_viewer_context::SpaceViewState,
+    ) -> Result<Vec<C>, ViewPropertyQueryError> {
+        let component_name = C::name();
+        Ok(C::from_arrow(
+            self.component_or_fallback_raw(component_name, fallback_provider, view_state)?
+                .as_ref(),
+        )?)
+    }
+
+    fn component_raw(
+        &self,
+        component_name: ComponentName,
+    ) -> Option<Box<dyn arrow2::array::Array>> {
+        self.query_results.get(component_name).and_then(|result| {
+            result.raw(self.viewer_ctx.blueprint_db().resolver(), component_name)
+        })
+    }
+
+    fn component_or_fallback_raw(
+        &self,
+        component_name: ComponentName,
+        fallback_provider: &dyn ComponentFallbackProvider,
+        view_state: &'a dyn re_viewer_context::SpaceViewState,
+    ) -> Result<Box<dyn arrow2::array::Array>, ComponentFallbackError> {
+        if let Some(value) = self.component_raw(component_name) {
+            Ok(value)
+        } else {
+            fallback_provider.fallback_for(&self.query_context(view_state), component_name)
+        }
+    }
+
+    /// Save change to a blueprint component.
+    pub fn save_blueprint_component<C: re_types::Component>(&self, component: &C) {
+        self.viewer_ctx
+            .save_blueprint_component(&self.blueprint_store_path, component);
+    }
+
+    /// Resets a blueprint component to the value it had in the default blueprint.
+    pub fn reset_blueprint_component<C: re_types::Component>(&self) {
+        self.viewer_ctx
+            .reset_blueprint_component_by_name(&self.blueprint_store_path, C::name());
+    }
+
+    fn query_context(
+        &self,
+        view_state: &'a dyn re_viewer_context::SpaceViewState,
+    ) -> QueryContext<'_> {
+        QueryContext {
+            viewer_ctx: self.viewer_ctx,
+            target_entity_path: &self.blueprint_store_path,
+            archetype_name: Some(self.archetype_name),
+            query: self.viewer_ctx.blueprint_query,
+            view_state,
+        }
+    }
+}
+
+// TODO(andreas): Replace all usages with `ViewProperty`.
+pub fn entity_path_for_view_property<T: Archetype>(
+    space_view_id: SpaceViewId,
+    _blueprint_entity_tree: &EntityTree,
+) -> EntityPath {
+    entity_path_for_view_property_from_archetype_name(
+        space_view_id,
+        _blueprint_entity_tree,
+        T::name(),
+    )
+}
+
+fn entity_path_for_view_property_from_archetype_name(
+    space_view_id: SpaceViewId,
+    _blueprint_entity_tree: &EntityTree,
+    archetype_name: ArchetypeName,
+) -> EntityPath {
+    // TODO(andreas,jleibs):
+    // We want to search the subtree for occurrences of the property archetype here.
+    // Only if none is found we make up a new (standardized) path.
+    // There's some nuances to figure out what happens when we find the archetype several times.
+    // Also, we need to specify what it means to "find" the archetype (likely just matching the indicator?).
+    let space_view_blueprint_path = space_view_id.as_entity_path();
+
+    // Use short_name instead of full_name since full_name has dots and looks too much like an indicator component.
+    space_view_blueprint_path.join(&EntityPath::from_single_string(archetype_name.short_name()))
+}
+
+// TODO(andreas): Replace all usages with `ViewProperty`.
+/// Return the archetype value for the given space view, or `None` if it doesn't exist.
+pub fn view_property<A: re_types::Archetype>(
+    ctx: &re_viewer_context::ViewerContext<'_>,
+    space_view_id: re_viewer_context::SpaceViewId,
+) -> Option<A>
+where
+    LatestAtResults: ToArchetype<A>,
+{
+    let blueprint_db = ctx.blueprint_db();
+    let blueprint_query = ctx.blueprint_query;
+    let path = entity_path_for_view_property::<A>(space_view_id, blueprint_db.tree());
+    blueprint_db
+        .latest_at_archetype(&path, blueprint_query)
+        .ok()
+        .flatten()
+        .map(|(_index, value)| value)
+}
+
+// TODO(andreas): Replace all usages with `ViewProperty`.
 pub fn query_view_property_or_default<A: Archetype + Default>(
     space_view_id: SpaceViewId,
     blueprint_db: &EntityDb,
@@ -70,6 +228,7 @@ where
     (arch.ok().flatten().unwrap_or_default(), path)
 }
 
+// TODO(andreas): Replace all usages with `ViewProperty`.
 /// Edit a single component of a blueprint archetype in a space view.
 ///
 /// Set to `None` to reset the value to the value in the default blueprint, if any,
@@ -79,7 +238,7 @@ pub fn edit_blueprint_component<A: re_types::Archetype, C: re_types::Component +
     space_view_id: SpaceViewId,
     edit_component: impl FnOnce(&mut Option<C>) -> R,
 ) -> R {
-    let active_blueprint = ctx.store_context.blueprint;
+    let active_blueprint = ctx.blueprint_db();
     let active_path = entity_path_for_view_property::<A>(space_view_id, active_blueprint.tree());
     let original_value: Option<C> = active_blueprint
         .latest_at_component::<C>(&active_path, ctx.blueprint_query)

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -136,10 +136,11 @@ impl<'a> ViewProperty<'a> {
         view_state: &'a dyn re_viewer_context::SpaceViewState,
     ) -> Result<Box<dyn arrow2::array::Array>, ComponentFallbackError> {
         if let Some(value) = self.component_raw(component_name) {
-            Ok(value)
-        } else {
-            fallback_provider.fallback_for(&self.query_context(view_state), component_name)
+            if value.len() > 0 {
+                return Ok(value);
+            }
         }
+        fallback_provider.fallback_for(&self.query_context(view_state), component_name)
     }
 
     /// Save change to a blueprint component.


### PR DESCRIPTION
### What

* Part of #6237
* New mechanism to query view properties while using fallback providers
* Add view state to information that is available to fallback providers

(I have usages for this lined up in various states of in progress, but it all uses this as its backbone, so I figured it makes for a good separate PR)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6479?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6479?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6479)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.