### PR TITLE
Make draw order editable & solve 2D flickering issues, add draw order to arrow2d archetype

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/float_drag.rs
+++ b/crates/re_edit_ui/src/datatype_editors/float_drag.rs
@@ -1,3 +1,5 @@
+use std::ops::RangeInclusive;
+
 use egui::NumExt as _;
 use re_types::datatypes;
 
@@ -7,7 +9,7 @@ pub fn edit_f32_zero_to_max(
     ui: &mut egui::Ui,
     value: &mut impl std::ops::DerefMut<Target = datatypes::Float32>,
 ) -> egui::Response {
-    edit_f32_zero_to_max_float_raw_impl(ui, &mut value.deref_mut().0)
+    edit_f32_float_raw_impl(ui, &mut value.deref_mut().0, 0.0..=f32::MAX)
 }
 
 /// Generic editor for a raw f32 value from zero to max float.
@@ -16,15 +18,28 @@ pub fn edit_f32_zero_to_max_float_raw(
     ui: &mut egui::Ui,
     value: &mut impl std::ops::DerefMut<Target = f32>,
 ) -> egui::Response {
-    edit_f32_zero_to_max_float_raw_impl(ui, value)
+    edit_f32_float_raw_impl(ui, value, 0.0..=f32::MAX)
 }
 
-/// Non monomorphized implementation of [`edit_f32_zero_to_max_float_raw`].
-fn edit_f32_zero_to_max_float_raw_impl(ui: &mut egui::Ui, value: &mut f32) -> egui::Response {
+/// Generic editor for a raw f32 value from min to max float.
+pub fn edit_f32_min_to_max_float_raw(
+    _ctx: &re_viewer_context::ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    value: &mut impl std::ops::DerefMut<Target = f32>,
+) -> egui::Response {
+    edit_f32_float_raw_impl(ui, value, f32::MIN..=f32::MAX)
+}
+
+/// Non monomorphized implementation for f32 float editing.
+fn edit_f32_float_raw_impl(
+    ui: &mut egui::Ui,
+    value: &mut f32,
+    range: RangeInclusive<f32>,
+) -> egui::Response {
     let speed = (*value * 0.01).at_least(0.001);
     ui.add(
         egui::DragValue::new(value)
-            .clamp_range(0.0..=f32::MAX) // TODO(#6633): Don't change incoming values
+            .clamp_range(range) // TODO(#6633): Don't change incoming values
             .speed(speed),
     )
 }

--- a/crates/re_edit_ui/src/datatype_editors/mod.rs
+++ b/crates/re_edit_ui/src/datatype_editors/mod.rs
@@ -5,5 +5,8 @@ mod singleline_string;
 
 pub use bool_toggle::{edit_bool, edit_bool_raw};
 pub use enum_combobox::edit_enum;
-pub use float_drag::{edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw, edit_f32_zero_to_one};
+pub use float_drag::{
+    edit_f32_min_to_max_float_raw, edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw,
+    edit_f32_zero_to_one,
+};
 pub use singleline_string::edit_singleline_string;

--- a/crates/re_edit_ui/src/lib.rs
+++ b/crates/re_edit_ui/src/lib.rs
@@ -10,15 +10,15 @@ mod response_utils;
 mod visual_bounds2d;
 
 use datatype_editors::{
-    edit_bool, edit_bool_raw, edit_enum, edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw,
-    edit_f32_zero_to_one, edit_singleline_string,
+    edit_bool, edit_bool_raw, edit_enum, edit_f32_min_to_max_float_raw, edit_f32_zero_to_max,
+    edit_f32_zero_to_max_float_raw, edit_f32_zero_to_one, edit_singleline_string,
 };
 use re_types::{
     blueprint::components::{BackgroundKind, Corner2D, LockRangeDuringZoom, ViewFit, Visible},
     components::{
-        AggregationPolicy, AxisLength, Color, Colormap, DepthMeter, FillRatio, GammaCorrection,
-        ImagePlaneDistance, MagnificationFilter, MarkerSize, Name, Opacity, Radius, StrokeWidth,
-        Text,
+        AggregationPolicy, AxisLength, Color, Colormap, DepthMeter, DrawOrder, FillRatio,
+        GammaCorrection, ImagePlaneDistance, MagnificationFilter, MarkerSize, Name, Opacity,
+        Radius, StrokeWidth, Text,
     },
 };
 use re_viewer_context::ViewerContext;
@@ -53,6 +53,8 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_editor_ui::<FillRatio>(edit_f32_zero_to_max);
     registry.add_singleline_editor_ui::<ImagePlaneDistance>(edit_f32_zero_to_max);
     registry.add_singleline_editor_ui::<GammaCorrection>(edit_f32_zero_to_max);
+
+    registry.add_singleline_editor_ui::<DrawOrder>(edit_f32_min_to_max_float_raw);
 
     registry.add_singleline_editor_ui::<DepthMeter>(edit_f32_zero_to_max_float_raw);
     registry.add_singleline_editor_ui::<MarkerSize>(edit_f32_zero_to_max_float_raw);

--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -14,7 +14,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{filter_visualizable_2d_entities, UiLabel, UiLabelTarget},
 };
