### PR TITLE
Use new `.clamp_to_range(false)` to make sure drag value inputs are not changed by looking at them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ahash",
  "egui",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ahash",
  "egui",
@@ -1752,7 +1752,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=3b9f964aed36bc0028fa55c60cd0a1cd0179a13e#3b9f964aed36bc0028fa55c60cd0a1cd0179a13e"
+source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,7 +1553,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1563,7 +1563,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1599,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1616,7 +1616,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1635,7 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ahash",
  "egui",
@@ -1691,7 +1691,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1709,7 +1709,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ahash",
  "egui",
@@ -1752,7 +1752,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.27.2"
-source = "git+https://github.com/emilk/egui.git?rev=10f092d9d4fefdb5c6340ebc6a8ac76a4302afda#10f092d9d4fefdb5c6340ebc6a8ac76a4302afda"
+source = "git+https://github.com/emilk/egui.git?rev=d4e8966aac9347965f8d02310ecf2c9f23bb9bbc#d4e8966aac9347965f8d02310ecf2c9f23bb9bbc"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,13 +481,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }      # egui master 2024-06-28
-eframe = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }      # egui master 2024-06-28
-egui = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }        # egui master 2024-06-28
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" } # egui master 2024-06-28
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }   # egui master 2024-06-28
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }   # egui master 2024-06-28
-emath = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }       # egui master 2024-06-28
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }      # egui master 2024-06-28
+eframe = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }      # egui master 2024-06-28
+egui = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }        # egui master 2024-06-28
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" } # egui master 2024-06-28
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }   # egui master 2024-06-28
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }   # egui master 2024-06-28
+emath = { git = "https://github.com/emilk/egui.git", rev = "d4e8966aac9347965f8d02310ecf2c9f23bb9bbc" }       # egui master 2024-06-28
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -481,13 +481,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }      # egui master 2024-06-28
-eframe = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }      # egui master 2024-06-28
-egui = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }        # egui master 2024-06-28
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" } # egui master 2024-06-28
-egui_plot = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }   # egui master 2024-06-28
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }   # egui master 2024-06-28
-emath = { git = "https://github.com/emilk/egui.git", rev = "3b9f964aed36bc0028fa55c60cd0a1cd0179a13e" }       # egui master 2024-06-28
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }      # egui master 2024-06-28
+eframe = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }      # egui master 2024-06-28
+egui = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }        # egui master 2024-06-28
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" } # egui master 2024-06-28
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }   # egui master 2024-06-28
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }   # egui master 2024-06-28
+emath = { git = "https://github.com/emilk/egui.git", rev = "10f092d9d4fefdb5c6340ebc6a8ac76a4302afda" }       # egui master 2024-06-28
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_edit_ui/src/datatype_editors/float_drag.rs
+++ b/crates/re_edit_ui/src/datatype_editors/float_drag.rs
@@ -39,7 +39,8 @@ fn edit_f32_float_raw_impl(
     let speed = (*value * 0.01).at_least(0.001);
     ui.add(
         egui::DragValue::new(value)
-            .clamp_range(range) // TODO(#6633): Don't change incoming values
+            .clamp_to_range(false)
+            .range(range)
             .speed(speed),
     )
 }
