### PR TITLE
Use proper colormap popup for the Colormap component

### DIFF
--- a/crates/re_edit_ui/src/lib.rs
+++ b/crates/re_edit_ui/src/lib.rs
@@ -12,6 +12,7 @@ mod range1d;
 mod response_utils;
 mod visual_bounds2d;
 
+use crate::response_utils::response_with_changes_of_inner;
 use datatype_editors::{
     display_name_ui, display_text_ui, edit_bool, edit_bool_raw, edit_enum,
     edit_f32_min_to_max_float_raw, edit_f32_zero_to_max, edit_f32_zero_to_max_float_raw,
@@ -20,13 +21,12 @@ use datatype_editors::{
 use re_types::{
     blueprint::components::{BackgroundKind, Corner2D, LockRangeDuringZoom, ViewFit, Visible},
     components::{
-        AggregationPolicy, AxisLength, Color, Colormap, DepthMeter, DrawOrder, FillRatio,
-        GammaCorrection, ImagePlaneDistance, MagnificationFilter, MarkerSize, Name, Opacity,
-        StrokeWidth, Text,
+        AggregationPolicy, AxisLength, Color, DepthMeter, DrawOrder, FillRatio, GammaCorrection,
+        ImagePlaneDistance, MagnificationFilter, MarkerSize, Name, Opacity, StrokeWidth, Text,
     },
     Loggable as _,
 };
-
+use re_viewer_context::gpu_bridge::colormap_dropdown_button_ui;
 // ----
 
 /// Registers all editors of this crate in the component UI registry.
@@ -65,7 +65,9 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_display_ui(Name::name(), Box::new(display_name_ui));
 
     registry.add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<BackgroundKind>(ui, value));
-    registry.add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<Colormap>(ui, value));
+    registry.add_singleline_editor_ui(|ctx, ui, value| {
+        response_with_changes_of_inner(colormap_dropdown_button_ui(ctx.render_ctx, ui, value))
+    });
     registry.add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<Corner2D>(ui, value));
     registry
         .add_singleline_editor_ui(|_ctx, ui, value| edit_enum::<MagnificationFilter>(ui, value));

--- a/crates/re_viewer_context/src/gpu_bridge/colormap.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/colormap.rs
@@ -113,6 +113,10 @@ pub fn colormap_dropdown_button_ui(
             response |= colormap_variant_ui(render_ctx, ui, option, map);
         }
 
+        if response.clicked() {
+            response.mark_changed();
+        }
+
         response
     };
 

--- a/crates/re_viewer_context/src/gpu_bridge/colormap.rs
+++ b/crates/re_viewer_context/src/gpu_bridge/colormap.rs
@@ -72,7 +72,7 @@ fn colormap_variant_ui(
 ) -> egui::Response {
     let list_item = list_item::ListItem::new().selected(option == map);
 
-    let response = if let Some(render_ctx) = render_ctx {
+    let mut response = if let Some(render_ctx) = render_ctx {
         list_item.show_flat(
             ui,
             list_item::PropertyContent::new(option.to_string())
@@ -89,6 +89,7 @@ fn colormap_variant_ui(
 
     if response.clicked() {
         *map = *option;
+        response.mark_changed();
     }
 
     response
@@ -111,10 +112,6 @@ pub fn colormap_dropdown_button_ui(
 
         for option in iter {
             response |= colormap_variant_ui(render_ctx, ui, option, map);
-        }
-
-        if response.clicked() {
-            response.mark_changed();
         }
 
         response


### PR DESCRIPTION
### What

☝🏻 

- fixes #6769

<img width="589" alt="image" src="https://github.com/rerun-io/rerun/assets/49431240/e4c029ad-4be2-46a3-85ed-be1d1229047a">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6771?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6771?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6771)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.