### PR TITLE
Fix `large_collapsing_header` implementation

### DIFF
--- a/crates/re_ui/examples/re_ui_example/main.rs
+++ b/crates/re_ui/examples/re_ui_example/main.rs
@@ -243,9 +243,16 @@ impl eframe::App for ExampleApp {
 
             // ---
 
-            ui.large_collapsing_header("Data", true, |ui| {
-                ui.label("Some data here");
-            });
+            ui.large_collapsing_header_with_button(
+                "Data",
+                true,
+                |ui| {
+                    ui.label("Some data here");
+                },
+                re_ui::HeaderMenuButton::new(&re_ui::icons::ADD, |ui| {
+                    ui.weak("empty");
+                }),
+            );
             ui.large_collapsing_header("Blueprint", true, |ui| {
                 ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                 ui.label("Some blueprint stuff here, that might be wide.");


### PR DESCRIPTION
### What

Improve `large_collapsing_header[_with_button]` with:
- text truncation when the available width is narrow
- fix sizing issue introduced in #6605 that would induce spurious horizontal scrolling


https://github.com/rerun-io/rerun/assets/49431240/d298dc17-6065-4297-88b4-e0a67c20846c



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6622?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6622?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6622)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.