### PR TITLE
Fix `HybridLatestAtResults` not using defaults correctly/surprisingly, clarify ResultExt method intention

### DIFF
--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -187,11 +187,18 @@ impl<'a> From<(RangeQuery, HybridRangeResults)> for HybridResults<'a> {
 /// Also turns all results into range results, so that views only have to worry about the ranged
 /// case.
 pub trait RangeResultsExt {
-    fn get_dense<'a, C: Component>(
+    /// Returns dense component data for the given component, ignores default data if the result distinguishes them.
+    ///
+    /// For results that are aware of the blueprint, only overrides & store results will be considered.
+    /// Defaults have no effect.
+    fn get_required_component_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'a, C>>>;
 
+    /// Returns dense component data for the given component or an empty array.
+    ///
+    /// For results that are aware of the blueprint, overrides, store results, and defaults will be considered.
     fn get_or_empty_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
@@ -199,13 +206,13 @@ pub trait RangeResultsExt {
 }
 
 impl RangeResultsExt for Results {
-    fn get_dense<'a, C: Component>(
+    fn get_required_component_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'a, C>>> {
         match self {
-            Self::LatestAt(_, results) => results.get_dense(resolver),
-            Self::Range(_, results) => results.get_dense(resolver),
+            Self::LatestAt(_, results) => results.get_required_component_dense(resolver),
+            Self::Range(_, results) => results.get_required_component_dense(resolver),
         }
     }
 
@@ -222,7 +229,7 @@ impl RangeResultsExt for Results {
 
 impl RangeResultsExt for RangeResults {
     #[inline]
-    fn get_dense<'a, C: Component>(
+    fn get_required_component_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'a, C>>> {
@@ -266,7 +273,7 @@ impl RangeResultsExt for RangeResults {
 
 impl RangeResultsExt for LatestAtResults {
     #[inline]
-    fn get_dense<'a, C: Component>(
+    fn get_required_component_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'a, C>>> {
@@ -318,7 +325,7 @@ impl RangeResultsExt for LatestAtResults {
 
 impl RangeResultsExt for HybridRangeResults {
     #[inline]
-    fn get_dense<'a, C: Component>(
+    fn get_required_component_dense<'a, C: Component>(
         &'a self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'a, C>>> {
@@ -347,7 +354,7 @@ impl RangeResultsExt for HybridRangeResults {
 
             Some(Ok(data))
         } else {
-            self.results.get_dense(resolver)
+            self.results.get_required_component_dense(resolver)
         }
     }
 
@@ -411,7 +418,7 @@ impl RangeResultsExt for HybridRangeResults {
 
 impl<'a> RangeResultsExt for HybridLatestAtResults<'a> {
     #[inline]
-    fn get_dense<'b, C: Component>(
+    fn get_required_component_dense<'b, C: Component>(
         &'b self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'b, C>>> {
@@ -440,7 +447,7 @@ impl<'a> RangeResultsExt for HybridLatestAtResults<'a> {
 
             Some(Ok(data))
         } else {
-            self.results.get_dense(resolver)
+            self.results.get_required_component_dense(resolver)
         }
     }
 
@@ -504,13 +511,13 @@ impl<'a> RangeResultsExt for HybridLatestAtResults<'a> {
 }
 
 impl<'a> RangeResultsExt for HybridResults<'a> {
-    fn get_dense<'b, C: Component>(
+    fn get_required_component_dense<'b, C: Component>(
         &'b self,
         resolver: &PromiseResolver,
     ) -> Option<re_query::Result<RangeData<'b, C>>> {
         match self {
-            Self::LatestAt(_, results) => results.get_dense(resolver),
-            Self::Range(_, results) => results.get_dense(resolver),
+            Self::LatestAt(_, results) => results.get_required_component_dense(resolver),
+            Self::Range(_, results) => results.get_required_component_dense(resolver),
         }
     }
 

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -86,7 +86,7 @@ impl<'a> HybridLatestAtResults<'a> {
 
     /// Utility for retrieving a single instance of a component.
     ///
-    /// If overrides or defaults are present, they will only be used respectively if they have the queried index.
+    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
     pub fn get_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
         let component_name = T::name();
@@ -109,7 +109,7 @@ impl<'a> HybridLatestAtResults<'a> {
 
     /// Utility for retrieving a single instance of a component.
     ///
-    /// If overrides or defaults are present, they will only be used respectively if they have the queried index.
+    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
     pub fn get_instance_with_fallback<T: re_types_core::Component + Default>(
         &self,

--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -231,7 +231,7 @@ impl VisualizerSystem for Arrows2DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let vectors = match results.get_dense::<Vector2D>(resolver) {
+                let vectors = match results.get_required_component_dense::<Vector2D>(resolver) {
                     Some(vectors) => vectors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -233,7 +233,7 @@ impl VisualizerSystem for Arrows3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let vectors = match results.get_dense::<Vector3D>(resolver) {
+                let vectors = match results.get_required_component_dense::<Vector3D>(resolver) {
                     Some(vectors) => vectors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -153,7 +153,7 @@ impl VisualizerSystem for Asset3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let blobs = match results.get_dense::<Blob>(resolver) {
+                let blobs = match results.get_required_component_dense::<Blob>(resolver) {
                     Some(blobs) => blobs?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -227,7 +227,8 @@ impl VisualizerSystem for Boxes2DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let half_sizes = match results.get_dense::<HalfSizes2D>(resolver) {
+                let half_sizes = match results.get_required_component_dense::<HalfSizes2D>(resolver)
+                {
                     Some(vectors) => vectors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -217,7 +217,7 @@ impl VisualizerSystem for Boxes3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let half_sizes = match results.get_dense::<HalfSizes3D>(resolver) {
+                let half_sizes = match results.get_required_component_dense::<HalfSizes3D>(resolver) {
                     Some(vectors) => vectors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -217,7 +217,8 @@ impl VisualizerSystem for Boxes3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let half_sizes = match results.get_required_component_dense::<HalfSizes3D>(resolver) {
+                let half_sizes = match results.get_required_component_dense::<HalfSizes3D>(resolver)
+                {
                     Some(vectors) => vectors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -310,7 +310,7 @@ impl VisualizerSystem for DepthImageVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let tensors = match results.get_dense::<TensorData>(resolver) {
+                let tensors = match results.get_required_component_dense::<TensorData>(resolver) {
                     Some(tensors) => tensors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/images.rs
@@ -101,7 +101,7 @@ impl VisualizerSystem for ImageVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let tensors = match results.get_dense::<TensorData>(resolver) {
+                let tensors = match results.get_required_component_dense::<TensorData>(resolver) {
                     Some(tensors) => tensors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -216,7 +216,7 @@ impl VisualizerSystem for Lines2DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let strips = match results.get_dense::<LineStrip2D>(resolver) {
+                let strips = match results.get_required_component_dense::<LineStrip2D>(resolver) {
                     Some(strips) => strips?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -224,7 +224,7 @@ impl VisualizerSystem for Lines3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let strips = match results.get_dense::<LineStrip3D>(resolver) {
+                let strips = match results.get_required_component_dense::<LineStrip3D>(resolver) {
                     Some(strips) => strips?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -185,7 +185,7 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let vertex_positions = match results.get_dense::<Position3D>(resolver) {
+                let vertex_positions = match results.get_required_component_dense::<Position3D>(resolver) {
                     Some(positions) => positions?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/re_space_view_spatial/src/visualizers/meshes.rs
@@ -185,10 +185,11 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let vertex_positions = match results.get_required_component_dense::<Position3D>(resolver) {
-                    Some(positions) => positions?,
-                    _ => return Ok(()),
-                };
+                let vertex_positions =
+                    match results.get_required_component_dense::<Position3D>(resolver) {
+                        Some(positions) => positions?,
+                        _ => return Ok(()),
+                    };
 
                 let vertex_normals = results.get_or_empty_dense(resolver)?;
                 let vertex_colors = results.get_or_empty_dense(resolver)?;

--- a/crates/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points2d.rs
@@ -234,7 +234,7 @@ impl VisualizerSystem for Points2DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let positions = match results.get_dense::<Position2D>(resolver) {
+                let positions = match results.get_required_component_dense::<Position2D>(resolver) {
                     Some(positions) => positions?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/points3d.rs
@@ -224,7 +224,7 @@ impl VisualizerSystem for Points3DVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let positions = match results.get_dense::<Position3D>(resolver) {
+                let positions = match results.get_required_component_dense::<Position3D>(resolver) {
                     Some(positions) => positions?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/re_space_view_spatial/src/visualizers/segmentation_images.rs
@@ -101,7 +101,7 @@ impl VisualizerSystem for SegmentationImageVisualizer {
 
                 let resolver = ctx.recording().resolver();
 
-                let tensors = match results.get_dense::<TensorData>(resolver) {
+                let tensors = match results.get_required_component_dense::<TensorData>(resolver) {
                     Some(tensors) => tensors?,
                     _ => return Ok(()),
                 };

--- a/crates/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/line_visualizer_system.rs
@@ -206,7 +206,7 @@ impl SeriesLineSystem {
             );
 
             // If we have no scalars, we can't do anything.
-            let Some(all_scalars) = results.get_dense::<Scalar>(resolver) else {
+            let Some(all_scalars) = results.get_required_component_dense::<Scalar>(resolver) else {
                 return Ok(());
             };
 

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -167,7 +167,8 @@ impl SeriesPointSystem {
                 );
 
                 // If we have no scalars, we can't do anything.
-                let Some(all_scalars) = results.get_required_component_dense::<Scalar>(resolver) else {
+                let Some(all_scalars) = results.get_required_component_dense::<Scalar>(resolver)
+                else {
                     return Ok(());
                 };
 

--- a/crates/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/re_space_view_time_series/src/point_visualizer_system.rs
@@ -167,7 +167,7 @@ impl SeriesPointSystem {
                 );
 
                 // If we have no scalars, we can't do anything.
-                let Some(all_scalars) = results.get_dense::<Scalar>(resolver) else {
+                let Some(all_scalars) = results.get_required_component_dense::<Scalar>(resolver) else {
                     return Ok(());
                 };
 


### PR DESCRIPTION
### What

Split out of some other work.
Afaik it was _very_ hard to run into an issue due to the things fixed in the first commit - simply because there's  not a lot of callsites of the changed methods. Main issue covered by this is picking not using a default set `DepthMeter` correctly.

Commit by commit!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6710?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6710?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6710)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.