### PR TITLE
Fix class id in absence of annotation context no longer being used for color.

### DIFF
--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -136,18 +136,21 @@ impl ResolvedAnnotationInfo {
     #[inline]
     pub fn color(&self, rgba: Option<[u8; 4]>) -> Option<re_renderer::Color32> {
         if let Some([r, g, b, a]) = rgba {
+            // Use passed color.
             Some(if a == 255 {
                 // Common-case optimization
                 re_renderer::Color32::from_rgb(r, g, b)
             } else {
                 re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
             })
+        } else if let Some(info) = self.annotation_info.as_ref() {
+            // Use annotation context based color.
+            info.color
+                .map(|c| c.into())
+                .or_else(|| Some(auto_color_egui(info.id)))
         } else {
-            self.annotation_info.as_ref().and_then(|info| {
-                info.color
-                    .map(|c| c.into())
-                    .or_else(|| Some(auto_color_egui(info.id)))
-            })
+            // Use class id based color (or give up).
+            self.class_id.map(|class_id| auto_color_egui(class_id.0))
         }
     }
 


### PR DESCRIPTION
### What

Regressed here https://github.com/rerun-io/rerun/pull/6703/files#diff-cd576f9001af1e24ebf07e0171fedefe2c0329dd8961606c4d4ca8574a0919b2L138

`SegmentAnything` is one of the examples that used the fact that classids are used for color even if there's no annotation context around

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
