### PR TITLE
Document support for `ogImageUrl` in docs frontmatter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -36,13 +36,14 @@ order: 6
 ```
 
 The available attributes are:
-| name     | type    | required | description                                   |
-| -------- | ------- | -------- | --------------------------------------------- |
-| title    | string  | yes      | navigation item title                         |
-| order    | number  | yes      | used to sort navigation items                 |
-| redirect | string  | no       | redirect to the given url                     |
-| hidden   | boolean | no       | don't show the item in navigation             |
-| expand   | boolean | no       | expand the sub-items in navigation by default |
+| name       | type    | required | description                                         |
+| ---------- | ------- | -------- | --------------------------------------------------- |
+| title      | string  | yes      | navigation item title                               |
+| order      | number  | yes      | used to sort navigation items                       |
+| redirect   | string  | no       | redirect to the given url                           |
+| hidden     | boolean | no       | don't show the item in navigation                   |
+| expand     | boolean | no       | expand the sub-items in navigation by default       |
+| ogImageUrl | string  | no       | url to an image to show as the open-graph thumbnail |
 
 ### Snippets
 


### PR DESCRIPTION
### What

It is now possible to set `ogImageUrl` in frontmatter for doc pages. When the page is linked to on Twitter, LinkedIn, Facebook, Discord, Slack, etc., it will use the given URL as the thumbnail.

Landing PR: https://github.com/rerun-io/landing/pull/994

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6786?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6786?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6786)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.