### PR TITLE
Better document limited effect of `DepthMeter` & `FillRatio` in 2D views

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -35,7 +35,7 @@ table DepthImage (
   /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
   /// and a range of up to ~65 meters (2^16 / 1000).
   ///
-  /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+  /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
   /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
   meter: rerun.components.DepthMeter ("attr.rerun.component_optional", nullable, order: 3100);
 

--- a/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -34,6 +34,9 @@ table DepthImage (
   ///
   /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
   /// and a range of up to ~65 meters (2^16 / 1000).
+  ///
+  /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+  /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
   meter: rerun.components.DepthMeter ("attr.rerun.component_optional", nullable, order: 3100);
 
   /// Colormap to use for rendering the depth image.
@@ -46,6 +49,8 @@ table DepthImage (
   /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
   /// if it is at the same depth, leaving no gaps.
   /// A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+  ///
+  /// TODO(#6744): This applies only to 3D views!
   point_fill_ratio: rerun.components.FillRatio ("attr.rerun.component_optional", nullable, order: 3300);
 
   /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.

--- a/crates/re_types/definitions/rerun/components/depth_meter.fbs
+++ b/crates/re_types/definitions/rerun/components/depth_meter.fbs
@@ -15,7 +15,7 @@ namespace rerun.components;
 /// For instance, if a depth map uses millimeters and the world uses meters,
 /// this value would be `1000`.
 ///
-/// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+/// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
 /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
 struct DepthMeter (
   "attr.python.aliases": "float",

--- a/crates/re_types/definitions/rerun/components/depth_meter.fbs
+++ b/crates/re_types/definitions/rerun/components/depth_meter.fbs
@@ -14,6 +14,9 @@ namespace rerun.components;
 /// This measures how many depth map units are in a world unit.
 /// For instance, if a depth map uses millimeters and the world uses meters,
 /// this value would be `1000`.
+///
+/// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+/// In 3D views on the other hand, this affects where the points of the point cloud are placed.
 struct DepthMeter (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.NDArray[np.float32]",

--- a/crates/re_types/definitions/rerun/components/fill_ratio.fbs
+++ b/crates/re_types/definitions/rerun/components/fill_ratio.fbs
@@ -11,7 +11,7 @@ namespace rerun.components;
 
 /// How much a primitive fills out the available space.
 ///
-/// Used for instance to scale the points of the point cloud created from `DepthImage` projection.
+/// Used for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.
 /// Valid range is from 0 to max float although typically values above 1.0 are not useful.
 ///
 /// Defaults to 1.0.

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -77,7 +77,7 @@ pub struct DepthImage {
     /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     /// and a range of up to ~65 meters (2^16 / 1000).
     ///
-    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
     /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     pub meter: Option<crate::components::DepthMeter>,
 
@@ -310,7 +310,7 @@ impl DepthImage {
     /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     /// and a range of up to ~65 meters (2^16 / 1000).
     ///
-    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
     /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     #[inline]
     pub fn with_meter(mut self, meter: impl Into<crate::components::DepthMeter>) -> Self {

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -76,6 +76,9 @@ pub struct DepthImage {
     ///
     /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     /// and a range of up to ~65 meters (2^16 / 1000).
+    ///
+    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     pub meter: Option<crate::components::DepthMeter>,
 
     /// Colormap to use for rendering the depth image.
@@ -88,6 +91,8 @@ pub struct DepthImage {
     /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
     /// if it is at the same depth, leaving no gaps.
     /// A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+    ///
+    /// TODO(#6744): This applies only to 3D views!
     pub point_fill_ratio: Option<crate::components::FillRatio>,
 
     /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
@@ -304,6 +309,9 @@ impl DepthImage {
     ///
     /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     /// and a range of up to ~65 meters (2^16 / 1000).
+    ///
+    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     #[inline]
     pub fn with_meter(mut self, meter: impl Into<crate::components::DepthMeter>) -> Self {
         self.meter = Some(meter.into());
@@ -324,6 +332,8 @@ impl DepthImage {
     /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
     /// if it is at the same depth, leaving no gaps.
     /// A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+    ///
+    /// TODO(#6744): This applies only to 3D views!
     #[inline]
     pub fn with_point_fill_ratio(
         mut self,

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -27,6 +27,9 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// This measures how many depth map units are in a world unit.
 /// For instance, if a depth map uses millimeters and the world uses meters,
 /// this value would be `1000`.
+///
+/// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+/// In 3D views on the other hand, this affects where the points of the point cloud are placed.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct DepthMeter(pub f32);

--- a/crates/re_types/src/components/depth_meter.rs
+++ b/crates/re_types/src/components/depth_meter.rs
@@ -28,7 +28,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// For instance, if a depth map uses millimeters and the world uses meters,
 /// this value would be `1000`.
 ///
-/// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+/// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
 /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -24,7 +24,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: How much a primitive fills out the available space.
 ///
-/// Used for instance to scale the points of the point cloud created from `DepthImage` projection.
+/// Used for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.
 /// Valid range is from 0 to max float although typically values above 1.0 are not useful.
 ///
 /// Defaults to 1.0.

--- a/crates/re_viewer/src/reflection/mod.rs
+++ b/crates/re_viewer/src/reflection/mod.rs
@@ -275,7 +275,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
         (
             <DepthMeter as Loggable>::name(),
             ComponentReflection {
-                docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.",
+                docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the effect on 2D views is what physical depth values are shown when interacting with the image,\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
                 placeholder: Some(DepthMeter::default().to_arrow()?),
             },
         ),
@@ -296,7 +296,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
         (
             <FillRatio as Loggable>::name(),
             ComponentReflection {
-                docstring_md: "How much a primitive fills out the available space.\n\nUsed for instance to scale the points of the point cloud created from `DepthImage` projection.\nValid range is from 0 to max float although typically values above 1.0 are not useful.\n\nDefaults to 1.0.",
+                docstring_md: "How much a primitive fills out the available space.\n\nUsed for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.\nValid range is from 0 to max float although typically values above 1.0 are not useful.\n\nDefaults to 1.0.",
                 placeholder: Some(FillRatio::default().to_arrow()?),
             },
         ),

--- a/crates/re_viewer/src/reflection/mod.rs
+++ b/crates/re_viewer/src/reflection/mod.rs
@@ -275,7 +275,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
         (
             <DepthMeter as Loggable>::name(),
             ComponentReflection {
-                docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the effect on 2D views is what physical depth values are shown when interacting with the image,\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
+                docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the only effect on 2D views is the physical depth values shown when hovering the image.\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
                 placeholder: Some(DepthMeter::default().to_arrow()?),
             },
         ),

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -9,7 +9,7 @@ This measures how many depth map units are in a world unit.
 For instance, if a depth map uses millimeters and the world uses meters,
 this value would be `1000`.
 
-Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+Note that the only effect on 2D views is the physical depth values shown when hovering the image.
 In 3D views on the other hand, this affects where the points of the point cloud are placed.
 
 ## Fields

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -9,6 +9,9 @@ This measures how many depth map units are in a world unit.
 For instance, if a depth map uses millimeters and the world uses meters,
 this value would be `1000`.
 
+Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+In 3D views on the other hand, this affects where the points of the point cloud are placed.
+
 ## Fields
 
 * value: `f32`

--- a/docs/content/reference/types/components/fill_ratio.md
+++ b/docs/content/reference/types/components/fill_ratio.md
@@ -5,7 +5,7 @@ title: "FillRatio"
 
 How much a primitive fills out the available space.
 
-Used for instance to scale the points of the point cloud created from `DepthImage` projection.
+Used for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.
 Valid range is from 0 to max float although typically values above 1.0 are not useful.
 
 Defaults to 1.0.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -80,6 +80,9 @@ namespace rerun::archetypes {
         ///
         /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
         /// and a range of up to ~65 meters (2^16 / 1000).
+        ///
+        /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+        /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
         std::optional<rerun::components::DepthMeter> meter;
 
         /// Colormap to use for rendering the depth image.
@@ -92,6 +95,8 @@ namespace rerun::archetypes {
         /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
         /// if it is at the same depth, leaving no gaps.
         /// A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+        ///
+        /// TODO(#6744): This applies only to 3D views!
         std::optional<rerun::components::FillRatio> point_fill_ratio;
 
         /// An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
@@ -148,6 +153,9 @@ namespace rerun::archetypes {
         ///
         /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
         /// and a range of up to ~65 meters (2^16 / 1000).
+        ///
+        /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+        /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
         DepthImage with_meter(rerun::components::DepthMeter _meter) && {
             meter = std::move(_meter);
             // See: https://github.com/rerun-io/rerun/issues/4027
@@ -168,6 +176,8 @@ namespace rerun::archetypes {
         /// A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
         /// if it is at the same depth, leaving no gaps.
         /// A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+        ///
+        /// TODO(#6744): This applies only to 3D views!
         DepthImage with_point_fill_ratio(rerun::components::FillRatio _point_fill_ratio) && {
             point_fill_ratio = std::move(_point_fill_ratio);
             // See: https://github.com/rerun-io/rerun/issues/4027

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -81,7 +81,7 @@ namespace rerun::archetypes {
         /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
         /// and a range of up to ~65 meters (2^16 / 1000).
         ///
-        /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+        /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
         /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
         std::optional<rerun::components::DepthMeter> meter;
 
@@ -154,7 +154,7 @@ namespace rerun::archetypes {
         /// For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
         /// and a range of up to ~65 meters (2^16 / 1000).
         ///
-        /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+        /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
         /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
         DepthImage with_meter(rerun::components::DepthMeter _meter) && {
             meter = std::move(_meter);

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -25,6 +25,9 @@ namespace rerun::components {
     /// This measures how many depth map units are in a world unit.
     /// For instance, if a depth map uses millimeters and the world uses meters,
     /// this value would be `1000`.
+    ///
+    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     struct DepthMeter {
         float value;
 

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -26,7 +26,7 @@ namespace rerun::components {
     /// For instance, if a depth map uses millimeters and the world uses meters,
     /// this value would be `1000`.
     ///
-    /// Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    /// Note that the only effect on 2D views is the physical depth values shown when hovering the image.
     /// In 3D views on the other hand, this affects where the points of the point cloud are placed.
     struct DepthMeter {
         float value;

--- a/rerun_cpp/src/rerun/components/fill_ratio.hpp
+++ b/rerun_cpp/src/rerun/components/fill_ratio.hpp
@@ -12,7 +12,7 @@
 namespace rerun::components {
     /// **Component**: How much a primitive fills out the available space.
     ///
-    /// Used for instance to scale the points of the point cloud created from `DepthImage` projection.
+    /// Used for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.
     /// Valid range is from 0 to max float although typically values above 1.0 are not useful.
     ///
     /// Defaults to 1.0.

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -86,6 +86,9 @@ class DepthImage(DepthImageExt, Archetype):
 
             For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
             and a range of up to ~65 meters (2^16 / 1000).
+
+            Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+            In 3D views on the other hand, this affects where the points of the point cloud are placed.
         colormap:
             Colormap to use for rendering the depth image.
 
@@ -96,6 +99,8 @@ class DepthImage(DepthImageExt, Archetype):
             A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
             if it is at the same depth, leaving no gaps.
             A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+
+            TODO(#6744): This applies only to 3D views!
         draw_order:
             An optional floating point value that specifies the 2D drawing order, used only if the depth image is shown as a 2D image.
 
@@ -146,6 +151,9 @@ class DepthImage(DepthImageExt, Archetype):
     # For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     # and a range of up to ~65 meters (2^16 / 1000).
     #
+    # Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    # In 3D views on the other hand, this affects where the points of the point cloud are placed.
+    #
     # (Docstring intentionally commented out to hide this field from the docs)
 
     colormap: components.ColormapBatch | None = field(
@@ -169,6 +177,8 @@ class DepthImage(DepthImageExt, Archetype):
     # A fill ratio of 1.0 (the default) means that each point is as big as to touch the center of its neighbor
     # if it is at the same depth, leaving no gaps.
     # A fill ratio of 0.5 means that each point touches the edge of its neighbor if it has the same depth.
+    #
+    # TODO(#6744): This applies only to 3D views!
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -87,7 +87,7 @@ class DepthImage(DepthImageExt, Archetype):
             For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
             and a range of up to ~65 meters (2^16 / 1000).
 
-            Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+            Note that the only effect on 2D views is the physical depth values shown when hovering the image.
             In 3D views on the other hand, this affects where the points of the point cloud are placed.
         colormap:
             Colormap to use for rendering the depth image.
@@ -151,7 +151,7 @@ class DepthImage(DepthImageExt, Archetype):
     # For instance: with uint16, perhaps meter=1000 which would mean you have millimeter precision
     # and a range of up to ~65 meters (2^16 / 1000).
     #
-    # Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    # Note that the only effect on 2D views is the physical depth values shown when hovering the image.
     # In 3D views on the other hand, this affects where the points of the point cloud are placed.
     #
     # (Docstring intentionally commented out to hide this field from the docs)

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -31,7 +31,7 @@ class DepthMeter(ComponentMixin):
     For instance, if a depth map uses millimeters and the world uses meters,
     this value would be `1000`.
 
-    Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    Note that the only effect on 2D views is the physical depth values shown when hovering the image.
     In 3D views on the other hand, this affects where the points of the point cloud are placed.
     """
 

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -30,6 +30,9 @@ class DepthMeter(ComponentMixin):
     This measures how many depth map units are in a world unit.
     For instance, if a depth map uses millimeters and the world uses meters,
     this value would be `1000`.
+
+    Note that the effect on 2D views is what physical depth values are shown when interacting with the image,
+    In 3D views on the other hand, this affects where the points of the point cloud are placed.
     """
 
     _BATCH_TYPE = None

--- a/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
@@ -18,7 +18,7 @@ class FillRatio(datatypes.Float32, ComponentMixin):
     """
     **Component**: How much a primitive fills out the available space.
 
-    Used for instance to scale the points of the point cloud created from `DepthImage` projection.
+    Used for instance to scale the points of the point cloud created from `DepthImage` projection in 3D views.
     Valid range is from 0 to max float although typically values above 1.0 are not useful.
 
     Defaults to 1.0.


### PR DESCRIPTION
### What

* Part of https://github.com/rerun-io/rerun/issues/6595

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6745?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6745?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6745)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.