### PR TITLE
Fix missing clamp to border semantics on displaying component ui for a specific instance

### DIFF
--- a/crates/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/re_viewer_context/src/component_ui_registry.rs
@@ -396,6 +396,10 @@ impl ComponentUiRegistry {
         } else {
             instance.get() as usize
         };
+
+        // Enforce clamp-to-border semantics.
+        // TODO(andreas): Is that always what we want?
+        let index = index.clamp(0, (cell.num_instances() as usize).saturating_sub(1));
         let component_raw = cell.as_arrow_ref().sliced(index, 1);
 
         self.ui_raw(


### PR DESCRIPTION
### What

Story here is that I had to roll out the contents of `instance_raw` but missed bringing along clamp-to-border semantics which `instance_raw` has.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6721?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6721?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6721)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.