@@ -224,7 +224,6 @@ impl VisualizerSystem for Arrows2DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -4,12 +4,13 @@ use re_query::range_zip_1x6;
 use re_renderer::{renderer::LineStripFlags, LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::Arrows2D,
-    components::{ClassId, Color, KeypointId, Position2D, Radius, Text, Vector2D},
+    components::{ClassId, Color, DrawOrder, KeypointId, Position2D, Radius, Text, Vector2D},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
-    SpaceViewSystemExecutionError, ViewContext, ViewContextCollection, ViewQuery,
-    VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, QueryContext, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext,
+    ViewContextCollection, ViewQuery, VisualizableEntities, VisualizableFilterContext,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -305,4 +306,10 @@ impl VisualizerSystem for Arrows2DVisualizer {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(Arrows2DVisualizer => []);
+impl TypedComponentFallbackProvider<DrawOrder> for Arrows2DVisualizer {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
+        DrawOrder::DEFAULT_LINES2D
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(Arrows2DVisualizer => [DrawOrder]);

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -13,7 +13,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{filter_visualizable_3d_entities, UiLabel, UiLabelTarget},
 };
@@ -226,7 +226,6 @@ impl VisualizerSystem for Arrows3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -15,7 +15,7 @@ use re_viewer_context::{
 
 use super::{filter_visualizable_3d_entities, SpatialViewVisualizerData};
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
     mesh_cache::{AnyMesh, MeshCache, MeshCacheKey},
     view_kind::SpatialSpaceViewKind,
@@ -145,7 +145,6 @@ impl VisualizerSystem for Asset3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -4,12 +4,13 @@ use re_query::range_zip_1x6;
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::Boxes2D,
-    components::{ClassId, Color, HalfSizes2D, KeypointId, Position2D, Radius, Text},
+    components::{ClassId, Color, DrawOrder, HalfSizes2D, KeypointId, Position2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
-    SpaceViewSystemExecutionError, ViewContext, ViewContextCollection, ViewQuery,
-    VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, QueryContext, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext,
+    ViewContextCollection, ViewQuery, VisualizableEntities, VisualizableFilterContext,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -311,4 +312,10 @@ impl VisualizerSystem for Boxes2DVisualizer {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(Boxes2DVisualizer => []);
+impl TypedComponentFallbackProvider<DrawOrder> for Boxes2DVisualizer {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
+        DrawOrder::DEFAULT_BOX2D
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(Boxes2DVisualizer => [DrawOrder]);

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -14,7 +14,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{UiLabel, UiLabelTarget},
 };
@@ -220,7 +220,6 @@ impl VisualizerSystem for Boxes2DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -13,7 +13,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{UiLabel, UiLabelTarget},
 };
@@ -210,7 +210,6 @@ impl VisualizerSystem for Boxes3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -261,6 +261,10 @@ impl ImageVisualizer {
             // TODO(andreas): We only support colormap for depth image at this point.
             let colormap = None;
 
+            let draw_order = data
+                .draw_order
+                .copied()
+                .unwrap_or_else(|| self.fallback_for(ctx));
             let opacity = data
                 .opacity
                 .copied()
@@ -297,7 +301,7 @@ impl ImageVisualizer {
                         meaning,
                         textured_rect,
                         parent_pinhole: parent_pinhole_path.map(|p| p.hash()),
-                        draw_order: data.draw_order.copied().unwrap_or(DrawOrder::DEFAULT_IMAGE),
+                        draw_order,
                     });
                 }
             }
@@ -361,6 +365,10 @@ impl ImageVisualizer {
             // TODO(andreas): colormap is only available for depth images right now.
             let colormap = None;
 
+            let draw_order = data
+                .draw_order
+                .copied()
+                .unwrap_or_else(|| self.fallback_for(ctx));
             let opacity = data
                 .opacity
                 .copied()
@@ -401,7 +409,7 @@ impl ImageVisualizer {
                     meaning,
                     textured_rect,
                     parent_pinhole: parent_pinhole_path.map(|p| p.hash()),
-                    draw_order: data.draw_order.copied().unwrap_or(DrawOrder::DEFAULT_IMAGE),
+                    draw_order,
                 });
             }
         }
