### PR TITLE
BarChartView now queries overrides & defaults

### DIFF
--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -5,8 +5,8 @@ use re_entity_db::EntityPath;
 use re_space_view::{diff_component_filter, DataResultQuery as _};
 use re_types::{
     archetypes::BarChart,
-    components::{self, Color},
-    datatypes::TensorData,
+    components::{self},
+    datatypes,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
@@ -17,7 +17,7 @@ use re_viewer_context::{
 /// A bar chart system, with everything needed to render it.
 #[derive(Default)]
 pub struct BarChartVisualizerSystem {
-    pub charts: BTreeMap<EntityPath, (TensorData, Color)>,
+    pub charts: BTreeMap<EntityPath, (datatypes::TensorData, components::Color)>,
 }
 
 impl IdentifiedViewSystem for BarChartVisualizerSystem {
@@ -30,9 +30,7 @@ struct BarChartVisualizerEntityFilter;
 
 impl VisualizerAdditionalApplicabilityFilter for BarChartVisualizerEntityFilter {
     fn update_applicability(&mut self, event: &re_data_store::StoreEvent) -> bool {
-        diff_component_filter(event, |tensor: &re_types::components::TensorData| {
-            tensor.is_vector()
-        })
+        diff_component_filter(event, |tensor: &components::TensorData| tensor.is_vector())
     }
 }
 
@@ -80,10 +78,17 @@ impl VisualizerSystem for BarChartVisualizerSystem {
     }
 }
 
-impl TypedComponentFallbackProvider<Color> for BarChartVisualizerSystem {
-    fn fallback_for(&self, ctx: &QueryContext<'_>) -> Color {
+impl TypedComponentFallbackProvider<components::Color> for BarChartVisualizerSystem {
+    fn fallback_for(&self, ctx: &QueryContext<'_>) -> components::Color {
         auto_color_for_entity_path(ctx.target_entity_path)
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(BarChartVisualizerSystem => [Color]);
+impl TypedComponentFallbackProvider<components::TensorData> for BarChartVisualizerSystem {
+    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> components::TensorData {
+        // Provide tensor data which visualizes as a series of simple steps.
+        [0_i64, 1, 2, 3, 4].as_slice().into()
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(BarChartVisualizerSystem => [components::TensorData, components::Color]);

--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -87,7 +87,7 @@ impl TypedComponentFallbackProvider<components::Color> for BarChartVisualizerSys
 impl TypedComponentFallbackProvider<components::TensorData> for BarChartVisualizerSystem {
     fn fallback_for(&self, _ctx: &QueryContext<'_>) -> components::TensorData {
         // Provide tensor data which visualizes as a series of simple steps.
-        [0_i64, 1, 2, 3, 4].as_slice().into()
+        [0_u8, 1, 2, 3, 4].as_slice().into()
     }
 }
 

--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -2,8 +2,12 @@ use std::collections::BTreeMap;
 
 use re_data_store::LatestAtQuery;
 use re_entity_db::EntityPath;
-use re_space_view::diff_component_filter;
-use re_types::{archetypes::BarChart, components::Color, datatypes::TensorData};
+use re_space_view::{diff_component_filter, DataResultQuery as _};
+use re_types::{
+    archetypes::BarChart,
+    components::{self, Color},
+    datatypes::TensorData,
+};
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
     TypedComponentFallbackProvider, ViewContext, ViewContextCollection, ViewQuery,
@@ -44,41 +48,23 @@ impl VisualizerSystem for BarChartVisualizerSystem {
     fn execute(
         &mut self,
         ctx: &ViewContext<'_>,
-        query: &ViewQuery<'_>,
+        view_query: &ViewQuery<'_>,
         _context_systems: &ViewContextCollection,
     ) -> Result<Vec<re_renderer::QueueableDrawData>, SpaceViewSystemExecutionError> {
-        re_tracing::profile_function!();
+        let timeline_query = LatestAtQuery::new(view_query.timeline, view_query.latest_at);
 
-        for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
-            // TODO(#5607): what should happen if the promise is still pending?
-            let query = LatestAtQuery::new(query.timeline, query.latest_at);
-            let query_ctx = ctx.query_context(data_result, &query);
+        for data_result in view_query.iter_visible_data_results(ctx, Self::identifier()) {
+            let results = data_result
+                .latest_at_with_blueprint_resolved_data::<BarChart>(ctx, &timeline_query);
 
-            let tensor = ctx
-                .recording()
-                .latest_at_component::<re_types::components::TensorData>(
-                    &data_result.entity_path,
-                    &query,
-                );
+            let Some(tensor) = results.get_required_mono::<components::TensorData>() else {
+                continue;
+            };
 
-            let color = ctx
-                .recording()
-                .latest_at_component::<re_types::components::Color>(
-                    &data_result.entity_path,
-                    &query,
-                );
-
-            if let Some(tensor) = tensor {
-                if tensor.is_vector() {
-                    self.charts.insert(
-                        data_result.entity_path.clone(),
-                        (
-                            tensor.value.0.clone(),
-                            color.map_or_else(|| self.fallback_for(&query_ctx), |c| c.value),
-                        ),
-                    );
-                    // shallow clones
-                }
+            if tensor.is_vector() {
+                let color = results.get_mono_with_fallback();
+                self.charts
+                    .insert(data_result.entity_path.clone(), (tensor.0.clone(), color));
             }
         }
 

--- a/crates/re_space_view_bar_chart/src/visualizer_system.rs
+++ b/crates/re_space_view_bar_chart/src/visualizer_system.rs
@@ -84,11 +84,4 @@ impl TypedComponentFallbackProvider<components::Color> for BarChartVisualizerSys
     }
 }
 
-impl TypedComponentFallbackProvider<components::TensorData> for BarChartVisualizerSystem {
-    fn fallback_for(&self, _ctx: &QueryContext<'_>) -> components::TensorData {
-        // Provide tensor data which visualizes as a series of simple steps.
-        [0_u8, 1, 2, 3, 4].as_slice().into()
-    }
-}
-
-re_viewer_context::impl_component_fallback_provider!(BarChartVisualizerSystem => [components::TensorData, components::Color]);
+re_viewer_context::impl_component_fallback_provider!(BarChartVisualizerSystem => [components::Color]);


### PR DESCRIPTION
### What

* Part of https://github.com/rerun-io/rerun/issues/6595

And because it was so easy, the fallback for the tensor in the bar chart is now meaningfully adjusted!

https://github.com/rerun-io/rerun/assets/1220815/9bc9e179-ef1e-4996-9611-b9dd0bb5d53e


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6717?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6717?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6717)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.