### PR TITLE
Fix overrides/defaults not working in TextDocumentView

### DIFF
--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -92,7 +92,7 @@ impl<'a> HybridLatestAtResults<'a> {
 
     /// Utility for retrieving a single instance of a component, not checking for defaults.
     ///
-    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
+    /// If overrides are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
     pub fn get_required_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
         let component_name = T::name();
@@ -109,7 +109,7 @@ impl<'a> HybridLatestAtResults<'a> {
 
     /// Utility for retrieving a single instance of a component.
     ///
-    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
+    /// If overrides are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
     pub fn get_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
         self.get_required_instance(index).or_else(|| {
@@ -122,7 +122,7 @@ impl<'a> HybridLatestAtResults<'a> {
 
     /// Utility for retrieving a single instance of a component.
     ///
-    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
+    /// If overrides are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
     pub fn get_instance_with_fallback<T: re_types_core::Component + Default>(
         &self,

--- a/crates/re_space_view/src/results_ext.rs
+++ b/crates/re_space_view/src/results_ext.rs
@@ -72,6 +72,12 @@ impl<'a> HybridLatestAtResults<'a> {
             .ok()
     }
 
+    /// Utility for retrieving a single instance of a component, ignoring defaults.
+    #[inline]
+    pub fn get_required_mono<T: re_types_core::Component>(&self) -> Option<T> {
+        self.get_required_instance(0)
+    }
+
     /// Utility for retrieving a single instance of a component.
     #[inline]
     pub fn get_mono<T: re_types_core::Component>(&self) -> Option<T> {
@@ -84,11 +90,11 @@ impl<'a> HybridLatestAtResults<'a> {
         self.get_instance_with_fallback(0)
     }
 
-    /// Utility for retrieving a single instance of a component.
+    /// Utility for retrieving a single instance of a component, not checking for defaults.
     ///
     /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
     #[inline]
-    pub fn get_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
+    pub fn get_required_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
         let component_name = T::name();
 
         self.overrides
@@ -99,12 +105,19 @@ impl<'a> HybridLatestAtResults<'a> {
                 self.results
                     .get(component_name)
                     .and_then(|r| r.try_instance::<T>(&self.resolver, index)))
-            .or_else(|| {
-                // No override & no store -> try default instead
-                self.defaults
-                    .get(T::name())
-                    .and_then(|r| r.try_instance::<T>(&self.resolver, 0))
-            })
+    }
+
+    /// Utility for retrieving a single instance of a component.
+    ///
+    /// If overrides or defaults are present, they will only be used respectively if they have a component at the specified index.
+    #[inline]
+    pub fn get_instance<T: re_types_core::Component>(&self, index: usize) -> Option<T> {
+        self.get_required_instance(index).or_else(|| {
+            // No override & no store -> try default instead
+            self.defaults
+                .get(T::name())
+                .and_then(|r| r.try_instance::<T>(&self.resolver, 0))
+        })
     }
 
     /// Utility for retrieving a single instance of a component.

--- a/crates/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/re_space_view_text_log/src/visualizer_system.rs
@@ -102,7 +102,10 @@ impl TextLogSystem {
             [Text::name(), TextLogLevel::name(), Color::name()],
         );
 
-        let Some(all_texts) = results.get_dense::<Text>(resolver).transpose()? else {
+        let Some(all_texts) = results
+            .get_required_component_dense::<Text>(resolver)
+            .transpose()?
+        else {
             return Ok(());
         };
 


### PR DESCRIPTION
### What
* based on https://github.com/rerun-io/rerun/pull/6710
* Part of https://github.com/rerun-io/rerun/issues/6595


https://github.com/rerun-io/rerun/assets/1220815/b3f433a1-af40-4a34-9057-a5a348d737e9


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6714?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6714?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6714)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.