### PR TITLE
Cleanup usage of `unwrap()` in `re_query`

### DIFF
--- a/crates/re_query/src/bin/range_zip.rs
+++ b/crates/re_query/src/bin/range_zip.rs
@@ -314,7 +314,7 @@ fn generate_struct(params: &Params) -> String {
 ///         let (r0_index, r0_data) = r0.next()?;
 ///         let (r1_index, r1_data) = r1.next()?;
 ///
-///         let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+///         let max_index = [r0_index, r1_index].into_iter().max()?;
 ///
 ///         let mut o0_data = None;
 ///         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -444,7 +444,7 @@ fn generate_impl(params: &Params) -> String {
 
                 {next_required}
 
-                let max_index = [{required_indices}].into_iter().max().unwrap();
+                let max_index = [{required_indices}].into_iter().max()?;
 
                 {next_optional}
 

--- a/crates/re_query/src/lib.rs
+++ b/crates/re_query/src/lib.rs
@@ -1,8 +1,5 @@
 //! Caching datastructures for `re_query`.
 
-// TODO(#3408): remove unwrap()
-#![allow(clippy::unwrap_used)]
-
 mod cache;
 mod cache_stats;
 mod flat_vec_deque;

--- a/crates/re_query/src/range/results.rs
+++ b/crates/re_query/src/range/results.rs
@@ -195,6 +195,7 @@ impl<'a, T: 'static> std::ops::Deref for Data<'a, T> {
             Data::Owned(data) => {
                 // Unwrap: only way to instantiate a `Data` is via the `From` impl below which we
                 // fully control.
+                #[allow(clippy::unwrap_used)]
                 data.as_any().downcast_ref().unwrap()
             }
             Data::Cached(data) => data,
@@ -461,6 +462,7 @@ impl RangeComponentResults {
                 let resolved_data = FlatVecDeque::from_vecs(resolved_data);
                 // Unwraps: the deque is created when entering this function -- we know it's there
                 // and we know its type.
+                #[allow(clippy::unwrap_used)]
                 let cached_dense = results
                     .cached_dense
                     .as_mut()
@@ -524,6 +526,7 @@ impl RangeComponentResults {
                 let resolved_data = FlatVecDeque::from_vecs(resolved_data);
                 // Unwraps: the deque is created when entering this function -- we know it's there
                 // and we know its type.
+                #[allow(clippy::unwrap_used)]
                 let cached_dense = results
                     .cached_dense
                     .as_mut()
@@ -602,6 +605,7 @@ impl RangeComponentResults {
         let data = RwLockReadGuard::map(self.inner.read_recursive(), |results| {
             // Unwraps: the data is created when entering this function -- we know it's there
             // and we know its type.
+            #[allow(clippy::unwrap_used)]
             results
                 .cached_dense
                 .as_ref()
@@ -703,8 +707,8 @@ impl std::fmt::Debug for RangeComponentResultsInner {
             f.write_str("<empty>")
         } else {
             // Unwrap: checked above.
-            let index_start = indices.front().unwrap();
-            let index_end = indices.back().unwrap();
+            #[allow(clippy::unwrap_used)]
+            let (index_start, index_end) = (indices.front().unwrap(), indices.back().unwrap());
             f.write_fmt(format_args!(
                 "[{:?}#{} .. {:?}#{}] {}",
                 index_start.0,

--- a/crates/re_query/src/range_zip/generated.rs
+++ b/crates/re_query/src/range_zip/generated.rs
@@ -71,7 +71,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -157,7 +157,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -262,7 +262,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -397,7 +397,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -560,7 +560,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -746,7 +746,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -953,7 +953,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -1240,7 +1240,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -1577,7 +1577,7 @@ where
 
         let (r0_index, r0_data) = r0.next()?;
 
-        let max_index = [r0_index].into_iter().max().unwrap();
+        let max_index = [r0_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -1719,7 +1719,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -1814,7 +1814,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -1939,7 +1939,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -2084,7 +2084,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -2260,7 +2260,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -2457,7 +2457,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -2734,7 +2734,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -3061,7 +3061,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {
@@ -3417,7 +3417,7 @@ where
         let (r0_index, r0_data) = r0.next()?;
         let (r1_index, r1_data) = r1.next()?;
 
-        let max_index = [r0_index, r1_index].into_iter().max().unwrap();
+        let max_index = [r0_index, r1_index].into_iter().max()?;
 
         let mut o0_data = None;
         while let Some((_, data)) = o0.next_if(|(index, _)| index <= &max_index) {


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Part of https://github.com/rerun-io/rerun/issues/6330
Removes or explicitly allows `unwrap()` where it makes sense.

Affected crates: `re_query`

Note: most of the usages of unwrap in this crate were already checked so they are explicitly allowed.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6564?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6564?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6564)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.