### PR TITLE
Fix Python codegen for enums

### DIFF
--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -875,7 +875,7 @@ fn code_for_enum(
         "Literal[{}]",
         obj.fields
             .iter()
-            .map(|v| format!("\"{}\"", v.pascal_case_name().to_lowercase()))
+            .map(|v| format!("{:?}", v.pascal_case_name().to_lowercase()))
             .join(", ")
     );
     code.push_unindented(format!("{name}Like = Union[{name}, {variants}]"), 1);

--- a/crates/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/re_types_builder/src/codegen/python/mod.rs
@@ -871,11 +871,13 @@ fn code_for_enum(
         }
     }
 
-    let variants = obj
-        .fields
-        .iter()
-        .map(|v| format!("Literal[{:?}]", v.pascal_case_name().to_lowercase()))
-        .join(" | ");
+    let variants = format!(
+        "Literal[{}]",
+        obj.fields
+            .iter()
+            .map(|v| format!("\"{}\"", v.pascal_case_name().to_lowercase()))
+            .join(", ")
+    );
     code.push_unindented(format!("{name}Like = Union[{name}, {variants}]"), 1);
     code.push_unindented(
         format!(

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -48,7 +48,7 @@ class BackgroundKind(Enum):
     """Simple uniform color."""
 
 
-BackgroundKindLike = Union[BackgroundKind, Literal["gradientdark"] | Literal["gradientbright"] | Literal["solidcolor"]]
+BackgroundKindLike = Union[BackgroundKind, Literal["gradientdark", "gradientbright", "solidcolor"]]
 BackgroundKindArrayLike = Union[BackgroundKindLike, Sequence[BackgroundKindLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -37,9 +37,7 @@ class ContainerKind(Enum):
     """Organize children in a grid layout"""
 
 
-ContainerKindLike = Union[
-    ContainerKind, Literal["tabs"] | Literal["horizontal"] | Literal["vertical"] | Literal["grid"]
-]
+ContainerKindLike = Union[ContainerKind, Literal["tabs", "horizontal", "vertical", "grid"]]
 ContainerKindArrayLike = Union[ContainerKindLike, Sequence[ContainerKindLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -37,9 +37,7 @@ class Corner2D(Enum):
     """Right bottom corner."""
 
 
-Corner2DLike = Union[
-    Corner2D, Literal["lefttop"] | Literal["righttop"] | Literal["leftbottom"] | Literal["rightbottom"]
-]
+Corner2DLike = Union[Corner2D, Literal["lefttop", "righttop", "leftbottom", "rightbottom"]]
 Corner2DArrayLike = Union[Corner2DLike, Sequence[Corner2DLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -34,7 +34,7 @@ class PanelState(Enum):
     """Fully expanded."""
 
 
-PanelStateLike = Union[PanelState, Literal["hidden"] | Literal["collapsed"] | Literal["expanded"]]
+PanelStateLike = Union[PanelState, Literal["hidden", "collapsed", "expanded"]]
 PanelStateArrayLike = Union[PanelStateLike, Sequence[PanelStateLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
@@ -34,7 +34,7 @@ class ViewFit(Enum):
     """Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio."""
 
 
-ViewFitLike = Union[ViewFit, Literal["original"] | Literal["fill"] | Literal["fillkeepaspectratio"]]
+ViewFitLike = Union[ViewFit, Literal["original", "fill", "fillkeepaspectratio"]]
 ViewFitArrayLike = Union[ViewFitLike, Sequence[ViewFitLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
+++ b/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
@@ -59,15 +59,7 @@ class AggregationPolicy(Enum):
     """Find both the minimum and maximum values in the range, then use the average of those."""
 
 
-AggregationPolicyLike = Union[
-    AggregationPolicy,
-    Literal["off"]
-    | Literal["average"]
-    | Literal["max"]
-    | Literal["min"]
-    | Literal["minmax"]
-    | Literal["minmaxaverage"],
-]
+AggregationPolicyLike = Union[AggregationPolicy, Literal["off", "average", "max", "min", "minmax", "minmaxaverage"]]
 AggregationPolicyArrayLike = Union[AggregationPolicyLike, Sequence[AggregationPolicyLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -80,15 +80,7 @@ class Colormap(Enum):
     """
 
 
-ColormapLike = Union[
-    Colormap,
-    Literal["grayscale"]
-    | Literal["inferno"]
-    | Literal["magma"]
-    | Literal["plasma"]
-    | Literal["turbo"]
-    | Literal["viridis"],
-]
+ColormapLike = Union[Colormap, Literal["grayscale", "inferno", "magma", "plasma", "turbo", "viridis"]]
 ColormapArrayLike = Union[ColormapLike, Sequence[ColormapLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
+++ b/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
@@ -46,7 +46,7 @@ class MagnificationFilter(Enum):
     """
 
 
-MagnificationFilterLike = Union[MagnificationFilter, Literal["nearest"] | Literal["linear"]]
+MagnificationFilterLike = Union[MagnificationFilter, Literal["nearest", "linear"]]
 MagnificationFilterArrayLike = Union[MagnificationFilterLike, Sequence[MagnificationFilterLike]]
 
 

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -56,17 +56,7 @@ class MarkerShape(Enum):
 
 
 MarkerShapeLike = Union[
-    MarkerShape,
-    Literal["circle"]
-    | Literal["diamond"]
-    | Literal["square"]
-    | Literal["cross"]
-    | Literal["plus"]
-    | Literal["up"]
-    | Literal["down"]
-    | Literal["left"]
-    | Literal["right"]
-    | Literal["asterisk"],
+    MarkerShape, Literal["circle", "diamond", "square", "cross", "plus", "up", "down", "left", "right", "asterisk"]
 ]
 MarkerShapeArrayLike = Union[MarkerShapeLike, Sequence[MarkerShapeLike]]
 

--- a/rerun_py/tests/test_types/components/enum_test.py
+++ b/rerun_py/tests/test_types/components/enum_test.py
@@ -42,10 +42,7 @@ class EnumTest(Enum):
     """Baby's got it."""
 
 
-EnumTestLike = Union[
-    EnumTest,
-    Literal["up"] | Literal["down"] | Literal["right"] | Literal["left"] | Literal["forward"] | Literal["back"],
-]
+EnumTestLike = Union[EnumTest, Literal["up", "down", "right", "left", "forward", "back"]]
 EnumTestArrayLike = Union[EnumTestLike, Sequence[EnumTestLike]]
 
 


### PR DESCRIPTION
### What

The way enum types were codegen'd in Python was incompatible with python <=3.9. This PR fixes this.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6746?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6746?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6746)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.