### PR TITLE
Fix ui_ext.rs by adding the missing colon in the unused_self Clippy configuration.

### DIFF
--- a/crates/re_ui/src/ui_ext.rs
+++ b/crates/re_ui/src/ui_ext.rs
@@ -577,7 +577,7 @@ pub trait UiExt {
     }
 
     /// Convenience function to create a [`crate::SectionCollapsingHeader`].
-    #[allow(clippy:unused_self)]
+    #[allow(clippy::unused_self)]
     fn section_collapsing_header<'a>(
         &self,
         label: impl Into<egui::WidgetText>,


### PR DESCRIPTION
resolves the build error while running `pixi run rerun-web` to compile the web viewer

![build_error](https://github.com/rerun-io/rerun/assets/1564923/f7b97828-1fd2-406e-a496-1ac134b237b2)