### PR TITLE
Optimize large point clouds

### DIFF
--- a/crates/re_renderer/src/point_cloud_builder.rs
+++ b/crates/re_renderer/src/point_cloud_builder.rs
@@ -192,14 +192,25 @@ impl<'a, 'ctx> PointCloudBatchBuilder<'a, 'ctx> {
             // TODO(andreas): It would be nice to pass on the iterator as is so we don't have to do yet another
             // copy of the data and instead write into the buffers directly - if done right this should be the fastest.
             // But it's surprisingly tricky to do this effectively.
-            let vertices = izip!(
-                positions.iter().copied(),
-                radii.iter().copied().chain(std::iter::repeat(
-                    *radii.last().unwrap_or(&Size::ONE_UI_POINT)
-                ))
-            )
-            .map(|(pos, radius)| PositionRadius { pos, radius })
-            .collect_vec();
+            let vertices = if positions.len() == radii.len() {
+                let vertices = izip!(positions.iter().copied(), radii.iter().copied())
+                    .map(|(pos, radius)| PositionRadius { pos, radius });
+
+                re_tracing::profile_scope!("collect_vec");
+                vertices.collect_vec()
+            } else {
+                let vertices = izip!(
+                    positions.iter().copied(),
+                    radii.iter().copied().chain(std::iter::repeat(
+                        *radii.last().unwrap_or(&Size::ONE_UI_POINT)
+                    ))
+                )
+                .map(|(pos, radius)| PositionRadius { pos, radius });
+
+                re_tracing::profile_scope!("collect_vec");
+                vertices.collect_vec()
+            };
+
             self.0
                 .position_radius_buffer
                 .extend_from_slice(&vertices)

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -147,7 +147,7 @@ pub fn process_color_slice<'a>(
             ResolvedAnnotationInfos::Same(count, annotation_info) => {
                 re_tracing::profile_scope!("no colors, same annotation");
                 let color = annotation_info
-                    .color(None)
+                    .color()
                     .unwrap_or_else(|| fallback_provider.fallback_for(ctx).into());
                 vec![color; *count]
             }
@@ -156,7 +156,7 @@ pub fn process_color_slice<'a>(
                 let fallback = fallback_provider.fallback_for(ctx).into();
                 annotation_info
                     .iter()
-                    .map(|annotation_info| annotation_info.color(None).unwrap_or(fallback))
+                    .map(|annotation_info| annotation_info.color().unwrap_or(fallback))
                     .collect()
             }
         }

--- a/crates/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/re_space_view_spatial/src/visualizers/mod.rs
@@ -161,31 +161,15 @@ pub fn process_color_slice<'a>(
             }
         }
     } else {
+        // If we have colors we can ignore the annotation infos/contexts:
+        re_tracing::profile_scope!("many-colors");
         let colors = entity_iterator::clamped(colors, num_instances);
-        let fallback = fallback_provider.fallback_for(ctx).into();
-        match annotation_infos {
-            ResolvedAnnotationInfos::Same(_count, annotation_info) => {
-                re_tracing::profile_scope!("many-colors, same annotation");
-                colors
-                    .map(|color| {
-                        annotation_info
-                            .color(Some(color.to_array()))
-                            .unwrap_or(fallback)
-                    })
-                    .collect()
-            }
-            ResolvedAnnotationInfos::Many(annotation_infos) => {
-                re_tracing::profile_scope!("many-colors, many annotations");
-                colors
-                    .zip(annotation_infos.iter())
-                    .map(move |(color, annotation_info)| {
-                        annotation_info
-                            .color(Some(color.to_array()))
-                            .unwrap_or(fallback)
-                    })
-                    .collect()
-            }
-        }
+        colors
+            .map(|color| {
+                let [r, g, b, a] = color.to_array();
+                re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
+            })
+            .collect()
     }
 }
 

--- a/crates/re_viewer_context/src/annotations.rs
+++ b/crates/re_viewer_context/src/annotations.rs
@@ -132,25 +132,21 @@ pub struct ResolvedAnnotationInfo {
 }
 
 impl ResolvedAnnotationInfo {
-    /// `rgba` should be unmultiplied
-    #[inline]
-    pub fn color(&self, rgba: Option<[u8; 4]>) -> Option<re_renderer::Color32> {
-        if let Some([r, g, b, a]) = rgba {
-            // Use passed color.
-            Some(if a == 255 {
-                // Common-case optimization
-                re_renderer::Color32::from_rgb(r, g, b)
-            } else {
-                re_renderer::Color32::from_rgba_unmultiplied(r, g, b, a)
-            })
-        } else if let Some(info) = self.annotation_info.as_ref() {
+    pub fn color(&self) -> Option<egui::Color32> {
+        #![allow(clippy::manual_map)] // for readability
+
+        if let Some(info) = &self.annotation_info {
             // Use annotation context based color.
-            info.color
-                .map(|c| c.into())
-                .or_else(|| Some(auto_color_egui(info.id)))
-        } else {
+            if let Some(color) = info.color {
+                Some(color.into())
+            } else {
+                Some(auto_color_egui(info.id))
+            }
+        } else if let Some(class_id) = self.class_id {
             // Use class id based color (or give up).
-            self.class_id.map(|class_id| auto_color_egui(class_id.0))
+            Some(auto_color_egui(class_id.0))
+        } else {
+            None
         }
     }
 

--- a/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/tensor_to_gpu.rs
@@ -255,7 +255,7 @@ fn class_id_tensor_to_gpu(
                 let color = annotations
                     .resolved_class_description(Some(ClassId::from(id as u16)))
                     .annotation_info()
-                    .color(None)
+                    .color()
                     .unwrap_or(re_renderer::Color32::TRANSPARENT);
                 color.to_array() // premultiplied!
             })


### PR DESCRIPTION
### What
This saves us a lot of time, with less code :)

Basically: if we have colors for all our points, then we can ignore the annotation contexts. Before we ignored them once for each point, now we ignore them all in one go.

I also added a happy path for position/radii

### `opf` before
![Screenshot 2024-07-04 at 15 19 19](https://github.com/rerun-io/rerun/assets/1148717/ca160055-7b40-403d-981c-f2bf47a3fcd3)

### `opf` after
![Screenshot 2024-07-04 at 15 20 23](https://github.com/rerun-io/rerun/assets/1148717/aee60a1c-7b7a-4542-83f8-74eabc5986a6)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6767?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6767?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6767)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.