### PR TITLE
Make it possible to use any python component as a batch

### DIFF
--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -275,6 +275,32 @@ class ComponentBatchMixin(ComponentBatchLike):
         return self._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
 
 
+class ComponentMixin(ComponentBatchLike):
+    """
+    Makes components adhere to the ComponentBatchLike interface.
+
+    A single component will always map to a batch of size 1.
+
+    The class using the mixin must define the `_BATCH_TYPE` field, which should be a subclass of `BaseBatch`.
+    """
+
+    def component_name(self) -> str:
+        """
+        The name of the component.
+
+        Part of the `ComponentBatchLike` logging interface.
+        """
+        return self._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
+
+    def as_arrow_array(self) -> pa.Array:
+        """
+        The component as an arrow batch.
+
+        Part of the `ComponentBatchLike` logging interface.
+        """
+        return self._BATCH_TYPE([self]).as_arrow_array()  # type: ignore[attr-defined, no-any-return]
+
+
 @catch_and_log_exceptions(context="creating empty array")
 def _empty_pa_array(type: pa.DataType) -> pa.Array:
     if type == pa.null():

--- a/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/annotation_context.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["AnnotationContext"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .arrows2d_ext import Arrows2DExt
 
 __all__ = ["Arrows2D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .arrows3d_ext import Arrows3DExt
 
 __all__ = ["Arrows3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .asset3d_ext import Asset3DExt
 
 __all__ = ["Asset3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/axes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/axes3d.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["Axes3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 from .bar_chart_ext import BarChartExt
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .boxes2d_ext import Boxes2DExt
 
 __all__ = ["Boxes2D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .boxes3d_ext import Boxes3DExt
 
 __all__ = ["Boxes3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/clear.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/clear.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .clear_ext import ClearExt
 
 __all__ = ["Clear"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 from .depth_image_ext import DepthImageExt
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/disconnected_space.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .disconnected_space_ext import DisconnectedSpaceExt
 
 __all__ = ["DisconnectedSpace"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 from .image_ext import ImageExt
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips2d.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["LineStrips2D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/line_strips3d.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["LineStrips3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .mesh3d_ext import Mesh3DExt
 
 __all__ = ["Mesh3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/pinhole.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .pinhole_ext import PinholeExt
 
 __all__ = ["Pinhole"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .points2d_ext import Points2DExt
 
 __all__ = ["Points2D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .points3d_ext import Points3DExt
 
 __all__ = ["Points3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/scalar.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["Scalar"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 from .segmentation_image_ext import SegmentationImageExt
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_line.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["SeriesLine"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/series_point.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["SeriesPoint"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .tensor_ext import TensorExt
 
 __all__ = ["Tensor"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_document.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["TextDocument"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/text_log.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components, datatypes
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 
 __all__ = ["TextLog"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from .transform3d_ext import Transform3DExt
 
 __all__ = ["Transform3D"]

--- a/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/view_coordinates.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from .. import components
-from .._baseclasses import Archetype
+from .._baseclasses import (
+    Archetype,
+)
 from ..error_utils import catch_and_log_exceptions
 from .view_coordinates_ext import ViewCoordinatesExt
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/background.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/background.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from attrs import define, field
 
 from ... import components
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from .background_ext import BackgroundExt
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/container_blueprint.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from ... import components, datatypes
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/panel_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/panel_blueprint.py
@@ -9,7 +9,9 @@ from typing import Any
 
 from attrs import define, field
 
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/plot_legend.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from attrs import define, field
 
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from .plot_legend_ext import PlotLegendExt
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/scalar_axis.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from ... import components, datatypes
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_blueprint.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from ... import components, datatypes
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/space_view_contents.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from ... import datatypes
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/viewport_blueprint.py
@@ -10,7 +10,9 @@ from typing import Any
 from attrs import define, field
 
 from ... import datatypes
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from ...error_utils import catch_and_log_exceptions
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visible_time_ranges.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from attrs import define, field
 
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from .visible_time_ranges_ext import VisibleTimeRangesExt
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/visual_bounds2d.py
@@ -7,7 +7,9 @@ from __future__ import annotations
 
 from attrs import define, field
 
-from ..._baseclasses import Archetype
+from ..._baseclasses import (
+    Archetype,
+)
 from ...blueprint import components as blueprint_components
 from .visual_bounds2d_ext import VisualBounds2DExt
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["ActiveTab", "ActiveTabBatch", "ActiveTabType"]
 
 
-class ActiveTab(datatypes.EntityPath):
+class ActiveTab(datatypes.EntityPath, ComponentMixin):
     """**Component**: The active tab in a tabbed container."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ActiveTabExt in active_tab_ext.py
 
     # Note: there are no fields here because ActiveTab delegates to datatypes.EntityPath
@@ -26,3 +30,7 @@ class ActiveTabType(datatypes.EntityPathType):
 
 class ActiveTabBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
     _ARROW_TYPE = ActiveTabType()
+
+
+# This is patched in late to avoid circular dependencies.
+ActiveTab._BATCH_TYPE = ActiveTabBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -11,14 +11,21 @@ import numpy as np
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["AutoLayout", "AutoLayoutArrayLike", "AutoLayoutBatch", "AutoLayoutLike", "AutoLayoutType"]
 
 
 @define(init=False)
-class AutoLayout:
+class AutoLayout(ComponentMixin):
     """**Component**: Whether the viewport layout is determined automatically."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, auto_layout: AutoLayoutLike):
         """Create a new instance of the AutoLayout component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -11,7 +11,12 @@ import numpy as np
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = [
     "AutoSpaceViews",
@@ -23,8 +28,10 @@ __all__ = [
 
 
 @define(init=False)
-class AutoSpaceViews:
+class AutoSpaceViews(ComponentMixin):
     """**Component**: Whether or not space views should be created automatically."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, auto_space_views: AutoSpaceViewsLike):
         """Create a new instance of the AutoSpaceViews component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = [
     "BackgroundKind",

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["ColumnShare", "ColumnShareArrayLike", "ColumnShareBatch", "ColumnShareLike", "ColumnShareType"]
 
 
 @define(init=False)
-class ColumnShare:
+class ColumnShare(ComponentMixin):
     """**Component**: The layout share of a column in the container."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, share: ColumnShareLike):
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["ContainerKind", "ContainerKindArrayLike", "ContainerKindBatch", "ContainerKindLike", "ContainerKindType"]
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["Corner2D", "Corner2DArrayLike", "Corner2DBatch", "Corner2DLike", "Corner2DType"]
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/entity_properties_component.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/entity_properties_component.py
@@ -12,7 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from ..._converters import (
     to_np_uint8,
 )
@@ -27,8 +32,10 @@ __all__ = [
 
 
 @define(init=False)
-class EntityPropertiesComponent:
+class EntityPropertiesComponent(ComponentMixin):
     """**Component**: The configurable set of overridable properties."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, props: EntityPropertiesComponentLike):
         """Create a new instance of the EntityPropertiesComponent component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["GridColumns", "GridColumnsArrayLike", "GridColumnsBatch", "GridColumnsLike", "GridColumnsType"]
 
 
 @define(init=False)
-class GridColumns:
+class GridColumns(ComponentMixin):
     """**Component**: How many columns a grid container should have."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, columns: GridColumnsLike):
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["IncludedContent", "IncludedContentBatch", "IncludedContentType"]
 
 
-class IncludedContent(datatypes.EntityPath):
+class IncludedContent(datatypes.EntityPath, ComponentMixin):
     """**Component**: All the contents in the container."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of IncludedContentExt in included_content_ext.py
 
     # Note: there are no fields here because IncludedContent delegates to datatypes.EntityPath
@@ -26,3 +30,7 @@ class IncludedContentType(datatypes.EntityPathType):
 
 class IncludedContentBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
     _ARROW_TYPE = IncludedContentType()
+
+
+# This is patched in late to avoid circular dependencies.
+IncludedContent._BATCH_TYPE = IncludedContentBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["IncludedSpaceView", "IncludedSpaceViewBatch", "IncludedSpaceViewType"]
 
 
-class IncludedSpaceView(datatypes.Uuid):
+class IncludedSpaceView(datatypes.Uuid, ComponentMixin):
     """**Component**: The unique id of a space view, used to refer to views in containers."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of IncludedSpaceViewExt in included_space_view_ext.py
 
     # Note: there are no fields here because IncludedSpaceView delegates to datatypes.Uuid
@@ -26,3 +30,7 @@ class IncludedSpaceViewType(datatypes.UuidType):
 
 class IncludedSpaceViewBatch(datatypes.UuidBatch, ComponentBatchMixin):
     _ARROW_TYPE = IncludedSpaceViewType()
+
+
+# This is patched in late to avoid circular dependencies.
+IncludedSpaceView._BATCH_TYPE = IncludedSpaceViewBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["LockRangeDuringZoom", "LockRangeDuringZoomBatch", "LockRangeDuringZoomType"]
 
 
-class LockRangeDuringZoom(datatypes.Bool):
+class LockRangeDuringZoom(datatypes.Bool, ComponentMixin):
     """
     **Component**: Indicate whether the range should be locked when zooming in on the data.
 
     Default is `false`, i.e. zoom will change the visualized range.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of LockRangeDuringZoomExt in lock_range_during_zoom_ext.py
 
     # Note: there are no fields here because LockRangeDuringZoom delegates to datatypes.Bool
@@ -30,3 +34,7 @@ class LockRangeDuringZoomType(datatypes.BoolType):
 
 class LockRangeDuringZoomBatch(datatypes.BoolBatch, ComponentBatchMixin):
     _ARROW_TYPE = LockRangeDuringZoomType()
+
+
+# This is patched in late to avoid circular dependencies.
+LockRangeDuringZoom._BATCH_TYPE = LockRangeDuringZoomBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["PanelState", "PanelStateArrayLike", "PanelStateBatch", "PanelStateLike", "PanelStateType"]
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["QueryExpression", "QueryExpressionBatch", "QueryExpressionType"]
 
 
-class QueryExpression(datatypes.Utf8):
+class QueryExpression(datatypes.Utf8, ComponentMixin):
     """
     **Component**: An individual `QueryExpression` used to filter a set of `EntityPath`s.
 
@@ -25,6 +28,7 @@ class QueryExpression(datatypes.Utf8):
     Other uses of `*` are not (yet) supported.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of QueryExpressionExt in query_expression_ext.py
 
     # Note: there are no fields here because QueryExpression delegates to datatypes.Utf8
@@ -37,3 +41,7 @@ class QueryExpressionType(datatypes.Utf8Type):
 
 class QueryExpressionBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = QueryExpressionType()
+
+
+# This is patched in late to avoid circular dependencies.
+QueryExpression._BATCH_TYPE = QueryExpressionBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["RootContainer", "RootContainerBatch", "RootContainerType"]
 
 
-class RootContainer(datatypes.Uuid):
+class RootContainer(datatypes.Uuid, ComponentMixin):
     """**Component**: The container that sits at the root of a viewport."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of RootContainerExt in root_container_ext.py
 
     # Note: there are no fields here because RootContainer delegates to datatypes.Uuid
@@ -26,3 +30,7 @@ class RootContainerType(datatypes.UuidType):
 
 class RootContainerBatch(datatypes.UuidBatch, ComponentBatchMixin):
     _ARROW_TYPE = RootContainerType()
+
+
+# This is patched in late to avoid circular dependencies.
+RootContainer._BATCH_TYPE = RootContainerBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["RowShare", "RowShareArrayLike", "RowShareBatch", "RowShareLike", "RowShareType"]
 
 
 @define(init=False)
-class RowShare:
+class RowShare(ComponentMixin):
     """**Component**: The layout share of a row in the container."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, share: RowShareLike):
         """

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["SpaceViewClass", "SpaceViewClassBatch", "SpaceViewClassType"]
 
 
-class SpaceViewClass(datatypes.Utf8):
+class SpaceViewClass(datatypes.Utf8, ComponentMixin):
     """**Component**: The class of a `SpaceView`."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of SpaceViewClassExt in space_view_class_ext.py
 
     # Note: there are no fields here because SpaceViewClass delegates to datatypes.Utf8
@@ -26,3 +30,7 @@ class SpaceViewClassType(datatypes.Utf8Type):
 
 class SpaceViewClassBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = SpaceViewClassType()
+
+
+# This is patched in late to avoid circular dependencies.
+SpaceViewClass._BATCH_TYPE = SpaceViewClassBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["SpaceViewMaximized", "SpaceViewMaximizedBatch", "SpaceViewMaximizedType"]
 
 
-class SpaceViewMaximized(datatypes.Uuid):
+class SpaceViewMaximized(datatypes.Uuid, ComponentMixin):
     """**Component**: Whether a space view is maximized."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of SpaceViewMaximizedExt in space_view_maximized_ext.py
 
     # Note: there are no fields here because SpaceViewMaximized delegates to datatypes.Uuid
@@ -26,3 +30,7 @@ class SpaceViewMaximizedType(datatypes.UuidType):
 
 class SpaceViewMaximizedBatch(datatypes.UuidBatch, ComponentBatchMixin):
     _ARROW_TYPE = SpaceViewMaximizedType()
+
+
+# This is patched in late to avoid circular dependencies.
+SpaceViewMaximized._BATCH_TYPE = SpaceViewMaximizedBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["SpaceViewOrigin", "SpaceViewOriginBatch", "SpaceViewOriginType"]
 
 
-class SpaceViewOrigin(datatypes.EntityPath):
+class SpaceViewOrigin(datatypes.EntityPath, ComponentMixin):
     """**Component**: The origin of a `SpaceView`."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of SpaceViewOriginExt in space_view_origin_ext.py
 
     # Note: there are no fields here because SpaceViewOrigin delegates to datatypes.EntityPath
@@ -26,3 +30,7 @@ class SpaceViewOriginType(datatypes.EntityPathType):
 
 class SpaceViewOriginBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
     _ARROW_TYPE = SpaceViewOriginType()
+
+
+# This is patched in late to avoid circular dependencies.
+SpaceViewOrigin._BATCH_TYPE = SpaceViewOriginBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["ViewerRecommendationHash", "ViewerRecommendationHashBatch", "ViewerRecommendationHashType"]
 
 
-class ViewerRecommendationHash(datatypes.UInt64):
+class ViewerRecommendationHash(datatypes.UInt64, ComponentMixin):
     """
     **Component**: Hash of a viewer recommendation.
 
     The formation of this hash is considered an internal implementation detail of the viewer.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ViewerRecommendationHashExt in viewer_recommendation_hash_ext.py
 
     # Note: there are no fields here because ViewerRecommendationHash delegates to datatypes.UInt64
@@ -30,3 +34,7 @@ class ViewerRecommendationHashType(datatypes.UInt64Type):
 
 class ViewerRecommendationHashBatch(datatypes.UInt64Batch, ComponentBatchMixin):
     _ARROW_TYPE = ViewerRecommendationHashType()
+
+
+# This is patched in late to avoid circular dependencies.
+ViewerRecommendationHash._BATCH_TYPE = ViewerRecommendationHashBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
@@ -11,14 +11,21 @@ import numpy as np
 import pyarrow as pa
 from attrs import define, field
 
-from ..._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from ..._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Visible", "VisibleArrayLike", "VisibleBatch", "VisibleLike", "VisibleType"]
 
 
 @define(init=False)
-class Visible:
+class Visible(ComponentMixin):
     """**Component**: Whether the container, space view, entity or instance is currently visible."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, visible: VisibleLike):
         """Create a new instance of the Visible component."""

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["VisibleTimeRange", "VisibleTimeRangeBatch", "VisibleTimeRangeType"]
 
 
-class VisibleTimeRange(datatypes.VisibleTimeRange):
+class VisibleTimeRange(datatypes.VisibleTimeRange, ComponentMixin):
     """
     **Component**: The range of values on a given timeline that will be included in a view's query.
 
     Refer to `VisibleTimeRanges` archetype for more information.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of VisibleTimeRangeExt in visible_time_range_ext.py
 
     # Note: there are no fields here because VisibleTimeRange delegates to datatypes.VisibleTimeRange
@@ -30,3 +34,7 @@ class VisibleTimeRangeType(datatypes.VisibleTimeRangeType):
 
 class VisibleTimeRangeBatch(datatypes.VisibleTimeRangeBatch, ComponentBatchMixin):
     _ARROW_TYPE = VisibleTimeRangeType()
+
+
+# This is patched in late to avoid circular dependencies.
+VisibleTimeRange._BATCH_TYPE = VisibleTimeRangeBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
@@ -6,15 +6,19 @@
 from __future__ import annotations
 
 from ... import datatypes
-from ..._baseclasses import ComponentBatchMixin
+from ..._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .visual_bounds2d_ext import VisualBounds2DExt
 
 __all__ = ["VisualBounds2D", "VisualBounds2DBatch", "VisualBounds2DType"]
 
 
-class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D):
+class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D, ComponentMixin):
     """**Component**: Visual bounds in 2D space used for `Spatial2DView`."""
 
+    _BATCH_TYPE = None
     # __init__ can be found in visual_bounds2d_ext.py
 
     # Note: there are no fields here because VisualBounds2D delegates to datatypes.Range2D
@@ -27,3 +31,7 @@ class VisualBounds2DType(datatypes.Range2DType):
 
 class VisualBounds2DBatch(datatypes.Range2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = VisualBounds2DType()
+
+
+# This is patched in late to avoid circular dependencies.
+VisualBounds2D._BATCH_TYPE = VisualBounds2DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -11,7 +11,12 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .annotation_context_ext import AnnotationContextExt
 
 __all__ = [
@@ -24,7 +29,7 @@ __all__ = [
 
 
 @define(init=False)
-class AnnotationContext(AnnotationContextExt):
+class AnnotationContext(AnnotationContextExt, ComponentMixin):
     """
     **Component**: The `AnnotationContext` provides additional information on how to display entities.
 
@@ -34,6 +39,8 @@ class AnnotationContext(AnnotationContextExt):
     path-hierarchy when searching up through the ancestors of a given entity
     path.
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, class_map: AnnotationContextLike):
         """

--- a/rerun_py/rerun_sdk/rerun/components/axis_length.py
+++ b/rerun_py/rerun_sdk/rerun/components/axis_length.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["AxisLength", "AxisLengthBatch", "AxisLengthType"]
 
 
-class AxisLength(datatypes.Float32):
+class AxisLength(datatypes.Float32, ComponentMixin):
     """**Component**: The length of an axis in local units of the space."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AxisLengthExt in axis_length_ext.py
 
     # Note: there are no fields here because AxisLength delegates to datatypes.Float32
@@ -26,3 +30,7 @@ class AxisLengthType(datatypes.Float32Type):
 
 class AxisLengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
     _ARROW_TYPE = AxisLengthType()
+
+
+# This is patched in late to avoid circular dependencies.
+AxisLength._BATCH_TYPE = AxisLengthBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -12,7 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .._converters import (
     to_np_uint8,
 )
@@ -22,8 +27,10 @@ __all__ = ["Blob", "BlobArrayLike", "BlobBatch", "BlobLike", "BlobType"]
 
 
 @define(init=False)
-class Blob(BlobExt):
+class Blob(BlobExt, ComponentMixin):
     """**Component**: A binary blob of data."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, data: BlobLike):
         """Create a new instance of the Blob component."""

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["ClassId", "ClassIdBatch", "ClassIdType"]
 
 
-class ClassId(datatypes.ClassId):
+class ClassId(datatypes.ClassId, ComponentMixin):
     """**Component**: A 16-bit ID representing a type of semantic class."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ClassIdExt in class_id_ext.py
 
     # Note: there are no fields here because ClassId delegates to datatypes.ClassId
@@ -26,3 +30,7 @@ class ClassIdType(datatypes.ClassIdType):
 
 class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
     _ARROW_TYPE = ClassIdType()
+
+
+# This is patched in late to avoid circular dependencies.
+ClassId._BATCH_TYPE = ClassIdBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -12,7 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = [
     "ClearIsRecursive",
@@ -24,8 +29,10 @@ __all__ = [
 
 
 @define(init=False)
-class ClearIsRecursive:
+class ClearIsRecursive(ComponentMixin):
     """**Component**: Configures how a clear operation should behave - recursive or not."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, recursive: ClearIsRecursiveLike):
         """

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Color", "ColorBatch", "ColorType"]
 
 
-class Color(datatypes.Rgba32):
+class Color(datatypes.Rgba32, ComponentMixin):
     """
     **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
 
@@ -23,6 +26,7 @@ class Color(datatypes.Rgba32):
     If there is an alpha, we assume it is in linear space, and separate (NOT pre-multiplied).
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ColorExt in color_ext.py
 
     # Note: there are no fields here because Color delegates to datatypes.Rgba32
@@ -35,3 +39,7 @@ class ColorType(datatypes.Rgba32Type):
 
 class ColorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
     _ARROW_TYPE = ColorType()
+
+
+# This is patched in late to avoid circular dependencies.
+Color._BATCH_TYPE = ColorBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["DepthMeter", "DepthMeterArrayLike", "DepthMeterBatch", "DepthMeterLike", "DepthMeterType"]
 
 
 @define(init=False)
-class DepthMeter:
+class DepthMeter(ComponentMixin):
     """**Component**: A component indicating how long a meter is, expressed in native units."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: DepthMeterLike):
         """Create a new instance of the DepthMeter component."""

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -12,7 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .disconnected_space_ext import DisconnectedSpaceExt
 
 __all__ = [
@@ -25,7 +30,7 @@ __all__ = [
 
 
 @define(init=False)
-class DisconnectedSpace(DisconnectedSpaceExt):
+class DisconnectedSpace(DisconnectedSpaceExt, ComponentMixin):
     """
     **Component**: Spatially disconnect this entity from its parent.
 
@@ -35,6 +40,7 @@ class DisconnectedSpace(DisconnectedSpaceExt):
     This is useful for specifying that a subgraph is independent of the rest of the scene.
     """
 
+    _BATCH_TYPE = None
     # __init__ can be found in disconnected_space_ext.py
 
     def __bool__(self) -> bool:

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -12,13 +12,18 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["DrawOrder", "DrawOrderArrayLike", "DrawOrderBatch", "DrawOrderLike", "DrawOrderType"]
 
 
 @define(init=False)
-class DrawOrder:
+class DrawOrder(ComponentMixin):
     """
     **Component**: Draw order used for the display order of 2D elements.
 
@@ -28,6 +33,8 @@ class DrawOrder:
 
     Draw order for entities with the same draw order is generally undefined.
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: DrawOrderLike):
         """Create a new instance of the DrawOrder component."""

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes2d.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["HalfSizes2D", "HalfSizes2DBatch", "HalfSizes2DType"]
 
 
-class HalfSizes2D(datatypes.Vec2D):
+class HalfSizes2D(datatypes.Vec2D, ComponentMixin):
     """
     **Component**: Half-sizes (extents) of a 2D box along its local axis, starting at its local origin/center.
 
@@ -19,6 +22,7 @@ class HalfSizes2D(datatypes.Vec2D):
     Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of HalfSizes2DExt in half_sizes2d_ext.py
 
     # Note: there are no fields here because HalfSizes2D delegates to datatypes.Vec2D
@@ -31,3 +35,7 @@ class HalfSizes2DType(datatypes.Vec2DType):
 
 class HalfSizes2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = HalfSizes2DType()
+
+
+# This is patched in late to avoid circular dependencies.
+HalfSizes2D._BATCH_TYPE = HalfSizes2DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_sizes3d.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["HalfSizes3D", "HalfSizes3DBatch", "HalfSizes3DType"]
 
 
-class HalfSizes3D(datatypes.Vec3D):
+class HalfSizes3D(datatypes.Vec3D, ComponentMixin):
     """
     **Component**: Half-sizes (extents) of a 3D box along its local axis, starting at its local origin/center.
 
@@ -19,6 +22,7 @@ class HalfSizes3D(datatypes.Vec3D):
     Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of HalfSizes3DExt in half_sizes3d_ext.py
 
     # Note: there are no fields here because HalfSizes3D delegates to datatypes.Vec3D
@@ -31,3 +35,7 @@ class HalfSizes3DType(datatypes.Vec3DType):
 
 class HalfSizes3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = HalfSizes3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+HalfSizes3D._BATCH_TYPE = HalfSizes3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["ImagePlaneDistance", "ImagePlaneDistanceBatch", "ImagePlaneDistanceType"]
 
 
-class ImagePlaneDistance(datatypes.Float32):
+class ImagePlaneDistance(datatypes.Float32, ComponentMixin):
     """
     **Component**: The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.
 
     This is only used for visualization purposes, and does not affect the projection itself.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ImagePlaneDistanceExt in image_plane_distance_ext.py
 
     # Note: there are no fields here because ImagePlaneDistance delegates to datatypes.Float32
@@ -30,3 +34,7 @@ class ImagePlaneDistanceType(datatypes.Float32Type):
 
 class ImagePlaneDistanceBatch(datatypes.Float32Batch, ComponentBatchMixin):
     _ARROW_TYPE = ImagePlaneDistanceType()
+
+
+# This is patched in late to avoid circular dependencies.
+ImagePlaneDistance._BATCH_TYPE = ImagePlaneDistanceBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["KeypointId", "KeypointIdBatch", "KeypointIdType"]
 
 
-class KeypointId(datatypes.KeypointId):
+class KeypointId(datatypes.KeypointId, ComponentMixin):
     """
     **Component**: A 16-bit ID representing a type of semantic keypoint within a class.
 
@@ -21,6 +24,7 @@ class KeypointId(datatypes.KeypointId):
     [`rerun.components.AnnotationContext`].
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of KeypointIdExt in keypoint_id_ext.py
 
     # Note: there are no fields here because KeypointId delegates to datatypes.KeypointId
@@ -33,3 +37,7 @@ class KeypointIdType(datatypes.KeypointIdType):
 
 class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
     _ARROW_TYPE = KeypointIdType()
+
+
+# This is patched in late to avoid circular dependencies.
+KeypointId._BATCH_TYPE = KeypointIdBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -13,14 +13,19 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .line_strip2d_ext import LineStrip2DExt
 
 __all__ = ["LineStrip2D", "LineStrip2DArrayLike", "LineStrip2DBatch", "LineStrip2DLike", "LineStrip2DType"]
 
 
 @define(init=False)
-class LineStrip2D(LineStrip2DExt):
+class LineStrip2D(LineStrip2DExt, ComponentMixin):
     r"""
     **Component**: A line strip in 2D space.
 
@@ -35,6 +40,8 @@ class LineStrip2D(LineStrip2DExt):
                      4
     ```
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, points: LineStrip2DLike):
         """Create a new instance of the LineStrip2D component."""

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -13,14 +13,19 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .line_strip3d_ext import LineStrip3DExt
 
 __all__ = ["LineStrip3D", "LineStrip3DArrayLike", "LineStrip3DBatch", "LineStrip3DLike", "LineStrip3DType"]
 
 
 @define(init=False)
-class LineStrip3D(LineStrip3DExt):
+class LineStrip3D(LineStrip3DExt, ComponentMixin):
     r"""
     **Component**: A line strip in 3D space.
 
@@ -35,6 +40,8 @@ class LineStrip3D(LineStrip3DExt):
                      4
     ```
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, points: LineStrip3DLike):
         """Create a new instance of the LineStrip3D component."""

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -9,7 +9,11 @@ from typing import Literal, Sequence, Union
 
 import pyarrow as pa
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["MarkerShape", "MarkerShapeArrayLike", "MarkerShapeBatch", "MarkerShapeLike", "MarkerShapeType"]
 

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["MarkerSize", "MarkerSizeArrayLike", "MarkerSizeBatch", "MarkerSizeLike", "MarkerSizeType"]
 
 
 @define(init=False)
-class MarkerSize:
+class MarkerSize(ComponentMixin):
     """**Component**: Size of a marker in UI points."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: MarkerSizeLike):
         """Create a new instance of the MarkerSize component."""

--- a/rerun_py/rerun_sdk/rerun/components/material.py
+++ b/rerun_py/rerun_sdk/rerun/components/material.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Material", "MaterialBatch", "MaterialType"]
 
 
-class Material(datatypes.Material):
+class Material(datatypes.Material, ComponentMixin):
     """**Component**: Material properties of a mesh."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of MaterialExt in material_ext.py
 
     # Note: there are no fields here because Material delegates to datatypes.Material
@@ -26,3 +30,7 @@ class MaterialType(datatypes.MaterialType):
 
 class MaterialBatch(datatypes.MaterialBatch, ComponentBatchMixin):
     _ARROW_TYPE = MaterialType()
+
+
+# This is patched in late to avoid circular dependencies.
+Material._BATCH_TYPE = MaterialBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -6,13 +6,16 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .media_type_ext import MediaTypeExt
 
 __all__ = ["MediaType", "MediaTypeBatch", "MediaTypeType"]
 
 
-class MediaType(MediaTypeExt, datatypes.Utf8):
+class MediaType(MediaTypeExt, datatypes.Utf8, ComponentMixin):
     """
     **Component**: A standardized media type (RFC2046, formerly known as MIME types), encoded as a utf8 string.
 
@@ -20,6 +23,7 @@ class MediaType(MediaTypeExt, datatypes.Utf8):
     consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of MediaTypeExt in media_type_ext.py
 
     # Note: there are no fields here because MediaType delegates to datatypes.Utf8
@@ -32,6 +36,10 @@ class MediaTypeType(datatypes.Utf8Type):
 
 class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = MediaTypeType()
+
+
+# This is patched in late to avoid circular dependencies.
+MediaType._BATCH_TYPE = MediaTypeBatch  # type: ignore[assignment]
 
 
 MediaTypeExt.deferred_patch_class(MediaType)

--- a/rerun_py/rerun_sdk/rerun/components/name.py
+++ b/rerun_py/rerun_sdk/rerun/components/name.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Name", "NameBatch", "NameType"]
 
 
-class Name(datatypes.Utf8):
+class Name(datatypes.Utf8, ComponentMixin):
     """**Component**: A display name, typically for an entity or a item like a plot series."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of NameExt in name_ext.py
 
     # Note: there are no fields here because Name delegates to datatypes.Utf8
@@ -26,3 +30,7 @@ class NameType(datatypes.Utf8Type):
 
 class NameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = NameType()
+
+
+# This is patched in late to avoid circular dependencies.
+Name._BATCH_TYPE = NameBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/out_of_tree_transform3d.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["OutOfTreeTransform3D", "OutOfTreeTransform3DBatch", "OutOfTreeTransform3DType"]
 
 
-class OutOfTreeTransform3D(datatypes.Transform3D):
+class OutOfTreeTransform3D(datatypes.Transform3D, ComponentMixin):
     """
     **Component**: An out-of-tree affine transform between two 3D spaces, represented in a given direction.
 
     "Out-of-tree" means that the transform only affects its own entity: children don't inherit from it.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of OutOfTreeTransform3DExt in out_of_tree_transform3d_ext.py
 
     # Note: there are no fields here because OutOfTreeTransform3D delegates to datatypes.Transform3D
@@ -30,3 +34,7 @@ class OutOfTreeTransform3DType(datatypes.Transform3DType):
 
 class OutOfTreeTransform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = OutOfTreeTransform3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+OutOfTreeTransform3D._BATCH_TYPE = OutOfTreeTransform3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["PinholeProjection", "PinholeProjectionBatch", "PinholeProjectionType"]
 
 
-class PinholeProjection(datatypes.Mat3x3):
+class PinholeProjection(datatypes.Mat3x3, ComponentMixin):
     """
     **Component**: Camera projection, from image coordinates to view coordinates.
 
@@ -28,6 +31,7 @@ class PinholeProjection(datatypes.Mat3x3):
 
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of PinholeProjectionExt in pinhole_projection_ext.py
 
     # Note: there are no fields here because PinholeProjection delegates to datatypes.Mat3x3
@@ -40,3 +44,7 @@ class PinholeProjectionType(datatypes.Mat3x3Type):
 
 class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
     _ARROW_TYPE = PinholeProjectionType()
+
+
+# This is patched in late to avoid circular dependencies.
+PinholeProjection._BATCH_TYPE = PinholeProjectionBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Position2D", "Position2DBatch", "Position2DType"]
 
 
-class Position2D(datatypes.Vec2D):
+class Position2D(datatypes.Vec2D, ComponentMixin):
     """**Component**: A position in 2D space."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Position2DExt in position2d_ext.py
 
     # Note: there are no fields here because Position2D delegates to datatypes.Vec2D
@@ -26,3 +30,7 @@ class Position2DType(datatypes.Vec2DType):
 
 class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Position2DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Position2D._BATCH_TYPE = Position2DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Position3D", "Position3DBatch", "Position3DType"]
 
 
-class Position3D(datatypes.Vec3D):
+class Position3D(datatypes.Vec3D, ComponentMixin):
     """**Component**: A position in 3D space."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Position3DExt in position3d_ext.py
 
     # Note: there are no fields here because Position3D delegates to datatypes.Vec3D
@@ -26,3 +30,7 @@ class Position3DType(datatypes.Vec3DType):
 
 class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Position3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Position3D._BATCH_TYPE = Position3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Radius", "RadiusArrayLike", "RadiusBatch", "RadiusLike", "RadiusType"]
 
 
 @define(init=False)
-class Radius:
+class Radius(ComponentMixin):
     """**Component**: A Radius component."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: RadiusLike):
         """Create a new instance of the Radius component."""

--- a/rerun_py/rerun_sdk/rerun/components/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/components/range1d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Range1D", "Range1DBatch", "Range1DType"]
 
 
-class Range1D(datatypes.Range1D):
+class Range1D(datatypes.Range1D, ComponentMixin):
     """**Component**: A 1D range, specifying a lower and upper bound."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Range1DExt in range1d_ext.py
 
     # Note: there are no fields here because Range1D delegates to datatypes.Range1D
@@ -26,3 +30,7 @@ class Range1DType(datatypes.Range1DType):
 
 class Range1DBatch(datatypes.Range1DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Range1DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Range1D._BATCH_TYPE = Range1DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -6,18 +6,22 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Resolution", "ResolutionBatch", "ResolutionType"]
 
 
-class Resolution(datatypes.Vec2D):
+class Resolution(datatypes.Vec2D, ComponentMixin):
     """
     **Component**: Pixel resolution width & height, e.g. of a camera sensor.
 
     Typically in integer units, but for some use cases floating point may be used.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ResolutionExt in resolution_ext.py
 
     # Note: there are no fields here because Resolution delegates to datatypes.Vec2D
@@ -30,3 +34,7 @@ class ResolutionType(datatypes.Vec2DType):
 
 class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = ResolutionType()
+
+
+# This is patched in late to avoid circular dependencies.
+Resolution._BATCH_TYPE = ResolutionBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation3d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Rotation3D", "Rotation3DBatch", "Rotation3DType"]
 
 
-class Rotation3D(datatypes.Rotation3D):
+class Rotation3D(datatypes.Rotation3D, ComponentMixin):
     """**Component**: A 3D rotation, represented either by a quaternion or a rotation around axis."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Rotation3DExt in rotation3d_ext.py
 
     # Note: there are no fields here because Rotation3D delegates to datatypes.Rotation3D
@@ -26,3 +30,7 @@ class Rotation3DType(datatypes.Rotation3DType):
 
 class Rotation3DBatch(datatypes.Rotation3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Rotation3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Rotation3D._BATCH_TYPE = Rotation3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -12,18 +12,25 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Scalar", "ScalarArrayLike", "ScalarBatch", "ScalarLike", "ScalarType"]
 
 
 @define(init=False)
-class Scalar:
+class Scalar(ComponentMixin):
     """
     **Component**: A double-precision scalar.
 
     Used for time series plots.
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: ScalarLike):
         """Create a new instance of the Scalar component."""

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -12,14 +12,21 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["StrokeWidth", "StrokeWidthArrayLike", "StrokeWidthBatch", "StrokeWidthLike", "StrokeWidthType"]
 
 
 @define(init=False)
-class StrokeWidth:
+class StrokeWidth(ComponentMixin):
     """**Component**: The width of a stroke specified in UI points."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, width: StrokeWidthLike):
         """Create a new instance of the StrokeWidth component."""

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["TensorData", "TensorDataBatch", "TensorDataType"]
 
 
-class TensorData(datatypes.TensorData):
+class TensorData(datatypes.TensorData, ComponentMixin):
     """
     **Component**: A multi-dimensional `Tensor` of data.
 
@@ -28,6 +31,7 @@ class TensorData(datatypes.TensorData):
     the shape has to be the shape of the decoded image.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of TensorDataExt in tensor_data_ext.py
 
     # Note: there are no fields here because TensorData delegates to datatypes.TensorData
@@ -40,3 +44,7 @@ class TensorDataType(datatypes.TensorDataType):
 
 class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
     _ARROW_TYPE = TensorDataType()
+
+
+# This is patched in late to avoid circular dependencies.
+TensorData._BATCH_TYPE = TensorDataBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Texcoord2D", "Texcoord2DBatch", "Texcoord2DType"]
 
 
-class Texcoord2D(datatypes.Vec2D):
+class Texcoord2D(datatypes.Vec2D, ComponentMixin):
     """
     **Component**: A 2D texture UV coordinate.
 
@@ -31,6 +34,7 @@ class Texcoord2D(datatypes.Vec2D):
     which places the origin at the bottom-left.
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Texcoord2DExt in texcoord2d_ext.py
 
     # Note: there are no fields here because Texcoord2D delegates to datatypes.Vec2D
@@ -43,3 +47,7 @@ class Texcoord2DType(datatypes.Vec2DType):
 
 class Texcoord2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Texcoord2DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Texcoord2D._BATCH_TYPE = Texcoord2DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Text", "TextBatch", "TextType"]
 
 
-class Text(datatypes.Utf8):
+class Text(datatypes.Utf8, ComponentMixin):
     """**Component**: A string of text, e.g. for labels and text documents."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of TextExt in text_ext.py
 
     # Note: there are no fields here because Text delegates to datatypes.Utf8
@@ -26,3 +30,7 @@ class TextType(datatypes.Utf8Type):
 
 class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = TextType()
+
+
+# This is patched in late to avoid circular dependencies.
+Text._BATCH_TYPE = TextBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -6,13 +6,16 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .text_log_level_ext import TextLogLevelExt
 
 __all__ = ["TextLogLevel", "TextLogLevelBatch", "TextLogLevelType"]
 
 
-class TextLogLevel(TextLogLevelExt, datatypes.Utf8):
+class TextLogLevel(TextLogLevelExt, datatypes.Utf8, ComponentMixin):
     """
     **Component**: The severity level of a text log message.
 
@@ -25,6 +28,7 @@ class TextLogLevel(TextLogLevelExt, datatypes.Utf8):
     * `"TRACE"`
     """
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of TextLogLevelExt in text_log_level_ext.py
 
     # Note: there are no fields here because TextLogLevel delegates to datatypes.Utf8
@@ -37,6 +41,10 @@ class TextLogLevelType(datatypes.Utf8Type):
 
 class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
     _ARROW_TYPE = TextLogLevelType()
+
+
+# This is patched in late to avoid circular dependencies.
+TextLogLevel._BATCH_TYPE = TextLogLevelBatch  # type: ignore[assignment]
 
 
 TextLogLevelExt.deferred_patch_class(TextLogLevel)

--- a/rerun_py/rerun_sdk/rerun/components/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform3d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Transform3D", "Transform3DBatch", "Transform3DType"]
 
 
-class Transform3D(datatypes.Transform3D):
+class Transform3D(datatypes.Transform3D, ComponentMixin):
     """**Component**: An affine transform between two 3D spaces, represented in a given direction."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Transform3DExt in transform3d_ext.py
 
     # Note: there are no fields here because Transform3D delegates to datatypes.Transform3D
@@ -26,3 +30,7 @@ class Transform3DType(datatypes.Transform3DType):
 
 class Transform3DBatch(datatypes.Transform3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Transform3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Transform3D._BATCH_TYPE = Transform3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
+++ b/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["TriangleIndices", "TriangleIndicesBatch", "TriangleIndicesType"]
 
 
-class TriangleIndices(datatypes.UVec3D):
+class TriangleIndices(datatypes.UVec3D, ComponentMixin):
     """**Component**: The three indices of a triangle mesh."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of TriangleIndicesExt in triangle_indices_ext.py
 
     # Note: there are no fields here because TriangleIndices delegates to datatypes.UVec3D
@@ -26,3 +30,7 @@ class TriangleIndicesType(datatypes.UVec3DType):
 
 class TriangleIndicesBatch(datatypes.UVec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = TriangleIndicesType()
+
+
+# This is patched in late to avoid circular dependencies.
+TriangleIndices._BATCH_TYPE = TriangleIndicesBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/vector2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector2d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Vector2D", "Vector2DBatch", "Vector2DType"]
 
 
-class Vector2D(datatypes.Vec2D):
+class Vector2D(datatypes.Vec2D, ComponentMixin):
     """**Component**: A vector in 2D space."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Vector2DExt in vector2d_ext.py
 
     # Note: there are no fields here because Vector2D delegates to datatypes.Vec2D
@@ -26,3 +30,7 @@ class Vector2DType(datatypes.Vec2DType):
 
 class Vector2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Vector2DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Vector2D._BATCH_TYPE = Vector2DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 from .. import datatypes
-from .._baseclasses import ComponentBatchMixin
+from .._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["Vector3D", "Vector3DBatch", "Vector3DType"]
 
 
-class Vector3D(datatypes.Vec3D):
+class Vector3D(datatypes.Vec3D, ComponentMixin):
     """**Component**: A vector in 3D space."""
 
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of Vector3DExt in vector3d_ext.py
 
     # Note: there are no fields here because Vector3D delegates to datatypes.Vec3D
@@ -26,3 +30,7 @@ class Vector3DType(datatypes.Vec3DType):
 
 class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
     _ARROW_TYPE = Vector3DType()
+
+
+# This is patched in late to avoid circular dependencies.
+Vector3D._BATCH_TYPE = Vector3DBatch  # type: ignore[assignment]

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -12,7 +12,12 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from .view_coordinates_ext import ViewCoordinatesExt
 
 __all__ = [
@@ -25,7 +30,7 @@ __all__ = [
 
 
 @define(init=False)
-class ViewCoordinates(ViewCoordinatesExt):
+class ViewCoordinates(ViewCoordinatesExt, ComponentMixin):
     """
     **Component**: How we interpret the coordinate system of an entity/space.
 
@@ -44,6 +49,8 @@ class ViewCoordinates(ViewCoordinatesExt):
      * Forward = 5
      * Back = 6
     """
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, coordinates: ViewCoordinatesLike):
         """

--- a/rerun_py/rerun_sdk/rerun/components/visualizer_overrides.py
+++ b/rerun_py/rerun_sdk/rerun/components/visualizer_overrides.py
@@ -10,7 +10,12 @@ from typing import Any, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = [
     "VisualizerOverrides",
@@ -22,8 +27,10 @@ __all__ = [
 
 
 @define(init=False)
-class VisualizerOverrides:
+class VisualizerOverrides(ComponentMixin):
     """**Component**: The name of a visualizer."""
+
+    _BATCH_TYPE = None
 
     def __init__(self: Any, value: VisualizerOverridesLike):
         """Create a new instance of the VisualizerOverrides component."""

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any, Literal, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .angle_ext import AngleExt
 
 __all__ = ["Angle", "AngleArrayLike", "AngleBatch", "AngleLike", "AngleType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .annotation_info_ext import AnnotationInfoExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/bool.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/bool.py
@@ -11,7 +11,10 @@ import numpy as np
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["Bool", "BoolArrayLike", "BoolBatch", "BoolLike", "BoolType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .class_description_ext import ClassDescriptionExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .class_description_map_elem_ext import ClassDescriptionMapElemExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["ClassId", "ClassIdArrayLike", "ClassIdBatch", "ClassIdLike", "ClassIdType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["EntityPath", "EntityPathArrayLike", "EntityPathBatch", "EntityPathLike", "EntityPathType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["Float32", "Float32ArrayLike", "Float32Batch", "Float32Like", "Float32Type"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["KeypointId", "KeypointIdArrayLike", "KeypointIdBatch", "KeypointIdLike", "KeypointIdType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .keypoint_pair_ext import KeypointPairExt
 
 __all__ = ["KeypointPair", "KeypointPairArrayLike", "KeypointPairBatch", "KeypointPairLike", "KeypointPairType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/material.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/material.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .material_ext import MaterialExt
 
 __all__ = ["Material", "MaterialArrayLike", "MaterialBatch", "MaterialLike", "MaterialType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float64,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/range2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range2d.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["Range2D", "Range2DArrayLike", "Range2DBatch", "Range2DLike", "Range2DType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .rgba32_ext import Rgba32Ext
 
 __all__ = ["Rgba32", "Rgba32ArrayLike", "Rgba32Batch", "Rgba32Like", "Rgba32Type"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation3d.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .rotation3d_ext import Rotation3DExt
 
 __all__ = ["Rotation3D", "Rotation3DArrayLike", "Rotation3DBatch", "Rotation3DLike", "Rotation3DType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .rotation_axis_angle_ext import RotationAxisAngleExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/scale3d.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .scale3d_ext import Scale3DExt
 
 __all__ = ["Scale3D", "Scale3DArrayLike", "Scale3DBatch", "Scale3DLike", "Scale3DType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .tensor_buffer_ext import TensorBufferExt
 
 __all__ = ["TensorBuffer", "TensorBufferArrayLike", "TensorBufferBatch", "TensorBufferLike", "TensorBufferType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -12,7 +12,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .tensor_data_ext import TensorDataExt
 
 __all__ = ["TensorData", "TensorDataArrayLike", "TensorDataBatch", "TensorDataLike", "TensorDataType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -10,7 +10,10 @@ from typing import Any, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     str_or_none,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .time_int_ext import TimeIntExt
 
 __all__ = ["TimeInt", "TimeIntArrayLike", "TimeIntBatch", "TimeIntLike", "TimeIntType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["TimeRange", "TimeRangeArrayLike", "TimeRangeBatch", "TimeRangeLike", "TimeRangeType"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .time_range_boundary_ext import TimeRangeBoundaryExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/transform3d.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .transform3d_ext import Transform3DExt
 
 __all__ = ["Transform3D", "Transform3DArrayLike", "Transform3DBatch", "Transform3DLike", "Transform3DType"]

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_and_mat3x3.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .translation_and_mat3x3_ext import TranslationAndMat3x3Ext
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/translation_rotation_scale3d.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .translation_rotation_scale3d_ext import TranslationRotationScale3DExt
 
 __all__ = [

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["UInt32", "UInt32ArrayLike", "UInt32Batch", "UInt32Like", "UInt32Type"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["UInt64", "UInt64ArrayLike", "UInt64Batch", "UInt64Like", "UInt64Type"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -10,7 +10,10 @@ from typing import TYPE_CHECKING, Any, Sequence, Union
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = ["Utf8", "Utf8ArrayLike", "Utf8Batch", "Utf8Like", "Utf8Type"]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_uint8,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_uint32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_uint32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_uint32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -12,7 +12,10 @@ import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
 
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .._converters import (
     to_np_float32,
 )

--- a/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
@@ -11,7 +11,10 @@ import pyarrow as pa
 from attrs import define, field
 
 from .. import datatypes
-from .._baseclasses import BaseBatch, BaseExtensionType
+from .._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from .visible_time_range_ext import VisibleTimeRangeExt
 
 __all__ = [

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer1.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from typing import Any
 
 from attrs import define, field
-from rerun._baseclasses import Archetype
+from rerun._baseclasses import (
+    Archetype,
+)
 from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer2.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from typing import Any
 
 from attrs import define, field
-from rerun._baseclasses import Archetype
+from rerun._baseclasses import (
+    Archetype,
+)
 from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer3.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from typing import Any
 
 from attrs import define, field
-from rerun._baseclasses import Archetype
+from rerun._baseclasses import (
+    Archetype,
+)
 from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes

--- a/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/archetypes/affix_fuzzer4.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 from typing import Any
 
 from attrs import define, field
-from rerun._baseclasses import Archetype
+from rerun._baseclasses import (
+    Archetype,
+)
 from rerun.error_utils import catch_and_log_exceptions
 
 from .. import components, datatypes

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer1", "AffixFuzzer1Batch", "AffixFuzzer1Type"]
 
 
-class AffixFuzzer1(datatypes.AffixFuzzer1):
+class AffixFuzzer1(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer1Ext in affix_fuzzer1_ext.py
 
     # Note: there are no fields here because AffixFuzzer1 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer1Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer1Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer1._BATCH_TYPE = AffixFuzzer1Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -9,7 +9,12 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from rerun._converters import (
     str_or_none,
 )
@@ -18,7 +23,9 @@ __all__ = ["AffixFuzzer10", "AffixFuzzer10ArrayLike", "AffixFuzzer10Batch", "Aff
 
 
 @define(init=False)
-class AffixFuzzer10:
+class AffixFuzzer10(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, single_string_optional: str | None = None):
         """Create a new instance of the AffixFuzzer10 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -11,7 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from rerun._converters import (
     to_np_float32,
 )
@@ -20,7 +25,9 @@ __all__ = ["AffixFuzzer11", "AffixFuzzer11ArrayLike", "AffixFuzzer11Batch", "Aff
 
 
 @define(init=False)
-class AffixFuzzer11:
+class AffixFuzzer11(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_floats_optional: npt.ArrayLike | None = None):
         """Create a new instance of the AffixFuzzer11 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -9,13 +9,20 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["AffixFuzzer12", "AffixFuzzer12ArrayLike", "AffixFuzzer12Batch", "AffixFuzzer12Like", "AffixFuzzer12Type"]
 
 
 @define(init=False)
-class AffixFuzzer12:
+class AffixFuzzer12(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_strings_required: AffixFuzzer12Like):
         """Create a new instance of the AffixFuzzer12 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -9,13 +9,20 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["AffixFuzzer13", "AffixFuzzer13ArrayLike", "AffixFuzzer13Batch", "AffixFuzzer13Like", "AffixFuzzer13Type"]
 
 
 @define(init=False)
-class AffixFuzzer13:
+class AffixFuzzer13(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_strings_optional: list[str] | None = None):
         """Create a new instance of the AffixFuzzer13 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer14", "AffixFuzzer14Batch", "AffixFuzzer14Type"]
 
 
-class AffixFuzzer14(datatypes.AffixFuzzer3):
+class AffixFuzzer14(datatypes.AffixFuzzer3, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer14Ext in affix_fuzzer14_ext.py
 
     # Note: there are no fields here because AffixFuzzer14 delegates to datatypes.AffixFuzzer3
@@ -25,3 +29,7 @@ class AffixFuzzer14Type(datatypes.AffixFuzzer3Type):
 
 class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer14Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer14._BATCH_TYPE = AffixFuzzer14Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer15", "AffixFuzzer15Batch", "AffixFuzzer15Type"]
 
 
-class AffixFuzzer15(datatypes.AffixFuzzer3):
+class AffixFuzzer15(datatypes.AffixFuzzer3, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer15Ext in affix_fuzzer15_ext.py
 
     # Note: there are no fields here because AffixFuzzer15 delegates to datatypes.AffixFuzzer3
@@ -25,3 +29,7 @@ class AffixFuzzer15Type(datatypes.AffixFuzzer3Type):
 
 class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer15Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer15._BATCH_TYPE = AffixFuzzer15Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -9,7 +9,12 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
@@ -17,7 +22,9 @@ __all__ = ["AffixFuzzer16", "AffixFuzzer16ArrayLike", "AffixFuzzer16Batch", "Aff
 
 
 @define(init=False)
-class AffixFuzzer16:
+class AffixFuzzer16(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_required_unions: AffixFuzzer16Like):
         """Create a new instance of the AffixFuzzer16 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -9,7 +9,12 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
@@ -17,7 +22,9 @@ __all__ = ["AffixFuzzer17", "AffixFuzzer17ArrayLike", "AffixFuzzer17Batch", "Aff
 
 
 @define(init=False)
-class AffixFuzzer17:
+class AffixFuzzer17(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_optional_unions: datatypes.AffixFuzzer3ArrayLike | None = None):
         """Create a new instance of the AffixFuzzer17 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -9,7 +9,12 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
@@ -17,7 +22,9 @@ __all__ = ["AffixFuzzer18", "AffixFuzzer18ArrayLike", "AffixFuzzer18Batch", "Aff
 
 
 @define(init=False)
-class AffixFuzzer18:
+class AffixFuzzer18(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_optional_unions: datatypes.AffixFuzzer4ArrayLike | None = None):
         """Create a new instance of the AffixFuzzer18 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer19", "AffixFuzzer19Batch", "AffixFuzzer19Type"]
 
 
-class AffixFuzzer19(datatypes.AffixFuzzer5):
+class AffixFuzzer19(datatypes.AffixFuzzer5, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer19Ext in affix_fuzzer19_ext.py
 
     # Note: there are no fields here because AffixFuzzer19 delegates to datatypes.AffixFuzzer5
@@ -25,3 +29,7 @@ class AffixFuzzer19Type(datatypes.AffixFuzzer5Type):
 
 class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer19Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer19._BATCH_TYPE = AffixFuzzer19Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer2", "AffixFuzzer2Batch", "AffixFuzzer2Type"]
 
 
-class AffixFuzzer2(datatypes.AffixFuzzer1):
+class AffixFuzzer2(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer2Ext in affix_fuzzer2_ext.py
 
     # Note: there are no fields here because AffixFuzzer2 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer2Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer2Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer2._BATCH_TYPE = AffixFuzzer2Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer20", "AffixFuzzer20Batch", "AffixFuzzer20Type"]
 
 
-class AffixFuzzer20(datatypes.AffixFuzzer20):
+class AffixFuzzer20(datatypes.AffixFuzzer20, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer20Ext in affix_fuzzer20_ext.py
 
     # Note: there are no fields here because AffixFuzzer20 delegates to datatypes.AffixFuzzer20
@@ -25,3 +29,7 @@ class AffixFuzzer20Type(datatypes.AffixFuzzer20Type):
 
 class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer20Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer20._BATCH_TYPE = AffixFuzzer20Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer21", "AffixFuzzer21Batch", "AffixFuzzer21Type"]
 
 
-class AffixFuzzer21(datatypes.AffixFuzzer21):
+class AffixFuzzer21(datatypes.AffixFuzzer21, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer21Ext in affix_fuzzer21_ext.py
 
     # Note: there are no fields here because AffixFuzzer21 delegates to datatypes.AffixFuzzer21
@@ -25,3 +29,7 @@ class AffixFuzzer21Type(datatypes.AffixFuzzer21Type):
 
 class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer21Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer21._BATCH_TYPE = AffixFuzzer21Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer22.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer22", "AffixFuzzer22Batch", "AffixFuzzer22Type"]
 
 
-class AffixFuzzer22(datatypes.AffixFuzzer22):
+class AffixFuzzer22(datatypes.AffixFuzzer22, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer22Ext in affix_fuzzer22_ext.py
 
     # Note: there are no fields here because AffixFuzzer22 delegates to datatypes.AffixFuzzer22
@@ -25,3 +29,7 @@ class AffixFuzzer22Type(datatypes.AffixFuzzer22Type):
 
 class AffixFuzzer22Batch(datatypes.AffixFuzzer22Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer22Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer22._BATCH_TYPE = AffixFuzzer22Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer3", "AffixFuzzer3Batch", "AffixFuzzer3Type"]
 
 
-class AffixFuzzer3(datatypes.AffixFuzzer1):
+class AffixFuzzer3(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer3Ext in affix_fuzzer3_ext.py
 
     # Note: there are no fields here because AffixFuzzer3 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer3Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer3Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer3._BATCH_TYPE = AffixFuzzer3Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer4", "AffixFuzzer4Batch", "AffixFuzzer4Type"]
 
 
-class AffixFuzzer4(datatypes.AffixFuzzer1):
+class AffixFuzzer4(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer4Ext in affix_fuzzer4_ext.py
 
     # Note: there are no fields here because AffixFuzzer4 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer4Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer4Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer4._BATCH_TYPE = AffixFuzzer4Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer5", "AffixFuzzer5Batch", "AffixFuzzer5Type"]
 
 
-class AffixFuzzer5(datatypes.AffixFuzzer1):
+class AffixFuzzer5(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer5Ext in affix_fuzzer5_ext.py
 
     # Note: there are no fields here because AffixFuzzer5 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer5Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer5Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer5._BATCH_TYPE = AffixFuzzer5Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -5,14 +5,18 @@
 
 from __future__ import annotations
 
-from rerun._baseclasses import ComponentBatchMixin
+from rerun._baseclasses import (
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
 __all__ = ["AffixFuzzer6", "AffixFuzzer6Batch", "AffixFuzzer6Type"]
 
 
-class AffixFuzzer6(datatypes.AffixFuzzer1):
+class AffixFuzzer6(datatypes.AffixFuzzer1, ComponentMixin):
+    _BATCH_TYPE = None
     # You can define your own __init__ function as a member of AffixFuzzer6Ext in affix_fuzzer6_ext.py
 
     # Note: there are no fields here because AffixFuzzer6 delegates to datatypes.AffixFuzzer1
@@ -25,3 +29,7 @@ class AffixFuzzer6Type(datatypes.AffixFuzzer1Type):
 
 class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
     _ARROW_TYPE = AffixFuzzer6Type()
+
+
+# This is patched in late to avoid circular dependencies.
+AffixFuzzer6._BATCH_TYPE = AffixFuzzer6Batch  # type: ignore[assignment]

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -9,7 +9,12 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 from .. import datatypes
 
@@ -17,7 +22,9 @@ __all__ = ["AffixFuzzer7", "AffixFuzzer7ArrayLike", "AffixFuzzer7Batch", "AffixF
 
 
 @define(init=False)
-class AffixFuzzer7:
+class AffixFuzzer7(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, many_optional: datatypes.AffixFuzzer1ArrayLike | None = None):
         """Create a new instance of the AffixFuzzer7 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -11,7 +11,12 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 from rerun._converters import (
     float_or_none,
 )
@@ -20,7 +25,9 @@ __all__ = ["AffixFuzzer8", "AffixFuzzer8ArrayLike", "AffixFuzzer8Batch", "AffixF
 
 
 @define(init=False)
-class AffixFuzzer8:
+class AffixFuzzer8(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, single_float_optional: float | None = None):
         """Create a new instance of the AffixFuzzer8 component."""
 

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -9,13 +9,20 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+    ComponentMixin,
+)
 
 __all__ = ["AffixFuzzer9", "AffixFuzzer9ArrayLike", "AffixFuzzer9Batch", "AffixFuzzer9Like", "AffixFuzzer9Type"]
 
 
 @define(init=False)
-class AffixFuzzer9:
+class AffixFuzzer9(ComponentMixin):
+    _BATCH_TYPE = None
+
     def __init__(self: Any, single_string_required: AffixFuzzer9Like):
         """Create a new instance of the AffixFuzzer9 component."""
 

--- a/rerun_py/tests/test_types/components/enum_test.py
+++ b/rerun_py/tests/test_types/components/enum_test.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 from typing import Literal, Sequence, Union
 
 import pyarrow as pa
-from rerun._baseclasses import BaseBatch, BaseExtensionType, ComponentBatchMixin
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+    ComponentBatchMixin,
+)
 
 __all__ = ["EnumTest", "EnumTestArrayLike", "EnumTestBatch", "EnumTestLike", "EnumTestType"]
 

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from rerun._converters import (
     bool_or_none,
     float_or_none,

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from rerun._converters import (
     float_or_none,
 )

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -9,7 +9,10 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 from .. import datatypes
 

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from rerun._converters import (
     to_np_float16,
 )

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 from rerun._converters import (
     to_np_uint8,
 )

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 from .. import datatypes
 

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -9,7 +9,10 @@ from typing import TYPE_CHECKING, Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 from .. import datatypes
 

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -9,7 +9,10 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 from .. import datatypes
 

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = [
     "FlattenedScalar",

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -11,7 +11,10 @@ import numpy as np
 import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = [
     "PrimitiveComponent",

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -9,7 +9,10 @@ from typing import Any, Sequence, Union
 
 import pyarrow as pa
 from attrs import define, field
-from rerun._baseclasses import BaseBatch, BaseExtensionType
+from rerun._baseclasses import (
+    BaseBatch,
+    BaseExtensionType,
+)
 
 __all__ = [
     "StringComponent",


### PR DESCRIPTION
### What
New blueprint APIs focus on overriding components rather than requiring that things be Archetypes.

However, using components directly was somewhat inconvenient. This lets you now pass in a component instance anywhere you would expect to pass in a ComponentBatchLike.

This component knows it's own batch type and uses it to construct the correct wrapper.

This means you can also do things now like:
```
rr.log("points", rr.Points3D(positions))
rr.log("points", [rr.components.Color([255, 0, 0])])
```

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
