### PR TITLE
Remove `panic="abort"` from `dev` builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,7 @@ opt-level = 1 # Make debug builds run faster
 # panic = "abort" leads to better optimizations and smaller binaries (and is the default in Wasm anyways),
 # but it also means backtraces don't work with the `backtrace` library (https://github.com/rust-lang/backtrace-rs/issues/397).
 # egui has a feature where if you hold down all modifiers keys on your keyboard and hover any UI widget,
-# you will see the backtrace to that widget, and we don't want to break that feature.
+# you will see the backtrace to that widget, and we don't want to break that feature in dev builds.
 
 [profile.dev.build-override]
 debug = true # enable debug symbols for build scripts when building in dev (codegen backtraces!)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,8 +273,12 @@ zip = { version = "0.6", default-features = false }
 
 # Our dev profile has some optimizations turned on, as well as debug assertions.
 [profile.dev]
-opt-level = 1   # Make debug builds run faster
-panic = "abort" # This leads to better optimizations and smaller binaries (and is the default in Wasm anyways).
+opt-level = 1 # Make debug builds run faster
+
+# panic = "abort" leads to better optimizations and smaller binaries (and is the default in Wasm anyways),
+# but it also means backtraces don't work with the `backtrace` library (https://github.com/rust-lang/backtrace-rs/issues/397).
+# egui has a feature where if you hold down all modifiers keys on your keyboard and hover any UI widget,
+# you will see the backtrace to that widget, and we don't want to break that feature.
 
 [profile.dev.build-override]
 debug = true # enable debug symbols for build scripts when building in dev (codegen backtraces!)


### PR DESCRIPTION
The `backtrace` crate isn't compatible with `panic="abort"` (see [docs](https://docs.rs/backtrace/latest/backtrace/) and [issue](https://github.com/rust-lang/backtrace-rs/issues/397)).

One great feature we have in egui is pressing down all modifier keys on your keyboard and seeing the backtrace to the widget you hover. This is awesome for when you want to change the code for some specific part of the UI. But it didn't work, at least not always.

This PR fixes it.

We still use `panic="abort"` in release builds, for the benefit of smaller binaries.

* See also https://github.com/emilk/egui/pull/4696

https://github.com/rerun-io/rerun/assets/1148717/cff9ddbe-838c-4e67-937a-e7dd97d1537f


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6608?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6608?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6608)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.