### PR TITLE
Opt-out of GC protection for `log_seq` and `log_time` when GCing blueprints

### DIFF
--- a/crates/re_data_store/benches/data_store.rs
+++ b/crates/re_data_store/benches/data_store.rs
@@ -338,7 +338,8 @@ fn gc(c: &mut Criterion) {
                 target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
                 protect_latest: 0,
                 purge_empty_tables: false,
-                dont_protect: Default::default(),
+                dont_protect_components: Default::default(),
+                dont_protect_timelines: Default::default(),
                 enable_batching: false,
                 time_budget: std::time::Duration::MAX,
             });
@@ -362,7 +363,8 @@ fn gc(c: &mut Criterion) {
                     target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
                     protect_latest: 0,
                     purge_empty_tables: false,
-                    dont_protect: Default::default(),
+                    dont_protect_components: Default::default(),
+                    dont_protect_timelines: Default::default(),
                     enable_batching: false,
                     time_budget: std::time::Duration::MAX,
                 });

--- a/crates/re_data_store/benches/gc.rs
+++ b/crates/re_data_store/benches/gc.rs
@@ -68,7 +68,8 @@ fn plotting_dashboard(c: &mut Criterion) {
         target: GarbageCollectionTarget::DropAtLeastFraction(DROP_AT_LEAST),
         protect_latest: 1,
         purge_empty_tables: false,
-        dont_protect: Default::default(),
+        dont_protect_components: Default::default(),
+        dont_protect_timelines: Default::default(),
         enable_batching: false,
         time_budget: std::time::Duration::MAX,
     };

--- a/crates/re_data_store/src/store_gc.rs
+++ b/crates/re_data_store/src/store_gc.rs
@@ -50,7 +50,10 @@ pub struct GarbageCollectionOptions {
     pub purge_empty_tables: bool,
 
     /// Components which should not be protected from GC when using `protect_latest`
-    pub dont_protect: HashSet<ComponentName>,
+    pub dont_protect_components: HashSet<ComponentName>,
+
+    /// Timelines which should not be protected from GC when using `protect_latest`
+    pub dont_protect_timelines: HashSet<Timeline>,
 
     /// Whether to enable batched bucket drops.
     ///
@@ -65,7 +68,8 @@ impl GarbageCollectionOptions {
             time_budget: std::time::Duration::MAX,
             protect_latest: 0,
             purge_empty_tables: true,
-            dont_protect: Default::default(),
+            dont_protect_components: Default::default(),
+            dont_protect_timelines: Default::default(),
             enable_batching: false,
         }
     }
@@ -122,7 +126,7 @@ impl DataStore {
         let (initial_num_rows, initial_num_bytes) = stats_before.total_rows_and_bytes();
 
         let protected_rows =
-            self.find_all_protected_rows(options.protect_latest, &options.dont_protect);
+            self.find_all_protected_rows(options.protect_latest, &options.dont_protect_components);
 
         let mut diffs = match options.target {
             GarbageCollectionTarget::DropAtLeastFraction(p) => {

--- a/crates/re_data_store/tests/correctness.rs
+++ b/crates/re_data_store/tests/correctness.rs
@@ -439,7 +439,8 @@ fn gc_metadata_size() -> anyhow::Result<()> {
                 target: re_data_store::GarbageCollectionTarget::DropAtLeastFraction(1.0),
                 protect_latest: 1,
                 purge_empty_tables: false,
-                dont_protect: Default::default(),
+                dont_protect_components: Default::default(),
+                dont_protect_timelines: Default::default(),
                 enable_batching,
                 time_budget: std::time::Duration::MAX,
             });
@@ -447,7 +448,8 @@ fn gc_metadata_size() -> anyhow::Result<()> {
                 target: re_data_store::GarbageCollectionTarget::DropAtLeastFraction(1.0),
                 protect_latest: 1,
                 purge_empty_tables: false,
-                dont_protect: Default::default(),
+                dont_protect_components: Default::default(),
+                dont_protect_timelines: Default::default(),
                 enable_batching,
                 time_budget: std::time::Duration::MAX,
             });

--- a/crates/re_data_store/tests/data_store.rs
+++ b/crates/re_data_store/tests/data_store.rs
@@ -598,7 +598,8 @@ fn gc_impl(store: &mut DataStore) {
             target: GarbageCollectionTarget::DropAtLeastFraction(1.0 / 3.0),
             protect_latest: 0,
             purge_empty_tables: false,
-            dont_protect: Default::default(),
+            dont_protect_components: Default::default(),
+            dont_protect_timelines: Default::default(),
             enable_batching: false,
             time_budget: std::time::Duration::MAX,
         });
