### PR TITLE
Use text-less checkbox instead of toggle

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/bool_toggle.rs
+++ b/crates/re_edit_ui/src/datatype_editors/bool_toggle.rs
@@ -20,11 +20,5 @@ pub fn edit_bool_raw(
 
 /// Non monomorphized implementation of [`edit_bool`].
 fn edit_bool_impl(ui: &mut egui::Ui, value: &mut bool) -> egui::Response {
-    ui.scope(move |ui| {
-        // ui.visuals_mut().widgets.hovered.expansion = 0.0;
-        // ui.visuals_mut().widgets.active.expansion = 0.0;
-        // ui.toggle_switch(15.0, value)
-        ui.re_checkbox(value, "")
-    })
-    .inner
+    ui.scope(move |ui| ui.re_checkbox(value, "")).inner
 }

--- a/crates/re_edit_ui/src/datatype_editors/bool_toggle.rs
+++ b/crates/re_edit_ui/src/datatype_editors/bool_toggle.rs
@@ -21,9 +21,10 @@ pub fn edit_bool_raw(
 /// Non monomorphized implementation of [`edit_bool`].
 fn edit_bool_impl(ui: &mut egui::Ui, value: &mut bool) -> egui::Response {
     ui.scope(move |ui| {
-        ui.visuals_mut().widgets.hovered.expansion = 0.0;
-        ui.visuals_mut().widgets.active.expansion = 0.0;
-        ui.toggle_switch(15.0, value)
+        // ui.visuals_mut().widgets.hovered.expansion = 0.0;
+        // ui.visuals_mut().widgets.active.expansion = 0.0;
+        // ui.toggle_switch(15.0, value)
+        ui.re_checkbox(value, "")
     })
     .inner
 }

--- a/crates/re_ui/src/list_item/property_content.rs
+++ b/crates/re_ui/src/list_item/property_content.rs
@@ -153,7 +153,7 @@ impl<'a> PropertyContent<'a> {
     #[inline]
     pub fn value_bool(self, mut b: bool) -> Self {
         self.value_fn(move |ui: &mut Ui, _| {
-            ui.add_enabled_ui(false, |ui| ui.toggle_switch(15.0, &mut b));
+            ui.add_enabled_ui(false, |ui| ui.re_checkbox(&mut b, ""));
         })
     }
 
@@ -161,10 +161,11 @@ impl<'a> PropertyContent<'a> {
     #[inline]
     pub fn value_bool_mut(self, b: &'a mut bool) -> Self {
         self.value_fn(|ui: &mut Ui, _| {
-            ui.visuals_mut().widgets.hovered.expansion = 0.0;
-            ui.visuals_mut().widgets.active.expansion = 0.0;
-
-            ui.toggle_switch(15.0, b);
+            // ui.visuals_mut().widgets.hovered.expansion = 0.0;
+            // ui.visuals_mut().widgets.active.expansion = 0.0;
+            //
+            // ui.toggle_switch(15.0, b);
+            ui.re_checkbox(b, "");
         })
     }
 

--- a/crates/re_ui/src/list_item/property_content.rs
+++ b/crates/re_ui/src/list_item/property_content.rs
@@ -161,10 +161,6 @@ impl<'a> PropertyContent<'a> {
     #[inline]
     pub fn value_bool_mut(self, b: &'a mut bool) -> Self {
         self.value_fn(|ui: &mut Ui, _| {
-            // ui.visuals_mut().widgets.hovered.expansion = 0.0;
-            // ui.visuals_mut().widgets.active.expansion = 0.0;
-            //
-            // ui.toggle_switch(15.0, b);
             ui.re_checkbox(b, "");
         })
     }


### PR DESCRIPTION
### What

Maybe the best way to improve the toggle button is to remove it entirely and use a regular checkbox for that.

![image](https://github.com/rerun-io/rerun/assets/49431240/71830012-5d82-4bac-bf85-37871cfbf9e6)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6691?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6691?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6691)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.