### PR TITLE
Use the blueprint API for styling in the `plots` example

### DIFF
--- a/examples/python/plots/plots.py
+++ b/examples/python/plots/plots.py
@@ -43,6 +43,12 @@ def log_bar_chart() -> None:
 
 
 def log_parabola() -> None:
+    # Time-independent styling can be achieved by logging static components to the data store. Here, by using the
+    # `SeriesLine` archetype, we further hint the viewer to use the line plot visualizer.
+    # Alternatively, you can achieve time-independent styling using overrides, as is everywhere else in this example
+    # (see the `main()` function).
+    rr.log("curves/parabola", rr.SeriesLine(name="f(t) = (0.01t - 3)³ + 1"), static=True)
+
     # Log a parabola as a time series
     for t in range(0, 1000, 10):
         rr.set_time_sequence("frame_nr", t)
@@ -116,9 +122,6 @@ def main() -> None:
                 rrb.TimeSeriesView(
                     name="Curves",
                     origin="/curves",
-                    overrides={
-                        "/curves/parabola": [rr.components.Name("f(t) = (0.01t - 3)³ + 1")],
-                    },
                 ),
                 rrb.TimeSeriesView(
                     name="Trig",

--- a/examples/python/plots/plots.py
+++ b/examples/python/plots/plots.py
@@ -43,9 +43,6 @@ def log_bar_chart() -> None:
 
 
 def log_parabola() -> None:
-    # Name never changes, log it only once.
-    rr.log("curves/parabola", rr.SeriesLine(name="f(t) = (0.01t - 3)³ + 1"), static=True)
-
     # Log a parabola as a time series
     for t in range(0, 1000, 10):
         rr.set_time_sequence("frame_nr", t)
@@ -58,6 +55,7 @@ def log_parabola() -> None:
         elif f_of_t > 10.0:
             color = [0, 255, 0]
 
+        # Note: by using the `rr.SeriesLine` archetype, we hint the viewer to use the line plot visualizer.
         rr.log(
             "curves/parabola",
             rr.Scalar(f_of_t),
@@ -66,10 +64,6 @@ def log_parabola() -> None:
 
 
 def log_trig() -> None:
-    # Styling doesn't change over time, log it once with static=True.
-    rr.log("trig/sin", rr.SeriesLine(color=[255, 0, 0], name="sin(0.01t)"), static=True)
-    rr.log("trig/cos", rr.SeriesLine(color=[0, 255, 0], name="cos(0.01t)"), static=True)
-
     for t in range(0, int(tau * 2 * 100.0)):
         rr.set_time_sequence("frame_nr", t)
 
@@ -81,9 +75,6 @@ def log_trig() -> None:
 
 
 def log_classification() -> None:
-    # Log components that don't change only once:
-    rr.log("classification/line", rr.SeriesLine(color=[255, 255, 0], width=3.0), static=True)
-
     for t in range(0, 1000, 2):
         rr.set_time_sequence("frame_nr", t)
 
@@ -98,7 +89,17 @@ def log_classification() -> None:
         else:
             color = [255, 255, 255]
         marker_size = abs(g_of_t - f_of_t)
-        rr.log("classification/samples", rr.Scalar(g_of_t), rr.SeriesPoint(color=color, marker_size=marker_size))
+
+        # Note: this log call doesn't include any hint as to which visualizer to use. We use a blueprint visualizer
+        # override instead (see `main()`)
+        rr.log(
+            "classification/samples",
+            rr.Scalar(g_of_t),
+            [
+                rr.components.Color(color),
+                rr.components.MarkerSize(marker_size),
+            ],
+        )
 
 
 def main() -> None:
@@ -112,9 +113,30 @@ def main() -> None:
         rrb.Horizontal(
             rrb.Grid(
                 rrb.BarChartView(name="Bar Chart", origin="/bar_chart"),
-                rrb.TimeSeriesView(name="Curves", origin="/curves"),
-                rrb.TimeSeriesView(name="Trig", origin="/trig"),
-                rrb.TimeSeriesView(name="Classification", origin="/classification"),
+                rrb.TimeSeriesView(
+                    name="Curves",
+                    origin="/curves",
+                    overrides={
+                        "/curves/parabola": [rr.components.Name("f(t) = (0.01t - 3)³ + 1")],
+                    },
+                ),
+                rrb.TimeSeriesView(
+                    name="Trig",
+                    origin="/trig",
+                    overrides={
+                        "/trig/sin": [rr.components.Color([255, 0, 0]), rr.components.Name("sin(0.01t)")],
+                        "/trig/cos": [rr.components.Color([0, 255, 0]), rr.components.Name("cos(0.01t)")],
+                    },
+                ),
+                rrb.TimeSeriesView(
+                    name="Classification",
+                    origin="/classification",
+                    overrides={
+                        "classification/line": [rr.components.Color([255, 255, 0]), rr.components.StrokeWidth(3.0)],
+                        # This ensures that the `SeriesPoint` visualizers is used for this entity.
+                        "classification/samples": [rrb.VisualizerOverrides("SeriesPoint")],
+                    },
+                ),
             ),
             rrb.TextDocumentView(name="Description", origin="/description"),
             column_shares=[3, 1],


### PR DESCRIPTION
### What

☝🏻 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6781?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6781?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6781)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.