@@ -674,7 +675,8 @@ fn protected_gc_impl(store: &mut DataStore) {
         target: GarbageCollectionTarget::Everything,
         protect_latest: 1,
         purge_empty_tables: true,
-        dont_protect: Default::default(),
+        dont_protect_components: Default::default(),
+        dont_protect_timelines: Default::default(),
         enable_batching: false,
         time_budget: std::time::Duration::MAX,
     });
@@ -771,7 +773,8 @@ fn protected_gc_clear_impl(store: &mut DataStore) {
         target: GarbageCollectionTarget::Everything,
         protect_latest: 1,
         purge_empty_tables: true,
-        dont_protect: Default::default(),
+        dont_protect_components: Default::default(),
+        dont_protect_timelines: Default::default(),
         enable_batching: false,
         time_budget: std::time::Duration::MAX,
     });
@@ -817,7 +820,8 @@ fn protected_gc_clear_impl(store: &mut DataStore) {
         target: GarbageCollectionTarget::Everything,
         protect_latest: 1,
         purge_empty_tables: true,
-        dont_protect: Default::default(),
+        dont_protect_components: Default::default(),
+        dont_protect_timelines: Default::default(),
         enable_batching: false,
         time_budget: std::time::Duration::MAX,
     });

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -581,12 +581,13 @@ impl EntityDb {
             target: re_data_store::GarbageCollectionTarget::Everything,
             protect_latest: 1, // TODO(jleibs): Bump this after we have an undo buffer
             purge_empty_tables: true,
-            dont_protect: [
+            dont_protect_components: [
                 re_types_core::components::ClearIsRecursive::name(),
                 re_types_core::archetypes::Clear::indicator().name(),
             ]
             .into_iter()
             .collect(),
+            dont_protect_timelines: Default::default(),
             enable_batching: false,
             time_budget: DEFAULT_GC_TIME_BUDGET,
         });
@@ -603,7 +604,8 @@ impl EntityDb {
             ),
             protect_latest: 1,
             purge_empty_tables: false,
-            dont_protect: Default::default(),
+            dont_protect_components: Default::default(),
+            dont_protect_timelines: Default::default(),
             enable_batching: false,
             time_budget: DEFAULT_GC_TIME_BUDGET,
         });

--- a/crates/re_entity_db/src/entity_db.rs
+++ b/crates/re_entity_db/src/entity_db.rs
@@ -574,7 +574,7 @@ impl EntityDb {
         self.set_store_info = Some(store_info);
     }
 
-    pub fn gc_everything_but_the_latest_row(&mut self) {
+    pub fn gc_everything_but_the_latest_row_on_non_default_timelines(&mut self) {
         re_tracing::profile_function!();
 
         self.gc(&GarbageCollectionOptions {
@@ -587,7 +587,9 @@ impl EntityDb {
             ]
             .into_iter()
             .collect(),
-            dont_protect_timelines: Default::default(),
+            dont_protect_timelines: [Timeline::log_tick(), Timeline::log_time()]
+                .into_iter()
+                .collect(),
             enable_batching: false,
             time_budget: DEFAULT_GC_TIME_BUDGET,
         });

--- a/crates/re_entity_db/tests/clear.rs
+++ b/crates/re_entity_db/tests/clear.rs
@@ -394,7 +394,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
 
         db.add_data_row(row)?;
 
-        db.gc_everything_but_the_latest_row();
+        db.gc_everything_but_the_latest_row_on_non_default_timelines();
 
         let stats = DataStoreStats::from_store(db.store());
         assert_eq!(stats.temporal.num_rows, 1);
@@ -411,7 +411,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
 
         db.add_data_row(clear)?;
 
-        db.gc_everything_but_the_latest_row();
+        db.gc_everything_but_the_latest_row_on_non_default_timelines();
 
         // No rows should remain because the table should have been purged
         let stats = DataStoreStats::from_store(db.store());

--- a/crates/re_viewer_context/src/store_hub.rs
+++ b/crates/re_viewer_context/src/store_hub.rs
@@ -631,7 +631,7 @@ impl StoreHub {
 
                 // TODO(jleibs): Decide a better tuning for this. Would like to save a
                 // reasonable amount of history, or incremental snapshots.
-                blueprint.gc_everything_but_the_latest_row();
+                blueprint.gc_everything_but_the_latest_row_on_non_default_timelines();
 
                 self.blueprint_last_gc
                     .insert(blueprint_id.clone(), blueprint.generation());


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/6521

We only care about the blueprint timeline when working with blueprints. Since we only log clears to the blueprint timeline, we need to avoid letting the default timelines lead to data-protection we don't otherwise want.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6534?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6534?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6534)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.