### PR TITLE
Pass view state through to visualizer systems

### DIFF
--- a/crates/re_context_menu/src/actions/add_entities_to_new_space_view.rs
+++ b/crates/re_context_menu/src/actions/add_entities_to_new_space_view.rs
@@ -45,7 +45,7 @@ impl ContextMenuAction for AddEntitiesToNewSpaceViewAction {
                     .map(|identifier| {
                         (
                             identifier,
-                            space_view_class_registry.get_class_or_log_error(identifier),
+                            space_view_class_registry.get_class_or_log_error(*identifier),
                         )
                     })
                     .sorted_by_key(|(_, class)| class.display_name().to_owned())
@@ -145,7 +145,7 @@ fn create_space_view_for_selected_entities(
     let origin = ctx
         .viewer_context
         .space_view_class_registry
-        .get_class_or_log_error(&identifier)
+        .get_class_or_log_error(identifier)
         .recommended_root_for_entities(&entities_of_interest, ctx.viewer_context.recording())
         .unwrap_or_else(EntityPath::root);
 

--- a/crates/re_context_menu/src/actions/add_space_view.rs
+++ b/crates/re_context_menu/src/actions/add_space_view.rs
@@ -23,7 +23,7 @@ impl ContextMenuAction for AddSpaceViewAction {
     fn label(&self, ctx: &ContextMenuContext<'_>) -> String {
         ctx.viewer_context
             .space_view_class_registry
-            .get_class_or_log_error(&self.id)
+            .get_class_or_log_error(self.id)
             .display_name()
             .to_owned()
     }

--- a/crates/re_selection_panel/src/override_ui.rs
+++ b/crates/re_selection_panel/src/override_ui.rs
@@ -48,7 +48,7 @@ pub fn override_ui(
 
     let view_systems = ctx
         .space_view_class_registry
-        .new_visualizer_collection(*space_view.class_identifier());
+        .new_visualizer_collection(space_view.class_identifier());
 
     let mut component_to_vis: BTreeMap<ComponentName, ViewSystemIdentifier> = Default::default();
 
@@ -393,7 +393,7 @@ pub fn add_new_visualizer(
             &applicable_entities_per_visualizer,
             entity_db,
             &ctx.space_view_class_registry
-                .new_visualizer_collection(*space_view.class_identifier()),
+                .new_visualizer_collection(space_view.class_identifier()),
             &space_view.space_origin,
         );
 

--- a/crates/re_selection_panel/src/query_range_ui.rs
+++ b/crates/re_selection_panel/src/query_range_ui.rs
@@ -39,7 +39,7 @@ pub fn query_range_ui_space_view(
     ui: &mut Ui,
     space_view: &SpaceViewBlueprint,
 ) {
-    if !space_view_with_visible_history(*space_view.class_identifier()) {
+    if !space_view_with_visible_history(space_view.class_identifier()) {
         return;
     }
 

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -167,7 +167,7 @@ impl SelectionPanel {
                         // TODO(jleibs): Overrides still require special handling inside the visualizers.
                         // For now, only show the override section for TimeSeries until support is implemented
                         // generically.
-                        if *view.class_identifier() == TimeSeriesSpaceView::identifier()
+                        if view.class_identifier() == TimeSeriesSpaceView::identifier()
                             || ctx.app_options.experimental_visualizer_selection
                         {
                             ctx.re_ui
@@ -176,7 +176,7 @@ impl SelectionPanel {
                                 });
 
                             let view_state = view_states
-                                .view_state_mut(
+                                .get_mut(
                                     ctx.space_view_class_registry,
                                     *view_id,
                                     view.class_identifier(),
@@ -281,12 +281,12 @@ impl SelectionPanel {
         ui.add_space(ui.spacing().item_spacing.y / 2.0);
 
         if let Some(space_view) = blueprint.space_view(&space_view_id) {
-            let class_identifier = *space_view.class_identifier();
+            let class_identifier = space_view.class_identifier();
 
-            let space_view_state = view_states.view_state_mut(
+            let space_view_state = view_states.get_mut(
                 ctx.space_view_class_registry,
                 space_view.id,
-                &class_identifier,
+                class_identifier,
             );
 
             query_range_ui_space_view(ctx, ui, space_view);

--- a/crates/re_selection_panel/src/space_view_entity_picker.rs
+++ b/crates/re_selection_panel/src/space_view_entity_picker.rs
@@ -322,7 +322,7 @@ fn create_entity_add_info(
         ctx.applicable_entities_per_visualizer,
         ctx.recording(),
         &ctx.space_view_class_registry
-            .new_visualizer_collection(*space_view.class_identifier()),
+            .new_visualizer_collection(space_view.class_identifier()),
         &space_view.space_origin,
     );
 

--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -5,8 +5,9 @@ use re_entity_db::EntityPath;
 use re_space_view::diff_component_filter;
 use re_types::{archetypes::BarChart, components::Color, datatypes::TensorData};
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerAdditionalApplicabilityFilter, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizerAdditionalApplicabilityFilter, VisualizerQueryInfo,
+    VisualizerSystem,
 };
 
 /// A bar chart system, with everything needed to render it.
@@ -44,6 +45,7 @@ impl VisualizerSystem for BarChartVisualizerSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         re_tracing::profile_function!();

--- a/crates/re_space_view_dataframe/src/visualizer_system.rs
+++ b/crates/re_space_view_dataframe/src/visualizer_system.rs
@@ -1,5 +1,5 @@
 use re_viewer_context::{
-    ComponentFallbackProvider, IdentifiedViewSystem, SpaceViewSystemExecutionError,
+    ComponentFallbackProvider, IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError,
     ViewContextCollection, ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
@@ -22,6 +22,7 @@ impl VisualizerSystem for EmptySystem {
         &mut self,
         _ctx: &ViewerContext<'_>,
         _query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         Ok(vec![])

--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, Position2D, Radius, Text, Vector2D},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -210,6 +210,7 @@ impl VisualizerSystem for Arrows2DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, Position3D, Radius, Text, Vector3D},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -213,6 +213,7 @@ impl VisualizerSystem for Arrows3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -8,9 +8,9 @@ use re_types::{
     components::{Blob, MediaType, OutOfTreeTransform3D},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo,
-    VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
+    VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
@@ -133,6 +133,7 @@ impl VisualizerSystem for Asset3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, HalfSizes2D, KeypointId, Position2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -206,6 +206,7 @@ impl VisualizerSystem for Boxes2DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, HalfSizes3D, KeypointId, Position3D, Radius, Rotation3D, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -197,6 +197,7 @@ impl VisualizerSystem for Boxes3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -7,9 +7,9 @@ use re_types::{
     components::{Transform3D, ViewCoordinates},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewSystemExecutionError,
-    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
-    VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewOutlineMasks, SpaceViewState,
+    SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
+    VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
@@ -204,6 +204,7 @@ impl VisualizerSystem for CamerasVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -20,9 +20,10 @@ use re_types::{
 };
 use re_viewer_context::{
     gpu_bridge, ApplicableEntities, DefaultColor, IdentifiedViewSystem, SpaceViewClass,
-    SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext,
-    VisualizerAdditionalApplicabilityFilter, VisualizerQueryInfo, VisualizerSystem,
+    SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache, TensorStatsCache,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
+    VisualizableFilterContext, VisualizerAdditionalApplicabilityFilter, VisualizerQueryInfo,
+    VisualizerSystem,
 };
 
 use crate::{
@@ -711,6 +712,7 @@ impl VisualizerSystem for ImageVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, LineStrip2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -195,6 +195,7 @@ impl VisualizerSystem for Lines2DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -7,7 +7,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, LineStrip3D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -204,6 +204,7 @@ impl VisualizerSystem for Lines3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -11,9 +11,9 @@ use re_types::{
     },
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo,
-    VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
+    VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -164,6 +164,7 @@ impl VisualizerSystem for Mesh3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -9,7 +9,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, Position2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -206,6 +206,7 @@ impl VisualizerSystem for Points2DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -9,7 +9,7 @@ use re_types::{
     components::{ClassId, Color, KeypointId, Position3D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
+    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewerContext,
     VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
@@ -197,6 +197,7 @@ impl VisualizerSystem for Points3DVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -2,9 +2,9 @@ use egui::Color32;
 use re_log_types::{EntityPath, Instance};
 use re_types::components::Transform3D;
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo,
-    VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizableEntities,
+    VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -47,6 +47,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let Some(render_ctx) = ctx.render_ctx else {

--- a/crates/re_space_view_tensor/src/visualizer_system.rs
+++ b/crates/re_space_view_tensor/src/visualizer_system.rs
@@ -3,8 +3,8 @@ use re_entity_db::{external::re_query::LatestAtMonoResult, EntityPath};
 use re_log_types::RowId;
 use re_types::{archetypes::Tensor, components::TensorData, tensor_data::DecodedTensor};
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, TensorDecodeCache, ViewContextCollection,
-    ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError, TensorDecodeCache,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 #[derive(Default)]
@@ -27,6 +27,7 @@ impl VisualizerSystem for TensorSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         re_tracing::profile_function!();

--- a/crates/re_space_view_text_document/src/visualizer_system.rs
+++ b/crates/re_space_view_text_document/src/visualizer_system.rs
@@ -2,8 +2,8 @@ use re_data_store::LatestAtQuery;
 use re_space_view::external::re_query::PromiseResult;
 use re_types::{archetypes::TextDocument, components};
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 // ---
@@ -35,6 +35,7 @@ impl VisualizerSystem for TextDocumentSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let timeline_query = LatestAtQuery::new(view_query.timeline, view_query.latest_at);

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -8,8 +8,8 @@ use re_types::{
     Component, Loggable as _,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery,
-    ViewerContext, VisualizerQueryInfo, VisualizerSystem,
+    IdentifiedViewSystem, SpaceViewState, SpaceViewSystemExecutionError, ViewContextCollection,
+    ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
 #[derive(Debug, Clone)]
@@ -49,6 +49,7 @@ impl VisualizerSystem for TextLogSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        _view_state: &dyn SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         let resolver = ctx.recording().resolver();

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -8,7 +8,7 @@ use re_types::{
     Archetype as _, ComponentNameSet, Loggable,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
+    IdentifiedViewSystem, QueryContext, SpaceViewState, SpaceViewSystemExecutionError,
     TypedComponentFallbackProvider, ViewQuery, ViewerContext, VisualizerQueryInfo,
     VisualizerSystem,
 };
@@ -52,11 +52,12 @@ impl VisualizerSystem for SeriesPointSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        view_state: &dyn SpaceViewState,
         _context: &re_viewer_context::ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         re_tracing::profile_function!();
 
-        match self.load_scalars(ctx, query) {
+        match self.load_scalars(ctx, query, view_state) {
             Ok(_) | Err(QueryError::PrimaryNotFound(_)) => Ok(Vec::new()),
             Err(err) => Err(err.into()),
         }
@@ -90,6 +91,7 @@ impl SeriesPointSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         view_query: &ViewQuery<'_>,
+        view_state: &dyn SpaceViewState,
     ) -> Result<(), QueryError> {
         re_tracing::profile_function!();
 
@@ -105,6 +107,7 @@ impl SeriesPointSystem {
                 archetype_name: Some(SeriesPoint::name()),
                 query: &ctx.current_query(),
                 target_entity_path: &data_result.entity_path,
+                view_state,
             };
 
             let fallback_color =

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -223,7 +223,7 @@ impl AppState {
                             &applicable_entities_per_visualizer,
                             recording,
                             &space_view_class_registry
-                                .new_visualizer_collection(*space_view.class_identifier()),
+                                .new_visualizer_collection(space_view.class_identifier()),
                             &space_view.space_origin,
                         );
 
@@ -279,7 +279,7 @@ impl AppState {
                             &applicable_entities_per_visualizer,
                             recording,
                             &space_view_class_registry
-                                .new_visualizer_collection(*space_view.class_identifier()),
+                                .new_visualizer_collection(space_view.class_identifier()),
                             &space_view.space_origin,
                         );
 

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -255,7 +255,7 @@ impl<'a> SpaceViewClassExt<'a> for dyn SpaceViewClass + 'a {}
 /// For any state that should be persisted, use the Blueprint!
 /// This state is used for transient state, such as animation or uncommitted ui state like dragging a camera.
 /// (on mouse release, the camera would be committed to the blueprint).
-pub trait SpaceViewState: std::any::Any {
+pub trait SpaceViewState: std::any::Any + Sync + Send {
     /// Converts itself to a reference of [`std::any::Any`], which enables downcasting to concrete types.
     fn as_any(&self) -> &dyn std::any::Any;
 

--- a/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class_registry.rs
@@ -248,25 +248,25 @@ impl SpaceViewClassRegistry {
     }
 
     /// Queries a Space View type by class name, returning `None` if it is not registered.
-    fn get_class(&self, name: &SpaceViewClassIdentifier) -> Option<&dyn SpaceViewClass> {
+    fn get_class(&self, name: SpaceViewClassIdentifier) -> Option<&dyn SpaceViewClass> {
         self.space_view_classes
-            .get(name)
+            .get(&name)
             .map(|boxed| boxed.class.as_ref())
     }
 
     /// Returns the user-facing name for the given space view class.
     ///
     /// If the class is unknown, returns a placeholder name.
-    pub fn display_name(&self, name: &SpaceViewClassIdentifier) -> &'static str {
+    pub fn display_name(&self, name: SpaceViewClassIdentifier) -> &'static str {
         self.space_view_classes
-            .get(name)
+            .get(&name)
             .map_or("<unknown space view class>", |boxed| {
                 boxed.class.display_name()
             })
     }
 
     /// Queries a Space View type by class name and logs if it fails, returning a placeholder class.
-    pub fn get_class_or_log_error(&self, name: &SpaceViewClassIdentifier) -> &dyn SpaceViewClass {
+    pub fn get_class_or_log_error(&self, name: SpaceViewClassIdentifier) -> &dyn SpaceViewClass {
         if let Some(result) = self.get_class(name) {
             result
         } else {

--- a/crates/re_viewer_context/src/space_view/view_states.rs
+++ b/crates/re_viewer_context/src/space_view/view_states.rs
@@ -29,6 +29,10 @@ pub struct ViewStates {
 static DEFAULT_PROPS: Lazy<EntityPropertyMap> = Lazy::<EntityPropertyMap>::new(Default::default);
 
 impl ViewStates {
+    pub fn get(&self, space_view_id: SpaceViewId) -> Option<&PerViewState> {
+        self.states.get(&space_view_id)
+    }
+
     pub fn get_mut(
         &mut self,
         view_class_registry: &SpaceViewClassRegistry,
@@ -41,10 +45,6 @@ impl ViewStates {
                 .get_class_or_log_error(view_class)
                 .new_state(),
         })
-    }
-
-    pub fn get(&self, space_view_id: SpaceViewId) -> Option<&PerViewState> {
-        self.states.get(&space_view_id)
     }
 
     pub fn legacy_auto_properties(&self, space_view_id: SpaceViewId) -> &EntityPropertyMap {

--- a/crates/re_viewer_context/src/space_view/view_states.rs
+++ b/crates/re_viewer_context/src/space_view/view_states.rs
@@ -29,20 +29,22 @@ pub struct ViewStates {
 static DEFAULT_PROPS: Lazy<EntityPropertyMap> = Lazy::<EntityPropertyMap>::new(Default::default);
 
 impl ViewStates {
-    pub fn view_state_mut(
+    pub fn get_mut(
         &mut self,
-        space_view_class_registry: &SpaceViewClassRegistry,
-        space_view_id: SpaceViewId,
-        space_view_class: &SpaceViewClassIdentifier,
+        view_class_registry: &SpaceViewClassRegistry,
+        view_id: SpaceViewId,
+        view_class: SpaceViewClassIdentifier,
     ) -> &mut PerViewState {
-        self.states
-            .entry(space_view_id)
-            .or_insert_with(|| PerViewState {
-                auto_properties: Default::default(),
-                view_state: space_view_class_registry
-                    .get_class_or_log_error(space_view_class)
-                    .new_state(),
-            })
+        self.states.entry(view_id).or_insert_with(|| PerViewState {
+            auto_properties: Default::default(),
+            view_state: view_class_registry
+                .get_class_or_log_error(view_class)
+                .new_state(),
+        })
+    }
+
+    pub fn get(&self, space_view_id: SpaceViewId) -> Option<&PerViewState> {
+        self.states.get(&space_view_id)
     }
 
     pub fn legacy_auto_properties(&self, space_view_id: SpaceViewId) -> &EntityPropertyMap {

--- a/crates/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_system.rs
@@ -3,7 +3,7 @@ use ahash::HashMap;
 use re_types::{Archetype, ComponentNameSet};
 
 use crate::{
-    ApplicableEntities, ComponentFallbackProvider, IdentifiedViewSystem,
+    ApplicableEntities, ComponentFallbackProvider, IdentifiedViewSystem, SpaceViewState,
     SpaceViewSystemExecutionError, ViewContextCollection, ViewQuery, ViewSystemIdentifier,
     ViewerContext, VisualizableEntities, VisualizableFilterContext,
     VisualizerAdditionalApplicabilityFilter,
@@ -84,6 +84,7 @@ pub trait VisualizerSystem: Send + Sync + ComponentFallbackProvider + 'static {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        view_state: &dyn SpaceViewState,
         view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError>;
 

--- a/crates/re_viewport/src/auto_layout.rs
+++ b/crates/re_viewport/src/auto_layout.rs
@@ -35,7 +35,7 @@ pub(crate) fn tree_from_space_views(
             )
         })
         .map(|(space_view_id, space_view)| {
-            let class_identifier = *space_view.class_identifier();
+            let class_identifier = space_view.class_identifier();
             let layout_priority = space_view
                 .class(space_view_class_registry)
                 .layout_priority();

--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -6,25 +6,25 @@ use rayon::prelude::*;
 use re_log_types::TimeInt;
 use re_types::SpaceViewClassIdentifier;
 use re_viewer_context::{
-    PerSystemDataResults, SpaceViewHighlights, SpaceViewId, SystemExecutionOutput, ViewQuery,
-    ViewerContext,
+    PerSystemDataResults, SpaceViewId, SpaceViewState, SystemExecutionOutput,
+    ViewContextCollection, ViewQuery, ViewStates, ViewerContext, VisualizerCollection,
 };
 
 use crate::space_view_highlights::highlights_for_space_view;
 use re_viewport_blueprint::SpaceViewBlueprint;
 
-pub fn create_and_run_space_view_systems(
+fn run_space_view_systems(
     ctx: &ViewerContext<'_>,
     space_view_class: SpaceViewClassIdentifier,
     query: &ViewQuery<'_>,
-) -> SystemExecutionOutput {
+    view_state: &dyn SpaceViewState,
+    context_systems: &mut ViewContextCollection,
+    view_systems: &mut VisualizerCollection,
+) -> Vec<re_renderer::QueueableDrawData> {
     re_tracing::profile_function!(space_view_class.as_str());
 
-    let context_systems = {
+    {
         re_tracing::profile_wait!("ViewContextSystem::execute");
-        let mut context_systems = ctx
-            .space_view_class_registry
-            .new_context_collection(space_view_class);
         context_systems
             .systems
             .par_iter_mut()
@@ -32,19 +32,15 @@ pub fn create_and_run_space_view_systems(
                 re_tracing::profile_scope!("ViewContextSystem::execute", _name.as_str());
                 system.execute(ctx, query);
             });
-        context_systems
     };
 
     re_tracing::profile_wait!("VisualizerSystem::execute");
-    let mut view_systems = ctx
-        .space_view_class_registry
-        .new_visualizer_collection(space_view_class);
-    let draw_data = view_systems
+    view_systems
         .systems
         .par_iter_mut()
         .map(|(name, part)| {
             re_tracing::profile_scope!("VisualizerSystem::execute", name.as_str());
-            match part.execute(ctx, query, &context_systems) {
+            match part.execute(ctx, query, view_state, context_systems) {
                 Ok(part_draw_data) => part_draw_data,
                 Err(err) => {
                     re_log::error_once!("Error executing visualizer {name:?}: {err}");
@@ -53,57 +49,20 @@ pub fn create_and_run_space_view_systems(
             }
         })
         .flatten()
-        .collect();
-
-    SystemExecutionOutput {
-        view_systems,
-        context_systems,
-        draw_data,
-    }
-}
-
-pub fn execute_systems_for_all_space_views<'a>(
-    ctx: &'a ViewerContext<'a>,
-    tree: &egui_tiles::Tree<SpaceViewId>,
-    space_views: &'a BTreeMap<SpaceViewId, SpaceViewBlueprint>,
-) -> HashMap<SpaceViewId, (ViewQuery<'a>, SystemExecutionOutput)> {
-    let Some(time_int) = ctx.rec_cfg.time_ctrl.read().time_int() else {
-        return HashMap::default();
-    };
-
-    re_tracing::profile_wait!("execute_systems");
-
-    tree.active_tiles()
-        .into_par_iter()
-        .filter_map(|tile_id| {
-            tree.tiles.get(tile_id).and_then(|tile| match tile {
-                egui_tiles::Tile::Pane(space_view_id) => {
-                    space_views.get(space_view_id).map(|space_view_blueprint| {
-                        let highlights = highlights_for_space_view(ctx, *space_view_id);
-                        let output = execute_systems_for_space_view(
-                            ctx,
-                            space_view_blueprint,
-                            time_int,
-                            highlights,
-                        );
-                        (*space_view_id, output)
-                    })
-                }
-                egui_tiles::Tile::Container(_) => None,
-            })
-        })
-        .collect::<HashMap<_, _>>()
+        .collect()
 }
 
 pub fn execute_systems_for_space_view<'a>(
     ctx: &'a ViewerContext<'_>,
-    space_view: &'a SpaceViewBlueprint,
+    view: &'a SpaceViewBlueprint,
     latest_at: TimeInt,
-    highlights: SpaceViewHighlights,
+    view_states: &ViewStates,
 ) -> (ViewQuery<'a>, SystemExecutionOutput) {
-    re_tracing::profile_function!(space_view.class_identifier().as_str());
+    re_tracing::profile_function!(view.class_identifier().as_str());
 
-    let query_result = ctx.lookup_query_result(space_view.id);
+    let highlights = highlights_for_space_view(ctx, view.id);
+
+    let query_result = ctx.lookup_query_result(view.id);
 
     let mut per_visualizer_data_results = PerSystemDataResults::default();
     {
@@ -121,16 +80,68 @@ pub fn execute_systems_for_space_view<'a>(
     }
 
     let query = re_viewer_context::ViewQuery {
-        space_view_id: space_view.id,
-        space_origin: &space_view.space_origin,
+        space_view_id: view.id,
+        space_origin: &view.space_origin,
         per_visualizer_data_results,
         timeline: *ctx.rec_cfg.time_ctrl.read().timeline(),
         latest_at,
         highlights,
     };
 
-    let system_output =
-        create_and_run_space_view_systems(ctx, *space_view.class_identifier(), &query);
+    let mut context_systems = ctx
+        .space_view_class_registry
+        .new_context_collection(view.class_identifier());
+    let mut view_systems = ctx
+        .space_view_class_registry
+        .new_visualizer_collection(view.class_identifier());
 
-    (query, system_output)
+    let draw_data = if let Some(view_state) = view_states.get(view.id) {
+        run_space_view_systems(
+            ctx,
+            view.class_identifier(),
+            &query,
+            view_state.view_state.as_ref(),
+            &mut context_systems,
+            &mut view_systems,
+        )
+    } else {
+        re_log::error_once!("No view state found for view {}", view.id);
+        Vec::new()
+    };
+
+    (
+        query,
+        SystemExecutionOutput {
+            view_systems,
+            context_systems,
+            draw_data,
+        },
+    )
+}
+
+pub fn execute_systems_for_all_views<'a>(
+    ctx: &'a ViewerContext<'a>,
+    tree: &egui_tiles::Tree<SpaceViewId>,
+    views: &'a BTreeMap<SpaceViewId, SpaceViewBlueprint>,
+    view_states: &ViewStates,
+) -> HashMap<SpaceViewId, (ViewQuery<'a>, SystemExecutionOutput)> {
+    let Some(time_int) = ctx.rec_cfg.time_ctrl.read().time_int() else {
+        return HashMap::default();
+    };
+
+    re_tracing::profile_wait!("execute_systems");
+
+    tree.active_tiles()
+        .into_par_iter()
+        .filter_map(|tile_id| {
+            tree.tiles.get(tile_id).and_then(|tile| match tile {
+                egui_tiles::Tile::Pane(view_id) => views.get(view_id).map(|view| {
+                    let result = execute_systems_for_space_view(ctx, view, time_int, view_states);
+
+                    (*view_id, result)
+                }),
+                egui_tiles::Tile::Container(_) => None,
+            })
+        })
+        .collect::<HashMap<_, _>>()
 }

--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -15,13 +15,13 @@ use re_viewport_blueprint::SpaceViewBlueprint;
 
 fn run_space_view_systems(
     ctx: &ViewerContext<'_>,
-    space_view_class: SpaceViewClassIdentifier,
+    _space_view_class: SpaceViewClassIdentifier,
     query: &ViewQuery<'_>,
     view_state: &dyn SpaceViewState,
     context_systems: &mut ViewContextCollection,
     view_systems: &mut VisualizerCollection,
 ) -> Vec<re_renderer::QueueableDrawData> {
-    re_tracing::profile_function!(space_view_class.as_str());
+    re_tracing::profile_function!(_space_view_class.as_str());
 
     {
         re_tracing::profile_wait!("ViewContextSystem::execute");

--- a/crates/re_viewport/src/system_execution.rs
+++ b/crates/re_viewport/src/system_execution.rs
@@ -126,7 +126,7 @@ pub fn execute_systems_for_all_views<'a>(
     view_states: &ViewStates,
 ) -> HashMap<SpaceViewId, (ViewQuery<'a>, SystemExecutionOutput)> {
     let Some(time_int) = ctx.rec_cfg.time_ctrl.read().time_int() else {
-        return HashMap::default();
+        return Default::default();
     };
 
     re_tracing::profile_wait!("execute_systems");

--- a/crates/re_viewport_blueprint/src/space_view.rs
+++ b/crates/re_viewport_blueprint/src/space_view.rs
@@ -315,15 +315,15 @@ impl SpaceViewBlueprint {
         }
     }
 
-    pub fn class_identifier(&self) -> &SpaceViewClassIdentifier {
-        &self.class_identifier
+    pub fn class_identifier(&self) -> SpaceViewClassIdentifier {
+        self.class_identifier
     }
 
     pub fn class<'a>(
         &self,
         space_view_class_registry: &'a re_viewer_context::SpaceViewClassRegistry,
     ) -> &'a dyn SpaceViewClass {
-        space_view_class_registry.get_class_or_log_error(&self.class_identifier)
+        space_view_class_registry.get_class_or_log_error(self.class_identifier)
     }
 
     pub fn on_frame_start(
@@ -440,7 +440,7 @@ impl SpaceViewBlueprint {
         time_range.map_or_else(
             || {
                 let space_view_class =
-                    space_view_class_registry.get_class_or_log_error(&self.class_identifier);
+                    space_view_class_registry.get_class_or_log_error(self.class_identifier);
                 space_view_class.default_query_range()
             },
             |time_range| QueryRange::TimeRange(time_range.clone()),

--- a/crates/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -179,7 +179,7 @@ impl ViewportBlueprint {
             && self
                 .space_views
                 .values()
-                .all(|sv| sv.class_identifier() == &SpaceViewClassIdentifier::invalid())
+                .all(|sv| sv.class_identifier() == SpaceViewClassIdentifier::invalid())
     }
 
     pub fn space_view_ids(&self) -> impl Iterator<Item = &SpaceViewId> + '_ {
@@ -365,7 +365,7 @@ impl ViewportBlueprint {
             let existing_path_filters = self
                 .space_views
                 .values()
-                .filter(|space_view| space_view.class_identifier() == &class_id)
+                .filter(|space_view| space_view.class_identifier() == class_id)
                 .map(|space_view| &space_view.contents.entity_path_filter)
                 .collect::<Vec<_>>();
             recommended_space_views.retain(|recommended_view| {

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -64,6 +64,7 @@ impl VisualizerSystem for InstanceColorSystem {
         &mut self,
         ctx: &ViewerContext<'_>,
         query: &ViewQuery<'_>,
+        _view_state: &dyn re_viewer_context::SpaceViewState,
         _view_ctx: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
         // For each entity in the space view that should be displayed with the `InstanceColorSystem`…


### PR DESCRIPTION
### What

.. and some cleanup on the way

This is an important piece that allows us to move arbitrary heuristics to visualizer implemented fallbacks.
(Fixes `main` build failure caused by a merge order issue - view systems started using the `ViewContext` struct before they had access to the view state)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6483?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6483?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6483)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.