### PR TITLE
Fix `check_annotations` relying on random values

### DIFF
--- a/tests/python/release_checklist/check_annotations.py
+++ b/tests/python/release_checklist/check_annotations.py
@@ -32,7 +32,11 @@ def log_readme() -> None:
 
 def log_annotations() -> None:
     # Log an annotation context to assign a label and color to each class
-    rr.log("/", rr.AnnotationContext([(1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]), static=True)
+    rr.log(
+        "/",
+        rr.AnnotationContext([(0, "black", (0, 0, 0)), (1, "red", (255, 0, 0)), (2, "green", (0, 255, 0))]),
+        static=True,
+    )
 
     # Log a batch of 2 rectangles with different `class_ids`
     rr.log("detections", rr.Boxes2D(mins=[[200, 50], [75, 150]], sizes=[[30, 30], [20, 20]], class_ids=[1, 2]))


### PR DESCRIPTION
The check for annotations says that you should expect most of the image to be black, and then you think something is wrong because in practice it looks like this:
![image](https://github.com/rerun-io/rerun/assets/2910679/c160ff30-07f0-45c7-b0f1-e787cfafd8ad)

That's because, at some point, we stopped hardcoding the zero color value of an annotation context to black, but rather to a random deterministic color.

So, specify the expected zero value in the script:
![image](https://github.com/rerun-io/rerun/assets/2910679/d9ac6d8e-6a52-4ddf-833d-4c5ba20eaf6e)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6770?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6770?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6770)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.