### PR TITLE
Reduce scene unit radius start value to 0.1 to mitigate sudden overdraw issues on ui interaction

### DIFF
--- a/crates/re_edit_ui/src/radius.rs
+++ b/crates/re_edit_ui/src/radius.rs
@@ -36,8 +36,10 @@ pub fn edit_radius_ui(
         {
             // When we change the type of units,the value is likely going to be _very wrong_.
             // Unfortunately, we don't have knowledge of a fallback here, so we use hardcoded "reasonable" values.
+            //
+            // Careful, if these "start values" are too big, they may cause overdraw issues on point clouds too often
             if is_scene_units {
-                abs_value = 0.5;
+                abs_value = 0.1;
             } else {
                 abs_value = 2.5;
             };


### PR DESCRIPTION
### What

* Fixes #6723
    * what's left of it anyways :)	

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6724?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6724?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6724)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.