### PR TITLE
Use overrides & defaults in nuscenes example

### DIFF
--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -274,7 +274,14 @@ def main() -> None:
     ]
     blueprint = rrb.Vertical(
         rrb.Horizontal(
-            rrb.Spatial3DView(name="3D", origin="world"),
+            rrb.Spatial3DView(
+                name="3D",
+                origin="world",
+                # Default for `ImagePlaneDistance` so that the pinhole frustum visualizations don't take up too much space.
+                defaults=[rr.components.ImagePlaneDistance(4.0)],
+                # Transform arrows for the vehicle shouldn't be too long.
+                overrides={"world/ego_vehicle": [rr.components.AxisLength(5.0)]},
+            ),
             rrb.TextDocumentView(origin="description", name="Description"),
             column_shares=[3, 1],
         ),


### PR DESCRIPTION
### What

Before (depends a bit on how bad the accumulated bbox gets):
<img width="1419" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/422ca693-889d-4fd1-8cd1-d48366885915">

After:
<img width="1701" alt="image" src="https://github.com/rerun-io/rerun/assets/1220815/9c6e5a9d-c6aa-4b5c-9bac-83e3da529b04">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6783?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6783?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6783)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.