### PR TITLE
Fix wrong depth projection value on picking when depth meter was edited

### DIFF
--- a/crates/re_entity_db/src/entity_properties.rs
+++ b/crates/re_entity_db/src/entity_properties.rs
@@ -97,11 +97,6 @@ pub struct EntityProperties {
     // TODO(#5067): Test property used so we don't have to continuously adjust existing tests while we're dismantling `EntityProperties`.
     pub test_property: bool,
 
-    /// How many depth units per world-space unit. e.g. 1000 for millimeters.
-    ///
-    /// This corresponds to `re_components::Tensor::meter`.
-    pub depth_from_world_scale: EditableAutoValue<f32>, // TODO(andreas): Just remove once we can edit meter & be able to set semi-clever defaults per visualizer.
-
     /// Used to scale the radii of the points in the resulting point cloud.
     pub backproject_radius_scale: EditableAutoValue<f32>, // TODO(andreas): should be a component on the DepthImage archetype.
 
@@ -114,7 +109,6 @@ impl Default for EntityProperties {
     fn default() -> Self {
         Self {
             test_property: true,
-            depth_from_world_scale: EditableAutoValue::Auto(1.0),
             backproject_radius_scale: EditableAutoValue::Auto(1.0),
             time_series_aggregator: EditableAutoValue::Auto(TimeSeriesAggregator::default()),
         }
@@ -128,10 +122,6 @@ impl EntityProperties {
         Self {
             test_property: self.test_property && child.test_property,
 
-            depth_from_world_scale: self
-                .depth_from_world_scale
-                .or(&child.depth_from_world_scale)
-                .clone(),
             backproject_radius_scale: self
                 .backproject_radius_scale
                 .or(&child.backproject_radius_scale)
@@ -155,10 +145,6 @@ impl EntityProperties {
         Self {
             test_property: other.test_property,
 
-            depth_from_world_scale: other
-                .depth_from_world_scale
-                .or(&self.depth_from_world_scale)
-                .clone(),
             backproject_radius_scale: other
                 .backproject_radius_scale
                 .or(&self.backproject_radius_scale)
@@ -175,13 +161,11 @@ impl EntityProperties {
     pub fn has_edits(&self, other: &Self) -> bool {
         let Self {
             test_property,
-            depth_from_world_scale,
             backproject_radius_scale,
             time_series_aggregator,
         } = self;
 
         test_property != &other.test_property
-            || depth_from_world_scale.has_edits(&other.depth_from_world_scale)
             || backproject_radius_scale.has_edits(&other.backproject_radius_scale)
             || time_series_aggregator.has_edits(&other.time_series_aggregator)
     }

--- a/crates/re_types/definitions/rerun/components/colormap.fbs
+++ b/crates/re_types/definitions/rerun/components/colormap.fbs
@@ -12,8 +12,9 @@ namespace rerun.components;
 /// This provides a number of popular pre-defined colormaps.
 /// In the future, the Rerun Viewer will allow users to define their own colormaps,
 /// but currently the Viewer is limited to the types defined here.
-enum Colormap: byte
-{
+enum Colormap: byte (
+    "attr.docs.unreleased"
+) {
     /// A simple black to white gradient.
     ///
     /// This is a sRGB gray gradient which is perceptually uniform.

--- a/docs/content/reference/types/components/colormap.md
+++ b/docs/content/reference/types/components/colormap.md
@@ -19,9 +19,9 @@ but currently the Viewer is limited to the types defined here.
 * Viridis
 
 ## API reference links
- * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
- * 🐍 [Python API docs for `Colormap`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Colormap)
- * 🦀 [Rust API docs for `Colormap`](https://docs.rs/rerun/latest/rerun/components/enum.Colormap.html)
+ * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html?speculative-link)
+ * 🐍 [Python API docs for `Colormap`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.Colormap)
+ * 🦀 [Rust API docs for `Colormap`](https://docs.rs/rerun/latest/rerun/components/enum.Colormap.html?speculative-link)
 
 
 ## Used by


### PR DESCRIPTION
### What
Previously, depth meter editing worked via the legacy `EntityProperties`, now it is a `DepthMeter` component override. Since `EntityProperties` wasn't always applied correctly, and  #6549 makes queries to images during picking go through the blueprint layer, this fixes picking interaction

After:
![image](https://github.com/rerun-io/rerun/assets/1220815/4ff24444-20f3-470b-8f4b-3e6ae7bb59f9)

Before, the same picking returned a different (wrong) depth value!)
![image](https://github.com/rerun-io/rerun/assets/1220815/1f9423b7-b12b-48c0-abef-5cbb22a1acee)

Part of:
* https://github.com/rerun-io/rerun/issues/5067https://github.com/rerun-io/rerun/issues/5067

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6551?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6551?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6551)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.