### PR TITLE
Reintroduce display color ui

### DIFF
--- a/crates/re_edit_ui/src/color.rs
+++ b/crates/re_edit_ui/src/color.rs
@@ -1,5 +1,9 @@
-use re_types::components::Color;
-use re_viewer_context::ViewerContext;
+use re_types::{components::Color, external::arrow2, Loggable};
+use re_ui::UiExt;
+use re_viewer_context::{
+    external::{re_data_store::LatestAtQuery, re_entity_db::EntityDb, re_log_types::EntityPath},
+    UiLayout, ViewerContext,
+};
 
 pub fn edit_color_ui(
     _ctx: &ViewerContext<'_>,
@@ -22,7 +26,47 @@ pub fn edit_color_ui(
         ui.visuals().widgets.noninteractive.fg_stroke,
     );
 
-    let [r, g, b, a] = edit_color.to_array();
+    color_hover(edit_color, response)
+}
+
+// TODO(#6661): Should be merged with above method.
+pub fn display_color_ui(
+    _ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    _layout: UiLayout,
+    _query: &LatestAtQuery,
+    _db: &EntityDb,
+    _path: &EntityPath,
+    data: &dyn arrow2::array::Array,
+) {
+    let color = match Color::from_arrow(data) {
+        Ok(color) => color.first().copied(),
+        Err(err) => {
+            ui.error_label("failed to deserialize")
+                .on_hover_text(err.to_string());
+            return;
+        }
+    };
+
+    let Some(color) = color else {
+        ui.weak("(none)");
+        return;
+    };
+
+    let [r, g, b, a] = color.0.to_array();
+    let color = egui::Color32::from_rgba_unmultiplied(r, g, b, a);
+    let response = egui::color_picker::show_color(ui, color, egui::Vec2::new(32.0, 16.0));
+    ui.painter().rect_stroke(
+        response.rect,
+        1.0,
+        ui.visuals().widgets.noninteractive.fg_stroke,
+    );
+
+    color_hover(color, response);
+}
+
+fn color_hover(color: egui::Color32, response: egui::Response) -> egui::Response {
+    let [r, g, b, a] = color.to_array();
     response.on_hover_ui(|ui| {
         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
         ui.monospace(format!("#{r:02x}{g:02x}{b:02x}{a:02x}"));

--- a/crates/re_edit_ui/src/lib.rs
+++ b/crates/re_edit_ui/src/lib.rs
@@ -18,10 +18,11 @@ use datatype_editors::{
 use re_types::{
     blueprint::components::{BackgroundKind, Corner2D, LockRangeDuringZoom, ViewFit, Visible},
     components::{
-        AggregationPolicy, AxisLength, Colormap, DepthMeter, FillRatio, GammaCorrection,
+        AggregationPolicy, AxisLength, Color, Colormap, DepthMeter, FillRatio, GammaCorrection,
         ImagePlaneDistance, MagnificationFilter, MarkerSize, Name, Opacity, Radius, StrokeWidth,
         Text,
     },
+    Loggable as _,
 };
 
 // ----
@@ -32,6 +33,8 @@ use re_types::{
 /// This crate is meant to be a leaf crate in the viewer ecosystem and should only be used by the `re_viewer` crate itself.
 pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_editor_ui(color::edit_color_ui);
+    registry.add_display_ui(Color::name(), Box::new(color::display_color_ui));
+
     registry.add_singleline_editor_ui(marker_shape::edit_marker_shape_ui);
     registry.add_singleline_editor_ui(material::edit_material_ui);
     registry.add_singleline_editor_ui(range1d::edit_range1d);


### PR DESCRIPTION
### What

<img width="341" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/267f8b80-cdf3-4792-a958-ae53c34275d8">

Reintroduce a display ui for color which was previously removed here:
https://github.com/rerun-io/rerun/pull/6645/files#diff-5426fd9a146d72f74d8f81c575b9c4fcf10098bdf08e573ed5f96eda7787110dL36

* Fixes #6658


Note that the new impl has to do its own deserialization because before we tended to implement `DataUi` for individual components. Going forward, we want to turn it around and implement a unified "componen_ui" method per component and then have a blanket `DataUi` impl for components (if needed). Details see
* #6661 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6663?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6663?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6663)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.