@@ -55,12 +56,10 @@ pub fn edit_f32_zero_to_one(
 
 /// Non monomorphized implementation of [`edit_f32_zero_to_one`].
 fn edit_f32_zero_to_one_raw(ui: &mut egui::Ui, value: &mut f32) -> egui::Response {
-    // TODO(#6633): Pre-clamp the value, so the ui won't change the value if there's no interaction.
-    // This means we won't see the real value in the ui if it's outside the range.
-    *value = value.clamp(0.0, 1.0);
     ui.add(
         egui::DragValue::new(value)
-            .clamp_range(0.0..=1.0)
+            .clamp_to_range(false)
+            .range(0.0..=1.0)
             .speed(0.005)
             .fixed_decimals(2),
     )

--- a/crates/re_edit_ui/src/range1d.rs
+++ b/crates/re_edit_ui/src/range1d.rs
@@ -14,13 +14,15 @@ pub fn edit_range1d(
     ui.label("Min:");
     let response_min = ui.add(
         egui::DragValue::new(min)
-            .clamp_range(f64::NEG_INFINITY..=*max)
+            .clamp_to_range(false)
+            .range(f64::NEG_INFINITY..=*max)
             .speed(speed),
     );
     ui.label("Max:");
     let response_max = ui.add(
         egui::DragValue::new(max)
-            .clamp_range(*min..=f64::INFINITY)
+            .clamp_to_range(false)
+            .range(*min..=f64::INFINITY)
             .speed(speed),
     );
 

--- a/crates/re_edit_ui/src/visual_bounds2d.rs
+++ b/crates/re_edit_ui/src/visual_bounds2d.rs
@@ -22,7 +22,8 @@ pub fn multiline_edit_visual_bounds2d(
                 .horizontal_centered(|ui| {
                     let response_min = ui.add(
                         egui::DragValue::new(x_range_start)
-                            .clamp_range(f64::MIN..=*x_range_end)
+                            .clamp_to_range(false)
+                            .range(f64::MIN..=*x_range_end)
                             .max_decimals(2)
                             .speed(speed),
                     );
@@ -31,7 +32,8 @@ pub fn multiline_edit_visual_bounds2d(
 
                     let response_max = ui.add(
                         egui::DragValue::new(x_range_end)
-                            .clamp_range(*x_range_start..=f64::MAX)
+                            .clamp_to_range(false)
+                            .range(*x_range_start..=f64::MAX)
                             .max_decimals(2)
                             .speed(speed),
                     );
@@ -55,7 +57,8 @@ pub fn multiline_edit_visual_bounds2d(
                 .horizontal_centered(|ui| {
                     let response_min = ui.add(
                         egui::DragValue::new(y_range_start)
-                            .clamp_range(f64::MIN..=*y_range_end)
+                            .clamp_to_range(false)
+                            .range(f64::MIN..=*y_range_end)
                             .max_decimals(2)
                             .speed(speed),
                     );
@@ -64,7 +67,8 @@ pub fn multiline_edit_visual_bounds2d(
 
                     let response_max = ui.add(
                         egui::DragValue::new(y_range_end)
-                            .clamp_range(*y_range_start..=f64::MAX)
+                            .clamp_to_range(false)
+                            .range(*y_range_start..=f64::MAX)
                             .max_decimals(2)
                             .speed(speed),
                     );
@@ -102,14 +106,16 @@ pub fn singleline_edit_visual_bounds2d(
 
     let response_width = ui.add(
         egui::DragValue::new(&mut width_edit)
-            .clamp_range(0.001..=f64::MAX)
+            .clamp_to_range(false)
+            .range(0.001..=f64::MAX)
             .max_decimals(1)
             .speed(speed_func(width)),
     );
     ui.label("×");
     let response_height = ui.add(
         egui::DragValue::new(&mut height_edit)
-            .clamp_range(0.001..=f64::MAX)
+            .clamp_to_range(false)
+            .range(0.001..=f64::MAX)
             .max_decimals(1)
             .speed(speed_func(height)),
     );

--- a/crates/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/re_selection_panel/src/visible_time_range_ui.rs
@@ -697,7 +697,7 @@ impl TimelineSpec {
 
         ui.add(
             egui::DragValue::new(&mut value.0)
-                .clamp_range(time_range)
+                .range(time_range)
                 .speed(speed),
         )
     }
@@ -757,7 +757,7 @@ impl TimelineSpec {
 
         let drag_value_response = ui.add(
             egui::DragValue::new(&mut time_unit)
-                .clamp_range(time_range)
+                .range(time_range)
                 .speed(speed)
                 .suffix(self.unit_symbol),
         );

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -266,7 +266,7 @@ fn size_ui(
             .add(
                 egui::DragValue::new(&mut displayed_size)
                     .speed(drag_speed)
-                    .clamp_range(clamp_range)
+                    .range(clamp_range)
                     .max_decimals(4),
             )
             .changed()

--- a/crates/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/re_space_view_tensor/src/space_view_class.rs
@@ -633,7 +633,7 @@ fn selectors_ui(
             if ui
                 .add(
                     egui::DragValue::new(selector_value)
-                        .clamp_range(0..=size - 1)
+                        .range(0..=size - 1)
                         .speed(0.5),
                 )
                 .on_hover_text(format!(

--- a/crates/re_time_panel/src/time_control_ui.rs
+++ b/crates/re_time_panel/src/time_control_ui.rs
@@ -54,7 +54,7 @@ impl TimeControlUi {
                         egui::DragValue::new(&mut fps)
                             .suffix(" FPS")
                             .speed(1)
-                            .clamp_range(0.0..=f32::INFINITY),
+                            .range(0.0..=f32::INFINITY),
                     )
                     .on_hover_text("Frames per second");
                 });


### PR DESCRIPTION
### What

* Fixes #6633
* Depends on https://github.com/emilk/egui/pull/4728

https://github.com/rerun-io/rerun/assets/1220815/7b1d06aa-9235-4545-b3d8-ae4ead26d4f5


Undraft condition:
* [x] land egui pr and point to master branch here instead

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6677?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6677?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6677)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.