### PR TITLE
Restore the clear test for the GC behavior blueprint depends on

### DIFF
--- a/crates/re_entity_db/src/time_histogram_per_timeline.rs
+++ b/crates/re_entity_db/src/time_histogram_per_timeline.rs
@@ -100,12 +100,9 @@ impl TimeHistogramPerTimeline {
                 });
         } else {
             for (timeline, time_value) in timepoint.iter() {
-                let remaining_count = self
-                    .times
-                    .entry(*timeline)
-                    .or_default()
-                    .decrement(time_value.as_i64(), n);
-                if remaining_count == 0 {
+                let hist = self.times.entry(*timeline).or_default();
+                hist.decrement(time_value.as_i64(), n);
+                if hist.is_empty() {
                     self.times.remove(timeline);
                 }
             }

--- a/crates/re_entity_db/tests/clear.rs
+++ b/crates/re_entity_db/tests/clear.rs
@@ -1,7 +1,7 @@
 // https://github.com/rust-lang/rust-clippy/issues/10011
 #![cfg(test)]
 
-use re_data_store::{DataStore, LatestAtQuery};
+use re_data_store::{DataStore, DataStoreStats, LatestAtQuery};
 use re_entity_db::EntityDb;
 use re_log_types::{
     example_components::{MyColor, MyIndex, MyPoint},
@@ -363,6 +363,62 @@ fn clears() -> anyhow::Result<()> {
                     .is_none()
             );
         }
+    }
+
+    Ok(())
+}
+
+/// Test for GC behavior following clear. This functionality is expected by blueprints.
+#[test]
+fn clear_and_gc() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    let mut db = EntityDb::new(StoreId::random(re_log_types::StoreKind::Recording));
+
+    let timepoint = TimePoint::default().with(Timeline::new_sequence("blueprint"), 0);
+    let entity_path: EntityPath = "space_view".into();
+
+    // Insert a component, then clear it, then GC.
+    {
+        // EntityTree is Empty when we start
+        assert_eq!(db.tree().num_children_and_fields(), 0);
+
+        let point = MyPoint::new(1.0, 2.0);
+
+        let row = DataRow::from_component_batches(
+            RowId::new(),
+            timepoint.clone(),
+            entity_path.clone(),
+            [&[point] as _],
+        )?;
+
+        db.add_data_row(row)?;
+
+        db.gc_everything_but_the_latest_row();
+
+        let stats = DataStoreStats::from_store(db.store());
+        assert_eq!(stats.temporal.num_rows, 1);
+
+        let clear = DataRow::from_component_batches(
+            RowId::new(),
+            timepoint.clone(),
+            entity_path.clone(),
+            Clear::recursive()
+                .as_component_batches()
+                .iter()
+                .map(|b| b.as_ref()),
+        )?;
+
+        db.add_data_row(clear)?;
+
+        db.gc_everything_but_the_latest_row();
+
+        // No rows should remain because the table should have been purged
+        let stats = DataStoreStats::from_store(db.store());
+        assert_eq!(stats.temporal.num_rows, 0);
+
+        // EntityTree should be empty again when we end since everything was GC'd
+        assert_eq!(db.tree().num_children_and_fields(), 0);
     }
 
     Ok(())

--- a/crates/re_entity_db/tests/time_histograms.rs
+++ b/crates/re_entity_db/tests/time_histograms.rs
@@ -668,6 +668,10 @@ fn assert_recursive_histogram<'a>(
         let histo = db.time_histogram(timeline);
 
         if let Some(expected) = expected_times {
+            if expected.is_empty() {
+                assert!(histo.is_none());
+                continue;
+            }
             let histo = histo.unwrap();
             let ranges = histo.range(i64::MIN.., 0).collect::<Vec<_>>();
             let expected: Vec<_> = expected.to_vec();
@@ -692,9 +696,13 @@ fn assert_histogram_for_component<'a>(
             .and_then(|tree| tree.time_histogram_for_component(timeline, component_name));
 
         if let Some(expected) = expected_times {
+            let expected: Vec<_> = expected.to_vec();
+            if expected.is_empty() {
+                assert!(histo.is_none());
+                continue;
+            }
             let histo = histo.unwrap();
             let ranges = histo.range(i64::MIN.., 0).collect::<Vec<_>>();
-            let expected: Vec<_> = expected.to_vec();
             similar_asserts::assert_eq!(expected, ranges);
         } else {
             assert!(histo.is_none());


### PR DESCRIPTION
### What
- Motivated by: https://github.com/rerun-io/rerun/issues/6521

This test was inadvertently removed here: https://github.com/rerun-io/rerun/pull/5535/files#r1631789722

The test was previously (incorrectly) testing for timeless clears even though the blueprint had been updated to use non-timeless / static data. This updates it to use a blueprint-representative timepoint as well.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6522?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6522?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6522)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.