### PR TITLE
Bring back display ui for `Name` and `Text` components

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/mod.rs
+++ b/crates/re_edit_ui/src/datatype_editors/mod.rs
@@ -9,4 +9,4 @@ pub use float_drag::{
     edit_f32_min_to_max_float_raw, edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw,
     edit_f32_zero_to_one,
 };
-pub use singleline_string::edit_singleline_string;
+pub use singleline_string::{display_name_ui, display_text_ui, edit_singleline_string};

--- a/crates/re_edit_ui/src/datatype_editors/singleline_string.rs
+++ b/crates/re_edit_ui/src/datatype_editors/singleline_string.rs
@@ -1,3 +1,14 @@
+use re_types::{
+    components::{Name, Text},
+    external::arrow2,
+    Loggable as _,
+};
+use re_ui::UiExt as _;
+use re_viewer_context::{
+    external::{re_data_store::LatestAtQuery, re_entity_db::EntityDb, re_log_types::EntityPath},
+    UiLayout, ViewerContext,
+};
+
 /// Generic singleline string editor.
 pub fn edit_singleline_string(
     _ctx: &re_viewer_context::ViewerContext<'_>,
@@ -16,4 +27,58 @@ fn edit_singleline_string_impl(
     let response = egui::TextEdit::singleline(&mut edit_name).show(ui).response;
     *value = edit_name.into();
     response
+}
+
+// TODO(#6661): Should be merged with edit_singleline_string.
+pub fn display_text_ui(
+    _ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    _layout: UiLayout,
+    _query: &LatestAtQuery,
+    _db: &EntityDb,
+    _path: &EntityPath,
+    data: &dyn arrow2::array::Array,
+) {
+    let text = match Text::from_arrow(data) {
+        Ok(text) => text.first().cloned(),
+        Err(err) => {
+            ui.error_label("failed to deserialize")
+                .on_hover_text(err.to_string());
+            return;
+        }
+    };
+
+    let Some(text) = text else {
+        ui.weak("(none)");
+        return;
+    };
+
+    ui.label(text.as_str());
+}
+
+// TODO(#6661): Should be merged with edit_singleline_string.
+pub fn display_name_ui(
+    _ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    _layout: UiLayout,
+    _query: &LatestAtQuery,
+    _db: &EntityDb,
+    _path: &EntityPath,
+    data: &dyn arrow2::array::Array,
+) {
+    let name = match Name::from_arrow(data) {
+        Ok(name) => name.first().cloned(),
+        Err(err) => {
+            ui.error_label("failed to deserialize")
+                .on_hover_text(err.to_string());
+            return;
+        }
+    };
+
+    let Some(name) = name else {
+        ui.weak("(none)");
+        return;
+    };
+
+    ui.label(name.as_str());
 }

--- a/crates/re_edit_ui/src/lib.rs
+++ b/crates/re_edit_ui/src/lib.rs
@@ -13,8 +13,9 @@ mod response_utils;
 mod visual_bounds2d;
 
 use datatype_editors::{
-    edit_bool, edit_bool_raw, edit_enum, edit_f32_min_to_max_float_raw, edit_f32_zero_to_max,
-    edit_f32_zero_to_max_float_raw, edit_f32_zero_to_one, edit_singleline_string,
+    display_name_ui, display_text_ui, edit_bool, edit_bool_raw, edit_enum,
+    edit_f32_min_to_max_float_raw, edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw,
+    edit_f32_zero_to_one, edit_singleline_string,
 };
 use re_types::{
     blueprint::components::{BackgroundKind, Corner2D, LockRangeDuringZoom, ViewFit, Visible},
@@ -59,7 +60,9 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_editor_ui::<LockRangeDuringZoom>(edit_bool);
 
     registry.add_singleline_editor_ui::<Text>(edit_singleline_string);
+    registry.add_display_ui(Text::name(), Box::new(display_text_ui));
     registry.add_singleline_editor_ui::<Name>(edit_singleline_string);
+    registry.add_display_ui(Name::name(), Box::new(display_name_ui));
 
     registry.add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<BackgroundKind>(ui, value));
     registry.add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<Colormap>(ui, value));


### PR DESCRIPTION
### What

* Fixes the worst offender of [#6661](https://github.com/rerun-io/rerun/issues/6661)

![Screenshot2024_07_04_141633](https://github.com/rerun-io/rerun/assets/1220815/e951e130-383d-4a1a-ad4c-02e15cb9ce9c)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6764?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6764?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6764)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.