### PR TITLE
Fix confusing naming in line strip textures

### DIFF
--- a/crates/re_renderer/shader/lines.wgsl
+++ b/crates/re_renderer/shader/lines.wgsl
@@ -8,9 +8,9 @@
 #import <./utils/depth_offset.wgsl>
 
 @group(1) @binding(0)
-var line_strip_texture: texture_2d<f32>;
+var position_texture: texture_2d<f32>;
 @group(1) @binding(1)
-var position_data_texture: texture_2d<u32>;
+var strip_data_texture: texture_2d<u32>;
 @group(1) @binding(2)
 var picking_instance_id_texture: texture_2d<u32>;
 
@@ -86,9 +86,9 @@ struct LineStripData {
 
 // Read and unpack line strip data at a given location
 fn read_strip_data(idx: u32) -> LineStripData {
-    let position_data_texture_size = textureDimensions(position_data_texture);
-    let raw_data = textureLoad(position_data_texture,
-         vec2u(idx % position_data_texture_size.x, idx / position_data_texture_size.x), 0);
+    let strip_data_texture_size = textureDimensions(strip_data_texture);
+    let raw_data = textureLoad(strip_data_texture,
+         vec2u(idx % strip_data_texture_size.x, idx / strip_data_texture_size.x), 0);
 
     let picking_instance_id_texture_size = textureDimensions(picking_instance_id_texture);
     let picking_instance_id = textureLoad(picking_instance_id_texture,
@@ -112,9 +112,9 @@ struct PositionData {
 
 // Read and unpack position data at a given location
 fn read_position_data(idx: u32) -> PositionData {
-    let texture_size = textureDimensions(line_strip_texture);
+    let texture_size = textureDimensions(position_texture);
     let coord = vec2u(idx % texture_size.x, idx / texture_size.x);
-    var raw_data = textureLoad(line_strip_texture, coord, 0);
+    var raw_data = textureLoad(position_texture, coord, 0);
 
     var data: PositionData;
     let pos_4d = batch.world_from_obj * vec4f(raw_data.xyz, 1.0);

--- a/crates/re_renderer/src/renderer/lines.rs
+++ b/crates/re_renderer/src/renderer/lines.rs
@@ -387,13 +387,13 @@ impl LineDrawData {
         let max_num_texels = max_texture_dimension_2d as usize * max_texture_dimension_2d as usize;
         let max_num_vertices = max_num_texels - NUM_SENTINEL_VERTICES;
 
-        let position_data_texture = vertices_buffer.finish(
+        let position_texture = vertices_buffer.finish(
             wgpu::TextureFormat::Rgba32Float,
-            "LineDrawData::position_data_texture",
+            "LineDrawData::position_texture",
         )?;
-        let line_strip_texture = strips_buffer.finish(
+        let strip_data_texture = strips_buffer.finish(
             wgpu::TextureFormat::Rg32Uint,
-            "LineDrawData::line_strip_texture",
+            "LineDrawData::strip_data_texture",
         )?;
         let picking_instance_id_texture = picking_instance_ids_buffer.finish(
             wgpu::TextureFormat::Rg32Uint,
@@ -421,8 +421,8 @@ impl LineDrawData {
             &BindGroupDesc {
                 label: "LineDrawData::bind_group_all_lines".into(),
                 entries: smallvec![
-                    BindGroupEntry::DefaultTextureView(position_data_texture.handle),
-                    BindGroupEntry::DefaultTextureView(line_strip_texture.handle),
+                    BindGroupEntry::DefaultTextureView(position_texture.handle),
+                    BindGroupEntry::DefaultTextureView(strip_data_texture.handle),
                     BindGroupEntry::DefaultTextureView(picking_instance_id_texture.handle),
                     draw_data_uniform_buffer_bindings[0].clone(),
                 ],
@@ -435,8 +435,8 @@ impl LineDrawData {
             &BindGroupDesc {
                 label: "LineDrawData::bind_group_all_lines_outline_mask".into(),
                 entries: smallvec![
-                    BindGroupEntry::DefaultTextureView(position_data_texture.handle),
-                    BindGroupEntry::DefaultTextureView(line_strip_texture.handle),
+                    BindGroupEntry::DefaultTextureView(position_texture.handle),
+                    BindGroupEntry::DefaultTextureView(strip_data_texture.handle),
                     BindGroupEntry::DefaultTextureView(picking_instance_id_texture.handle),
                     draw_data_uniform_buffer_bindings[1].clone(),
                 ],


### PR DESCRIPTION
### What

Stumbled upon this a couple days ago when investigating a WSL issue.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6790?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6790?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6790)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.