### PR TITLE
Remove background highlight when list item is non-interactive

### DIFF
--- a/crates/re_ui/src/list_item/list_item.rs
+++ b/crates/re_ui/src/list_item/list_item.rs
@@ -69,6 +69,9 @@ impl ListItem {
     /// Can the user click and interact with it?
     ///
     /// Set to `false` for items that only show info, but shouldn't be interactive.
+    /// Note: making the list item non-interactive does not necessarily make its content
+    /// non-interactive. For example, a non-interactive list item may be used in conjunction with
+    /// [`super::PropertyContent`] to build property-like editors.
     #[inline]
     pub fn interactive(mut self, interactive: bool) -> Self {
         self.interactive = interactive;
@@ -329,7 +332,7 @@ impl ListItem {
                         (1.0, ui.visuals().selection.bg_fill),
                     ),
                 );
-            } else {
+            } else if interactive {
                 let bg_fill = if !response.hovered() && ui.rect_contains_pointer(bg_rect) {
                     // if some part of the content is active and hovered, our background should
                     // become dimmer


### PR DESCRIPTION
### What

* Fixes #6481

So far, non-interactive list item would draw a background when hovered, but that was mostly invisible due to the colour being the same as our regular window background. This became visible in tooltips though, as those have a different background colour. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6513?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6513?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6513)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.