### PR TITLE
Add a `debugging` cargo profile

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,7 +32,7 @@
             "cargo": {
                 "args": [
                     "test",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "-p=re_log_encoding",
                     "--no-run",
                     "--lib",
@@ -51,7 +51,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -74,7 +74,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -99,7 +99,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -121,7 +121,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--package=minimal",
                 ],
                 "filter": {
@@ -142,7 +142,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--example=multiview"
                 ],
                 "filter": {
@@ -160,7 +160,7 @@
             "cargo": {
                 "args": [
                     "build",
-                    "--profile=debug",
+                    "--profile=debugging",
                     "--package=re_types_builder",
                 ],
                 "filter": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,7 @@
             "cargo": {
                 "args": [
                     "test",
+                    "--profile=debug",
                     "-p=re_log_encoding",
                     "--no-run",
                     "--lib",
@@ -50,6 +51,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -72,6 +74,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -96,6 +99,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--package=rerun-cli",
                     "--no-default-features",
                     "--features=native_viewer"
@@ -117,6 +121,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--package=minimal",
                 ],
                 "filter": {
@@ -137,6 +142,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--example=multiview"
                 ],
                 "filter": {
@@ -154,6 +160,7 @@
             "cargo": {
                 "args": [
                     "build",
+                    "--profile=debug",
                     "--package=re_types_builder",
                 ],
                 "filter": {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,8 @@ panic = "abort" # This leads to better optimizations and smaller binaries (and i
 debug = true
 
 
-# Set up a `debug` profile that turns of optimization of the workspace and select packages.
+# Set up a `debugging` profile that turns of optimization of the workspace and select packages.
+# Note that the profile name `debug` is reserved.
 [profile.debugging]
 inherits = "dev"
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,10 @@ xshell = "0.2"
 zip = { version = "0.6", default-features = false }
 
 
+# ---------------------------------------------------------------------------------
+[profile]
+
+# Our dev profile has some optimizations turned on, as well as debug assertions.
 [profile.dev]
 opt-level = 1   # Make debug builds run faster
 panic = "abort" # This leads to better optimizations and smaller binaries (and is the default in Wasm anyways).
@@ -274,12 +278,25 @@ debug = true # enable debug symbols for build scripts when building in dev (code
 [profile.dev.package."*"]
 opt-level = 2
 
+
 [profile.release]
 # debug = true # good for profilers
 panic = "abort" # This leads to better optimizations and smaller binaries (and is the default in Wasm anyways).
 
+
 [profile.bench]
 debug = true
+
+
+# Set up a `debug` profile that turns of optimization of the workspace and select packages.
+[profile.debug]
+inherits = "dev"
+opt-level = 0
+[profile.debug.package.egui]
+opt-level = 0 # we often debug egui via Rerun
+
+
+# ---------------------------------------------------------------------------------
 
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -289,10 +289,10 @@ debug = true
 
 
 # Set up a `debug` profile that turns of optimization of the workspace and select packages.
-[profile.debug]
+[profile.debugging]
 inherits = "dev"
 opt-level = 0
-[profile.debug.package.egui]
+[profile.debugging.package.egui]
 opt-level = 0 # we often debug egui via Rerun
 
 


### PR DESCRIPTION
### What
We use `opt-level = 1` for the `dev` profile as a sweet-spot between compile-time and run-time. It's not great for debugging though.

So I've created a new profile `debugging` with `opt-level = 0`. This means you can more quickly debug without having to edit `Cargo.toml`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6598?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6598?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6598)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.