### PR TITLE
Bring back py-wheel command for building test wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _deps
 **/venv*
 **/.venv*
 .python-version
+.nox/
 
 # Python build artifacts:
 __pycache__
@@ -36,19 +37,26 @@ __pycache__
 *.so
 **/.pytest_cache
 
+# Python wheel build:
+rerun_py/rerun_sdk
+
 # Pixi environment
 .pixi
 
+# Debugging artifacts.
 .gdb_history
 perf.data*
-
-**/dataset/
 
 # Screenshots from samples etc.
 screenshot*.png
 
+# Sample downloads
+**/dataset/
+
 # Saved example `.rrd` files
 example_data
+*.rrd
+
 
 # Various builds
 dist
@@ -57,9 +65,5 @@ wheels
 # Screenshot comparison build
 /compare_screenshot
 
-.nox/
-*.rrd
-
+# Search index
 /meilisearch
-
-.pixi/*

--- a/pixi.toml
+++ b/pixi.toml
@@ -216,13 +216,15 @@ mdlint = "python scripts/ci/mdlint.py"
 
 [target.win-64.tasks]
 # Builds a debug mode Python wheel for install in an environment.
-py-wheel = { cmd = "cp target/debug/rerun.exe rerun_py/rerun_sdk/rerun_cli/rerun.exe && pixi run maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+py-wheel = { cmd = "cp target/debug/rerun.exe rerun_py/rerun_sdk/rerun_cli/rerun.exe && maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+  "rerun-build-web-cli",
   "py-build",
 ] }
 
 [target.unix.tasks]
 # Builds a debug mode Python wheel for install in an environment.
-py-wheel = { cmd = "cp target/debug/rerun rerun_py/rerun_sdk/rerun_cli/rerun && pixi run maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+py-wheel = { cmd = "cp target/debug/rerun rerun_py/rerun_sdk/rerun_cli/rerun && maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+  "rerun-build-web-cli",
   "py-build",
 ] }
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -214,6 +214,18 @@ py-docs-serve = "mkdocs serve -f rerun_py/mkdocs.yml -w rerun_py"
 # Lint markdown
 mdlint = "python scripts/ci/mdlint.py"
 
+[target.win-64.tasks]
+# Builds a debug mode Python wheel for install in an environment.
+py-wheel = { cmd = "cp target/debug/rerun.exe rerun_py/rerun_sdk/rerun_cli/rerun.exe && pixi run maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+  "py-build",
+] }
+
+[target.unix.tasks]
+# Builds a debug mode Python wheel for install in an environment.
+py-wheel = { cmd = "cp target/debug/rerun rerun_py/rerun_sdk/rerun_cli/rerun && pixi run maturin build --manifest-path rerun_py/Cargo.toml --no-default-features --features pypi", depends_on = [
+  "py-build",
+] }
+
 [feature.cpp.tasks]
 # All the cpp-* tasks can be configured with environment variables, e.g.: RERUN_WERROR=ON CXX=clang++
 cpp-prepare-release = "cmake -G 'Ninja' -B build/release -S . -DCMAKE_BUILD_TYPE=Release"


### PR DESCRIPTION
### What

Got lost at some point but we still mention it in [our build instructions](https://github.com/rerun-io/rerun/tree/main/rerun_py#building-rerun-from-source).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6490?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6490?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6490)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.