### PR TITLE
Allow manually setting full span scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1626,7 +1626,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1645,7 +1645,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1664,7 +1664,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark"
 version = "0.16.1"
-source = "git+https://github.com/rerun-io/egui_commonmark?rev=11a04af9177214f4cb7dce3733d1e14f6890ceb9#11a04af9177214f4cb7dce3733d1e14f6890ceb9"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=63d5c8933445b9ea9088c4a50b71f4ede1f3c247#63d5c8933445b9ea9088c4a50b71f4ede1f3c247"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark_backend"
 version = "0.16.1"
-source = "git+https://github.com/rerun-io/egui_commonmark?rev=11a04af9177214f4cb7dce3733d1e14f6890ceb9#11a04af9177214f4cb7dce3733d1e14f6890ceb9"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=63d5c8933445b9ea9088c4a50b71f4ede1f3c247#63d5c8933445b9ea9088c4a50b71f4ede1f3c247"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1685,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ahash",
  "egui",
@@ -1701,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1719,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ahash",
  "egui",
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "egui_tiles"
 version = "0.8.0"
-source = "git+https://github.com/rerun-io/egui_tiles?rev=7ed84adfa20e1a62d1a1da75a6083d3fc194164d#7ed84adfa20e1a62d1a1da75a6083d3fc194164d"
+source = "git+https://github.com/rerun-io/egui_tiles?rev=cd8a1acdfca67e0b98ebc5722ee89b74bb20f5d3#cd8a1acdfca67e0b98ebc5722ee89b74bb20f5d3"
 dependencies = [
  "ahash",
  "egui",
@@ -1762,7 +1762,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1863,7 +1863,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=a28792194ddacbdb8012dafa49cdfb84c6a3ba65#a28792194ddacbdb8012dafa49cdfb84c6a3ba65"
+source = "git+https://github.com/emilk/egui.git?rev=cbb5d6aa936c7498214dba03b594fbe75dbe7488#cbb5d6aa936c7498214dba03b594fbe75dbe7488"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,13 +454,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }      # egui master 2024-06-04
-eframe = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }      # egui master 2024-06-04
-egui = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }        # egui master 2024-06-04
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" } # egui master 2024-06-04
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }   # egui master 2024-06-04
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }   # egui master 2024-06-04
-emath = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012dafa49cdfb84c6a3ba65" }       # egui master 2024-06-04
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }      # egui master 2024-06-05
+eframe = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }      # egui master 2024-06-05
+egui = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }        # egui master 2024-06-05
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" } # egui master 2024-06-05
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }   # egui master 2024-06-05
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }   # egui master 2024-06-05
+emath = { git = "https://github.com/emilk/egui.git", rev = "cbb5d6aa936c7498214dba03b594fbe75dbe7488" }       # egui master 2024-06-05
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }
@@ -471,6 +471,6 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "a28792194ddacbdb8012
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "7ed84adfa20e1a62d1a1da75a6083d3fc194164d" } # main 2024-06-04, which works with egui master
+egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "cd8a1acdfca67e0b98ebc5722ee89b74bb20f5d3" } # main 2024-06-05, which works with egui master
 
-egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "11a04af9177214f4cb7dce3733d1e14f6890ceb9" } # https://github.com/lampsitter/egui_commonmark/pull/51
+egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "63d5c8933445b9ea9088c4a50b71f4ede1f3c247" } # https://github.com/lampsitter/egui_commonmark/pull/51

--- a/crates/re_time_panel/src/lib.rs
+++ b/crates/re_time_panel/src/lib.rs
@@ -443,25 +443,20 @@ impl TimePanel {
             ui.min_rect().bottom()..=ui.max_rect().bottom(),
         ));
 
-        //TODO(ab): using clip rect here should be replaced by a better mechanism based on `UiStack`
-        let old_clip_rect = ui.clip_rect();
-        ui.set_clip_rect(egui::Rect::from_x_y_ranges(
-            0.0..=time_x_left,
-            ui.max_rect().y_range(),
-        ));
-        // All the entity rows and their data density graphs:
-        list_item::list_item_scope(ui, "streams_tree", |ui| {
-            self.tree_ui(
-                ctx,
-                viewport_blueprint,
-                entity_db,
-                time_ctrl,
-                &time_area_response,
-                &lower_time_area_painter,
-                ui,
-            );
+        // All the entity rows and their data density graphs
+        ui.full_span_scope(0.0..=time_x_left, |ui| {
+            list_item::list_item_scope(ui, "streams_tree", |ui| {
+                self.tree_ui(
+                    ctx,
+                    viewport_blueprint,
+                    entity_db,
+                    time_ctrl,
+                    &time_area_response,
+                    &lower_time_area_painter,
+                    ui,
+                );
+            });
         });
-        ui.set_clip_rect(old_clip_rect);
 
         {
             // Paint a shadow between the stream names on the left


### PR DESCRIPTION
### What

When #6491 migrated to using `UiStack` for full span scopes, it wasn't possible to manually set a full span scope somewhere. Because of that, a clip rect hack was used for the streams tree. With https://github.com/emilk/egui/pull/4617, it's now possible to support that correctly, so this PR introduces `UiExt::full_span_scope()` and uses it for the streams tree.

This PR also bumps the egui/egui_commonmark/egui_tiles commits.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
