### PR TITLE
Fix annotation context labels not showing in views

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -60,32 +60,32 @@ impl Boxes2DVisualizer {
             "Cannot add labels without colors"
         );
 
-        let labels = clamped(labels, annotation_infos.len());
+        let labels = annotation_infos
+            .iter()
+            .zip(labels.iter().map(Some).chain(std::iter::repeat(None)))
+            .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
         let colors = clamped(colors, annotation_infos.len());
 
-        itertools::izip!(annotation_infos.iter(), half_sizes, centers, labels, colors)
+        itertools::izip!(half_sizes, centers, labels, colors)
             .enumerate()
-            .filter_map(
-                move |(i, (annotation_info, half_size, center, label, color))| {
-                    let label = annotation_info.label(Some(label.as_str()));
-                    label.map(|label| {
-                        let min = half_size.box_min(*center);
-                        let max = half_size.box_max(*center);
-                        UiLabel {
-                            text: label,
-                            color: *color,
-                            target: UiLabelTarget::Rect(egui::Rect::from_min_max(
-                                egui::pos2(min.x, min.y),
-                                egui::pos2(max.x, max.y),
-                            )),
-                            labeled_instance: InstancePathHash::instance(
-                                entity_path,
-                                Instance::from(i as u64),
-                            ),
-                        }
-                    })
-                },
-            )
+            .filter_map(move |(i, (half_size, center, label, color))| {
+                label.map(|label| {
+                    let min = half_size.box_min(*center);
+                    let max = half_size.box_max(*center);
+                    UiLabel {
+                        text: label,
+                        color: *color,
+                        target: UiLabelTarget::Rect(egui::Rect::from_min_max(
+                            egui::pos2(min.x, min.y),
+                            egui::pos2(max.x, max.y),
+                        )),
+                        labeled_instance: InstancePathHash::instance(
+                            entity_path,
+                            Instance::from(i as u64),
+                        ),
+                    }
+                })
+            })
     }
 
     fn process_data<'a>(

--- a/crates/re_space_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/re_space_view_spatial/src/visualizers/utilities/labels.rs
@@ -51,13 +51,15 @@ pub fn process_labels_3d<'a>(
         "Cannot add labels without colors"
     );
 
-    let labels = clamped(labels, annotation_infos.len());
+    let labels = annotation_infos
+        .iter()
+        .zip(labels.iter().map(Some).chain(std::iter::repeat(None)))
+        .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
     let colors = clamped(colors, annotation_infos.len());
 
-    itertools::izip!(annotation_infos.iter(), positions, labels, colors)
+    itertools::izip!(positions, labels, colors)
         .enumerate()
-        .filter_map(move |(i, (annotation_info, point, label, color))| {
-            let label = annotation_info.label(Some(label.as_str()));
+        .filter_map(move |(i, (point, label, color))| {
             label.map(|label| UiLabel {
                 text: label,
                 color: *color,
@@ -85,13 +87,15 @@ pub fn process_labels_2d<'a>(
         "Cannot add labels without colors"
     );
 
-    let labels = clamped(labels, annotation_infos.len());
+    let labels = annotation_infos
+        .iter()
+        .zip(labels.iter().map(Some).chain(std::iter::repeat(None)))
+        .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
     let colors = clamped(colors, annotation_infos.len());
 
-    itertools::izip!(annotation_infos.iter(), positions, labels, colors)
+    itertools::izip!(positions, labels, colors)
         .enumerate()
-        .filter_map(move |(i, (annotation_info, point, label, color))| {
-            let label = annotation_info.label(Some(label.as_str()));
+        .filter_map(move |(i, (point, label, color))| {
             label.map(|label| {
                 let point = world_from_obj.transform_point3(glam::Vec3::new(point.x, point.y, 0.0));
                 UiLabel {


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/6093
* Based on https://github.com/rerun-io/rerun/pull/6741

![image](https://github.com/rerun-io/rerun/assets/1220815/e76a865f-c48d-4d06-9125-e1c7fb26de58)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6742?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6742?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6742)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.