### PR TITLE
Disable `Component Defaults` button if there are no editors

### DIFF
--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -180,7 +180,7 @@ fn add_new_default(
                 true // show it
             } else {
                 missing_editors.push(component);
-                false // don't shopw
+                false // don't show
             }
         });
 

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -191,7 +191,7 @@ fn add_new_default(
                 } else {
                     "editors"
                 },
-                missing_editors.iter().map(|c| c.short_name()).join(" ")
+                missing_editors.iter().map(|c| c.short_name()).join(", ")
             ));
         }
     }

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use itertools::Itertools as _;
 use re_data_store::LatestAtQuery;
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_log_types::{DataCell, DataRow, EntityPath, RowId};
@@ -139,26 +140,68 @@ pub fn defaults_ui(ctx: &ViewContext<'_>, space_view: &SpaceViewBlueprint, ui: &
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn add_new_default(
+fn add_new_default(
     ctx: &ViewContext<'_>,
     query: &LatestAtQuery,
     ui: &mut egui::Ui,
     component_to_vis: &BTreeMap<ComponentName, ViewSystemIdentifier>,
-    active_overrides: &BTreeSet<ComponentName>,
+    active_defaults: &BTreeSet<ComponentName>,
     defaults_path: &EntityPath,
 ) {
-    let remaining_components = component_to_vis
-        .keys()
-        .filter(|c| !active_overrides.contains(*c))
+    let mut disabled_reason = None;
+    if component_to_vis.is_empty() {
+        disabled_reason = Some("No components to visualize".to_owned());
+    }
+
+    let mut component_to_vis = component_to_vis
+        .iter()
+        .filter(|(component, _)| !active_defaults.contains(*component))
         .collect::<Vec<_>>();
 
-    let enabled = !remaining_components.is_empty();
+    if component_to_vis.is_empty() && disabled_reason.is_none() {
+        disabled_reason = Some("All components already have active defaults".to_owned());
+    }
 
-    ui.add_enabled_ui(enabled, |ui| {
-        let mut opened = false;
+    {
+        // Make sure we have editors. If we don't, explain to the user.
+        let mut missing_editors = vec![];
+
+        component_to_vis.retain(|(component, _)| {
+            let component = **component;
+
+            // If there is no registered editor, don't let the user create an override
+            // TODO(andreas): Can only handle single line editors right now.
+            let types = ctx
+                .viewer_ctx
+                .component_ui_registry
+                .registered_ui_types(component);
+
+            if types.contains(ComponentUiTypes::SingleLineEditor) {
+                true // show it
+            } else {
+                missing_editors.push(component);
+                false // don't shopw
+            }
+        });
+
+        if component_to_vis.is_empty() && disabled_reason.is_none() {
+            disabled_reason = Some(format!(
+                "Rerun lacks {} for: {}",
+                if missing_editors.len() == 1 {
+                    "an editor"
+                } else {
+                    "editors"
+                },
+                missing_editors.iter().map(|c| c.short_name()).join(" ")
+            ));
+        }
+    }
+
+    let button_ui = |ui: &mut egui::Ui| -> egui::Response {
+        let mut open = false;
         let menu = ui
             .menu_button("Add", |ui| {
-                opened = true;
+                open = true;
                 ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
 
                 let query_context = QueryContext {
@@ -173,21 +216,6 @@ pub fn add_new_default(
                 // Present the option to add new components for each component that doesn't
                 // already have an active override.
                 for (component, viz) in component_to_vis {
-                    if active_overrides.contains(component) {
-                        continue;
-                    }
-
-                    // If there is no registered editor, don't let the user create an override
-                    // TODO(andreas): Can only handle single line editors right now.
-                    if !ctx
-                        .viewer_ctx
-                        .component_ui_registry
-                        .registered_ui_types(*component)
-                        .contains(ComponentUiTypes::SingleLineEditor)
-                    {
-                        continue;
-                    }
-
                     if ui.button(component.short_name()).clicked() {
                         // We are creating a new override. We need to decide what initial value to give it.
                         // - First see if there's an existing splat in the recording.
@@ -237,10 +265,17 @@ pub fn add_new_default(
                     }
                 }
             })
-            .response
-            .on_disabled_hover_text("No additional components available.");
-        if !opened {
-            menu.on_hover_text("Choose a component to specify an override value.".to_owned());
+            .response;
+        if open {
+            menu
+        } else {
+            menu.on_hover_text("Choose a component to specify an override value.".to_owned())
         }
-    });
+    };
+
+    let enabled = disabled_reason.is_none();
+    let button_response = ui.add_enabled_ui(enabled, button_ui).inner;
+    if let Some(disabled_reason) = disabled_reason {
+        button_response.on_disabled_hover_text(disabled_reason);
+    }
 }

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -185,12 +185,7 @@ fn add_new_default(
 
         if component_to_vis.is_empty() && disabled_reason.is_none() {
             disabled_reason = Some(format!(
-                "Rerun lacks {} for: {}",
-                if missing_editors.len() == 1 {
-                    "an editor"
-                } else {
-                    "editors"
-                },
+                "Rerun lacks edit UI for: {}",
                 missing_editors.iter().map(|c| c.short_name()).join(", ")
             ));
         }

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -139,7 +139,6 @@ pub fn defaults_ui(ctx: &ViewContext<'_>, space_view: &SpaceViewBlueprint, ui: &
     });
 }
 
-#[allow(clippy::too_many_arguments)]
 fn add_new_default(
     ctx: &ViewContext<'_>,
     query: &LatestAtQuery,


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6603

![image](https://github.com/rerun-io/rerun/assets/1148717/bdc0b84c-cd90-4c52-a219-51c42b6e47eb)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6634?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6634?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6634)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.