### PR TITLE
Show batches of default components correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5281,6 +5281,7 @@ dependencies = [
  "re_data_source",
  "re_data_store",
  "re_entity_db",
+ "re_format",
  "re_log",
  "re_log_types",
  "re_query",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5281,6 +5281,7 @@ dependencies = [
  "re_data_source",
  "re_data_store",
  "re_entity_db",
+ "re_error",
  "re_format",
  "re_log",
  "re_log_types",

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 re_data_source.workspace = true
 re_data_store.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
+re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true

--- a/crates/re_viewer_context/Cargo.toml
+++ b/crates/re_viewer_context/Cargo.toml
@@ -22,6 +22,7 @@ all-features = true
 re_data_source.workspace = true
 re_data_store.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
+re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_query.workspace = true


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/6565

This blueprint:
```
blueprint = Blueprint(
        Spatial2DView(
            origin="/",
            defaults=[
                rr.components.ColorBatch([0xFF9001FF, 0xFFFFFFFF]),
                rr.components.Radius(2),
            ], 
        ),
)
```
Shows now these defaults:
![image](https://github.com/rerun-io/rerun/assets/1220815/d736d309-d650-41c6-a457-1ab4f9b9cfeb)

Tried to unify handling of single/many components a bit. A lot of it depends on `DataUi` today, but we should move more towards having this small detail directly on component ui. More to be done here in the future

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6692?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6692?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6692)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.