### PR TITLE
Fix display for `Text` and `Name` components

### DIFF
--- a/crates/re_edit_ui/src/datatype_editors/singleline_string.rs
+++ b/crates/re_edit_ui/src/datatype_editors/singleline_string.rs
@@ -33,7 +33,7 @@ fn edit_singleline_string_impl(
 pub fn display_text_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _layout: UiLayout,
+    ui_layout: UiLayout,
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _path: &EntityPath,
@@ -53,14 +53,14 @@ pub fn display_text_ui(
         return;
     };
 
-    ui.label(text.as_str());
+    ui_layout.data_label(ui, text);
 }
 
 // TODO(#6661): Should be merged with edit_singleline_string.
 pub fn display_name_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    _layout: UiLayout,
+    ui_layout: UiLayout,
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _path: &EntityPath,
@@ -80,5 +80,5 @@ pub fn display_name_ui(
         return;
     };
 
-    ui.label(name.as_str());
+    ui_layout.data_label(ui, name);
 }


### PR DESCRIPTION
### What

- Fixes #6772 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6774?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6774?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6774)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.