### PR TITLE
Fix notebook timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,8 +1553,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cabe0a45c3736c274bc650ca02ab293eb2ad1a3870f6033590ca7a3ee9963c"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1564,8 +1563,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20189790fd16dc370379cee34032a114a029707947fe1b0d6b6362d3847c296"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1601,8 +1599,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dce16991290ee6395f3780b9b0db15bf0368bce2f31f2e9ba276d26e4b09cda"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1619,8 +1616,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f62b48d3c8eec54aa662da7d353628ae6b36f37c268f020cba198b83e642034"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1639,8 +1635,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6d149cc9db915f34df8a90eb81853c9376044fc938f67d848729b27c6b0128"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1682,8 +1677,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9caa162e2d75084e637fbb46637fb864b7411e8ce772425a0e7e4746f81368"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ahash",
  "egui",
@@ -1699,8 +1693,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa80fb1b442fdf521db80dd3fb8fd01cf885f428c1b16d62959a249909bf541e"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1718,8 +1711,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a18a7b9dbbc7115df8f0b724dfddaddde6b1ccd27d95437d4066f2e4e4cc88"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ahash",
  "egui",
@@ -1764,8 +1756,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275f98c04af8359eeef56af16dfafd2bc7a65d9c0e5f2f00918057ca90a9fba8"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1866,8 +1857,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205d6fcd02317e3e06cb32d28f821dd549b14ab12da6ff283dda57c4ebe4cb45"
+source = "git+https://github.com/emilk/egui.git?rev=29dd56d03768b94542f628698dfb6587a2f77c1c#29dd56d03768b94542f628698dfb6587a2f77c1c"
 dependencies = [
  "ab_glyph",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -483,13 +483,13 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-# ecolor = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }      # egui master 2024-07-02
-# eframe = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }      # egui master 2024-07-02
-# egui = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }        # egui master 2024-07-02
-# egui_extras = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" } # egui master 2024-07-02
-# egui_plot = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }   # egui master 2024-07-02
-# egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }   # egui master 2024-07-02
-# emath = { git = "https://github.com/emilk/egui.git", rev = "249b69d534d4c92c1b5da83178cf8ba450886436" }       # egui master 2024-07-02
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }      # egui master 2024-07-02
+eframe = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }      # egui master 2024-07-02
+egui = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }        # egui master 2024-07-02
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" } # egui master 2024-07-02
+egui_plot = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }   # egui master 2024-07-02
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }   # egui master 2024-07-02
+emath = { git = "https://github.com/emilk/egui.git", rev = "29dd56d03768b94542f628698dfb6587a2f77c1c" }       # egui master 2024-07-02
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/re_viewer/src/web.rs
+++ b/crates/re_viewer/src/web.rs
@@ -51,7 +51,10 @@ impl WebHandle {
     /// - `manifest_url` is an optional URL to an `examples_manifest.json` file over http.
     /// - `force_wgpu_backend` is an optional string to force a specific backend, either `webgl` or `webgpu`.
     #[wasm_bindgen]
-    pub async fn start(&self, canvas_id: String) -> Result<(), wasm_bindgen::JsValue> {
+    pub async fn start(
+        &self,
+        canvas: web_sys::HtmlCanvasElement,
+    ) -> Result<(), wasm_bindgen::JsValue> {
         let app_options = self.app_options.clone();
         let web_options = eframe::WebOptions {
             follow_system_theme: false,
@@ -62,7 +65,7 @@ impl WebHandle {
 
         self.runner
             .start(
-                &canvas_id,
+                canvas,
                 web_options,
                 Box::new(move |cc| Ok(Box::new(create_app(cc, app_options)?))),
             )

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -11,6 +11,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b4e30963",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%env RERUN_NOTEBOOK_ASSET serve-local"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1076c3a0",
    "metadata": {},
    "outputs": [],

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -31,11 +31,6 @@ function wasm(mode) {
   }
 }
 
-child_process.execSync(
-  "cargo run -p re_dev_tools -- build-web-viewer --debug --target no-modules-base -o rerun_js/web-viewer",
-  { cwd: __dirname, stdio: "inherit" },
-);
-
 function script() {
   let code = fs.readFileSync(path.join(__dirname, "re_viewer.js"), "utf-8");
 

--- a/rerun_js/web-viewer/index.ts
+++ b/rerun_js/web-viewer/index.ts
@@ -140,19 +140,14 @@ export class WebViewer {
     if (this.#state !== "stopped") return;
     this.#state = "starting";
 
+    let WebHandle_class = await load();
+    if (this.#state !== "starting") return;
+
     this.#canvas = document.createElement("canvas");
     this.#canvas.style.width = options.width ?? "640px";
     this.#canvas.style.height = options.height ?? "360px";
     this.#canvas.id = this.#id;
     parent.append(this.#canvas);
-
-    // This yield appears to be necessary to ensure that the canvas is attached to the DOM
-    // and visible. Without it we get occasionally get a panic about a failure to find a canvas
-    // element with the given ID.
-    await delay(0);
-
-    let WebHandle_class = await load();
-    if (this.#state !== "starting") return;
 
     const fullscreen = this.#allow_fullscreen
       ? {
@@ -163,7 +158,7 @@ export class WebViewer {
 
     this.#handle = new WebHandle_class({ ...options, fullscreen });
     try {
-      await this.#handle.start(this.#canvas.id);
+      await this.#handle.start(this.#canvas);
     } catch (e) {
       this.stop();
       throw e;

--- a/web_viewer/index.html
+++ b/web_viewer/index.html
@@ -381,7 +381,10 @@
 
         check_for_panic();
 
-        handle.start("the_canvas_id").then(on_app_started).catch(on_wasm_error);
+        handle
+          .start(document.getElementById("the_canvas_id"))
+          .then(on_app_started)
+          .catch(on_wasm_error);
       }
 
       function get_query_bool(


### PR DESCRIPTION
### What

This should fix the timeouts when running the notebook on Linux using a remotely-served widget.

To test:
```
pixi shell
pixi run py-build-notebook
jupyter notebook examples/python/notebook/cube.ipynb
```

- egui PR: https://github.com/emilk/egui/pull/4780

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6763?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6763?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6763)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.