### PR TITLE
Use edit ui when no data ui is available

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/enum_combobox.rs
+++ b/crates/re_edit_ui/src/datatype_editors/enum_combobox.rs
@@ -6,20 +6,25 @@ pub fn edit_enum<Value: PartialEq + std::fmt::Display + Copy>(
     value: &mut Value,
     variants: &[Value],
 ) -> egui::Response {
-    response_with_changes_of_inner(
-        egui::ComboBox::from_id_source(id_source)
-            .selected_text(format!("{value}"))
-            .show_ui(ui, |ui| {
-                let mut iter = variants.iter().copied();
-                let Some(first) = iter.next() else {
-                    return ui.label("<no variants>");
-                };
+    if ui.is_enabled() {
+        response_with_changes_of_inner(
+            egui::ComboBox::from_id_source(id_source)
+                .selected_text(format!("{value}"))
+                .show_ui(ui, |ui| {
+                    let mut iter = variants.iter().copied();
+                    let Some(first) = iter.next() else {
+                        return ui.label("<no variants>");
+                    };
 
-                let mut response = ui.selectable_value(value, first, format!("{first}"));
-                for variant in iter {
-                    response |= ui.selectable_value(value, variant, format!("{variant}"));
-                }
-                response
-            }),
-    )
+                    let mut response = ui.selectable_value(value, first, format!("{first}"));
+                    for variant in iter {
+                        response |= ui.selectable_value(value, variant, format!("{variant}"));
+                    }
+                    response
+                }),
+        )
+    } else {
+        // Don't show the combo box drop down if it's disabled.
+        ui.selectable_label(false, format!("{value}"))
+    }
 }

--- a/crates/re_edit_ui/src/lib.rs
+++ b/crates/re_edit_ui/src/lib.rs
@@ -13,7 +13,8 @@ use datatype_editors::edit_enum;
 use re_types::{
     blueprint::components::{BackgroundKind, Corner2D, LockRangeDuringZoom, Visible},
     components::{
-        AxisLength, Color, ImagePlaneDistance, MarkerSize, Name, Radius, StrokeWidth, Text,
+        AxisLength, Color, Colormap, ImagePlaneDistance, MarkerSize, Name, Radius, StrokeWidth,
+        Text,
     },
 };
 use re_viewer_context::ViewerContext;
@@ -58,10 +59,13 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_editor_ui::<StrokeWidth>(datatype_editors::edit_f32_zero_to_inf_raw);
 
     registry.add_singleline_editor_ui(|_ctx, ui, value| {
-        edit_enum(ui, "corner2d", value, &Corner2D::ALL)
+        edit_enum(ui, "backgroundkind", value, &BackgroundKind::ALL)
     });
     registry.add_singleline_editor_ui(|_ctx, ui, value| {
-        edit_enum(ui, "backgroundkind", value, &BackgroundKind::ALL)
+        edit_enum(ui, "colormap", value, &Colormap::ALL)
+    });
+    registry.add_singleline_editor_ui(|_ctx, ui, value| {
+        edit_enum(ui, "corner2d", value, &Corner2D::ALL)
     });
 
     registry.add_multiline_editor_ui(visual_bounds2d::multiline_edit_visual_bounds2d);


### PR DESCRIPTION
### What

And add a colormap edit ui - this allows to use colormap in overrides/defaults and makes it visible when logged:

Before:
<img width="302" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/1b79b6c8-e441-4cc2-87a9-fc89282a1a84">

After:
<img width="303" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/c44c720c-3b89-4eee-b2f8-468d4eb5af9b">


Discovered while working on #6558 which had the same issue.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6559?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6559?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6559)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.