### PR TITLE
Bug fix: allow removing blueprint entries even when they are invisible

### DIFF
--- a/crates/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/re_blueprint_tree/src/blueprint_tree.rs
@@ -1054,9 +1054,11 @@ fn visibility_button_ui(
     enabled: bool,
     visible: &mut bool,
 ) -> egui::Response {
-    ui.set_enabled(enabled);
-    re_ui
-        .visibility_toggle_button(ui, visible)
-        .on_hover_text("Toggle visibility")
-        .on_disabled_hover_text("A parent is invisible")
+    ui.add_enabled_ui(enabled, |ui| {
+        re_ui
+            .visibility_toggle_button(ui, visible)
+            .on_hover_text("Toggle visibility")
+            .on_disabled_hover_text("A parent is invisible")
+    })
+    .inner
 }


### PR DESCRIPTION
The `visibility_button_ui` would change the calling `Ui`, which was wrong.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6503?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6503?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6503)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.