### PR TITLE
Fix rerun-web canvas size

### DIFF
--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -44,15 +44,11 @@
 
       /* Position canvas in center-top: */
       canvas {
-        margin-right: auto;
-        margin-left: auto;
-        display: block;
         position: absolute;
-        top: 0%;
-        left: 50%;
-        transform: translate(-50%, 0%);
-        /* canvas must be on top when visible */
-        z-index: 1000;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
       }
 
       /* Match the Rerun header bar. */


### PR DESCRIPTION
### What

The canvas size was the default of 300x150 because we didn't update the CSS in `index.html` after
- https://github.com/emilk/egui/pull/4536

Closes
- https://github.com/rerun-io/rerun/issues/6507

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6511?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6511?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6511)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.