### PR TITLE
Fix draw order slider moving too slowly when negative

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/float_drag.rs
+++ b/crates/re_edit_ui/src/datatype_editors/float_drag.rs
@@ -36,7 +36,7 @@ fn edit_f32_float_raw_impl(
     value: &mut f32,
     range: RangeInclusive<f32>,
 ) -> egui::Response {
-    let speed = (*value * 0.01).at_least(0.001);
+    let speed = (value.abs() * 0.01).at_least(0.001);
     ui.add(
         egui::DragValue::new(value)
             .clamp_to_range(false)


### PR DESCRIPTION
### What

* mentioned in https://github.com/rerun-io/rerun/issues/6595

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6718?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6718?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6718)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.