### PR TITLE
New temporal batch APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "test_temporal_batch"
-version = "0.17.0-alpha.8"
+version = "0.17.0-alpha.9"
 dependencies = [
  "re_arrow2",
  "re_chunk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,6 +4774,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "re_arrow2",
  "re_build_info",
  "re_build_tools",
  "re_chunk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6480,7 +6480,7 @@ dependencies = [
 
 [[package]]
 name = "test_temporal_batch"
-version = "0.17.0-alpha.4"
+version = "0.17.0-alpha.8"
 dependencies = [
  "re_arrow2",
  "re_chunk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6479,6 +6479,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_temporal_batch"
+version = "0.17.0-alpha.4"
+dependencies = [
+ "re_arrow2",
+ "re_chunk",
+ "rerun",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/re_chunk/src/batcher.rs
+++ b/crates/re_chunk/src/batcher.rs
@@ -344,7 +344,7 @@ impl Drop for ChunkBatcherInner {
 }
 
 enum Command {
-    // TODO(#4184): AppendChunk(EntityPath, Chunk)
+    AppendChunk(Chunk),
     AppendRow(EntityPath, PendingRow),
     Flush(Sender<()>),
     Shutdown,
@@ -404,7 +404,9 @@ impl ChunkBatcher {
 
     // --- Send commands ---
 
-    // TODO(#4184): push_chunk
+    pub fn push_chunk(&self, chunk: Chunk) {
+        self.inner.push_chunk(chunk);
+    }
 
     /// Pushes a [`PendingRow`] down the batching pipeline.
     ///
@@ -449,6 +451,10 @@ impl ChunkBatcher {
 }
 
 impl ChunkBatcherInner {
+    fn push_chunk(&self, chunk: Chunk) {
+        self.send_cmd(Command::AppendChunk(chunk));
+    }
+
     fn push_row(&self, entity_path: EntityPath, row: PendingRow) {
         self.send_cmd(Command::AppendRow(entity_path, row));
     }
@@ -567,6 +573,9 @@ fn batching_thread(config: ChunkBatcherConfig, rx_cmd: Receiver<Command>, tx_chu
 
 
                 match cmd {
+                    Command::AppendChunk(chunk) => {
+                        tx_chunk.send(chunk).ok();
+                    },
                     Command::AppendRow(entity_path, row) => {
                         let acc = accs.entry(entity_path.clone())
                             .or_insert_with(|| Accumulator::new(entity_path));

--- a/crates/re_chunk/src/batcher.rs
+++ b/crates/re_chunk/src/batcher.rs
@@ -507,8 +507,6 @@ fn batching_thread(config: ChunkBatcherConfig, rx_cmd: Receiver<Command>, tx_chu
 
     let mut accs: IntMap<EntityPath, Accumulator> = IntMap::default();
 
-    // TODO(#4184): do_push_chunk
-
     fn do_push_row(acc: &mut Accumulator, row: PendingRow) {
         acc.pending_num_bytes += row.total_size_bytes();
         acc.pending_rows.push(row);
@@ -574,6 +572,8 @@ fn batching_thread(config: ChunkBatcherConfig, rx_cmd: Receiver<Command>, tx_chu
 
                 match cmd {
                     Command::AppendChunk(chunk) => {
+                        // NOTE: This can only fail if all receivers have been dropped, which simply cannot happen
+                        // as long the batching thread is alive… which is where we currently are.
                         tx_chunk.send(chunk).ok();
                     },
                     Command::AppendRow(entity_path, row) => {

--- a/crates/re_chunk/src/chunk.rs
+++ b/crates/re_chunk/src/chunk.rs
@@ -377,7 +377,7 @@ impl Chunk {
     /// This will fail if the passed in data is malformed in any way -- see [`Self::sanity_check`]
     /// for details.
     ///
-    /// The data is assumed to be sorted in row-order. Sequential row-ids will be generate for each
+    /// The data is assumed to be sorted in `RowId`-order. Sequential `RowId`s will be generated for each
     /// row in the chunk.
     pub fn from_auto_row_ids(
         id: ChunkId,
@@ -388,7 +388,7 @@ impl Chunk {
         let count = components
             .iter()
             .next()
-            .map_or(0, |(_, components)| components.len());
+            .map_or(0, |(_, list_array)| list_array.len());
 
         let row_ids = std::iter::from_fn({
             let tuid: re_tuid::Tuid = *id;

--- a/crates/re_chunk/src/chunk.rs
+++ b/crates/re_chunk/src/chunk.rs
@@ -377,8 +377,8 @@ impl Chunk {
     /// This will fail if the passed in data is malformed in any way -- see [`Self::sanity_check`]
     /// for details.
     ///
-    /// Iff you know for sure whether the data is already appropriately sorted or not, specify `is_sorted`.
-    /// When left unspecified (`None`), it will be computed in O(n) time.
+    /// The data is assumed to be sorted in row-order. Sequential row-ids will be generate for each
+    /// row in the chunk.
     pub fn from_auto_row_ids(
         id: ChunkId,
         entity_path: EntityPath,

--- a/crates/re_chunk/src/chunk.rs
+++ b/crates/re_chunk/src/chunk.rs
@@ -438,6 +438,13 @@ impl Chunk {
             components: Default::default(),
         }
     }
+
+    #[inline]
+    pub fn add_timeline(&mut self, chunk_timeline: ChunkTimeline) -> ChunkResult<()> {
+        self.timelines
+            .insert(chunk_timeline.timeline, chunk_timeline);
+        self.sanity_check()
+    }
 }
 
 impl ChunkTimeline {

--- a/crates/re_chunk/src/id.rs
+++ b/crates/re_chunk/src/id.rs
@@ -178,6 +178,11 @@ impl RowId {
         Self(re_tuid::Tuid::new())
     }
 
+    #[inline]
+    pub fn from_tuid(tuid: re_tuid::Tuid) -> Self {
+        Self(tuid)
+    }
+
     /// Returns the next logical [`RowId`].
     ///
     /// Beware: wrong usage can easily lead to conflicts.

--- a/crates/re_chunk/src/transport.rs
+++ b/crates/re_chunk/src/transport.rs
@@ -30,8 +30,6 @@ use crate::{Chunk, ChunkError, ChunkId, ChunkResult, ChunkTimeline, RowId};
 /// This means we have to be very careful when checking the validity of the data: slipping corrupt
 /// data into the store could silently break all the index search logic (e.g. think of a chunk
 /// claiming to be sorted while it is in fact not).
-//
-// TODO(#4184): Provide APIs in all SDKs to log these all at once (temporal batches).
 #[derive(Debug)]
 pub struct TransportChunk {
     /// The schema of the dataframe, and all chunk-level and field-level metadata.

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -50,6 +50,7 @@ web_viewer = [
 
 
 [dependencies]
+arrow2.workspace = true
 re_build_info.workspace = true
 re_chunk.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder"] }

--- a/crates/re_sdk/Cargo.toml
+++ b/crates/re_sdk/Cargo.toml
@@ -50,7 +50,6 @@ web_viewer = [
 
 
 [dependencies]
-arrow2.workspace = true
 re_build_info.workspace = true
 re_chunk.workspace = true
 re_log_encoding = { workspace = true, features = ["encoder"] }
@@ -61,6 +60,7 @@ re_sdk_comms = { workspace = true, features = ["client"] }
 re_types_core.workspace = true
 
 ahash.workspace = true
+arrow2.workspace = true
 crossbeam.workspace = true
 document-features.workspace = true
 itertools.workspace = true

--- a/crates/re_sdk/src/recording_stream.rs
+++ b/crates/re_sdk/src/recording_stream.rs
@@ -891,7 +891,12 @@ impl RecordingStream {
     }
 
     #[inline]
-    /// TODO
+    /// Lower-level logging API to provide data spanning multiple timepoints.
+    ///
+    /// Unlike the regular `log` API, which is row-oriented, this API lets you submit the data
+    /// in a columnar form. The lengths of all of the [`ChunkTimeline`] and the [`ArrowListArray`]s
+    /// must match. All data that occurs at the same index across the different time and components
+    /// arrays will act as a single logical row.
     pub fn log_temporal_batch(
         &self,
         ent_path: impl Into<EntityPath>,

--- a/crates/rerun/src/sdk.rs
+++ b/crates/rerun/src/sdk.rs
@@ -22,6 +22,7 @@ mod prelude {
     pub use re_types::archetypes::*;
 
     // Also import any component or datatype that has a unique name:
+    pub use re_chunk::ChunkTimeline;
     pub use re_types::components::{
         Color, HalfSizes2D, HalfSizes3D, LineStrip2D, LineStrip3D, Material, MediaType,
         OutOfTreeTransform3D, Position2D, Position3D, Radius, Text, TextLogLevel, TriangleIndices,

--- a/docs/snippets/all/tutorials/temporal_batch.py
+++ b/docs/snippets/all/tutorials/temporal_batch.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Very minimal test of using the temporal batch APIs.."""
+
+from __future__ import annotations
+
+import numpy as np
+import rerun as rr
+
+rr.init("rerun_example_temporal_batch", spawn=True)
+
+times = np.arange(0, 64)
+scalars = np.sin(times / 10.0)
+
+rr.log_temporal_batch(
+    "scalars",
+    times=[rr.TimeSequenceBatch("step", times)],
+    components=[rr.components.ScalarBatch(scalars)],
+)

--- a/docs/snippets/all/tutorials/temporal_batch.rs
+++ b/docs/snippets/all/tutorials/temporal_batch.rs
@@ -1,0 +1,24 @@
+//! Very minimal test of using the temporal batch APIs.
+
+use rerun::components::Scalar;
+use rerun::ChunkTimeline;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_temporal_batch").spawn()?;
+
+    // Native time / scalars
+    let timeline_values = (0..64).collect::<Vec<_>>();
+
+    let scalar_data: Vec<f64> = timeline_values
+        .iter()
+        .map(|step| (*step as f64 / 10.0).sin())
+        .collect();
+
+    // Convert to rerun time / scalars
+    let timeline_values = ChunkTimeline::new_sequence("step", timeline_values);
+    let scalar_data = scalar_data.into_iter().map(Scalar).collect::<Vec<_>>();
+
+    rec.log_temporal_batch("scalars", [timeline_values], [&scalar_data as _])?;
+
+    Ok(())
+}

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -55,6 +55,9 @@ views = [
   "rust", # Not implemented
   "py",   # Doesn't terminate
 ]
+"tutorials/temporal_batch" = [
+  "cpp", # Not impolemented yet
+]
 "tutorials/visualizer-overrides" = [
   "cpp",  # Not implemented
   "rust", # Not implemented

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -138,6 +138,12 @@ from .sinks import (
     spawn as spawn,
     stdout as stdout,
 )
+from .temporal_batch import (
+    TimeNanosBatch as TimeNanosBatch,
+    TimeSecondsBatch as TimeSecondsBatch,
+    TimeSequenceBatch as TimeSequenceBatch,
+    log_temporal_batch as log_temporal_batch,
+)
 from .time import (
     disable_timeline as disable_timeline,
     reset_time as reset_time,

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -318,7 +318,7 @@ class ComponentBatchMixin(ComponentBatchLike):
         """
         return self._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
 
-    def partition(self, offsets: npt.ArrayLike) -> PartitionedComponentBatch:
+    def partition(self, lengths: npt.ArrayLike) -> PartitionedComponentBatch:
         """
         Partitions the component into multiple sub-batches. This wraps the inner arrow
         array in a `pyarrow.ListArray` where the different lists have the lengths specified.
@@ -327,7 +327,7 @@ class ComponentBatchMixin(ComponentBatchLike):
 
         Parameters
         ----------
-        offsets : npt.ArrayLike
+        lengths : npt.ArrayLike
             The offsets to partition the component at.
 
         Returns
@@ -335,7 +335,7 @@ class ComponentBatchMixin(ComponentBatchLike):
         The partitioned component.
 
         """  # noqa: D205
-        return PartitionedComponentBatch(self, offsets)
+        return PartitionedComponentBatch(self, lengths)
 
 
 class ComponentMixin(ComponentBatchLike):
@@ -347,14 +347,13 @@ class ComponentMixin(ComponentBatchLike):
     The class using the mixin must define the `_BATCH_TYPE` field, which should be a subclass of `BaseBatch`.
     """
 
-    @classmethod
-    def component_name(cls) -> str:
+    def component_name(self) -> str:
         """
         The name of the component.
 
         Part of the `ComponentBatchLike` logging interface.
         """
-        return cls._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
+        return self._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
 
     def as_arrow_array(self) -> pa.Array:
         """

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -284,13 +284,14 @@ class ComponentMixin(ComponentBatchLike):
     The class using the mixin must define the `_BATCH_TYPE` field, which should be a subclass of `BaseBatch`.
     """
 
-    def component_name(self) -> str:
+    @classmethod
+    def component_name(cls) -> str:
         """
         The name of the component.
 
         Part of the `ComponentBatchLike` logging interface.
         """
-        return self._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
+        return cls._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
 
     def as_arrow_array(self) -> pa.Array:
         """

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Generic, Iterable, Protocol, TypeVar
 
-import numpy.typing as npt
 import numpy as np
+import numpy.typing as npt
 import pyarrow as pa
 from attrs import define, fields
 

--- a/rerun_py/rerun_sdk/rerun/temporal_batch.py
+++ b/rerun_py/rerun_sdk/rerun/temporal_batch.py
@@ -7,10 +7,12 @@ import rerun_bindings as bindings
 
 from ._baseclasses import Archetype, ComponentBatchLike
 from ._log import IndicatorComponentBatch
+from .error_utils import catch_and_log_exceptions
+from .recording_stream import RecordingStream
 
 
 class TimeBatchLike(Protocol):
-    """Describes interface for objects that can be converted to batch of rerun Components."""
+    """Describes interface for objects that can be converted to batch of rerun timepoints."""
 
     def timeline_name(self) -> str:
         """Returns the name of the timeline."""
@@ -22,6 +24,12 @@ class TimeBatchLike(Protocol):
 
 
 class TimeSequenceBatch(TimeBatchLike):
+    """
+    A batch of timepoints that are represented as an integer sequence.
+
+    Equivalent to `rr.set_time_sequence`.
+    """
+
     def __init__(self, timeline: str, times: Iterable[int]):
         self.timeline = timeline
         self.times = times
@@ -34,6 +42,12 @@ class TimeSequenceBatch(TimeBatchLike):
 
 
 class TimeSecondsBatch(TimeBatchLike):
+    """
+    A batch of timepoints that are represented as an floating point seconds.
+
+    Equivalent to `rr.set_time_seconds`.
+    """
+
     def __init__(self, timeline: str, times: Iterable[float]):
         self.timeline = timeline
         self.times = times
@@ -46,6 +60,12 @@ class TimeSecondsBatch(TimeBatchLike):
 
 
 class TimeNanosBatch(TimeBatchLike):
+    """
+    A batch of timepoints that are represented as an integer nanoseconds.
+
+    Equivalent to `rr.set_time_nanos`.
+    """
+
     def __init__(self, timeline: str, times: Iterable[int]):
         self.timeline = timeline
         self.times = times
@@ -60,22 +80,82 @@ class TimeNanosBatch(TimeBatchLike):
 TArchetype = TypeVar("TArchetype", bound=Archetype)
 
 
+@catch_and_log_exceptions()
 def log_temporal_batch(
     entity_path: str,
     times: Iterable[TimeBatchLike],
     components: Iterable[ComponentBatchLike],
+    recording: RecordingStream | None = None,
+    strict: bool | None = None,
 ) -> None:
-    """
-    Log a temporal batch of data.
+    r"""
+    Directly log a temporal batch of data to Rerun.
+
+    Unlike the regular `log` API, which is row-oriented, this API lets you submit the data
+    in a columnar form. Each `TimeBatchLike` and `ComponentBatchLike` object represents a column
+    of data that will be sent to Rerun. The lengths of all of these columns must match, and all
+    data that shares the same index across the different columns will act as a single logical row,
+    equivalent to a single call to `rr.log()`.
+
+    Note that this API ignores any stateful time set on the log stream via the `rerun.set_time_*` APIs.
+
+    When using a regular `ComponentBatch` input, the batch data will map to single-valued component
+    instance at each timepoint.
+
+    For example, scalars would be logged as:
+    ```py
+    times = np.arange(0, 64)
+    scalars = np.sin(times / 10.0)
+
+    rr.log_temporal_batch(
+        "scalars",
+        times=[rr.TimeSequenceBatch("step", times)],
+        components=[rr.components.ScalarBatch(scalars)],
+    )
+    ```
+    In the viewer this will show up as 64 individual scalar values, one for each timepoint.
+
+    However, it is still possible to log temporal batches of batch data. To do this the source data first must
+    be created as a single contiguous batch, and can then be partitioned using the `.partition()` helper on the
+    `ComponentBatch` objects.
+
+    For example, to log 5 batches of 20 point clouds, first create a batch of 100 (20 * 5) point clouds and then
+    partition it into 5 batches of 20 point clouds:
+    ```py
+    times = np.arange(0, 5)
+    positions = rng.uniform(-5, 5, size=[100, 3])
+
+    rr.log_temporal_batch(
+        "points",
+        times=[rr.TimeSequenceBatch("step", times)],
+        components=[
+            rr.Points3D.indicator(),
+            rr.components.Position3DBatch(positions).partition([20, 20, 20, 20, 20]),
+        ],
+    )
+    ```
+    In the viewer this will show up as 5 individual point clouds, one for each timepoint.
 
     Parameters
     ----------
     entity_path:
-        The entity path to log.
+        Path to the entity in the space hierarchy.
+
+        See <https://www.rerun.io/docs/concepts/entity-path> for more on entity paths.
     times:
-        The time data to log.
+        The timepoints of this batch of data. Each `TimeBatchLike` object represents a single column
+        of timestamps. Generally you should use one of the provided classes: [`TimeSequenceBatch`][],
+        [`TimeSecondsBatch`][], or [`TimeNanosBatch`][].
     components:
-        The components to log.
+        The batches of components to log. Each `ComponentBatchLike` object represents a single column of data.
+    recording:
+        Specifies the [`rerun.RecordingStream`][] to use.
+        If left unspecified, defaults to the current active data recording, if there is one.
+        See also: [`rerun.init`][], [`rerun.set_global_data_recording`][].
+    strict:
+        If True, raise exceptions on non-loggable data.
+        If False, warn on non-loggable data.
+        if None, use the global default from `rerun.strict_mode()`
 
     """
     expected_length = None
@@ -121,4 +201,5 @@ def log_temporal_batch(
         entity_path,
         timelines={t.timeline_name(): t.as_arrow_array() for t in times},
         components=components_args,
+        recording=recording,
     )

--- a/rerun_py/rerun_sdk/rerun/temporal_batch.py
+++ b/rerun_py/rerun_sdk/rerun/temporal_batch.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Iterable, Protocol, TypeVar
+
+import pyarrow as pa
+import rerun_bindings as bindings
+
+from ._baseclasses import Archetype, ComponentBatchLike
+from ._log import IndicatorComponentBatch
+
+
+class TimeBatchLike(Protocol):
+    """Describes interface for objects that can be converted to batch of rerun Components."""
+
+    def timeline_name(self) -> str:
+        """Returns the name of the timeline."""
+        ...
+
+    def as_arrow_array(self) -> pa.Array:
+        """Returns the name of the component."""
+        ...
+
+
+class TimeSequenceBatch(TimeBatchLike):
+    def __init__(self, timeline: str, times: Iterable[int]):
+        self.timeline = timeline
+        self.times = times
+
+    def timeline_name(self) -> str:
+        return self.timeline
+
+    def as_arrow_array(self) -> pa.Array:
+        return pa.array(self.times, type=pa.int64())
+
+
+class TimeSecondsBatch(TimeBatchLike):
+    def __init__(self, timeline: str, times: Iterable[float]):
+        self.timeline = timeline
+        self.times = times
+
+    def timeline_name(self) -> str:
+        return self.timeline
+
+    def as_arrow_array(self) -> pa.Array:
+        return pa.array([int(t * 1e9) for t in self.times], type=pa.timestamp("ns"))
+
+
+class TimeNanosBatch(TimeBatchLike):
+    def __init__(self, timeline: str, times: Iterable[int]):
+        self.timeline = timeline
+        self.times = times
+
+    def timeline_name(self) -> str:
+        return self.timeline
+
+    def as_arrow_array(self) -> pa.Array:
+        return pa.array(self.times, type=pa.timestamp("ns"))
+
+
+TArchetype = TypeVar("TArchetype", bound=Archetype)
+
+
+def log_temporal_batch(
+    entity_path: str,
+    times: Iterable[TimeBatchLike],
+    components: Iterable[ComponentBatchLike | Iterable[ComponentBatchLike]],
+) -> None:
+    """
+    Log a temporal batch of data.
+
+    Parameters
+    ----------
+    entity_path:
+        The entity path to log.
+    times:
+        The time data to log.
+    components:
+        The components to log.
+
+    """
+    expected_length = None
+
+    timelines_args = {}
+    for t in times:
+        temporal_batch = t.as_arrow_array()
+        if expected_length is None:
+            expected_length = len(temporal_batch)
+        elif len(temporal_batch) != expected_length:
+            raise ValueError("All times and components in a batch must have the same length.")
+
+        timelines_args[t.timeline_name()] = temporal_batch
+
+    indicators = []
+
+    components_args = {}
+    for c in components:
+        if isinstance(c, IndicatorComponentBatch):
+            indicators.append(c)
+            continue
+        if hasattr(c, "component_name"):
+            temporal_batch = c.as_arrow_array()  # type: ignore[union-attr]
+            if expected_length is None:
+                expected_length = len(temporal_batch)
+            elif len(temporal_batch) != expected_length:
+                raise ValueError("All times and components in a batch must have the same length.")
+
+            components_args[c.component_name()] = temporal_batch
+        else:
+            # TODO(jleibs): We can probably code-gen some helpers to make this more efficient.
+            # Would be better to extend an existing array than produce a new one.
+            component_name = None
+            arrays = []
+            offsets = []
+            accum = 0
+            offsets.append(accum)
+            for cc in c:
+                if component_name is None:
+                    component_name = cc.component_name()
+                elif component_name != cc.component_name():
+                    raise ValueError("All components in a batch must have the same component name.")
+                arrays.append(cc.as_arrow_array())
+                accum += len(arrays[-1])
+                offsets.append(accum)
+            if component_name is None:
+                raise ValueError("Empty batch of components.")
+            if expected_length is None:
+                expected_length = len(arrays)
+            elif len(arrays) != expected_length:
+                raise ValueError("All times and components in a batch must have the same length.")
+            temporal_batch = pa.concat_arrays(arrays)
+
+            components_args[component_name] = pa.ListArray.from_arrays(offsets=offsets, values=temporal_batch)
+
+    for i in indicators:
+        if expected_length is None:
+            expected_length = 1
+
+        components_args[i.component_name()] = pa.nulls(expected_length, type=pa.null())
+
+    bindings.log_arrow_chunk(
+        entity_path,
+        timelines={t.timeline_name(): t.as_arrow_array() for t in times},
+        components=components_args,
+    )

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1090,11 +1090,11 @@ fn log_arrow_msg(
 ///
 /// Params
 /// ------
-/// entity_path: str
+/// entity_path: `str`
 ///     The entity path to log the chunk to.
-/// timelines: Dict[str, ArrowPrimitiveArray<i64>]
+/// timelines: `Dict[str, ArrowPrimitiveArray<i64>]`
 ///     A dictionary mapping timeline names to their values.
-/// components: Dict[str, ArrowListArray<i32>]
+/// components: `Dict[str, ArrowListArray<i32>]`
 ///     A dictionary mapping component names to their values.
 #[pyfunction]
 #[pyo3(signature = (

--- a/tests/python/test_temporal_batch/main.py
+++ b/tests/python/test_temporal_batch/main.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Log a scalar scalar batch."""
+
+import numpy as np
+import pyarrow as pa
+import rerun as rr
+
+rr.init("rerun_example_temporal_batch", spawn=True)
+
+times = np.arange(0, 64, 1)
+scalars = np.sin(times / 10.0)
+
+times = pa.array(times, type=pa.int64())
+scalars = pa.array(scalars, type=pa.float64())
+
+rr.bindings.log_arrow_chunk(
+    "scalars", timelines={"step": times}, components={rr.components.Scalar.component_name(): scalars}
+)

--- a/tests/python/test_temporal_batch/main.py
+++ b/tests/python/test_temporal_batch/main.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Log a scalar scalar batch."""
 
+from __future__ import annotations
+
 import numpy as np
 import rerun as rr
-import rerun.blueprint as rrb
 
 rr.init("rerun_example_temporal_batch", spawn=True)
 

--- a/tests/python/test_temporal_batch/main.py
+++ b/tests/python/test_temporal_batch/main.py
@@ -2,17 +2,35 @@
 """Log a scalar scalar batch."""
 
 import numpy as np
-import pyarrow as pa
 import rerun as rr
+import rerun.blueprint as rrb
 
 rr.init("rerun_example_temporal_batch", spawn=True)
 
-times = np.arange(0, 64, 1)
+times = np.arange(0, 64)
 scalars = np.sin(times / 10.0)
 
-times = pa.array(times, type=pa.int64())
-scalars = pa.array(scalars, type=pa.float64())
+rr.log_temporal_batch(
+    "scalars",
+    times=[rr.TimeSequenceBatch("step", times)],
+    components=[rr.components.ScalarBatch(scalars)],
+)
 
-rr.bindings.log_arrow_chunk(
-    "scalars", timelines={"step": times}, components={rr.components.Scalar.component_name(): scalars}
+
+rng = np.random.default_rng(12345)
+
+times = np.arange(0, 10)
+positions = rng.uniform(-5, 5, size=[100, 3])
+colors = rng.uniform(0, 255, size=[100, 3])
+radii = rng.uniform(0, 1, size=[100])
+
+rr.log_temporal_batch(
+    "points",
+    times=[rr.TimeSequenceBatch("step", times)],
+    components=[
+        rr.Points3D.indicator(),
+        rr.components.Position3DBatch(positions).partition([10] * 10),
+        rr.components.ColorBatch(colors).partition([10] * 10),
+        rr.components.RadiusBatch(radii).partition([10] * 10),
+    ],
 )

--- a/tests/python/test_temporal_batch/main.py
+++ b/tests/python/test_temporal_batch/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Log a scalar scalar batch."""
+"""Log different temporal batches of data."""
 
 from __future__ import annotations
 

--- a/tests/rust/test_temporal_batch/Cargo.toml
+++ b/tests/rust/test_temporal_batch/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_temporal_batch"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+arrow2.workspace = true
+re_chunk.workspace = true
+rerun = { path = "../../../crates/rerun" }

--- a/tests/rust/test_temporal_batch/src/main.rs
+++ b/tests/rust/test_temporal_batch/src/main.rs
@@ -1,40 +1,24 @@
 //! Very minimal test of using the temporal batch APIs.
 
-use arrow2::{
-    array::{ListArray as ArrowListArray, PrimitiveArray as ArrowPrimitiveArray},
-    offset::Offsets,
-};
 use re_chunk::ChunkTimeline;
-use rerun::{components::Scalar, Loggable, Timeline};
+use rerun::components::Scalar;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_temporal_batch").spawn()?;
 
-    let timeline = Timeline::new_sequence("step");
-    let timeline_values: Vec<i64> = (0..64).collect();
+    // Native time / scalars
+    let timeline_values = (0..64).collect::<Vec<_>>();
 
     let scalar_data: Vec<f64> = timeline_values
         .iter()
         .map(|step| (*step as f64 / 10.0).sin())
         .collect();
 
-    // TODO(jleibs): hide this with assorted helpers
-    // ---
-    let chunk_timeline =
-        ArrowPrimitiveArray::<i64>::from_vec(timeline_values).to(timeline.datatype());
-    let chunk_timeline = ChunkTimeline::new(None, timeline, chunk_timeline);
+    // Convert to rerun time / scalars
+    let timeline_values = ChunkTimeline::new_sequence("step", timeline_values);
+    let scalar_data = scalar_data.into_iter().map(Scalar).collect::<Vec<_>>();
 
-    let scalar_data = ArrowPrimitiveArray::<f64>::from_vec(scalar_data);
-    let offsets = Offsets::try_from_lengths(std::iter::repeat(1).take(scalar_data.len()))?;
-    let data_type = ArrowListArray::<i32>::default_datatype(scalar_data.data_type().clone());
-    let scalar_data =
-        ArrowListArray::<i32>::try_new(data_type, offsets.into(), scalar_data.boxed(), None)?;
-    // ---
-
-    let timelines = std::iter::once((timeline, chunk_timeline)).collect();
-    let components = std::iter::once((Scalar::name(), scalar_data)).collect();
-
-    rec.log_temporal_batch("scalar", timelines, components)?;
+    rec.log_temporal_batch("scalar", [timeline_values], [&scalar_data as _])?;
 
     Ok(())
 }

--- a/tests/rust/test_temporal_batch/src/main.rs
+++ b/tests/rust/test_temporal_batch/src/main.rs
@@ -1,0 +1,40 @@
+//! Very minimal test of using the temporal batch APIs.
+
+use arrow2::{
+    array::{ListArray as ArrowListArray, PrimitiveArray as ArrowPrimitiveArray},
+    offset::Offsets,
+};
+use re_chunk::ChunkTimeline;
+use rerun::{components::Scalar, Loggable, Timeline};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_temporal_batch").spawn()?;
+
+    let timeline = Timeline::new_sequence("step");
+    let timeline_values: Vec<i64> = (0..64).collect();
+
+    let scalar_data: Vec<f64> = timeline_values
+        .iter()
+        .map(|step| (*step as f64 / 10.0).sin())
+        .collect();
+
+    // TODO(jleibs): hide this with assorted helpers
+    // ---
+    let chunk_timeline =
+        ArrowPrimitiveArray::<i64>::from_vec(timeline_values).to(timeline.datatype());
+    let chunk_timeline = ChunkTimeline::new(None, timeline, chunk_timeline);
+
+    let scalar_data = ArrowPrimitiveArray::<f64>::from_vec(scalar_data);
+    let offsets = Offsets::try_from_lengths(std::iter::repeat(1).take(scalar_data.len()))?;
+    let data_type = ArrowListArray::<i32>::default_datatype(scalar_data.data_type().clone());
+    let scalar_data =
+        ArrowListArray::<i32>::try_new(data_type, offsets.into(), scalar_data.boxed(), None)?;
+    // ---
+
+    let timelines = std::iter::once((timeline, chunk_timeline)).collect();
+    let components = std::iter::once((Scalar::name(), scalar_data)).collect();
+
+    rec.log_temporal_batch("scalar", timelines, components)?;
+
+    Ok(())
+}


### PR DESCRIPTION
 ### What
- Resolves: https://github.com/rerun-io/rerun/issues/4184

This primarily introduces a new logging API for temporal batches. This API is a slightly lower-level than the existing `log` API but has a fairly familiar feel to it if you've worked with our data-types.

The biggest difference is that it does not currently support Archetypes. Data must be specifically logged using raw components arranged in (possibly partitioned) batches. The main reason for this is that Archetypes aren't required to have matched-length components and as such you would need to provide a per-component parititioning, which starts to look very similar to the manual component-level API.

Note that we automatically wrap regular batches in the correct way to turn them into "mono-batches". Partitions only need to be generated manually to support batch-batches.

This also requires a few helper classes for the 3 `TimeBatch` types, but otherwise makes use of the existing `ComponentBatch` constructors.


### New python API docstring:
```python
def log_temporal_batch(
    entity_path: str,
    times: Iterable[TimeBatchLike],
    components: Iterable[ComponentBatchLike],
    recording: RecordingStream | None = None,
    strict: bool | None = None,
) -> None:
```
  Directly log a temporal batch of data to Rerun.

  Unlike the regular `log` API, which is row-oriented, this API lets you submit the data
  in a columnar form. Each `TimeBatchLike` and `ComponentBatchLike` object represents a column
  of data that will be sent to Rerun. The lengths of all of these columns must match, and all
  data that shares the same index across the different columns will act as a single logical row,
  equivalent to a single call to `rr.log()`.

  Note that this API ignores any stateful time set on the log stream via the `rerun.set_time_*` APIs.

  When using a regular `ComponentBatch` input, the batch data will map to single-valued component
  instance at each timepoint.

  For example, scalars would be logged as:
  ```py
  times = np.arange(0, 64)
  scalars = np.sin(times / 10.0)

  rr.log_temporal_batch(
      "scalars",
      times=[rr.TimeSequenceBatch("step", times)],
      components=[rr.components.ScalarBatch(scalars)],
  )
  ```
  In the viewer this will show up as 64 individual scalar values, one for each timepoint.

  However, it is still possible to log temporal batches of batch data. To do this the source data first must
  be created as a single contiguous batch, and can then be partitioned using the `.partition()` helper on the
  `ComponentBatch` objects.

  For example, to log 5 batches of 20 point clouds, first create a batch of 100 (20 * 5) point clouds and then
  partition it into 5 batches of 20 point clouds:
  ```py
  times = np.arange(0, 5)
  positions = rng.uniform(-5, 5, size=[100, 3])

  rr.log_temporal_batch(
      "points",
      times=[rr.TimeSequenceBatch("step", times)],
      components=[
          rr.Points3D.indicator(),
          rr.components.Position3DBatch(positions).partition([20, 20, 20, 20, 20]),
      ],
  )
  ```
  In the viewer this will show up as 5 individual point clouds, one for each timepoint.

### TODO
 - [x] Round-tripped snippet for Python + Rust

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6587?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6587?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6587)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.