@@ -504,6 +512,10 @@ impl ImageVisualizer {
                 };
             }
 
+            let draw_order = data
+                .draw_order
+                .copied()
+                .unwrap_or_else(|| self.fallback_for(ctx));
             let color = ent_context
                 .annotations
                 .resolved_class_description(None)
@@ -543,7 +555,7 @@ impl ImageVisualizer {
                     meaning,
                     textured_rect,
                     parent_pinhole: parent_pinhole_path.map(|p| p.hash()),
-                    draw_order: data.draw_order.copied().unwrap_or(DrawOrder::DEFAULT_IMAGE),
+                    draw_order,
                 });
             }
         }
@@ -989,4 +1001,10 @@ impl TypedComponentFallbackProvider<Opacity> for ImageVisualizer {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(ImageVisualizer => [Colormap, DepthMeter, Opacity]);
+impl TypedComponentFallbackProvider<DrawOrder> for ImageVisualizer {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
+        DrawOrder::DEFAULT_IMAGE
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(ImageVisualizer => [Colormap, DepthMeter, DrawOrder, Opacity]);

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -29,7 +29,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext, TransformContext},
+    contexts::{SpatialSceneEntityContext, TransformContext},
     query_pinhole_legacy,
     ui::SpatialSpaceViewState,
     view_kind::SpatialSpaceViewKind,
@@ -875,7 +875,6 @@ impl ImageVisualizer {
             ctx,
             view_query,
             view_ctx,
-            view_ctx.get::<EntityDepthOffsets>()?.image,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -4,12 +4,13 @@ use re_query::range_zip_1x5;
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips2D,
-    components::{ClassId, Color, KeypointId, LineStrip2D, Radius, Text},
+    components::{ClassId, Color, DrawOrder, KeypointId, LineStrip2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
-    SpaceViewSystemExecutionError, ViewContext, ViewContextCollection, ViewQuery,
-    VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, QueryContext, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext,
+    ViewContextCollection, ViewQuery, VisualizableEntities, VisualizableFilterContext,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -291,4 +292,10 @@ impl VisualizerSystem for Lines2DVisualizer {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(Lines2DVisualizer => []);
+impl TypedComponentFallbackProvider<DrawOrder> for Lines2DVisualizer {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
+        DrawOrder::DEFAULT_IMAGE
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(Lines2DVisualizer => [DrawOrder]);

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -293,7 +293,7 @@ impl VisualizerSystem for Lines2DVisualizer {
 
 impl TypedComponentFallbackProvider<DrawOrder> for Lines2DVisualizer {
     fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
-        DrawOrder::DEFAULT_IMAGE
+        DrawOrder::DEFAULT_LINES2D
     }
 }
 

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -14,7 +14,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{UiLabel, UiLabelTarget},
 };
@@ -209,7 +209,6 @@ impl VisualizerSystem for Lines2DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -13,7 +13,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{UiLabel, UiLabelTarget},
 };
@@ -217,7 +217,6 @@ impl VisualizerSystem for Lines3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -17,7 +17,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     instance_hash_conversions::picking_layer_id_from_instance_path_hash,
     mesh_cache::{AnyMesh, MeshCache, MeshCacheKey},
     view_kind::SpatialSpaceViewKind,
@@ -176,7 +176,6 @@ impl VisualizerSystem for Mesh3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -31,9 +31,10 @@ use re_types::{
     datatypes::{KeypointId, KeypointPair},
 };
 use re_viewer_context::{
-    auto_color, Annotations, ApplicableEntities, DefaultColor, ResolvedAnnotationInfos,
-    SpaceViewClassRegistryError, SpaceViewSystemExecutionError, SpaceViewSystemRegistrator,
-    VisualizableEntities, VisualizableFilterContext, VisualizerCollection,
+    auto_color, Annotations, ApplicableEntities, DefaultColor, IdentifiedViewSystem,
+    ResolvedAnnotationInfos, SpaceViewClassRegistryError, SpaceViewSystemExecutionError,
+    SpaceViewSystemRegistrator, ViewSystemIdentifier, VisualizableEntities,
+    VisualizableFilterContext, VisualizerCollection,
 };
 
 use crate::view_2d::VisualizableFilterContext2D;
@@ -91,6 +92,18 @@ pub fn register_3d_spatial_visualizers(
     system_registry.register_visualizer::<transform3d_arrows::Transform3DArrowsVisualizer>()?;
     system_registry.register_visualizer::<transform3d_arrows::Transform3DDetector>()?;
     Ok(())
+}
+
+/// List of all visualizers that read [`re_types::components::DrawOrder`].
+pub fn visualizers_processing_draw_order() -> impl Iterator<Item = ViewSystemIdentifier> {
+    [
+        arrows2d::Arrows2DVisualizer::identifier(),
+        boxes2d::Boxes2DVisualizer::identifier(),
+        images::ImageVisualizer::identifier(),
+        lines2d::Lines2DVisualizer::identifier(),
+        points2d::Points2DVisualizer::identifier(),
+    ]
+    .into_iter()
 }
 
 pub fn collect_ui_labels(visualizers: &VisualizerCollection) -> Vec<UiLabel> {

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -6,12 +6,13 @@ use re_query::range_zip_1x5;
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId, PointCloudBuilder};
 use re_types::{
     archetypes::Points2D,
-    components::{ClassId, Color, KeypointId, Position2D, Radius, Text},
+    components::{ClassId, Color, DrawOrder, KeypointId, Position2D, Radius, Text},
 };
 use re_viewer_context::{
-    ApplicableEntities, IdentifiedViewSystem, ResolvedAnnotationInfos,
-    SpaceViewSystemExecutionError, ViewContext, ViewContextCollection, ViewQuery,
-    VisualizableEntities, VisualizableFilterContext, VisualizerQueryInfo, VisualizerSystem,
+    ApplicableEntities, IdentifiedViewSystem, QueryContext, ResolvedAnnotationInfos,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext,
+    ViewContextCollection, ViewQuery, VisualizableEntities, VisualizableFilterContext,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
@@ -306,4 +307,10 @@ impl VisualizerSystem for Points2DVisualizer {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(Points2DVisualizer => []);
+impl TypedComponentFallbackProvider<DrawOrder> for Points2DVisualizer {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> DrawOrder {
+        DrawOrder::DEFAULT_POINTS2D
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(Points2DVisualizer => [DrawOrder]);

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -16,7 +16,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{
         load_keypoint_connections, process_annotation_and_keypoint_slices, process_color_slice,
@@ -227,7 +227,6 @@ impl VisualizerSystem for Points2DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -15,7 +15,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::{EntityDepthOffsets, SpatialSceneEntityContext},
+    contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
     visualizers::{
         load_keypoint_connections, process_annotation_and_keypoint_slices, process_color_slice,
@@ -217,7 +217,6 @@ impl VisualizerSystem for Points3DVisualizer {
             ctx,
             view_query,
             context_systems,
-            context_systems.get::<EntityDepthOffsets>()?.points,
             |ctx, entity_path, spatial_ctx, results| {
                 re_tracing::profile_scope!(format!("{entity_path}"));
 

--- a/crates/re_types/definitions/rerun/archetypes/arrows2d.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/arrows2d.fbs
@@ -45,8 +45,13 @@ table Arrows2D (
   /// Optional text labels for the arrows.
   labels: [rerun.components.Text] ("attr.rerun.component_optional", nullable, order: 3200);
 
+  /// An optional floating point value that specifies the 2D drawing order.
+  ///
+  /// Objects with higher values are drawn on top of those with lower values.
+  draw_order: rerun.components.DrawOrder ("attr.rerun.component_optional", nullable, order: 3300);
+
   /// Optional class Ids for the points.
   ///
   /// The class ID provides colors and labels if not specified explicitly.
-  class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3300);
+  class_ids: [rerun.components.ClassId] ("attr.rerun.component_optional", nullable, order: 3400);
 }

--- a/crates/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_system.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use ahash::HashMap;
 
 use re_types::{Archetype, ComponentName, ComponentNameSet};
@@ -135,7 +137,7 @@ pub trait VisualizerSystem: Send + Sync + ComponentFallbackProvider + 'static {
 }
 
 pub struct VisualizerCollection {
-    pub systems: HashMap<ViewSystemIdentifier, Box<dyn VisualizerSystem>>,
+    pub systems: BTreeMap<ViewSystemIdentifier, Box<dyn VisualizerSystem>>,
 }
 
 impl VisualizerCollection {

--- a/crates/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/re_viewer_context/src/space_view/visualizer_system.rs
@@ -1,7 +1,5 @@
 use std::collections::BTreeMap;
 
-use ahash::HashMap;
-
 use re_types::{Archetype, ComponentName, ComponentNameSet};
 
 use crate::{

--- a/docs/content/reference/types/archetypes/arrows2d.md
+++ b/docs/content/reference/types/archetypes/arrows2d.md
@@ -11,7 +11,7 @@ title: "Arrows2D"
 
 **Recommended**: [`Position2D`](../components/position2d.md)
 
-**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`ClassId`](../components/class_id.md)
+**Optional**: [`Radius`](../components/radius.md), [`Color`](../components/color.md), [`Text`](../components/text.md), [`DrawOrder`](../components/draw_order.md), [`ClassId`](../components/class_id.md)
 
 ## Shown in
 * [Spatial2DView](../views/spatial2d_view.md)

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -22,6 +22,7 @@ Draw order for entities with the same draw order is generally undefined.
 
 ## Used by
 
+* [`Arrows2D`](../archetypes/arrows2d.md)
 * [`Boxes2D`](../archetypes/boxes2d.md)
 * [`DepthImage`](../archetypes/depth_image.md)
 * [`Image`](../archetypes/image.md)

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<DataCell> cells;
-        cells.reserve(7);
+        cells.reserve(8);
 
         {
             auto result = DataCell::from_loggable(archetype.vectors);
@@ -38,6 +38,11 @@ namespace rerun {
         }
         if (archetype.labels.has_value()) {
             auto result = DataCell::from_loggable(archetype.labels.value());
+            RR_RETURN_NOT_OK(result.error);
+            cells.push_back(std::move(result.value));
+        }
+        if (archetype.draw_order.has_value()) {
+            auto result = DataCell::from_loggable(archetype.draw_order.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/arrows2d.hpp
@@ -7,6 +7,7 @@
 #include "../compiler_utils.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
+#include "../components/draw_order.hpp"
 #include "../components/position2d.hpp"
 #include "../components/radius.hpp"
 #include "../components/text.hpp"
@@ -66,6 +67,11 @@ namespace rerun::archetypes {
         /// Optional text labels for the arrows.
         std::optional<Collection<rerun::components::Text>> labels;
 
+        /// An optional floating point value that specifies the 2D drawing order.
+        ///
+        /// Objects with higher values are drawn on top of those with lower values.
+        std::optional<rerun::components::DrawOrder> draw_order;
+
         /// Optional class Ids for the points.
         ///
         /// The class ID provides colors and labels if not specified explicitly.
@@ -120,6 +126,15 @@ namespace rerun::archetypes {
         /// Optional text labels for the arrows.
         Arrows2D with_labels(Collection<rerun::components::Text> _labels) && {
             labels = std::move(_labels);
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        /// An optional floating point value that specifies the 2D drawing order.
+        ///
+        /// Objects with higher values are drawn on top of those with lower values.
+        Arrows2D with_draw_order(rerun::components::DrawOrder _draw_order) && {
+            draw_order = std::move(_draw_order);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d.py
@@ -62,6 +62,7 @@ class Arrows2D(Arrows2DExt, Archetype):
             radii=None,  # type: ignore[arg-type]
             colors=None,  # type: ignore[arg-type]
             labels=None,  # type: ignore[arg-type]
+            draw_order=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
         )
 
@@ -118,6 +119,17 @@ class Arrows2D(Arrows2DExt, Archetype):
         converter=components.TextBatch._optional,  # type: ignore[misc]
     )
     # Optional text labels for the arrows.
+    #
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    draw_order: components.DrawOrderBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.DrawOrderBatch._optional,  # type: ignore[misc]
+    )
+    # An optional floating point value that specifies the 2D drawing order.
+    #
+    # Objects with higher values are drawn on top of those with lower values.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What

Making `DrawOrder` editable resulting in changing the depth offset system (it has to read overrides etc.).
This in turn solved the bug of `fallback` not showing correctly for `DrawOrder` and also giving everything a draw order via the fallback system.
This + collecting visualizers into an order preserving set instead of a hashmap fixes flickering!

With all these refactors I included `Arrows2D` as well, so the only thing was left is to add a line to codegen in order to fix it seemingly not supporting draw order.

* Fixes #5549
* Fixes #6600
* Part of #6548
   * without this change set the separated image visualizers show flickering as well

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6644?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6644?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6644)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.