### PR TITLE
Fix incorrect label placement for 3D arrows with origins

### DIFF
--- a/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -132,7 +132,7 @@ impl Arrows2DVisualizer {
                     itertools::Either::Right(data.vectors.iter().zip(origins).map(
                         |(vector, origin)| {
                             // `0.45` rather than `0.5` to account for cap and such
-                            (glam::Vec2::from(origin.0) + glam::Vec2::from(vector.0)) * 0.45
+                            glam::Vec2::from(origin.0) + glam::Vec2::from(vector.0) * 0.45
                         },
                     ))
                 };

--- a/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -132,7 +132,7 @@ impl Arrows3DVisualizer {
                     itertools::Either::Right(data.vectors.iter().zip(origins).map(
                         |(vector, origin)| {
                             // `0.45` rather than `0.5` to account for cap and such
-                            (glam::Vec3::from(origin.0) + glam::Vec3::from(vector.0)) * 0.45
+                            glam::Vec3::from(origin.0) + glam::Vec3::from(vector.0) * 0.45
                         },
                     ))
                 };


### PR DESCRIPTION
### What

Title says 3D because that's what this fixes compard to 0.16. However, on `main` both was broken.

What happend?

On 0.16.1
* arrows2d: note no incorrect paranthesis https://github.com/rerun-io/rerun/blob/release-0.16.1/crates/re_space_view_spatial/src/visualizers/arrows2d.rs#L66
* arrows3d: note incorrect paranthesis https://github.com/rerun-io/rerun/blob/release-0.16.1/crates/re_space_view_spatial/src/visualizers/arrows3d.rs#L66

Recently I did a refactor of label positioning code and ended up propagating the broken code to 2D arrows. Which then in turn was noticed by @teh-cmc as it broke a recently added release checklist item.

<img width="1021" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/7704df11-87eb-469c-acfa-890889942630">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6779?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6779?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6779)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.