### PR TITLE
Use new query result hash to fix mesh cache keying

### DIFF
--- a/crates/re_query/src/range/results.rs
+++ b/crates/re_query/src/range/results.rs
@@ -870,4 +870,9 @@ impl RangeComponentResultsInner {
     pub fn clear(&mut self) {
         *self = Self::empty();
     }
+
+    #[inline]
+    pub fn indices(&self) -> impl Iterator<Item = &(TimeInt, RowId)> {
+        self.indices.iter()
+    }
 }

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -1,5 +1,5 @@
 use re_data_store::{LatestAtQuery, RangeQuery};
-use re_log_types::{external::arrow2, RowId, TimeInt};
+use re_log_types::{external::arrow2, hash::Hash64, RowId, TimeInt};
 use re_query::{
     LatestAtComponentResults, LatestAtResults, PromiseResolver, PromiseResult, RangeData,
     RangeResults, Results,
@@ -152,6 +152,43 @@ impl<'a> HybridLatestAtResults<'a> {
 pub enum HybridResults<'a> {
     LatestAt(LatestAtQuery, HybridLatestAtResults<'a>),
     Range(RangeQuery, HybridRangeResults),
+}
+
+impl<'a> HybridResults<'a> {
+    pub fn query_result_hash(&self) -> Hash64 {
+        re_tracing::profile_function!();
+        // TODO(andreas/jleibs/teh): We should be able to do better than this and determine hashes for queries on the fly.
+
+        match self {
+            Self::LatestAt(_, r) => {
+                let mut indices = Vec::with_capacity(
+                    r.defaults.components.len()
+                        + r.overrides.components.len()
+                        + r.results.components.len(),
+                );
+                indices.extend(r.defaults.components.values().map(|r| *r.index()));
+                indices.extend(r.overrides.components.values().map(|r| *r.index()));
+                indices.extend(r.results.components.values().map(|r| *r.index()));
+
+                Hash64::hash(&indices)
+            }
+            Self::Range(_, r) => {
+                let mut indices = Vec::with_capacity(
+                    r.defaults.components.len()
+                        + r.overrides.components.len()
+                        + r.results.components.len(), // Don't know how many results per component.
+                );
+                indices.extend(r.defaults.components.values().map(|r| *r.index()));
+                indices.extend(r.overrides.components.values().map(|r| *r.index()));
+                indices.extend(r.results.components.values().flat_map(|r| {
+                    // Have top collect in order to release the lock.
+                    r.read().indices().copied().collect::<Vec<_>>()
+                }));
+
+                Hash64::hash(&indices)
+            }
+        }
+    }
 }
 
 impl<'a> From<(LatestAtQuery, HybridLatestAtResults<'a>)> for HybridResults<'a> {

--- a/crates/re_space_view_spatial/src/mesh_cache.rs
+++ b/crates/re_space_view_spatial/src/mesh_cache.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use re_entity_db::VersionedInstancePathHash;
+use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
 use re_types::components::MediaType;
 use re_viewer_context::Cache;
@@ -12,11 +13,11 @@ use crate::mesh_loader::LoadedMesh;
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct MeshCacheKey {
     pub versioned_instance_path_hash: VersionedInstancePathHash,
+    pub query_result_hash: Hash64,
     pub media_type: Option<MediaType>,
 }
 
-/// Caches meshes based on their [`VersionedInstancePathHash`], i.e. a specific instance of a specific
-/// entity path for a specific row in the store.
+/// Caches meshes based on their [`MeshCacheKey`].
 #[derive(Default)]
 pub struct MeshCache(ahash::HashMap<MeshCacheKey, Option<Arc<LoadedMesh>>>);
 

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -1,5 +1,5 @@
 use re_entity_db::EntityPath;
-use re_log_types::{Instance, RowId, TimeInt};
+use re_log_types::{hash::Hash64, Instance, RowId, TimeInt};
 use re_query::range_zip_1x2;
 use re_renderer::renderer::MeshInstance;
 use re_renderer::RenderContext;
@@ -72,6 +72,7 @@ impl Asset3DVisualizer {
                     MeshCacheKey {
                         versioned_instance_path_hash: picking_instance_hash
                             .versioned(primary_row_id),
+                        query_result_hash: Hash64::ZERO,
                         media_type: data.media_type.cloned(),
                     },
                     AnyMesh::Asset(&mesh),


### PR DESCRIPTION
### What

* Fixes #6624

<img width="2406" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/60a5b8ec-9ffb-4115-9b5a-7fe6aa967c3b">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
