### PR TITLE
Add opacity override to `rgbd` example

### DIFF
--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -178,7 +178,7 @@ def main() -> None:
             rrb.Vertical(
                 rrb.Spatial3DView(name="3D", origin="world"),
                 rrb.TextDocumentView(name="Description", origin="/description"),
-                row_shares=[0.7, 0.3],
+                row_shares=[7, 3],
             ),
             rrb.Vertical(
                 # Put the origin for both 2D spaces where the pinhole is logged. Doing so allows them to understand how they're connected to the 3D space.

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -175,22 +175,30 @@ def main() -> None:
         args,
         "rerun_example_rgbd",
         default_blueprint=rrb.Horizontal(
-            rrb.Spatial3DView(name="3D", origin="world"),
+            rrb.Vertical(
+                rrb.Spatial3DView(name="3D", origin="world"),
+                rrb.TextDocumentView(name="Description", origin="/description"),
+                row_shares=[0.7, 0.3],
+            ),
             rrb.Vertical(
                 # Put the origin for both 2D spaces where the pinhole is logged. Doing so allows them to understand how they're connected to the 3D space.
                 # This enables interactions like clicking on a point in the 3D space to show the corresponding point in the 2D spaces and vice versa.
-                rrb.Spatial2DView(name="RGB & Depth", origin="world/camera/image"),
+                rrb.Spatial2DView(
+                    name="RGB & Depth",
+                    origin="world/camera/image",
+                    overrides={"world/camera/image/rgb": [rr.components.Opacity(0.5)]},
+                ),
                 rrb.Tabs(
                     rrb.Spatial2DView(name="RGB", origin="world/camera/image", contents="world/camera/image/rgb"),
                     rrb.Spatial2DView(name="Depth", origin="world/camera/image", contents="world/camera/image/depth"),
                 ),
-                rrb.TextDocumentView(name="Description", origin="/description"),
                 name="2D",
                 row_shares=[3, 3, 2],
             ),
             column_shares=[2, 1],
         ),
     )
+
     recording_path = ensure_recording_downloaded(args.recording)
 
     rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)


### PR DESCRIPTION
### What

To make `rgbd` look like it did in `0.16`. Also moved the `/description` to the left under the 3D view, because it felt a bit too squished under the two 2D views.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6747?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6747?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6747)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.