### PR TITLE
Cleanup view property querying

### DIFF
--- a/crates/re_space_view_spatial/src/lib.rs
+++ b/crates/re_space_view_spatial/src/lib.rs
@@ -25,6 +25,7 @@ mod view_3d;
 mod view_3d_properties;
 mod visualizers;
 
+use re_viewer_context::ViewerContext;
 pub use view_2d::SpatialSpaceView2D;
 pub use view_3d::SpatialSpaceView3D;
 
@@ -80,6 +81,7 @@ fn query_pinhole(
 }
 
 pub(crate) fn configure_background(
+    ctx: &ViewerContext<'_>,
     background: &ViewProperty<'_>,
     render_ctx: &RenderContext,
     view_system: &dyn re_viewer_context::ComponentFallbackProvider,
@@ -87,7 +89,7 @@ pub(crate) fn configure_background(
 ) -> Result<(Option<re_renderer::QueueableDrawData>, re_renderer::Rgba), ViewPropertyQueryError> {
     use re_renderer::renderer;
 
-    let kind: BackgroundKind = background.component_or_fallback(view_system, state)?;
+    let kind: BackgroundKind = background.component_or_fallback(ctx, view_system, state)?;
 
     match kind {
         BackgroundKind::GradientDark => Ok((
@@ -113,7 +115,7 @@ pub(crate) fn configure_background(
         )),
 
         BackgroundKind::SolidColor => {
-            let color: Color = background.component_or_fallback(view_system, state)?;
+            let color: Color = background.component_or_fallback(ctx, view_system, state)?;
             Ok((None, color.into()))
         }
     }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -43,7 +43,7 @@ fn ui_from_scene(
 ) -> RectTransform {
     let bounds_property = ViewProperty::from_archetype::<VisualBounds2D>(ctx, view_id);
     let bounds: blueprint_components::VisualBounds2D = bounds_property
-        .component_or_fallback(view_class, view_state)
+        .component_or_fallback(ctx, view_class, view_state)
         .ok_or_log_error()
         .unwrap_or_default();
     let mut bounds_rect: egui::Rect = bounds.into();
@@ -106,9 +106,9 @@ fn ui_from_scene(
     // Update blueprint if changed
     let updated_bounds: blueprint_components::VisualBounds2D = bounds_rect.into();
     if response.double_clicked() {
-        bounds_property.reset_blueprint_component::<blueprint_components::VisualBounds2D>();
+        bounds_property.reset_blueprint_component::<blueprint_components::VisualBounds2D>(ctx);
     } else if bounds != updated_bounds {
-        bounds_property.save_blueprint_component(&updated_bounds);
+        bounds_property.save_blueprint_component(ctx, &updated_bounds);
     }
 
     RectTransform::from_to(letterboxed_bounds, response.rect)
@@ -231,7 +231,7 @@ impl SpatialSpaceView2D {
 
         let background = ViewProperty::from_archetype::<Background>(ctx, query.space_view_id);
         let (background_drawable, clear_color) =
-            crate::configure_background(&background, render_ctx, self, state)?;
+            crate::configure_background(ctx, &background, render_ctx, self, state)?;
         if let Some(background_drawable) = background_drawable {
             view_builder.queue_draw(background_drawable);
         }

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -41,7 +41,11 @@ fn ui_from_scene(
     view_class: &SpatialSpaceView2D,
     view_state: &SpatialSpaceViewState,
 ) -> RectTransform {
-    let bounds_property = ViewProperty::from_archetype::<VisualBounds2D>(ctx, view_id);
+    let bounds_property = ViewProperty::from_archetype::<VisualBounds2D>(
+        ctx.blueprint_db(),
+        ctx.blueprint_query,
+        view_id,
+    );
     let bounds: blueprint_components::VisualBounds2D = bounds_property
         .component_or_fallback(ctx, view_class, view_state)
         .ok_or_log_error()
@@ -229,7 +233,11 @@ impl SpatialSpaceView2D {
             view_builder.queue_draw(draw_data);
         }
 
-        let background = ViewProperty::from_archetype::<Background>(ctx, query.space_view_id);
+        let background = ViewProperty::from_archetype::<Background>(
+            ctx.blueprint_db(),
+            ctx.blueprint_query,
+            query.space_view_id,
+        );
         let (background_drawable, clear_color) =
             crate::configure_background(ctx, &background, render_ctx, self, state)?;
         if let Some(background_drawable) = background_drawable {

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -678,7 +678,7 @@ impl SpatialSpaceView3D {
 
         let background = ViewProperty::from_archetype::<Background>(ctx, query.space_view_id);
         let (background_drawable, clear_color) =
-            crate::configure_background(&background, render_ctx, self, state)?;
+            crate::configure_background(ctx, &background, render_ctx, self, state)?;
         if let Some(background_drawable) = background_drawable {
             view_builder.queue_draw(background_drawable);
         }

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -676,7 +676,11 @@ impl SpatialSpaceView3D {
         // Commit ui induced lines.
         view_builder.queue_draw(line_builder.into_draw_data()?);
 
-        let background = ViewProperty::from_archetype::<Background>(ctx, query.space_view_id);
+        let background = ViewProperty::from_archetype::<Background>(
+            ctx.blueprint_db(),
+            ctx.blueprint_query,
+            query.space_view_id,
+        );
         let (background_drawable, clear_color) =
             crate::configure_background(ctx, &background, render_ctx, self, state)?;
         if let Some(background_drawable) = background_drawable {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -300,11 +300,16 @@ impl SpaceViewClass for TimeSeriesSpaceView {
 
         let state = state.downcast_mut::<TimeSeriesSpaceViewState>()?;
 
-        let plot_legend = ViewProperty::from_archetype::<PlotLegend>(ctx, query.space_view_id);
+        let blueprint_db = ctx.blueprint_db();
+        let view_id = query.space_view_id;
+
+        let plot_legend =
+            ViewProperty::from_archetype::<PlotLegend>(blueprint_db, ctx.blueprint_query, view_id);
         let legend_visible = plot_legend.component_or_fallback::<Visible>(ctx, self, state)?;
         let legend_corner = plot_legend.component_or_fallback::<Corner2D>(ctx, self, state)?;
 
-        let scalar_axis = ViewProperty::from_archetype::<ScalarAxis>(ctx, query.space_view_id);
+        let scalar_axis =
+            ViewProperty::from_archetype::<ScalarAxis>(blueprint_db, ctx.blueprint_query, view_id);
         let y_range = scalar_axis.component_or_fallback::<Range1D>(ctx, self, state)?;
         let y_zoom_lock =
             scalar_axis.component_or_fallback::<LockRangeDuringZoom>(ctx, self, state)?;

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -301,12 +301,13 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         let state = state.downcast_mut::<TimeSeriesSpaceViewState>()?;
 
         let plot_legend = ViewProperty::from_archetype::<PlotLegend>(ctx, query.space_view_id);
-        let legend_visible = plot_legend.component_or_fallback::<Visible>(self, state)?;
-        let legend_corner = plot_legend.component_or_fallback::<Corner2D>(self, state)?;
+        let legend_visible = plot_legend.component_or_fallback::<Visible>(ctx, self, state)?;
+        let legend_corner = plot_legend.component_or_fallback::<Corner2D>(ctx, self, state)?;
 
         let scalar_axis = ViewProperty::from_archetype::<ScalarAxis>(ctx, query.space_view_id);
-        let y_range = scalar_axis.component_or_fallback::<Range1D>(self, state)?;
-        let y_zoom_lock = scalar_axis.component_or_fallback::<LockRangeDuringZoom>(self, state)?;
+        let y_range = scalar_axis.component_or_fallback::<Range1D>(ctx, self, state)?;
+        let y_zoom_lock =
+            scalar_axis.component_or_fallback::<LockRangeDuringZoom>(ctx, self, state)?;
         let y_zoom_lock = y_zoom_lock.0 .0;
 
         let (current_time, time_type, timeline) = {
@@ -508,9 +509,9 @@ impl SpaceViewClass for TimeSeriesSpaceView {
         // Write new y_range if it has changed.
         let new_y_range = Range1D::new(transform.bounds().min()[1], transform.bounds().max()[1]);
         if is_resetting {
-            scalar_axis.reset_blueprint_component::<Range1D>();
+            scalar_axis.reset_blueprint_component::<Range1D>(ctx);
         } else if new_y_range != y_range {
-            scalar_axis.save_blueprint_component(&new_y_range);
+            scalar_axis.save_blueprint_component(ctx, &new_y_range);
         }
 
         // Decide if the time cursor should be displayed, and if so where:

--- a/crates/re_types/src/blueprint/archetypes/visible_time_ranges_ext.rs
+++ b/crates/re_types/src/blueprint/archetypes/visible_time_ranges_ext.rs
@@ -4,7 +4,7 @@ use super::VisibleTimeRanges;
 
 impl VisibleTimeRanges {
     /// Retrieves the time range for a given timeline.
-    pub fn range_for_timeline(&self, timeline_name: &str) -> Option<&'_ TimeRange> {
+    pub fn range_for_timeline(&self, timeline_name: &str) -> Option<&TimeRange> {
         self.ranges
             .iter()
             .find(|range| range.timeline.as_str() == timeline_name)

--- a/crates/re_viewport_blueprint/src/lib.rs
+++ b/crates/re_viewport_blueprint/src/lib.rs
@@ -15,9 +15,7 @@ use re_viewer_context::ViewerContext;
 pub use space_view::SpaceViewBlueprint;
 pub use space_view_contents::SpaceViewContents;
 pub use tree_actions::TreeAction;
-pub use view_properties::{
-    entity_path_for_view_property, query_view_property, ViewProperty, ViewPropertyQueryError,
-};
+pub use view_properties::{entity_path_for_view_property, ViewProperty, ViewPropertyQueryError};
 pub use viewport_blueprint::ViewportBlueprint;
 
 pub const VIEWPORT_PATH: &str = "viewport";

--- a/crates/re_viewport_blueprint/src/lib.rs
+++ b/crates/re_viewport_blueprint/src/lib.rs
@@ -16,8 +16,7 @@ pub use space_view::SpaceViewBlueprint;
 pub use space_view_contents::SpaceViewContents;
 pub use tree_actions::TreeAction;
 pub use view_properties::{
-    entity_path_for_view_property, query_view_property, query_view_property_or_default,
-    ViewProperty, ViewPropertyQueryError,
+    entity_path_for_view_property, query_view_property, ViewProperty, ViewPropertyQueryError,
 };
 pub use viewport_blueprint::ViewportBlueprint;
 

--- a/crates/re_viewport_blueprint/src/space_view.rs
+++ b/crates/re_viewport_blueprint/src/space_view.rs
@@ -429,7 +429,7 @@ impl SpaceViewBlueprint {
         // * can't be specified in the data store
         // Here, we query the visual time range that serves as the default for all entities in this space.
 
-        let property = ViewProperty::from_archetype_no_ctx::<blueprint_archetypes::VisibleTimeRanges>(
+        let property = ViewProperty::from_archetype::<blueprint_archetypes::VisibleTimeRanges>(
             blueprint,
             blueprint_query,
             self.id,

--- a/crates/re_viewport_blueprint/src/space_view.rs
+++ b/crates/re_viewport_blueprint/src/space_view.rs
@@ -2,7 +2,7 @@ use itertools::{FoldWhile, Itertools};
 use re_entity_db::{external::re_query::PromiseResult, EntityProperties};
 use re_types::SpaceViewClassIdentifier;
 
-use crate::SpaceViewContents;
+use crate::{SpaceViewContents, ViewProperty};
 use re_data_store::LatestAtQuery;
 use re_entity_db::{EntityDb, EntityPath, EntityPropertiesComponent, EntityPropertyMap};
 use re_log_types::{DataRow, EntityPathSubs, RowId, Timeline};
@@ -428,15 +428,21 @@ impl SpaceViewBlueprint {
         // * default does not vary per visualizer
         // * can't be specified in the data store
         // Here, we query the visual time range that serves as the default for all entities in this space.
-        let (visible_time_range_archetype, _) = crate::query_view_property::<
-            blueprint_archetypes::VisibleTimeRanges,
-        >(self.id, blueprint, blueprint_query);
 
-        let visible_time_range_archetype = visible_time_range_archetype.ok().flatten();
+        let property = ViewProperty::from_archetype_no_ctx::<blueprint_archetypes::VisibleTimeRanges>(
+            blueprint,
+            blueprint_query,
+            self.id,
+        );
+        let ranges = property.component_array();
 
-        let time_range = visible_time_range_archetype
-            .as_ref()
-            .and_then(|arch| arch.range_for_timeline(active_timeline.name().as_str()));
+        let time_range = ranges.and_then(|ranges| {
+            ranges.ok().and_then(|ranges| {
+                blueprint_archetypes::VisibleTimeRanges { ranges }
+                    .range_for_timeline(active_timeline.name().as_str())
+                    .cloned()
+            })
+        });
         time_range.map_or_else(
             || {
                 let space_view_class =

--- a/crates/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/re_viewport_blueprint/src/space_view_contents.rs
@@ -107,7 +107,7 @@ impl SpaceViewContents {
         view_class_identifier: SpaceViewClassIdentifier,
         space_env: &EntityPathSubs,
     ) -> Self {
-        let property = ViewProperty::from_archetype_no_ctx::<blueprint_archetypes::SpaceViewContents>(
+        let property = ViewProperty::from_archetype::<blueprint_archetypes::SpaceViewContents>(
             blueprint_db,
             query,
             view_id,

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -37,17 +37,6 @@ pub struct ViewProperty<'a> {
 impl<'a> ViewProperty<'a> {
     /// Query a specific view property for a given view.
     pub fn from_archetype<A: Archetype>(
-        viewer_ctx: &'a ViewerContext<'a>,
-        view_id: SpaceViewId,
-    ) -> Self {
-        let blueprint_db = viewer_ctx.blueprint_db();
-        let blueprint_query = viewer_ctx.blueprint_query;
-
-        Self::from_archetype_no_ctx::<A>(blueprint_db, blueprint_query, view_id)
-    }
-
-    /// Query a specific view property for a given view, without proving a viewer context.
-    pub fn from_archetype_no_ctx<A: Archetype>(
         blueprint_db: &'a EntityDb,
         blueprint_query: &'a LatestAtQuery,
         view_id: SpaceViewId,

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -182,15 +182,3 @@ pub fn entity_path_for_view_property(
     space_view_blueprint_path.join(&EntityPath::from_single_string(archetype_name.short_name()))
 }
 
-// TODO(andreas): Replace all usages with `ViewProperty`.
-pub fn query_view_property_or_default<A: Archetype + Default>(
-    space_view_id: SpaceViewId,
-    blueprint_db: &EntityDb,
-    query: &LatestAtQuery,
-) -> (A, EntityPath)
-where
-    LatestAtResults: ToArchetype<A>,
-{
-    let (arch, path) = query_view_property(space_view_id, blueprint_db, query);
-    (arch.ok().flatten().unwrap_or_default(), path)
-}

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -1,33 +1,11 @@
 use re_data_store::LatestAtQuery;
-use re_entity_db::{
-    external::re_query::{LatestAtResults, PromiseResult, ToArchetype},
-    EntityDb,
-};
+use re_entity_db::{external::re_query::LatestAtResults, EntityDb};
 use re_log_types::EntityPath;
-use re_types::{external::arrow2, Archetype, ArchetypeName, ComponentName};
+use re_types::{external::arrow2, Archetype, ArchetypeName, ComponentName, DeserializationError};
 use re_viewer_context::{
     external::re_entity_db::EntityTree, ComponentFallbackError, ComponentFallbackProvider,
     QueryContext, SpaceViewId, SpaceViewSystemExecutionError, ViewerContext,
 };
-
-// TODO(andreas): Replace all usages with `ViewProperty`.
-/// Returns `Ok(None)` if any of the required components are missing.
-pub fn query_view_property<A: Archetype>(
-    space_view_id: SpaceViewId,
-    blueprint_db: &EntityDb,
-    query: &LatestAtQuery,
-) -> (PromiseResult<Option<A>>, EntityPath)
-where
-    LatestAtResults: ToArchetype<A>,
-{
-    let path = entity_path_for_view_property(space_view_id, blueprint_db.tree(), A::name());
-    (
-        blueprint_db
-            .latest_at_archetype(&path, query)
-            .map(|res| res.map(|(_, arch)| arch)),
-        path,
-    )
-}
 
 #[derive(thiserror::Error, Debug)]
 pub enum ViewPropertyQueryError {
@@ -49,10 +27,11 @@ impl From<ViewPropertyQueryError> for SpaceViewSystemExecutionError {
 
 /// Utility for querying view properties.
 pub struct ViewProperty<'a> {
-    blueprint_store_path: EntityPath,
+    pub blueprint_store_path: EntityPath,
     archetype_name: ArchetypeName,
     query_results: LatestAtResults,
-    viewer_ctx: &'a ViewerContext<'a>,
+    blueprint_db: &'a EntityDb,
+    blueprint_query: &'a LatestAtQuery,
 }
 
 impl<'a> ViewProperty<'a> {
@@ -61,22 +40,39 @@ impl<'a> ViewProperty<'a> {
         viewer_ctx: &'a ViewerContext<'a>,
         view_id: SpaceViewId,
     ) -> Self {
-        Self::from_archetype_impl(viewer_ctx, view_id, A::name(), A::all_components().as_ref())
+        let blueprint_db = viewer_ctx.blueprint_db();
+        let blueprint_query = viewer_ctx.blueprint_query;
+
+        Self::from_archetype_no_ctx::<A>(blueprint_db, blueprint_query, view_id)
+    }
+
+    /// Query a specific view property for a given view, without proving a viewer context.
+    pub fn from_archetype_no_ctx<A: Archetype>(
+        blueprint_db: &'a EntityDb,
+        blueprint_query: &'a LatestAtQuery,
+        view_id: SpaceViewId,
+    ) -> Self {
+        Self::from_archetype_impl(
+            blueprint_db,
+            blueprint_query,
+            view_id,
+            A::name(),
+            A::all_components().as_ref(),
+        )
     }
 
     fn from_archetype_impl(
-        viewer_ctx: &'a ViewerContext<'a>,
+        blueprint_db: &'a EntityDb,
+        blueprint_query: &'a LatestAtQuery,
         space_view_id: SpaceViewId,
         archetype_name: ArchetypeName,
         component_names: &[ComponentName],
     ) -> Self {
-        let blueprint_db = viewer_ctx.blueprint_db();
-
         let blueprint_store_path =
             entity_path_for_view_property(space_view_id, blueprint_db.tree(), archetype_name);
 
         let query_results = blueprint_db.latest_at(
-            viewer_ctx.blueprint_query,
+            blueprint_query,
             &blueprint_store_path,
             component_names.iter().copied(),
         );
@@ -85,8 +81,8 @@ impl<'a> ViewProperty<'a> {
             blueprint_store_path,
             archetype_name,
             query_results,
-
-            viewer_ctx,
+            blueprint_db,
+            blueprint_query,
         }
     }
 
@@ -95,10 +91,11 @@ impl<'a> ViewProperty<'a> {
     // This sadly means that there's a bit of unnecessary back and forth between arrow array and untyped that could be avoided otherwise.
     pub fn component_or_fallback<C: re_types::Component + Default>(
         &self,
+        ctx: &'a ViewerContext<'a>,
         fallback_provider: &dyn ComponentFallbackProvider,
         view_state: &'a dyn re_viewer_context::SpaceViewState,
     ) -> Result<C, ViewPropertyQueryError> {
-        self.component_array_or_fallback::<C>(fallback_provider, view_state)?
+        self.component_array_or_fallback::<C>(ctx, fallback_provider, view_state)?
             .into_iter()
             .next()
             .ok_or(ComponentFallbackError::UnexpectedEmptyFallback.into())
@@ -107,27 +104,38 @@ impl<'a> ViewProperty<'a> {
     /// Get the value of a specific component or its fallback if the component is not present.
     pub fn component_array_or_fallback<C: re_types::Component + Default>(
         &self,
+        ctx: &'a ViewerContext<'a>,
         fallback_provider: &dyn ComponentFallbackProvider,
         view_state: &'a dyn re_viewer_context::SpaceViewState,
     ) -> Result<Vec<C>, ViewPropertyQueryError> {
         let component_name = C::name();
         Ok(C::from_arrow(
-            self.component_or_fallback_raw(component_name, fallback_provider, view_state)?
+            self.component_or_fallback_raw(ctx, component_name, fallback_provider, view_state)?
                 .as_ref(),
         )?)
+    }
+
+    /// Get the value of a specific component or its fallback if the component is not present.
+    pub fn component_array<C: re_types::Component + Default>(
+        &self,
+    ) -> Option<Result<Vec<C>, DeserializationError>> {
+        let component_name = C::name();
+        self.component_raw(component_name)
+            .map(|raw| C::from_arrow(raw.as_ref()))
     }
 
     fn component_raw(
         &self,
         component_name: ComponentName,
     ) -> Option<Box<dyn arrow2::array::Array>> {
-        self.query_results.get(component_name).and_then(|result| {
-            result.raw(self.viewer_ctx.blueprint_db().resolver(), component_name)
-        })
+        self.query_results
+            .get(component_name)
+            .and_then(|result| result.raw(self.blueprint_db.resolver(), component_name))
     }
 
     fn component_or_fallback_raw(
         &self,
+        ctx: &'a ViewerContext<'a>,
         component_name: ComponentName,
         fallback_provider: &dyn ComponentFallbackProvider,
         view_state: &'a dyn re_viewer_context::SpaceViewState,
@@ -137,30 +145,33 @@ impl<'a> ViewProperty<'a> {
                 return Ok(value);
             }
         }
-        fallback_provider.fallback_for(&self.query_context(view_state), component_name)
+        fallback_provider.fallback_for(&self.query_context(ctx, view_state), component_name)
     }
 
     /// Save change to a blueprint component.
-    pub fn save_blueprint_component<C: re_types::Component>(&self, component: &C) {
-        self.viewer_ctx
-            .save_blueprint_component(&self.blueprint_store_path, component);
+    pub fn save_blueprint_component<C: re_types::Component>(
+        &self,
+        ctx: &'a ViewerContext<'a>,
+        component: &C,
+    ) {
+        ctx.save_blueprint_component(&self.blueprint_store_path, component);
     }
 
     /// Resets a blueprint component to the value it had in the default blueprint.
-    pub fn reset_blueprint_component<C: re_types::Component>(&self) {
-        self.viewer_ctx
-            .reset_blueprint_component_by_name(&self.blueprint_store_path, C::name());
+    pub fn reset_blueprint_component<C: re_types::Component>(&self, ctx: &'a ViewerContext<'a>) {
+        ctx.reset_blueprint_component_by_name(&self.blueprint_store_path, C::name());
     }
 
     fn query_context(
         &self,
+        viewer_ctx: &'a ViewerContext<'a>,
         view_state: &'a dyn re_viewer_context::SpaceViewState,
     ) -> QueryContext<'_> {
         QueryContext {
-            viewer_ctx: self.viewer_ctx,
+            viewer_ctx,
             target_entity_path: &self.blueprint_store_path,
             archetype_name: Some(self.archetype_name),
-            query: self.viewer_ctx.blueprint_query,
+            query: self.blueprint_query,
             view_state,
         }
     }
@@ -181,4 +192,3 @@ pub fn entity_path_for_view_property(
     // Use short_name instead of full_name since full_name has dots and looks too much like an indicator component.
     space_view_blueprint_path.join(&EntityPath::from_single_string(archetype_name.short_name()))
 }
-

--- a/crates/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/re_viewport_blueprint/src/view_properties.rs
@@ -90,7 +90,7 @@ impl<'a> ViewProperty<'a> {
             .ok_or(ComponentFallbackError::UnexpectedEmptyFallback.into())
     }
 
-    /// Get the value of a specific component or its fallback if the component is not present.
+    /// Get the component array for a given type or its fallback if the component is not present or empty.
     pub fn component_array_or_fallback<C: re_types::Component + Default>(
         &self,
         ctx: &'a ViewerContext<'a>,
@@ -104,7 +104,7 @@ impl<'a> ViewProperty<'a> {
         )?)
     }
 
-    /// Get the value of a specific component or its fallback if the component is not present.
+    /// Get the component array for a given type.
     pub fn component_array<C: re_types::Component + Default>(
         &self,
     ) -> Option<Result<Vec<C>, DeserializationError>> {


### PR DESCRIPTION
### What

Remove all previous ways of querying view properties and funnel them (almost) always through the `ViewProperty` struct

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6500?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6500?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6500)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.