### PR TITLE
Use "more" menu button instead of reset for view property ui

### DIFF
--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -181,27 +181,38 @@ fn menu_more(
 
     let property_differs_from_default = component_results.raw(resolver, component_name)
         != ctx.raw_latest_at_in_default_blueprint(blueprint_path, component_name);
-    ui.add_enabled_ui(property_differs_from_default, |ui| {
-    if ui.button("Reset to default blueprint")
-        .on_hover_text("Resets this property to the value in the default blueprint.\n
-        If no default blueprint was set or it didn't set any value for this field, this is the same as resetting to empty.")
-        .on_disabled_hover_text("The property is already set to the same value it has in the default blueprint")
-        .clicked() {
-            ctx.reset_blueprint_component_by_name(blueprint_path, component_name);
-            ui.close_menu();
-        }
-    });
 
-    ui.add_enabled_ui(!component_results.is_empty(resolver), |ui| {
-            if ui.button("Reset to empty")
-                .on_hover_text("Resets this property to an unset value, meaning that a heuristically determined value will be used instead.\n
-This has the same effect as not setting the value in the blueprint at all.")
-                .on_disabled_hover_text("The property is already unset.")
-                .clicked() {
-                ctx.save_empty_blueprint_component_by_name(blueprint_path, component_name);
-                ui.close_menu();
-            }
-        });
+    let response = ui
+        .add_enabled(
+            property_differs_from_default,
+            egui::Button::new("Reset to default blueprint"),
+        )
+        .on_hover_text(
+"Resets this property to the value in the default blueprint.
+If no default blueprint was set or it didn't set any value for this field, this is the same as resetting to empty."
+        )
+        .on_disabled_hover_text(
+            "The property is already set to the same value it has in the default blueprint",
+        );
+    if response.clicked() {
+        ctx.reset_blueprint_component_by_name(blueprint_path, component_name);
+        ui.close_menu();
+    }
+
+    let response = ui
+        .add_enabled(
+            !component_results.is_empty(resolver),
+            egui::Button::new("Reset to empty"),
+        )
+        .on_hover_text(
+"Resets this property to an unset value, meaning that a heuristically determined value will be used instead.\n
+This has the same effect as not setting the value in the blueprint at all."
+        )
+        .on_disabled_hover_text("The property is already unset.");
+    if response.clicked() {
+        ctx.save_empty_blueprint_component_by_name(blueprint_path, component_name);
+        ui.close_menu();
+    }
 
     // TODO(andreas): The next logical thing here is now to save it to the default blueprint!
     // This should be fairly straight forward except that we need to make sure that a default blueprint exists in the first place.

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -177,16 +177,22 @@ fn menu_more(
     component_name: ComponentName,
     component_results: &re_query::LatestAtComponentResults,
 ) {
+    let resolver = ctx.blueprint_db().resolver();
+
+    let property_differs_from_default = component_results.raw(resolver, component_name)
+        != ctx.raw_latest_at_in_default_blueprint(blueprint_path, component_name);
+    ui.add_enabled_ui(property_differs_from_default, |ui| {
     if ui.button("Reset to default blueprint.")
         .on_hover_text("Resets this property to the value in the default blueprint.\n
         If no default blueprint was set or it didn't set any value for this field, this is the same as resetting to empty.")
+        .on_disabled_hover_text("The property is already set to the same value it has in the default blueprint.")
         .clicked() {
             ctx.reset_blueprint_component_by_name(blueprint_path, component_name);
             ui.close_menu();
         }
+    });
 
-    let blueprint_db = ctx.blueprint_db();
-    ui.add_enabled_ui(!component_results.is_empty(blueprint_db.resolver()), |ui| {
+    ui.add_enabled_ui(!component_results.is_empty(resolver), |ui| {
             if ui.button("Reset to empty.")
                 .on_hover_text("Resets this property to an unset value, meaning that a heuristically determined value will be used instead.\n
 This has the same effect as not setting the value in the blueprint at all.")

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -205,7 +205,7 @@ If no default blueprint was set or it didn't set any value for this field, this 
             egui::Button::new("Reset to empty"),
         )
         .on_hover_text(
-"Resets this property to an unset value, meaning that a heuristically determined value will be used instead.\n
+"Resets this property to an unset value, meaning that a heuristically determined value will be used instead.
 This has the same effect as not setting the value in the blueprint at all."
         )
         .on_disabled_hover_text("The property is already unset.");

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -134,7 +134,7 @@ fn view_property_component_ui(
         .component_ui_registry
         .registered_ui_types(component_name);
 
-    let mut list_item_response = if ui_types.contains(ComponentUiTypes::MultiLineEditor) {
+    let list_item_response = if ui_types.contains(ComponentUiTypes::MultiLineEditor) {
         let default_open = false;
         let id = egui::Id::new((blueprint_path.hash(), component_name));
         ui.list_item()

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -202,7 +202,7 @@ If no default blueprint was set or it didn't set any value for this field, this 
     let response = ui
         .add_enabled(
             !component_results.is_empty(resolver),
-            egui::Button::new("Reset to empty"),
+            egui::Button::new("Unset"),
         )
         .on_hover_text(
 "Resets this property to an unset value, meaning that a heuristically determined value will be used instead.

--- a/crates/re_space_view/src/view_property_ui.rs
+++ b/crates/re_space_view/src/view_property_ui.rs
@@ -182,10 +182,10 @@ fn menu_more(
     let property_differs_from_default = component_results.raw(resolver, component_name)
         != ctx.raw_latest_at_in_default_blueprint(blueprint_path, component_name);
     ui.add_enabled_ui(property_differs_from_default, |ui| {
-    if ui.button("Reset to default blueprint.")
+    if ui.button("Reset to default blueprint")
         .on_hover_text("Resets this property to the value in the default blueprint.\n
         If no default blueprint was set or it didn't set any value for this field, this is the same as resetting to empty.")
-        .on_disabled_hover_text("The property is already set to the same value it has in the default blueprint.")
+        .on_disabled_hover_text("The property is already set to the same value it has in the default blueprint")
         .clicked() {
             ctx.reset_blueprint_component_by_name(blueprint_path, component_name);
             ui.close_menu();
@@ -193,7 +193,7 @@ fn menu_more(
     });
 
     ui.add_enabled_ui(!component_results.is_empty(resolver), |ui| {
-            if ui.button("Reset to empty.")
+            if ui.button("Reset to empty")
                 .on_hover_text("Resets this property to an unset value, meaning that a heuristically determined value will be used instead.\n
 This has the same effect as not setting the value in the blueprint at all.")
                 .on_disabled_hover_text("The property is already unset.")


### PR DESCRIPTION
### What
* Fixes https://github.com/rerun-io/rerun/issues/6614

also, grey out "reset to default blueprint" when that's already the case.

https://github.com/rerun-io/rerun/assets/1220815/f6c56839-2768-441f-bb6e-0f4a862dc33f



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6759?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6759?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6759)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.