### PR TITLE
Ensure we have roundtrip tests for each archetype in PR CI

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -180,6 +180,11 @@ jobs:
       - name: Run e2e test
         run: pixi run -e wheel-test RUST_LOG=debug python scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
 
+      - name: Check for archetype roundtrip tests
+        if: ${{ inputs.FAST }}
+        # Only check that we have the archetype roundtrip tests, but don't spend time actually running them
+        run: pixi run -e wheel-test RUST_LOG=debug python tests/roundtrips.py --no-run
+
       - name: Run tests/roundtrips.py
         if: ${{ !inputs.FAST }}
         # --release so we can inherit from some of the artifacts that maturin has just built before

--- a/crates/re_space_view_bar_chart/Cargo.toml
+++ b/crates/re_space_view_bar_chart/Cargo.toml
@@ -26,7 +26,7 @@ re_log.workspace = true
 re_renderer.workspace = true
 re_space_view.workspace = true
 re_tracing.workspace = true
-re_types.workspace = true
+re_types = { workspace = true, features = ["egui_plot"] }
 re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -49,6 +49,7 @@ opt_out = {
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run our end-to-end cross-language roundtrip tests for all SDK")
+    parser.add_argument("--no-run", action="store_true", help="Do not build or run anything. Only check that the roundtrip tests exists.")
     parser.add_argument("--no-py-build", action="store_true", help="Skip building rerun-sdk for Python")
     parser.add_argument(
         "--no-cpp-build",
@@ -79,19 +80,23 @@ def main() -> None:
         ]
         assert len(archetypes) > 0, "No archetypes found!"
 
-        # Check that we have a roundtrip test for each language for each archetype:
-        errors = []
-        for arch in archetypes:
-            for lang in ["cpp", "python", "rust"]:
-                if lang not in opt_out.get(arch, []):
-                    dir_path = f"tests/{lang}/roundtrips/{arch}"
-                    if not os.path.exists(dir_path):
-                        errors.append(f"Missing {lang} roundtrip test for archetype '{arch}' (should be in '{dir_path}')")
-        if errors:
-            print("ERROR: Missing roundtrip tests for some archetypes!")
-            for error in errors:
-                print(f"  {error}")
-            sys.exit(1)
+    # Check that we have a roundtrip test for each language for each archetype:
+    errors = []
+    for arch in archetypes:
+        for lang in ["cpp", "python", "rust"]:
+            if lang not in opt_out.get(arch, []):
+                dir_path = f"tests/{lang}/roundtrips/{arch}"
+                if not os.path.exists(dir_path):
+                    errors.append(f"Missing {lang} roundtrip test for archetype '{arch}' (should be in '{dir_path}')")
+    if errors:
+        print("ERROR: Missing roundtrip tests for some archetypes!")
+        for error in errors:
+            print(f"  {error}")
+        sys.exit(1)
+
+    if args.no_run:
+        print("All archetypes have roundtrip tests.")
+        sys.exit(0)
 
     build_env = os.environ.copy()
     if "RUST_LOG" in build_env:

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -27,7 +27,7 @@ ARCHETYPES_PATHS = [
 
 opt_out = {
     "asset3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
-    "axes3d": ["cpp", "python", "rust"],  # TODO(#6525)
+    "axes3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
     "bar_chart": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
     "clear": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
     "mesh3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -26,24 +26,24 @@ ARCHETYPES_PATHS = [
 ]
 
 opt_out = {
-    "asset3d": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
-    "bar_chart": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
-    "clear": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
-    "mesh3d": ["cpp", "py", "rust"],  # Don't need it, API example roundtrips cover it all
-    "scalar": ["cpp", "py", "rust"],  # TODO(jleibs)
-    "series_line": ["cpp", "py", "rust"],  # TODO(jleibs)
-    "series_point": ["cpp", "py", "rust"],  # TODO(jleibs)
+    "asset3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
+    "bar_chart": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
+    "clear": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
+    "mesh3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
+    "scalar": ["cpp", "python", "rust"],  # TODO(jleibs)
+    "series_line": ["cpp", "python", "rust"],  # TODO(jleibs)
+    "series_point": ["cpp", "python", "rust"],  # TODO(jleibs)
     #
     # Most blueprint archetypes are untested currently:
-    "background": ["cpp", "py", "rust"],
-    "container_blueprint": ["cpp", "py", "rust"],
-    "panel_blueprint": ["cpp", "py", "rust"],
-    "plot_legend": ["cpp", "py", "rust"],
-    "scalar_axis": ["cpp", "py", "rust"],
-    "space_view_blueprint": ["cpp", "py", "rust"],
-    "space_view_contents": ["cpp", "py", "rust"],
-    "viewport_blueprint": ["cpp", "py", "rust"],
-    "visual_bounds2d": ["cpp", "py", "rust"],
+    "background": ["cpp", "python", "rust"],
+    "container_blueprint": ["cpp", "python", "rust"],
+    "panel_blueprint": ["cpp", "python", "rust"],
+    "plot_legend": ["cpp", "python", "rust"],
+    "scalar_axis": ["cpp", "python", "rust"],
+    "space_view_blueprint": ["cpp", "python", "rust"],
+    "space_view_contents": ["cpp", "python", "rust"],
+    "viewport_blueprint": ["cpp", "python", "rust"],
+    "visual_bounds2d": ["cpp", "python", "rust"],
 }
 
 
@@ -125,7 +125,7 @@ def main() -> None:
         jobs = []
         for arch in archetypes:
             arch_opt_out = opt_out.get(arch, [])
-            for language in ["py", "rust"]:
+            for language in ["python", "rust"]:
                 if language in arch_opt_out:
                     continue
                 job = pool.apply_async(build, (arch, language, args))
@@ -152,7 +152,7 @@ def main() -> None:
             python_output_path = f"tests/python/roundtrips/{arch}/out.rrd"
             rust_output_path = f"tests/rust/roundtrips/{arch}/out.rrd"
 
-            if "py" not in arch_opt_out:
+            if "python" not in arch_opt_out:
                 run_comparison(python_output_path, rust_output_path, args.full_dump)
 
             if "cpp" not in arch_opt_out:
@@ -169,7 +169,7 @@ def main() -> None:
 def build(arch: str, language: str, args: argparse.Namespace) -> None:
     if language == "cpp":
         run_roundtrip_cpp(arch, args.release)
-    elif language == "py":
+    elif language == "python":
         run_roundtrip_python(arch)
     elif language == "rust":
         run_roundtrip_rust(arch, args.release, args.target, args.target_dir)

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -27,6 +27,7 @@ ARCHETYPES_PATHS = [
 
 opt_out = {
     "asset3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
+    "axes3d": ["cpp", "python", "rust"],  # TODO(#6525)
     "bar_chart": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
     "clear": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all
     "mesh3d": ["cpp", "python", "rust"],  # Don't need it, API example roundtrips cover it all

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -49,7 +49,11 @@ opt_out = {
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run our end-to-end cross-language roundtrip tests for all SDK")
-    parser.add_argument("--no-run", action="store_true", help="Do not build or run anything. Only check that the roundtrip tests exists.")
+    parser.add_argument(
+        "--no-run",
+        action="store_true",
+        help="Do not build or run anything. Only check that the roundtrip tests exists.",
+    )
     parser.add_argument("--no-py-build", action="store_true", help="Skip building rerun-sdk for Python")
     parser.add_argument(
         "--no-cpp-build",


### PR DESCRIPTION
`main` CI is failing: https://github.com/rerun-io/rerun/actions/runs/9436507239/job/25991550784

https://github.com/rerun-io/rerun/pull/6510 added a new archetype (`Axes3D`) without adding roundtrip tests for it. This was easily missed because the PR CI doesn't run the roundtrip tests.

This PR adds a fast PR CI check to make sure we have roundtrip tests for all archetype, but without paying the cost of actually running them. The failure looks like this:

![image](https://github.com/rerun-io/rerun/assets/1148717/61bf60b6-4a88-4f13-be65-917741d7aff8)

This PR also adds an exception for the `Axes3D` archetype. I've created a separate issue for that, adding it to this cycle:
* https://github.com/rerun-io/rerun/issues/6525

---

* [x] I love checkboxes