### PR TITLE
Fix confusing code around plot marker size vs stroke width

### DIFF
--- a/crates/re_space_view_time_series/src/aggregation.rs
+++ b/crates/re_space_view_time_series/src/aggregation.rs
@@ -34,7 +34,7 @@ impl AverageAggregator {
                 let point = &points[i + j];
 
                 acc.value += point.value;
-                acc.attrs.marker_size += point.attrs.marker_size;
+                acc.attrs.radius_ui += point.attrs.radius_ui;
 
                 ratio += 1.0;
                 j += 1;
@@ -49,14 +49,14 @@ impl AverageAggregator {
 
                 let w = aggregation_factor_fract;
                 acc.value += point.value * w;
-                acc.attrs.marker_size += (point.attrs.marker_size as f64 * w) as f32;
+                acc.attrs.radius_ui += (point.attrs.radius_ui as f64 * w) as f32;
 
                 ratio += aggregation_factor_fract;
                 j += 1;
             }
 
             acc.value /= ratio;
-            acc.attrs.marker_size = (acc.attrs.marker_size as f64 / ratio) as _;
+            acc.attrs.radius_ui = (acc.attrs.radius_ui as f64 / ratio) as _;
 
             aggregated.push(acc);
 
@@ -125,21 +125,21 @@ impl MinMaxAggregator {
                 match self {
                     Self::MinMax | Self::MinMaxAverage => {
                         acc_min.value = f64::min(acc_min.value, point.value);
-                        acc_min.attrs.marker_size =
-                            f32::min(acc_min.attrs.marker_size, point.attrs.marker_size);
+                        acc_min.attrs.radius_ui =
+                            f32::min(acc_min.attrs.radius_ui, point.attrs.radius_ui);
                         acc_max.value = f64::max(acc_max.value, point.value);
-                        acc_max.attrs.marker_size =
-                            f32::max(acc_max.attrs.marker_size, point.attrs.marker_size);
+                        acc_max.attrs.radius_ui =
+                            f32::max(acc_max.attrs.radius_ui, point.attrs.radius_ui);
                     }
                     Self::Min => {
                         acc_min.value = f64::min(acc_min.value, point.value);
-                        acc_min.attrs.marker_size =
-                            f32::min(acc_min.attrs.marker_size, point.attrs.marker_size);
+                        acc_min.attrs.radius_ui =
+                            f32::min(acc_min.attrs.radius_ui, point.attrs.radius_ui);
                     }
                     Self::Max => {
                         acc_max.value = f64::max(acc_max.value, point.value);
-                        acc_max.attrs.marker_size =
-                            f32::max(acc_max.attrs.marker_size, point.attrs.marker_size);
+                        acc_max.attrs.radius_ui =
+                            f32::max(acc_max.attrs.radius_ui, point.attrs.radius_ui);
                     }
                 }
 
@@ -158,8 +158,8 @@ impl MinMaxAggregator {
                     // Don't average a single point with itself.
                     if j > 1 {
                         acc_min.value = (acc_min.value + acc_max.value) * 0.5;
-                        acc_min.attrs.marker_size =
-                            (acc_min.attrs.marker_size + acc_max.attrs.marker_size) * 0.5;
+                        acc_min.attrs.radius_ui =
+                            (acc_min.attrs.radius_ui + acc_max.attrs.radius_ui) * 0.5;
                     }
                     aggregated.push(acc_min);
                 }
@@ -196,7 +196,7 @@ fn are_aggregatable(point1: &PlotPoint, point2: &PlotPoint, window_size: usize) 
     let PlotPointAttrs {
         label,
         color,
-        marker_size: _,
+        radius_ui: _,
         kind,
     } = attrs;
 

--- a/crates/re_space_view_time_series/src/lib.rs
+++ b/crates/re_space_view_time_series/src/lib.rs
@@ -37,7 +37,10 @@ pub(crate) fn plot_id(space_view_id: re_viewer_context::SpaceViewId) -> egui::Id
 pub struct PlotPointAttrs {
     pub label: Option<Utf8>,
     pub color: egui::Color32,
-    pub marker_size: f32,
+
+    /// Radius of markers, or stroke radius for lines.
+    pub radius_ui: f32,
+
     pub kind: PlotSeriesKind,
 }
 
@@ -51,12 +54,12 @@ impl PartialEq for PlotPointAttrs {
         let Self {
             label,
             color,
-            marker_size,
+            radius_ui,
             kind,
         } = self;
         label.eq(&rhs.label)
             && color.eq(&rhs.color)
-            && marker_size.total_cmp(&rhs.marker_size).is_eq()
+            && radius_ui.total_cmp(&rhs.radius_ui).is_eq()
             && kind.eq(&rhs.kind)
     }
 }
@@ -81,7 +84,10 @@ pub enum PlotSeriesKind {
 pub struct PlotSeries {
     pub label: Utf8,
     pub color: egui::Color32,
-    pub width: f32,
+
+    /// Radius of markers, or stroke radius for lines.
+    pub radius_ui: f32,
+
     pub kind: PlotSeriesKind,
     pub points: Vec<(i64, f64)>,
     pub entity_path: EntityPath,

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -152,7 +152,7 @@ impl SeriesLineSystem {
         let query_ctx = ctx.query_context(data_result, &current_query);
 
         let fallback_color: Color = self.fallback_for(&query_ctx);
-        let fallback_stroke: StrokeWidth = self.fallback_for(&query_ctx);
+        let fallback_stroke_width: StrokeWidth = self.fallback_for(&query_ctx);
 
         // All the default values for a `PlotPoint`, accounting for both overrides and default
         // values.
@@ -162,7 +162,7 @@ impl SeriesLineSystem {
             attrs: PlotPointAttrs {
                 label: None,
                 color: fallback_color.into(),
-                marker_size: fallback_stroke.into(),
+                radius_ui: 0.5 * fallback_stroke_width.0,
                 kind: PlotSeriesKind::Continuous,
             },
         };
@@ -307,7 +307,7 @@ impl SeriesLineSystem {
                     if let Some(stroke_width) =
                         stroke_widths.and_then(|stroke_widths| stroke_widths.first().map(|r| r.0))
                     {
-                        points[i].attrs.marker_size = stroke_width;
+                        points[i].attrs.radius_ui = 0.5 * stroke_width;
                     }
                 }
             }

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -120,7 +120,7 @@ impl SeriesPointSystem {
                 attrs: PlotPointAttrs {
                     label: None,
                     color: fallback_color.into(),
-                    marker_size: fallback_size.into(),
+                    radius_ui: fallback_size.into(),
                     kind: PlotSeriesKind::Scatter(ScatterAttrs {
                         marker: fallback_shape,
                     }),
@@ -272,7 +272,7 @@ impl SeriesPointSystem {
                         if let Some(marker_size) =
                             marker_sizes.and_then(|marker_sizes| marker_sizes.first().copied())
                         {
-                            points[i].attrs.marker_size = marker_size.0;
+                            points[i].attrs.radius_ui = marker_size.0;
                         }
                     }
                 }

--- a/crates/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/re_space_view_time_series/src/space_view_class.rs
@@ -448,14 +448,14 @@ impl SpaceViewClass for TimeSeriesSpaceView {
                         Line::new(points)
                             .name(series.label.as_str())
                             .color(color)
-                            .width(series.width)
+                            .width(2.0 * series.radius_ui)
                             .id(id),
                     ),
                     PlotSeriesKind::Scatter(scatter_attrs) => plot_ui.points(
                         Points::new(points)
                             .name(series.label.as_str())
                             .color(color)
-                            .radius(series.width)
+                            .radius(series.radius_ui)
                             .shape(scatter_attrs.marker.into())
                             .id(id),
                     ),

--- a/crates/re_space_view_time_series/src/util.rs
+++ b/crates/re_space_view_time_series/src/util.rs
@@ -116,7 +116,7 @@ pub fn points_to_series(
         all_series.push(PlotSeries {
             label: series_label,
             color: points[0].attrs.color,
-            width: 2.0 * points[0].attrs.marker_size,
+            radius_ui: points[0].attrs.radius_ui,
             kind,
             points: vec![(points[0].time, points[0].value)],
             entity_path: entity_path.clone(),
@@ -220,7 +220,7 @@ fn add_series_runs(
     let mut series: PlotSeries = PlotSeries {
         label: series_label.clone(),
         color: attrs.color,
-        width: 2.0 * attrs.marker_size,
+        radius_ui: attrs.radius_ui,
         points: Vec::with_capacity(num_points),
         kind: attrs.kind,
         entity_path: entity_path.clone(),
@@ -244,7 +244,7 @@ fn add_series_runs(
                 PlotSeries {
                     label: series_label.clone(),
                     color: attrs.color,
-                    width: 2.0 * attrs.marker_size,
+                    radius_ui: attrs.radius_ui,
                     kind: attrs.kind,
                     points: Vec::with_capacity(num_points - i),
                     entity_path: entity_path.clone(),


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/6540

The existing code was using the same field to mean different things at different times. I have no idea if the original code was buggy, since it didn't document expected behavior.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6630?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6630?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6630)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.