### PR TITLE
Update to latest `egui` master, with fixes for notebook focus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ahash",
  "egui",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ahash",
  "egui",
@@ -1752,7 +1752,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=fee6719f99d002ba16211c01f944b9216d228a18#fee6719f99d002ba16211c01f944b9216d228a18"
+source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ahash",
  "egui",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ahash",
  "egui",
@@ -1752,7 +1752,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=65326c2#65326c23e668af3cf63bdedd8bd6cf10ee907fed"
+source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,13 +481,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }      # egui master 2024-06-26
-eframe = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }      # egui master 2024-06-26
-egui = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }        # egui master 2024-06-26
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" } # egui master 2024-06-26
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }   # egui master 2024-06-26
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }   # egui master 2024-06-26
-emath = { git = "https://github.com/emilk/egui.git", rev = "fee6719f99d002ba16211c01f944b9216d228a18" }       # egui master 2024-06-26
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }      # egui master 2024-06-26
+eframe = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }      # egui master 2024-06-26
+egui = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }        # egui master 2024-06-26
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "65326c2" } # egui master 2024-06-26
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }   # egui master 2024-06-26
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }   # egui master 2024-06-26
+emath = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }       # egui master 2024-06-26
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,13 +481,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }      # egui master 2024-06-26
-eframe = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }      # egui master 2024-06-26
-egui = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }        # egui master 2024-06-26
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "65326c2" } # egui master 2024-06-26
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }   # egui master 2024-06-26
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }   # egui master 2024-06-26
-emath = { git = "https://github.com/emilk/egui.git", rev = "65326c2" }       # egui master 2024-06-26
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }      # egui master 2024-06-28
+eframe = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }      # egui master 2024-06-28
+egui = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }        # egui master 2024-06-28
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" } # egui master 2024-06-28
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }   # egui master 2024-06-28
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }   # egui master 2024-06-28
+emath = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }       # egui master 2024-06-28
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -87,6 +87,8 @@ class ViewerWidget {
       canvas.style.minHeight = "";
       canvas.style.maxHeight = "";
     }
+
+    canvas.tabIndex = 0;
   };
 
   on_change_url = (_: unknown, new_url?: Opt<string>) => {

--- a/rerun_notebook/src/js/widget.ts
+++ b/rerun_notebook/src/js/widget.ts
@@ -87,8 +87,6 @@ class ViewerWidget {
       canvas.style.minHeight = "";
       canvas.style.maxHeight = "";
     }
-
-    canvas.tabIndex = 0;
   };
 
   on_change_url = (_: unknown, new_url?: Opt<string>) => {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6638
* Uses https://github.com/emilk/egui/pull/4718

Instructions:
```
pixi run -e examples py-build-notebook
pixi run -e examples jupyter notebook examples/python/notebook/cube.ipynb
```
Run the first few 3 cells.

### Known issues:
 - Hitting 'a' when the viewer selected still bypasses Rerun and adds a new preceding cell in the notebook. This is because of how Jupyter Notebook Classic does things.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6674?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6674?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6674)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.