### PR TITLE
Fix the Axes3D heuristics

### DIFF
--- a/crates/re_space_view_bar_chart/src/space_view_class.rs
+++ b/crates/re_space_view_bar_chart/src/space_view_class.rs
@@ -8,8 +8,8 @@ use re_types::View;
 use re_types::{datatypes::TensorBuffer, SpaceViewClassIdentifier};
 use re_ui::list_item;
 use re_viewer_context::{
-    auto_color, IdentifiedViewSystem as _, IndicatedEntities, PerVisualizer, SpaceViewClass,
-    SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewStateExt,
+    auto_color, ApplicableEntities, IdentifiedViewSystem as _, IndicatedEntities, PerVisualizer,
+    SpaceViewClass, SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewStateExt,
     SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewQuery, ViewerContext,
     VisualizableEntities,
 };
@@ -78,6 +78,7 @@ impl SpaceViewClass for BarChartSpaceView {
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,
+        _applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         _indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> re_viewer_context::SmallVisualizerSet {

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -17,10 +17,10 @@ use re_types::{
 use re_ui::{ContextExt as _, UiExt as _};
 use re_viewer_context::{
     gpu_bridge::{self, colormap_dropdown_button_ui},
-    IdentifiedViewSystem as _, IndicatedEntities, PerVisualizer, SpaceViewClass,
-    SpaceViewClassRegistryError, SpaceViewId, SpaceViewState, SpaceViewStateExt as _,
-    SpaceViewSystemExecutionError, TensorStatsCache, ViewQuery, ViewerContext,
-    VisualizableEntities,
+    ApplicableEntities, IdentifiedViewSystem as _, IndicatedEntities, PerVisualizer,
+    SpaceViewClass, SpaceViewClassRegistryError, SpaceViewId, SpaceViewState,
+    SpaceViewStateExt as _, SpaceViewSystemExecutionError, TensorStatsCache, ViewQuery,
+    ViewerContext, VisualizableEntities,
 };
 
 use crate::{tensor_dimension_mapper::dimension_mapping_ui, visualizer_system::TensorSystem};
@@ -107,6 +107,7 @@ impl SpaceViewClass for TensorSpaceView {
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,
+        _applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         _indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> re_viewer_context::SmallVisualizerSet {

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -14,9 +14,9 @@ use re_viewer_context::external::re_entity_db::{
     EditableAutoValue, EntityProperties, TimeSeriesAggregator,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem, IndicatedEntities, PerVisualizer, QueryRange, RecommendedSpaceView,
-    SmallVisualizerSet, SpaceViewClass, SpaceViewClassRegistryError, SpaceViewId,
-    SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewStateExt as _,
+    ApplicableEntities, IdentifiedViewSystem, IndicatedEntities, PerVisualizer, QueryRange,
+    RecommendedSpaceView, SmallVisualizerSet, SpaceViewClass, SpaceViewClassRegistryError,
+    SpaceViewId, SpaceViewSpawnHeuristics, SpaceViewState, SpaceViewStateExt as _,
     SpaceViewSystemExecutionError, SystemExecutionOutput, TypedComponentFallbackProvider,
     ViewQuery, ViewSystemIdentifier, ViewerContext, VisualizableEntities,
 };
@@ -249,6 +249,7 @@ impl SpaceViewClass for TimeSeriesSpaceView {
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,
+        _applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> SmallVisualizerSet {

--- a/crates/re_viewer/src/app_state.rs
+++ b/crates/re_viewer/src/app_state.rs
@@ -286,6 +286,7 @@ impl AppState {
                     let resolver = space_view.contents.build_resolver(
                         space_view_class_registry,
                         space_view,
+                        &applicable_entities_per_visualizer,
                         &visualizable_entities,
                         &indicated_entities_per_visualizer,
                     );

--- a/crates/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/re_viewer_context/src/space_view/space_view_class.rs
@@ -135,6 +135,7 @@ pub trait SpaceViewClass: Send + Sync {
     fn choose_default_visualizers(
         &self,
         entity_path: &EntityPath,
+        _applicable_entities_per_visualizer: &PerVisualizer<ApplicableEntities>,
         visualizable_entities_per_visualizer: &PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &PerVisualizer<IndicatedEntities>,
     ) -> SmallVisualizerSet {

--- a/crates/re_viewer_context/src/typed_entity_collections.rs
+++ b/crates/re_viewer_context/src/typed_entity_collections.rs
@@ -45,7 +45,7 @@ impl std::ops::Deref for IndicatedEntities {
 ///
 /// This is a subset of [`ApplicableEntities`] and differs on a
 /// per space view instance base.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct VisualizableEntities(pub IntSet<EntityPath>);
 
 impl std::ops::Deref for VisualizableEntities {

--- a/crates/re_viewport_blueprint/src/space_view.rs
+++ b/crates/re_viewport_blueprint/src/space_view.rs
@@ -537,8 +537,8 @@ mod tests {
     };
     use re_types::{archetypes::Points3D, ComponentBatch, ComponentName, Loggable as _};
     use re_viewer_context::{
-        test_context::TestContext, IndicatedEntities, OverridePath, PerVisualizer, StoreContext,
-        VisualizableEntities,
+        test_context::TestContext, ApplicableEntities, IndicatedEntities, OverridePath,
+        PerVisualizer, StoreContext, VisualizableEntities,
     };
     use std::collections::HashMap;
 
@@ -597,6 +597,14 @@ mod tests {
                     .collect(),
                 )
             });
+
+        let applicable_entities = PerVisualizer::<ApplicableEntities>(
+            visualizable_entities
+                .0
+                .iter()
+                .map(|(id, entities)| (*id, ApplicableEntities(entities.iter().cloned().collect())))
+                .collect(),
+        );
         let indicated_entities_per_visualizer = PerVisualizer::<IndicatedEntities>(
             visualizable_entities
                 .0
@@ -610,6 +618,7 @@ mod tests {
         let resolver = contents.build_resolver(
             &test_ctx.space_view_class_registry,
             &space_view,
+            &applicable_entities,
             &visualizable_entities,
             &indicated_entities_per_visualizer,
         );
@@ -761,6 +770,14 @@ mod tests {
                 .or_insert_with(|| VisualizableEntities(entity_paths.into_iter().collect()));
         }
 
+        let applicable_entities = PerVisualizer::<ApplicableEntities>(
+            visualizable_entities
+                .0
+                .iter()
+                .map(|(id, entities)| (*id, ApplicableEntities(entities.iter().cloned().collect())))
+                .collect(),
+        );
+
         // Basic blueprint - a single space view that queries everything.
         let space_view = SpaceViewBlueprint::new("3D".into(), RecommendedSpaceView::root());
         let individual_override_root = space_view
@@ -777,6 +794,7 @@ mod tests {
         let resolver = space_view.contents.build_resolver(
             &test_ctx.space_view_class_registry,
             &space_view,
+            &applicable_entities,
             &visualizable_entities,
             &indicated_entities_per_visualizer,
         );

--- a/crates/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/re_viewport_blueprint/src/space_view_contents.rs
@@ -18,8 +18,8 @@ use re_types::{
 };
 use re_types_core::{components::VisualizerOverrides, ComponentName};
 use re_viewer_context::{
-    DataQueryResult, DataResult, DataResultHandle, DataResultNode, DataResultTree,
-    IndicatedEntities, OverridePath, PerVisualizer, PropertyOverrides, QueryRange,
+    ApplicableEntities, DataQueryResult, DataResult, DataResultHandle, DataResultNode,
+    DataResultTree, IndicatedEntities, OverridePath, PerVisualizer, PropertyOverrides, QueryRange,
     SpaceViewClassRegistry, SpaceViewId, ViewerContext, VisualizableEntities,
 };
 
@@ -179,6 +179,7 @@ impl SpaceViewContents {
         &self,
         space_view_class_registry: &'a re_viewer_context::SpaceViewClassRegistry,
         space_view: &'a SpaceViewBlueprint,
+        applicable_entities_per_visualizer: &'a PerVisualizer<ApplicableEntities>,
         visualizable_entities_per_visualizer: &'a PerVisualizer<VisualizableEntities>,
         indicated_entities_per_visualizer: &'a PerVisualizer<IndicatedEntities>,
     ) -> DataQueryPropertyResolver<'a> {
@@ -192,6 +193,7 @@ impl SpaceViewContents {
             space_view,
             individual_override_root,
             recursive_override_root,
+            applicable_entities_per_visualizer,
             visualizable_entities_per_visualizer,
             indicated_entities_per_visualizer,
         }
@@ -372,6 +374,7 @@ pub struct DataQueryPropertyResolver<'a> {
     space_view: &'a SpaceViewBlueprint,
     individual_override_root: EntityPath,
     recursive_override_root: EntityPath,
+    applicable_entities_per_visualizer: &'a PerVisualizer<ApplicableEntities>,
     visualizable_entities_per_visualizer: &'a PerVisualizer<VisualizableEntities>,
     indicated_entities_per_visualizer: &'a PerVisualizer<IndicatedEntities>,
 }
@@ -495,6 +498,7 @@ impl DataQueryPropertyResolver<'_> {
                         .class(self.space_view_class_registry)
                         .choose_default_visualizers(
                             &node.data_result.entity_path,
+                            self.applicable_entities_per_visualizer,
                             self.visualizable_entities_per_visualizer,
                             self.indicated_entities_per_visualizer,
                         );


### PR DESCRIPTION
### What

My attempt to use the Transform3DDetector mechanism previously was flawed.

Since the detector is never visualixable, we want to use applicable, not visualizable, which means plumbing through applicable to the right places.

The following now shows axes correctly:
```
import rerun as rr

rr.init("rerun_example_transform3d_axes", spawn=True)

for deg in range(360):
    rr.set_time_sequence("step", deg)
    rr.log(
        "base/rotated",
        rr.Transform3D(
            rotation=rr.RotationAxisAngle(
                axis=[1.0, 1.0, 1.0],
                degrees=deg,
            )
        ),
    )
    rr.log(
        "base/rotated/translated",
        rr.Transform3D(
            translation=[2.0, 0, 0],
        ),
    )
```

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
