### PR TITLE
Add help to several sections in the Selection Panel

### DIFF
--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -45,6 +45,12 @@ pub fn view_components_defaults_section_ui(
         add_button = add_button.enabled(false).disabled_hover_text(reason);
     }
 
+    let markdown = "# Component defaults\n
+This section lists default values for components in the scope of the present view. The visualizers \
+corresponding to this view's entities use these defaults when no per-entity \
+override is specified.\n
+Click on the `+` button to add a new default value.";
+
     let body = |ui: &mut egui::Ui| {
         active_default_ui(
             ctx,
@@ -58,6 +64,7 @@ pub fn view_components_defaults_section_ui(
     };
     ui.section_collapsing_header("Component defaults")
         .button(add_button)
+        .help_markdown(markdown)
         .show(ui, body);
 }
 

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -47,7 +47,7 @@ pub fn view_components_defaults_section_ui(
 
     let markdown = "# Component defaults\n
 This section lists default values for components in the scope of the present view. The visualizers \
-corresponding to this view's entities use these defaults when no per-entity \
+corresponding to this view's entities use these defaults when no per-entity store value or \
 override is specified.\n
 Click on the `+` button to add a new default value.";
 

--- a/crates/re_selection_panel/src/defaults_ui.rs
+++ b/crates/re_selection_panel/src/defaults_ui.rs
@@ -104,7 +104,8 @@ fn active_default_ui(
                 .get_by_identifier(*visualizer_identifier)
             else {
                 re_log::warn!(
-                    "Failed to resolve visualizer identifier {visualizer_identifier}, to a visualizer implementation"
+                    "Failed to resolve visualizer identifier {visualizer_identifier}, to a \
+                    visualizer implementation"
                 );
                 continue;
             };

--- a/crates/re_selection_panel/src/selection_panel.rs
+++ b/crates/re_selection_panel/src/selection_panel.rs
@@ -319,8 +319,7 @@ impl SelectionPanel {
         view_id: &SpaceViewId,
         view_states: &mut ViewStates,
     ) {
-        fn entity_path_filter_help_ui(ui: &mut egui::Ui) {
-            let markdown = r#"
+        let markdown = r#"
 # Entity path query syntax
 
 Entity path queries are described as a list of include/exclude rules that act on paths:
@@ -355,10 +354,7 @@ The last rule matching `/world/car/hood` is `- /world/car/**`, so it is excluded
 The last rule matching `/world` is `- /world`, so it is excluded.
 The last rule matching `/world/house` is `+ /world/**`, so it is included.
     "#
-            .trim();
-
-            ui.markdown_ui(egui::Id::new("entity_path_filter_help_ui"), markdown);
-        }
+        .trim();
 
         clone_space_view_button_ui(ctx, ui, blueprint, *view_id);
 
@@ -370,7 +366,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
                     })
                     .hover_text("Modify the entity query using the editor"),
                 )
-                .help_ui(entity_path_filter_help_ui)
+                .help_markdown(markdown)
                 .show(ui, |ui| {
                     // TODO(#6075): Because `list_item_scope` changes it. Temporary until everything is `ListItem`.
                     ui.spacing_mut().item_spacing.y = ui.ctx().style().spacing.item_spacing.y;

--- a/crates/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/re_selection_panel/src/visible_time_range_ui.rs
@@ -176,27 +176,18 @@ fn query_range_ui(
     let time_type = time_ctrl.timeline().typ();
 
     let mut interacting_with_controls = false;
-    let markdown = format!(
-        "# Visible time range\n
+    let markdown = "# Visible time range\n
 This feature controls the time range used to display data in the space view.
 
-The settings are inherited from the parent entity or enclosing space view if not overridden.
-
-Visible time range properties are stored separately for each _type_ of timelines. They may differ \
-depending on whether the current timeline is temporal or a sequence. The current settings apply to \
-all _{}_ timelines.
-
-Notes that the data current as of the time range starting time is included.",
-        match time_type {
-            TimeType::Time => "temporal",
-            TimeType::Sequence => "sequence",
-        }
-    );
+Notes:
+- The settings are inherited from the parent entity or enclosing space view if not overridden.
+- Visible time range properties are stored on a per-timeline basis.
+- The data current as of the time range starting time is included.";
 
     let collapsing_response = ui
         .section_collapsing_header("Visible time range")
         .default_open(false)
-        .help_markdown(&markdown)
+        .help_markdown(markdown)
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.re_radio_value(has_individual_time_range, false, "Default")

--- a/crates/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/re_selection_panel/src/visible_time_range_ui.rs
@@ -149,7 +149,10 @@ fn save_visible_time_ranges(
         let time_range = match query_range {
             QueryRange::TimeRange(time_range) => time_range,
             QueryRange::LatestAt => {
-                re_log::error!("Latest-at queries can't be used as an override yet. They can only come from defaults.");
+                re_log::error!(
+                    "Latest-at queries can't be used as an override yet. They can only \
+                come from defaults."
+                );
                 return;
             }
         };
@@ -173,10 +176,27 @@ fn query_range_ui(
     let time_type = time_ctrl.timeline().typ();
 
     let mut interacting_with_controls = false;
+    let markdown = format!(
+        "# Visible time range\n
+This feature controls the time range used to display data in the space view.
+
+The settings are inherited from the parent entity or enclosing space view if not overridden.
+
+Visible time range properties are stored separately for each _type_ of timelines. They may differ \
+depending on whether the current timeline is temporal or a sequence. The current settings apply to \
+all _{}_ timelines.
+
+Notes that the data current as of the time range starting time is included.",
+        match time_type {
+            TimeType::Time => "temporal",
+            TimeType::Sequence => "sequence",
+        }
+    );
 
     let collapsing_response = ui
         .section_collapsing_header("Visible time range")
         .default_open(false)
+        .help_markdown(&markdown)
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.re_radio_value(has_individual_time_range, false, "Default")
@@ -264,25 +284,6 @@ fn query_range_ui(
             }
         }
     }
-
-    let markdown = format!("# Visible time range\n
-This feature controls the time range used to display data in the space view.
-
-The settings are inherited from the parent entity or enclosing space view if not overridden.
-
-Visible time range properties are stored separately for each _type_ of timelines. They may differ depending on \
-whether the current timeline is temporal or a sequence. The current settings apply to all _{}_ timelines.
-
-Notes that the data current as of the time range starting time is included.",
-        match time_type {
-            TimeType::Time => "temporal",
-            TimeType::Sequence => "sequence",
-        }
-    );
-
-    collapsing_response.header_response.on_hover_ui(|ui| {
-        ui.markdown_ui(egui::Id::new(markdown.as_str()), &markdown);
-    });
 }
 
 fn time_range_editor(

--- a/crates/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/re_selection_panel/src/visualizer_ui.rs
@@ -50,8 +50,27 @@ pub fn visualizer_ui(
     .hover_text("Add additional visualizers")
     .disabled_hover_text("No additional visualizers available");
 
+    let markdown = "# Visualizers
+
+This section lists the active visualizers for the selected entity. Visualizers use an entity's \
+components to display it in the current view.
+
+Each visualizer lists the components it uses and their values. The component values may come from \
+a variety of sources and can be overridden in place.
+
+The final component value is determined using the following priority order:
+- **Override**: A value set from the UI and/or the blueprint. It has the highest precedence and is \
+always used if set.
+- **Store**: If any, the value logged to the data store for this entity, e.g. via the SDK's `log` \
+function.
+- **Default**: If set, the default value for this component in the current view, which can be set \
+in the blueprint or in the UI by selecting the view.
+- **Fallback**: A context-sensitive value that is used if no other value is available. It is \
+specific to the visualizer and the current view type.";
+
     ui.section_collapsing_header("Visualizers")
         .button(button)
+        .help_markdown(markdown)
         .show(ui, |ui| {
             visualizer_ui_impl(ctx, ui, &data_result, &active_visualizers);
         });

--- a/crates/re_ui/src/section_collapsing_header.rs
+++ b/crates/re_ui/src/section_collapsing_header.rs
@@ -49,7 +49,18 @@ impl<'a> SectionCollapsingHeader<'a> {
         self
     }
 
+    /// Set the help markdown tooltip to be shown in the header.
+    //TODO(#6191): the help button should be just another `impl ItemButton`.
+    #[inline]
+    pub fn help_markdown(mut self, help: &'a str) -> Self {
+        self.help = Some(Box::new(move |ui| {
+            ui.markdown_ui(egui::Id::new(help), help);
+        }));
+        self
+    }
+
     /// Set the help UI closure to be shown in the header.
+    //TODO(#6191): the help button should be just another `impl ItemButton`.
     #[inline]
     pub fn help_ui(mut self, help: impl FnOnce(&mut egui::Ui) + 'a) -> Self {
         self.help = Some(Box::new(help));


### PR DESCRIPTION
### What

- Part of #6655 

Adds a bunch of help buttons to various sections in the selection panel, in particular for component default and visualisers.


<img width="308" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/c5107e00-68a0-465e-ab46-dafd94218784">
<img width="732" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e6d85997-d83d-4c2e-80ca-834608aeffea">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6668?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6668?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6668)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.