### PR TITLE
Reorganize Selection Panel

### DIFF
--- a/crates/re_context_menu/src/actions/remove.rs
+++ b/crates/re_context_menu/src/actions/remove.rs
@@ -46,7 +46,7 @@ impl ContextMenuAction for RemoveAction {
         space_view_id: &SpaceViewId,
         instance_path: &InstancePath,
     ) {
-        if let Some(space_view) = ctx.viewport_blueprint.space_view(space_view_id) {
+        if let Some(space_view) = ctx.viewport_blueprint.view(space_view_id) {
             space_view.contents.remove_subtree_and_matching_rules(
                 ctx.viewer_context,
                 instance_path.entity_path.clone(),

--- a/crates/re_edit_ui/src/visual_bounds2d.rs
+++ b/crates/re_edit_ui/src/visual_bounds2d.rs
@@ -13,8 +13,7 @@ pub fn multiline_edit_visual_bounds2d(
 
     let mut any_edit = false;
 
-    let response_x = ui.list_item().interactive(false).show_flat(
-        ui,
+    let response_x = ui.list_item_flat_noninteractive(
         re_ui::list_item::PropertyContent::new("x").value_fn(|ui, _| {
             let [x_range_start, x_range_end] = &mut value.x_range.0;
             let speed = speed_func(*x_range_start, *x_range_end);
@@ -47,8 +46,7 @@ pub fn multiline_edit_visual_bounds2d(
         }),
     );
 
-    let response_y = ui.list_item().interactive(false).show_flat(
-        ui,
+    let response_y = ui.list_item_flat_noninteractive(
         re_ui::list_item::PropertyContent::new("y").value_fn(|ui, _| {
             let [y_range_start, y_range_end] = &mut value.y_range.0;
             let speed = speed_func(*y_range_start, *y_range_end);

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -127,27 +127,24 @@ fn active_default_ui(
                     );
                 };
 
-                ui.list_item()
-                    .interactive(false)
-                    .show_flat(
+                ui.list_item_flat_noninteractive(
+                    re_ui::list_item::PropertyContent::new(component_name.short_name())
+                        .min_desired_width(150.0)
+                        .action_button(&re_ui::icons::CLOSE, || {
+                            ctx.save_empty_blueprint_component_by_name(
+                                &space_view.defaults_path,
+                                component_name,
+                            );
+                        })
+                        .value_fn(|ui, _| value_fn(ui)),
+                )
+                .on_hover_ui(|ui| {
+                    component_name.data_ui_recording(
+                        ctx.viewer_ctx,
                         ui,
-                        re_ui::list_item::PropertyContent::new(component_name.short_name())
-                            .min_desired_width(150.0)
-                            .action_button(&re_ui::icons::CLOSE, || {
-                                ctx.save_empty_blueprint_component_by_name(
-                                    &space_view.defaults_path,
-                                    component_name,
-                                );
-                            })
-                            .value_fn(|ui, _| value_fn(ui)),
-                    )
-                    .on_hover_ui(|ui| {
-                        component_name.data_ui_recording(
-                            ctx.viewer_ctx,
-                            ui,
-                            re_viewer_context::UiLayout::Tooltip,
-                        );
-                    });
+                        re_viewer_context::UiLayout::Tooltip,
+                    );
+                });
             }
         }
     });

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -8,7 +8,7 @@ use re_types_core::ComponentName;
 use re_ui::UiExt as _;
 use re_viewer_context::{
     blueprint_timeline, ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _,
-    ViewContext, ViewSystemIdentifier,
+    UiLayout, ViewContext, ViewSystemIdentifier,
 };
 use re_viewport_blueprint::SpaceViewBlueprint;
 
@@ -265,7 +265,11 @@ fn add_popup_ui(
     // Present the option to add new components for each component that doesn't
     // already have an active override.
     for (component, viz) in component_to_vis {
-        if ui.button(component.short_name()).clicked() {
+        if ui
+            .button(component.short_name())
+            .on_hover_ui(|ui| component.data_ui_recording(ctx.viewer_ctx, ui, UiLayout::Tooltip))
+            .clicked()
+        {
             // We are creating a new override. We need to decide what initial value to give it.
             // - First see if there's an existing splat in the recording.
             // - Next see if visualizer system wants to provide a value.

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -5,7 +5,7 @@ use re_data_store::LatestAtQuery;
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_log_types::{DataCell, DataRow, EntityPath, RowId};
 use re_types_core::ComponentName;
-use re_ui::UiExt as _;
+use re_ui::{list_item::LabelContent, UiExt as _};
 use re_viewer_context::{
     blueprint_timeline, ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _,
     UiLayout, ViewContext, ViewSystemIdentifier,
@@ -83,7 +83,7 @@ fn active_default_ui(
         ui.spacing_mut().item_spacing.y = 0.0;
 
         if sorted_overrides.is_empty() {
-            ui.weak("(none)");
+            ui.list_item_flat_noninteractive(LabelContent::new("(none)").weak(true));
         }
 
         for component_name in sorted_overrides {

--- a/crates/re_selection_panel/src/lib.rs
+++ b/crates/re_selection_panel/src/lib.rs
@@ -1,11 +1,11 @@
 //! The UI for the selection panel.
 
 mod defaults_ui;
-mod query_range_ui;
 mod selection_history_ui;
 mod selection_panel;
 mod space_view_entity_picker;
 mod space_view_space_origin_ui;
+mod visible_time_range_ui;
 mod visualizer_ui;
 
 pub use selection_panel::SelectionPanel;

--- a/crates/re_selection_panel/src/query_range_ui.rs
+++ b/crates/re_selection_panel/src/query_range_ui.rs
@@ -111,13 +111,17 @@ fn visible_time_range_ui(
     let has_individual_range_before = has_individual_range;
     let query_range_before = resolved_query_range.clone();
 
-    query_range_ui(
-        ctx,
-        ui,
-        &mut resolved_query_range,
-        &mut has_individual_range,
-        is_space_view,
-    );
+    ui.scope(|ui| {
+        // TODO(#6075): Because `list_item_scope` changes it. Temporary until everything is `ListItem`.
+        ui.spacing_mut().item_spacing.y = ui.ctx().style().spacing.item_spacing.y;
+        query_range_ui(
+            ctx,
+            ui,
+            &mut resolved_query_range,
+            &mut has_individual_range,
+            is_space_view,
+        );
+    });
 
     if query_range_before != resolved_query_range
         || has_individual_range_before != has_individual_range
@@ -238,16 +242,6 @@ fn query_range_ui(
                 }
             }
         });
-
-    // Add spacer after the visible history section.
-    //TODO(ab): figure out why `item_spacing.y` is added _only_ in collapsed state.
-    if collapsing_response.body_response.is_some() {
-        ui.add_space(ui.spacing().item_spacing.y / 2.0);
-    } else {
-        ui.add_space(-ui.spacing().item_spacing.y / 2.0);
-    }
-    ui.full_span_separator();
-    ui.add_space(ui.spacing().item_spacing.y / 2.0);
 
     // Decide when to show the visible history highlight in the timeline. The trick is that when
     // interacting with the controls, the mouse might end up outside the collapsing header rect,

--- a/crates/re_selection_panel/src/query_range_ui.rs
+++ b/crates/re_selection_panel/src/query_range_ui.rs
@@ -170,71 +170,74 @@ fn query_range_ui(
 
     let mut interacting_with_controls = false;
 
-    let collapsing_response = ui.collapsing_header("Visible time range", false, |ui| {
-        ui.horizontal(|ui| {
-            ui.re_radio_value(has_individual_time_range, false, "Default")
-                .on_hover_text(if is_space_view {
-                    "Default query range settings for this kind of space view"
-                } else {
-                    "Query range settings inherited from parent entity or enclosing \
+    let default_open = false;
+    let collapsing_response =
+        ui.large_collapsing_header("Visible time range", default_open, |ui| {
+            ui.horizontal(|ui| {
+                ui.re_radio_value(has_individual_time_range, false, "Default")
+                    .on_hover_text(if is_space_view {
+                        "Default query range settings for this kind of space view"
+                    } else {
+                        "Query range settings inherited from parent entity or enclosing \
                         space view"
-                });
-            ui.re_radio_value(has_individual_time_range, true, "Override")
-                .on_hover_text(if is_space_view {
-                    "Set query range settings for the contents of this space view"
+                    });
+                ui.re_radio_value(has_individual_time_range, true, "Override")
+                    .on_hover_text(if is_space_view {
+                        "Set query range settings for the contents of this space view"
+                    } else {
+                        "Set query range settings for this entity"
+                    });
+            });
+            let timeline_spec =
+                if let Some(times) = ctx.recording().time_histogram(time_ctrl.timeline()) {
+                    TimelineSpec::from_time_histogram(times)
                 } else {
-                    "Set query range settings for this entity"
-                });
-        });
-        let timeline_spec =
-            if let Some(times) = ctx.recording().time_histogram(time_ctrl.timeline()) {
-                TimelineSpec::from_time_histogram(times)
+                    TimelineSpec::from_time_range(0..=0)
+                };
+
+            let current_time = TimeInt(
+                time_ctrl
+                    .time_i64()
+                    .unwrap_or_default()
+                    .at_least(*timeline_spec.range.start()),
+            ); // accounts for timeless time (TimeInt::MIN)
+
+            if *has_individual_time_range {
+                let time_range = match query_range {
+                    QueryRange::TimeRange(time_range) => time_range,
+                    QueryRange::LatestAt => {
+                        // This should only happen if we just flipped to an individual range and the parent used latest-at queries.
+                        *query_range = QueryRange::TimeRange(TimeRange::AT_CURSOR);
+                        match query_range {
+                            QueryRange::TimeRange(range) => range,
+                            QueryRange::LatestAt => unreachable!(),
+                        }
+                    }
+                };
+
+                time_range_editor(
+                    ctx,
+                    ui,
+                    time_range,
+                    current_time,
+                    &mut interacting_with_controls,
+                    time_type,
+                    &timeline_spec,
+                );
             } else {
-                TimelineSpec::from_time_range(0..=0)
-            };
-
-        let current_time = TimeInt(
-            time_ctrl
-                .time_i64()
-                .unwrap_or_default()
-                .at_least(*timeline_spec.range.start()),
-        ); // accounts for timeless time (TimeInt::MIN)
-
-        if *has_individual_time_range {
-            let time_range = match query_range {
-                QueryRange::TimeRange(time_range) => time_range,
-                QueryRange::LatestAt => {
-                    // This should only happen if we just flipped to an individual range and the parent used latest-at queries.
-                    *query_range = QueryRange::TimeRange(TimeRange::AT_CURSOR);
-                    match query_range {
-                        QueryRange::TimeRange(range) => range,
-                        QueryRange::LatestAt => unreachable!(),
+                match &query_range {
+                    QueryRange::TimeRange(range) => {
+                        show_visual_time_range(ctx, ui, range, time_type, current_time);
+                    }
+                    QueryRange::LatestAt => {
+                        let current_time =
+                            time_type.format(current_time, ctx.app_options.time_zone);
+                        ui.label(format!("Latest-at query at: {current_time}"))
+                            .on_hover_text("Uses the latest known value for each component.");
                     }
                 }
-            };
-
-            time_range_editor(
-                ctx,
-                ui,
-                time_range,
-                current_time,
-                &mut interacting_with_controls,
-                time_type,
-                &timeline_spec,
-            );
-        } else {
-            match &query_range {
-                QueryRange::TimeRange(range) => {
-                    show_visual_time_range(ctx, ui, range, time_type, current_time);
-                }
-                QueryRange::LatestAt => {
-                    let current_time = time_type.format(current_time, ctx.app_options.time_zone);
-                    ui.label(format!("Latest-at query at: {current_time}"))
-                        .on_hover_text("Uses the latest known value for each component.");
-                }
             }
-        }
-    });
+        });
 
     // Add spacer after the visible history section.
     //TODO(ab): figure out why `item_spacing.y` is added _only_ in collapsed state.

--- a/crates/re_selection_panel/src/query_range_ui.rs
+++ b/crates/re_selection_panel/src/query_range_ui.rs
@@ -35,22 +35,18 @@ fn space_view_with_visible_history(space_view_class: SpaceViewClassIdentifier) -
     VISIBLE_HISTORY_SUPPORTED_SPACE_VIEWS.contains(&space_view_class)
 }
 
-pub fn query_range_ui_space_view(
-    ctx: &ViewerContext<'_>,
-    ui: &mut Ui,
-    space_view: &SpaceViewBlueprint,
-) {
-    if !space_view_with_visible_history(space_view.class_identifier()) {
+pub fn query_range_ui_space_view(ctx: &ViewerContext<'_>, ui: &mut Ui, view: &SpaceViewBlueprint) {
+    if !space_view_with_visible_history(view.class_identifier()) {
         return;
     }
 
     let property_path = entity_path_for_view_property(
-        space_view.id,
+        view.id,
         ctx.store_context.blueprint.tree(),
         re_types::blueprint::archetypes::VisibleTimeRanges::name(),
     );
 
-    let query_range = space_view.query_range(
+    let query_range = view.query_range(
         ctx.store_context.blueprint,
         ctx.blueprint_query,
         ctx.rec_cfg.time_ctrl.read().timeline(),

--- a/crates/re_selection_panel/src/selection_history_ui.rs
+++ b/crates/re_selection_panel/src/selection_history_ui.rs
@@ -184,7 +184,7 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
         Item::StoreId(store_id) => store_id.to_string(),
         Item::SpaceView(space_view_id) => {
             // TODO(#4678): unnamed space views should have their label formatted accordingly (subdued)
-            if let Some(space_view) = blueprint.space_view(space_view_id) {
+            if let Some(space_view) = blueprint.view(space_view_id) {
                 space_view.display_name_or_default().as_ref().to_owned()
             } else {
                 "<removed space view>".to_owned()
@@ -193,12 +193,11 @@ fn item_to_string(blueprint: &ViewportBlueprint, item: &Item) -> String {
         Item::InstancePath(instance_path) => instance_path.to_string(),
         Item::DataResult(space_view_id, instance_path) => {
             // TODO(#4678): unnamed space views should have their label formatted accordingly (subdued)
-            let space_view_display_name =
-                if let Some(space_view) = blueprint.space_view(space_view_id) {
-                    space_view.display_name_or_default().as_ref().to_owned()
-                } else {
-                    "<removed space view>".to_owned()
-                };
+            let space_view_display_name = if let Some(space_view) = blueprint.view(space_view_id) {
+                space_view.display_name_or_default().as_ref().to_owned()
+            } else {
+                "<removed space view>".to_owned()
+            };
 
             format!("{instance_path} in {space_view_display_name}")
         }

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -24,8 +24,9 @@ use re_viewport_blueprint::{ui::show_add_space_view_or_container_modal, Viewport
 use crate::space_view_entity_picker::SpaceViewEntityPicker;
 use crate::{defaults_ui::view_components_defaults_section_ui, visualizer_ui::visualizer_ui};
 use crate::{
-    query_range_ui::query_range_ui_data_result, query_range_ui::query_range_ui_space_view,
     selection_history_ui::SelectionHistoryUi,
+    visible_time_range_ui::visible_time_range_ui_for_data_result,
+    visible_time_range_ui::visible_time_range_ui_for_view,
 };
 
 // ---
@@ -373,7 +374,7 @@ impl SelectionPanel {
         }
 
         if let Some(view) = blueprint.view(view_id) {
-            query_range_ui_space_view(ctx, ui, view);
+            visible_time_range_ui_for_view(ctx, ui, view);
         }
     }
 
@@ -548,7 +549,7 @@ fn entity_selection_ui(
     }
 
     if let Some(data_result) = &data_result {
-        query_range_ui_data_result(ctx, ui, data_result);
+        visible_time_range_ui_for_data_result(ctx, ui, data_result);
     }
 }
 

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -850,7 +850,7 @@ fn space_view_top_level_properties(
                     "The name of the space view used for display purposes. This can be any text \
                     string.",
                 );
-                ui.text_edit_singleline(&mut name);
+                ui.add(egui::TextEdit::singleline(&mut name).hint_text("(default)"));
                 space_view.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });
 
                 ui.end_row();

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -1,4 +1,3 @@
-use egui::{NumExt as _, Ui};
 use egui_tiles::ContainerKind;
 
 use re_context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
@@ -183,7 +182,7 @@ impl SelectionPanel {
     fn space_view_selection_ui(
         &mut self,
         ctx: &ViewerContext<'_>,
-        ui: &mut Ui,
+        ui: &mut egui::Ui,
         blueprint: &ViewportBlueprint,
         view_id: &SpaceViewId,
         view_states: &mut ViewStates,
@@ -344,30 +343,6 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
                 .clone()
         });
 
-        let rightmost_x = ui.cursor().min.x;
-        ui.horizontal(|ui| {
-            let current_x = ui.cursor().min.x;
-            // Compute a width that results in these things to be right-aligned with the following text edit.
-            let desired_width = (ui.available_width() - ui.spacing().item_spacing.x)
-                .at_most(ui.spacing().text_edit_width - (current_x - rightmost_x));
-
-            ui.allocate_ui_with_layout(
-                egui::vec2(desired_width, ui.available_height()),
-                egui::Layout::right_to_left(egui::Align::Center),
-                |ui| {
-                    ui.help_hover_button()
-                        .on_hover_ui(entity_path_filter_help_ui);
-                    if ui
-                        .button("Edit")
-                        .on_hover_text("Modify the entity query using the editor")
-                        .clicked()
-                    {
-                        self.space_view_entity_modal.open(space_view_id);
-                    }
-                },
-            );
-        });
-
         let response =
             ui.add(egui::TextEdit::multiline(&mut filter_string).layouter(&mut text_layouter));
 
@@ -394,6 +369,19 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
             ));
         }
 
+        ui.horizontal(|ui| {
+            ui.help_hover_button()
+                .on_hover_ui(entity_path_filter_help_ui);
+
+            if ui
+                .button("Edit")
+                .on_hover_text("Modify the entity query using the editor")
+                .clicked()
+            {
+                self.space_view_entity_modal.open(space_view_id);
+            }
+        });
+
         // Apply the edit.
         let new_filter = EntityPathFilter::parse_forgiving(&filter_string, &Default::default());
         if &new_filter == filter {
@@ -406,7 +394,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
 
 fn entity_selection_ui(
     ctx: &ViewerContext<'_>,
-    ui: &mut Ui,
+    ui: &mut egui::Ui,
     entity_path: &EntityPath,
     blueprint: &ViewportBlueprint,
     view_id: &SpaceViewId,
@@ -443,7 +431,7 @@ fn entity_selection_ui(
 
 fn clone_space_view_button_ui(
     ctx: &ViewerContext<'_>,
-    ui: &mut Ui,
+    ui: &mut egui::Ui,
     blueprint: &ViewportBlueprint,
     view_id: SpaceViewId,
 ) {
@@ -993,7 +981,7 @@ fn container_top_level_properties(
         });
 }
 
-fn container_kind_selection_ui(ui: &mut Ui, in_out_kind: &mut ContainerKind) {
+fn container_kind_selection_ui(ui: &mut egui::Ui, in_out_kind: &mut ContainerKind) {
     let selected_text = format!("{in_out_kind:?}");
 
     ui.drop_down_menu("container_kind", selected_text, |ui| {

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -222,7 +222,7 @@ impl SelectionPanel {
                 }
             });
 
-            ui.large_collapsing_header("Component Defaults", true, |ui| {
+            ui.large_collapsing_header("Component defaults", true, |ui| {
                 let view_ctx = view.bundle_context_with_state(ctx, view_state);
                 defaults_ui(&view_ctx, view, ui);
             });

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -508,8 +508,7 @@ fn container_children(
         }
 
         if !has_child {
-            ui.list_item().interactive(false).show_flat(
-                ui,
+            ui.list_item_flat_noninteractive(
                 list_item::LabelContent::new("empty — use the + button to add content")
                     .weak(true)
                     .italics(true),
@@ -1143,10 +1142,7 @@ fn visible_interactive_toggle_ui(
             ""
         };
 
-        ui.list_item()
-            .interactive(false)
-            .show_flat(
-                ui,
+        ui.list_item_flat_noninteractive(
                 list_item::PropertyContent::new("Visible").value_bool_mut(&mut visible),
             )
             .on_hover_text(format!(
@@ -1172,10 +1168,7 @@ fn visible_interactive_toggle_ui(
             ""
         };
 
-        ui.list_item()
-            .interactive(false)
-            .show_flat(
-                ui,
+        ui.list_item_flat_noninteractive(
                 list_item::PropertyContent::new("Interactive").value_bool_mut(&mut interactive),
             )
             .on_hover_text(format!(

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -155,7 +155,9 @@ impl SelectionPanel {
             }
 
             Item::SpaceView(space_view_id) => {
-                space_view_top_level_properties(ctx, blueprint, ui, space_view_id);
+                if let Some(space_view) = blueprint.space_view(space_view_id) {
+                    space_view_top_level_properties(ctx, ui, space_view);
+                }
             }
 
             Item::DataResult(view_id, instance_path) => {
@@ -860,47 +862,44 @@ fn list_existing_data_blueprints(
 /// shown at the very top.
 fn space_view_top_level_properties(
     ctx: &ViewerContext<'_>,
-    viewport: &ViewportBlueprint,
     ui: &mut egui::Ui,
-    space_view_id: &SpaceViewId,
+    space_view: &re_viewport_blueprint::SpaceViewBlueprint,
 ) {
-    if let Some(space_view) = viewport.space_view(space_view_id) {
-        egui::Grid::new("space_view_top_level_properties")
-            .num_columns(2)
-            .show(ui, |ui| {
-                let mut name = space_view.display_name.clone().unwrap_or_default();
-                ui.label("Name").on_hover_text(
-                    "The name of the space view used for display purposes. This can be any text \
+    egui::Grid::new("space_view_top_level_properties")
+        .num_columns(2)
+        .show(ui, |ui| {
+            let mut name = space_view.display_name.clone().unwrap_or_default();
+            ui.label("Name").on_hover_text(
+                "The name of the space view used for display purposes. This can be any text \
                     string.",
-                );
-                ui.add(egui::TextEdit::singleline(&mut name).hint_text("(default)"));
-                space_view.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });
+            );
+            ui.add(egui::TextEdit::singleline(&mut name).hint_text("(default)"));
+            space_view.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });
 
-                ui.end_row();
+            ui.end_row();
 
-                ui.label("Space origin").on_hover_text(
-                    "The origin entity for this space view. For spatial space views, the space \
+            ui.label("Space origin").on_hover_text(
+                "The origin entity for this space view. For spatial space views, the space \
                     View's origin is the same as this entity's origin and all transforms are \
                     relative to it.",
-                );
+            );
 
-                super::space_view_space_origin_ui::space_view_space_origin_widget_ui(
-                    ui, ctx, space_view,
-                );
+            super::space_view_space_origin_ui::space_view_space_origin_widget_ui(
+                ui, ctx, space_view,
+            );
 
-                ui.end_row();
+            ui.end_row();
 
-                ui.label("View type")
-                    .on_hover_text("The type of this space view");
-                ui.label(
-                    space_view
-                        .class(ctx.space_view_class_registry)
-                        .display_name(),
-                );
+            ui.label("View type")
+                .on_hover_text("The type of this space view");
+            ui.label(
+                space_view
+                    .class(ctx.space_view_class_registry)
+                    .display_name(),
+            );
 
-                ui.end_row();
-            });
-    }
+            ui.end_row();
+        });
 }
 
 fn container_top_level_properties(

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -829,16 +829,19 @@ impl ItemTitle {
         }
     }
 
+    #[inline]
     fn with_tooltip(mut self, hover: impl Into<String>) -> Self {
         self.hover = Some(hover.into());
         self
     }
 
+    #[inline]
     fn with_icon(mut self, icon: &'static re_ui::Icon) -> Self {
         self.icon = Some(icon);
         self
     }
 
+    #[inline]
     fn with_label_style(mut self, label_style: re_ui::LabelStyle) -> Self {
         self.label_style = Some(label_style);
         self

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -247,7 +247,7 @@ impl SelectionPanel {
             .header_response
             .on_hover_text(
                 "The entity path query consists of a list of include/exclude rules \
-            that determines what entities are part of this space view",
+                that determines what entities are part of this space view",
             );
         }
 
@@ -255,7 +255,7 @@ impl SelectionPanel {
             let view_class = view.class(ctx.space_view_class_registry);
             let view_state = view_states.get_mut_or_create(view.id, view_class);
 
-            ui.large_collapsing_header("View settings", true, |ui| {
+            ui.large_collapsing_header("View properties", true, |ui| {
                 // TODO(#6075): Because `list_item_scope` changes it. Temporary until everything is `ListItem`.
                 ui.spacing_mut().item_spacing.y = ui.ctx().style().spacing.item_spacing.y;
 

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -242,11 +242,11 @@ impl SelectionPanel {
                         }
                     }
 
-                    ui.list_item_flat_noninteractive(
-                        PropertyContent::new("In space view").value_fn(|ui, _| {
+                    ui.list_item_flat_noninteractive(PropertyContent::new("In view").value_fn(
+                        |ui, _| {
                             space_view_button(ctx, ui, view);
-                        }),
-                    );
+                        },
+                    ));
                 }
 
                 if instance_path.is_all() {
@@ -339,7 +339,7 @@ impl SelectionPanel {
             .header_response
             .on_hover_text(
                 "The entity path query consists of a list of include/exclude rules \
-                that determines what entities are part of this space view",
+                that determines what entities are part of this view",
             );
         }
 
@@ -357,7 +357,7 @@ impl SelectionPanel {
                     view_class.selection_ui(ctx, ui, view_state, &view.space_origin, view.id)
                 {
                     re_log::error_once!(
-                        "Error in space view selection UI (class: {}, display name: {}): {err}",
+                        "Error in view selection UI (class: {}, display name: {}): {err}",
                         view.class_identifier(),
                         view_class.display_name(),
                     );
@@ -501,7 +501,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
         if query.num_matching_entities != 0 && query.num_visualized_entities == 0 {
             // TODO(andreas): Talk about this root bit only if it's a spatial view.
             ui.label(ui.ctx().warning_text(
-                format!("This space view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),
+                format!("This view is not able to visualize any of the matched entities using the current root \"{origin:?}\"."),
             ));
         }
 
@@ -560,10 +560,8 @@ fn clone_space_view_button_ui(
 ) {
     if ui
         .list_item()
-        .show_flat(ui, LabelContent::new("Clone this space view"))
-        .on_hover_text(
-            "Create an exact duplicate of this space view including all blueprint settings",
-        )
+        .show_flat(ui, LabelContent::new("Clone this view"))
+        .on_hover_text("Create an exact duplicate of this view including all blueprint settings")
         .clicked()
     {
         if let Some(new_space_view_id) = blueprint.duplicate_space_view(&view_id, ctx) {
@@ -765,7 +763,7 @@ fn item_tile(
                         view_class.display_name()
                     )
                 } else {
-                    format!("Unnamed space view of type {}", view_class.display_name())
+                    format!("Unnamed view of type {}", view_class.display_name())
                 };
 
                 let view_name = view.display_name_or_default();
@@ -801,7 +799,7 @@ fn item_tile(
                     ItemTitle::new(name)
                         .with_icon(guess_instance_path_icon(ctx, instance_path))
                         .with_tooltip(format!(
-                            "{typ} '{instance_path}' as shown in space view {:?}",
+                            "{typ} '{instance_path}' as shown in view {:?}",
                             view.display_name
                         )),
                 )
@@ -882,7 +880,7 @@ impl ItemTitle {
     }
 }
 
-/// Display a list of all the space views an entity appears in.
+/// Display a list of all the views an entity appears in.
 fn list_existing_data_blueprints(
     ctx: &ViewerContext<'_>,
     blueprint: &ViewportBlueprint,
@@ -895,7 +893,7 @@ fn list_existing_data_blueprints(
     let (query, db) = guess_query_and_db_for_selected_entity(ctx, &instance_path.entity_path);
 
     if space_views_with_path.is_empty() {
-        ui.weak("(Not shown in any space view)");
+        ui.weak("(Not shown in any view)");
     } else {
         for &view_id in &space_views_with_path {
             if let Some(view) = blueprint.view(&view_id) {
@@ -916,10 +914,10 @@ fn list_existing_data_blueprints(
     }
 }
 
-/// Display the top-level properties of a space view.
+/// Display the top-level properties of a view.
 ///
-/// This includes the name, space origin entity, and space view type. These properties are singled
-/// out as needing to be edited in most case when creating a new space view, which is why they are
+/// This includes the name, space origin entity, and view type. These properties are singled
+/// out as needing to be edited in most case when creating a new view, which is why they are
 /// shown at the very top.
 fn view_top_level_properties(
     ctx: &ViewerContext<'_>,
@@ -936,7 +934,7 @@ fn view_top_level_properties(
         super::space_view_space_origin_ui::space_view_space_origin_widget_ui(ui, ctx, view);
     }))
     .on_hover_text(
-        "The origin entity for this space view. For spatial space views, the space \
+        "The origin entity for this view. For spatial views, the space \
                     view's origin is the same as this entity's origin and all transforms are \
                     relative to it.",
     );
@@ -945,7 +943,7 @@ fn view_top_level_properties(
         PropertyContent::new("View type")
             .value_text(view.class(ctx.space_view_class_registry).display_name()),
     )
-    .on_hover_text("The type of this space view");
+    .on_hover_text("The type of this view");
 }
 
 fn container_top_level_properties(
@@ -1098,7 +1096,7 @@ fn show_list_item_for_container_child(
     let (item, list_item_content) = match child_contents {
         Contents::SpaceView(view_id) => {
             let Some(view) = blueprint.view(view_id) else {
-                re_log::warn_once!("Could not find space view with ID {view_id:?}",);
+                re_log::warn_once!("Could not find view with ID {view_id:?}",);
                 return false;
             };
 
@@ -1111,7 +1109,7 @@ fn show_list_item_for_container_child(
                     .with_buttons(|ui| {
                         let response = ui
                             .small_icon_button(&icons::REMOVE)
-                            .on_hover_text("Remove this space view");
+                            .on_hover_text("Remove this view");
 
                         if response.clicked() {
                             remove_contents = true;

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -10,7 +10,7 @@ use re_data_ui::{
 use re_entity_db::{EntityPath, InstancePath};
 use re_log_types::EntityPathFilter;
 use re_types::blueprint::components::Interactive;
-use re_ui::{icons, list_item, ContextExt as _, DesignTokens, SyntaxHighlighting as _, UiExt as _};
+use re_ui::{icons, list_item, ContextExt as _, DesignTokens, SyntaxHighlighting as _, UiExt};
 use re_viewer_context::{
     contents_name_style, icon_for_container_kind, ContainerId, Contents, DataQueryResult,
     DataResult, HoverHighlight, Item, SpaceViewId, UiLayout, ViewContext, ViewStates,
@@ -19,7 +19,7 @@ use re_viewer_context::{
 use re_viewport_blueprint::{ui::show_add_space_view_or_container_modal, ViewportBlueprint};
 
 use crate::space_view_entity_picker::SpaceViewEntityPicker;
-use crate::{defaults_ui::defaults_ui, visualizer_ui::visualizer_ui};
+use crate::{defaults_ui::space_view_components_defaults_section_ui, visualizer_ui::visualizer_ui};
 use crate::{
     query_range_ui::query_range_ui_data_result, query_range_ui::query_range_ui_space_view,
     selection_history_ui::SelectionHistoryUi,
@@ -222,10 +222,8 @@ impl SelectionPanel {
                 }
             });
 
-            ui.large_collapsing_header("Component defaults", true, |ui| {
-                let view_ctx = view.bundle_context_with_state(ctx, view_state);
-                defaults_ui(&view_ctx, view, ui);
-            });
+            let view_ctx = view.bundle_context_with_state(ctx, view_state);
+            space_view_components_defaults_section_ui(&view_ctx, ui, view);
         }
 
         if let Some(view) = blueprint.space_view(view_id) {

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -448,7 +448,7 @@ fn clone_space_view_button_ui(
     view_id: SpaceViewId,
 ) {
     if ui
-        .button("Clone space view")
+        .button("Clone this space view")
         .on_hover_text(
             "Create an exact duplicate of this space view including all blueprint settings",
         )
@@ -867,7 +867,7 @@ fn space_view_top_level_properties(
 
                 ui.end_row();
 
-                ui.label("Type")
+                ui.label("View type")
                     .on_hover_text("The type of this space view");
                 ui.label(
                     space_view

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -8,7 +8,7 @@ use re_data_ui::{
 };
 use re_entity_db::{EntityPath, InstancePath};
 use re_log_types::EntityPathFilter;
-use re_types::{blueprint::components::Interactive, external::image::flat::view};
+use re_types::blueprint::components::Interactive;
 use re_ui::{
     icons,
     list_item::{self, LabelContent, PropertyContent},

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -191,17 +191,24 @@ impl SelectionPanel {
         clone_space_view_button_ui(ctx, ui, blueprint, *view_id);
 
         if let Some(space_view) = blueprint.space_view(view_id) {
-            if let Some(new_entity_path_filter) = self.entity_path_filter_ui(
-                ctx,
-                ui,
-                *view_id,
-                &space_view.contents.entity_path_filter,
-                &space_view.space_origin,
-            ) {
-                space_view
-                    .contents
-                    .set_entity_path_filter(ctx, &new_entity_path_filter);
-            }
+            ui.large_collapsing_header("Entity path filter", true, |ui| {
+                if let Some(new_entity_path_filter) = self.entity_path_filter_ui(
+                    ctx,
+                    ui,
+                    *view_id,
+                    &space_view.contents.entity_path_filter,
+                    &space_view.space_origin,
+                ) {
+                    space_view
+                        .contents
+                        .set_entity_path_filter(ctx, &new_entity_path_filter);
+                }
+            })
+            .header_response
+            .on_hover_text(
+                "The entity path query consists of a list of include/exclude rules \
+            that determines what entities are part of this space view",
+            );
         }
 
         if let Some(view) = blueprint.space_view(view_id) {
@@ -339,11 +346,6 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
 
         let rightmost_x = ui.cursor().min.x;
         ui.horizontal(|ui| {
-            ui.label("Entity path query").on_hover_text(
-                "The entity path query consists of a list of include/exclude rules \
-            that determines what entities are part of this space view",
-            );
-
             let current_x = ui.cursor().min.x;
             // Compute a width that results in these things to be right-aligned with the following text edit.
             let desired_width = (ui.available_width() - ui.spacing().item_spacing.x)

--- a/crates/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/re_selection_panel/src/visible_time_range_ui.rs
@@ -35,7 +35,11 @@ fn space_view_with_visible_history(space_view_class: SpaceViewClassIdentifier) -
     VISIBLE_HISTORY_SUPPORTED_SPACE_VIEWS.contains(&space_view_class)
 }
 
-pub fn query_range_ui_space_view(ctx: &ViewerContext<'_>, ui: &mut Ui, view: &SpaceViewBlueprint) {
+pub fn visible_time_range_ui_for_view(
+    ctx: &ViewerContext<'_>,
+    ui: &mut Ui,
+    view: &SpaceViewBlueprint,
+) {
     if !space_view_with_visible_history(view.class_identifier()) {
         return;
     }
@@ -57,7 +61,7 @@ pub fn query_range_ui_space_view(ctx: &ViewerContext<'_>, ui: &mut Ui, view: &Sp
     visible_time_range_ui(ctx, ui, query_range, &property_path, is_space_view);
 }
 
-pub fn query_range_ui_data_result(
+pub fn visible_time_range_ui_for_data_result(
     ctx: &ViewerContext<'_>,
     ui: &mut Ui,
     data_result: &re_viewer_context::DataResult,

--- a/crates/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/re_selection_panel/src/visualizer_ui.rs
@@ -284,25 +284,22 @@ fn visualizer_components(
             }
             // Store (if available)
             if let Some(result_store) = result_store {
-                ui.list_item()
-                    .interactive(false)
-                    .show_flat(
-                        ui,
-                        list_item::PropertyContent::new("Store").value_fn(|ui, _style| {
-                            re_data_ui::EntityLatestAtResults {
-                                entity_path: data_result.entity_path.clone(),
-                                results: result_store,
-                            }
-                            .data_ui(
-                                ctx.viewer_ctx,
-                                ui,
-                                UiLayout::List,
-                                &store_query,
-                                ctx.recording(),
-                            );
-                        }),
-                    )
-                    .on_hover_text("The value that was logged to the data store");
+                ui.list_item_flat_noninteractive(list_item::PropertyContent::new("Store").value_fn(
+                    |ui, _style| {
+                        re_data_ui::EntityLatestAtResults {
+                            entity_path: data_result.entity_path.clone(),
+                            results: result_store,
+                        }
+                        .data_ui(
+                            ctx.viewer_ctx,
+                            ui,
+                            UiLayout::List,
+                            &store_query,
+                            ctx.recording(),
+                        );
+                    },
+                ))
+                .on_hover_text("The value that was logged to the data store");
             }
             // Default (if available)
             if let (Some(result_default), Some(raw_default)) =
@@ -321,26 +318,22 @@ fn visualizer_components(
             }
             // Fallback (always there)
             {
-                ui.list_item()
-                    .interactive(false)
-                    .show_flat(
-                        ui,
-                        list_item::PropertyContent::new("Fallback").value_fn(|ui, _| {
-                            // TODO(andreas): db & entity path don't make sense here.
-                            ctx.viewer_ctx.component_ui_registry.ui_raw(
-                                ctx.viewer_ctx,
-                                ui,
-                                UiLayout::List,
-                                &store_query,
-                                ctx.recording(),
-                                &data_result.entity_path,
-                                component,
-                                raw_fallback.as_ref(),
-                            );
-                        }),
-                    )
-                    .on_hover_text("Context sensitive fallback value for this component type, used only if nothing else was specified.
-Unlike the other values, this may differ per visualizer.");
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Fallback").value_fn(|ui, _| {
+                        // TODO(andreas): db & entity path don't make sense here.
+                        ctx.viewer_ctx.component_ui_registry.ui_raw(
+                            ctx.viewer_ctx,
+                            ui,
+                            UiLayout::List,
+                            &store_query,
+                            ctx.recording(),
+                            &data_result.entity_path,
+                            component,
+                            raw_fallback.as_ref(),
+                        );
+                    }),
+                )
+                .on_hover_text("Context sensitive fallback value for this component type, used only if nothing else was specified. Unlike the other values, this may differ per visualizer.");
             }
         };
 
@@ -384,8 +377,7 @@ fn editable_blueprint_component_list_item(
     raw_override: &dyn arrow2::array::Array,
     result_override: &LatestAtComponentResults,
 ) -> egui::Response {
-    ui.list_item().interactive(false).show_flat(
-        ui,
+    ui.list_item_flat_noninteractive(
         list_item::PropertyContent::new(name)
             .value_fn(|ui, _style| {
                 let multiline = false;

--- a/crates/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/re_selection_panel/src/visualizer_ui.rs
@@ -284,8 +284,8 @@ fn visualizer_components(
             }
             // Store (if available)
             if let Some(result_store) = result_store {
-                ui.list_item_flat_noninteractive(list_item::PropertyContent::new("Store").value_fn(
-                    |ui, _style| {
+                ui.list_item_flat_noninteractive(
+                    list_item::PropertyContent::new("Store").value_fn(|ui, _style| {
                         re_data_ui::EntityLatestAtResults {
                             entity_path: data_result.entity_path.clone(),
                             results: result_store,
@@ -297,8 +297,8 @@ fn visualizer_components(
                             &store_query,
                             ctx.recording(),
                         );
-                    },
-                ))
+                    }),
+                )
                 .on_hover_text("The value that was logged to the data store");
             }
             // Default (if available)

--- a/crates/re_ui/src/ui_ext.rs
+++ b/crates/re_ui/src/ui_ext.rs
@@ -961,7 +961,9 @@ pub trait UiExt {
 
     fn help_hover_button(&mut self) -> egui::Response {
         self.ui_mut().add(
-            egui::Label::new("❓").sense(egui::Sense::click()), // sensing clicks also gives hover effect
+            egui::Label::new("❓")
+                .sense(egui::Sense::click()) // sensing clicks also gives hover effect
+                .selectable(false),
         )
     }
 

--- a/crates/re_ui/src/ui_ext.rs
+++ b/crates/re_ui/src/ui_ext.rs
@@ -649,6 +649,16 @@ pub trait UiExt {
         list_item::ListItem::new()
     }
 
+    /// Convenience for adding a flat non-interactive [`list_item::ListItemContent`]
+    fn list_item_flat_noninteractive(
+        &mut self,
+        content: impl list_item::ListItemContent,
+    ) -> egui::Response {
+        self.list_item()
+            .interactive(false)
+            .show_flat(self.ui_mut(), content)
+    }
+
     fn selectable_label_with_icon(
         &mut self,
 

--- a/crates/re_viewer/src/ui/top_panel.rs
+++ b/crates/re_viewer/src/ui/top_panel.rs
@@ -269,7 +269,7 @@ fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui:
                 &mut app_blueprint.selection_panel_state().is_expanded(),
             )
             .on_hover_text(format!(
-                "Toggle Selection View{}",
+                "Toggle selection view{}",
                 UICommand::ToggleSelectionPanel.format_shortcut_tooltip_suffix(ui.ctx())
             ))
             .clicked()
@@ -285,7 +285,7 @@ fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui:
                 &mut app_blueprint.time_panel_state().is_expanded(),
             )
             .on_hover_text(format!(
-                "Toggle Timeline View{}",
+                "Toggle timeline view{}",
                 UICommand::ToggleTimePanel.format_shortcut_tooltip_suffix(ui.ctx())
             ))
             .clicked()

--- a/crates/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -189,7 +189,7 @@ impl ViewportBlueprint {
         self.space_views.keys()
     }
 
-    pub fn space_view(&self, space_view: &SpaceViewId) -> Option<&SpaceViewBlueprint> {
+    pub fn view(&self, space_view: &SpaceViewId) -> Option<&SpaceViewBlueprint> {
         self.space_views.get(space_view)
     }
 
@@ -233,7 +233,7 @@ impl ViewportBlueprint {
         space_view_id: &SpaceViewId,
         ctx: &ViewerContext<'_>,
     ) -> Option<SpaceViewId> {
-        let space_view = self.space_view(space_view_id)?;
+        let space_view = self.view(space_view_id)?;
 
         let new_space_view = space_view.duplicate(ctx.store_context, ctx.blueprint_query);
         let new_space_view_id = new_space_view.id;
@@ -274,10 +274,10 @@ impl ViewportBlueprint {
             | Item::ComponentPath(_)
             | Item::InstancePath(_) => true,
 
-            Item::SpaceView(space_view_id) => self.space_view(space_view_id).is_some(),
+            Item::SpaceView(space_view_id) => self.view(space_view_id).is_some(),
 
             Item::DataResult(space_view_id, instance_path) => {
-                self.space_view(space_view_id).map_or(false, |space_view| {
+                self.view(space_view_id).map_or(false, |space_view| {
                     let entity_path = &instance_path.entity_path;
 
                     // TODO(#5742): including any path that is—or descend from—the space origin is
@@ -693,7 +693,7 @@ impl ViewportBlueprint {
                 }
             }
             Contents::SpaceView(space_view_id) => {
-                if let Some(space_view) = self.space_view(space_view_id) {
+                if let Some(space_view) = self.view(space_view_id) {
                     space_view.visible
                 } else {
                     re_log::warn_once!(
@@ -735,7 +735,7 @@ impl ViewportBlueprint {
                 }
             }
             Contents::SpaceView(space_view_id) => {
-                if let Some(space_view) = self.space_view(space_view_id) {
+                if let Some(space_view) = self.view(space_view_id) {
                     if visible != space_view.visible {
                         if self.auto_layout() {
                             re_log::trace!(


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6615
* Part of https://github.com/rerun-io/rerun/issues/6075

Each section now only does one thing, with a good name to describe it, and in a good order.

![image](https://github.com/rerun-io/rerun/assets/1148717/a5f845cf-e0e4-496c-b495-85b7972c49f9) ![image](https://github.com/rerun-io/rerun/assets/1148717/b507f678-9139-4432-a2b6-c733ae0b0c94)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6637?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6637?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6637)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.