### PR TITLE
Improve bounding box based heuristics

### DIFF
--- a/crates/re_space_view_spatial/src/scene_bounding_boxes.rs
+++ b/crates/re_space_view_spatial/src/scene_bounding_boxes.rs
@@ -7,9 +7,6 @@ use crate::visualizers::SpatialViewVisualizerData;
 
 #[derive(Clone)]
 pub struct SceneBoundingBoxes {
-    /// Accumulated bounding box over several frames.
-    pub accumulated: macaw::BoundingBox,
-
     /// Overall bounding box of the scene for the current query.
     pub current: macaw::BoundingBox,
 
@@ -25,7 +22,6 @@ pub struct SceneBoundingBoxes {
 impl Default for SceneBoundingBoxes {
     fn default() -> Self {
         Self {
-            accumulated: macaw::BoundingBox::nothing(),
             current: macaw::BoundingBox::nothing(),
             smoothed: macaw::BoundingBox::nothing(),
             per_entity: IntMap::default(),
@@ -57,12 +53,6 @@ impl SceneBoundingBoxes {
 
         for bbox in self.per_entity.values() {
             self.current = self.current.union(*bbox);
-        }
-
-        if self.accumulated.is_nothing() || !self.accumulated.size().is_finite() {
-            self.accumulated = self.current;
-        } else {
-            self.accumulated = self.accumulated.union(self.current);
         }
 
         // Update smoothed bounding box.

--- a/crates/re_space_view_spatial/src/scene_bounding_boxes.rs
+++ b/crates/re_space_view_spatial/src/scene_bounding_boxes.rs
@@ -1,3 +1,4 @@
+use egui::NumExt as _;
 use nohash_hasher::IntMap;
 use re_log_types::EntityPathHash;
 use re_viewer_context::VisualizerCollection;
@@ -12,6 +13,11 @@ pub struct SceneBoundingBoxes {
     /// Overall bounding box of the scene for the current query.
     pub current: macaw::BoundingBox,
 
+    /// A bounding box that smoothly transitions to the current bounding box.
+    ///
+    /// If discontinuities are detected, this bounding box will be reset immediately to the current bounding box.
+    pub smoothed: macaw::BoundingBox,
+
     /// Per-entity bounding boxes for the current query.
     pub per_entity: IntMap<EntityPathHash, macaw::BoundingBox>,
 }
@@ -21,15 +27,17 @@ impl Default for SceneBoundingBoxes {
         Self {
             accumulated: macaw::BoundingBox::nothing(),
             current: macaw::BoundingBox::nothing(),
+            smoothed: macaw::BoundingBox::nothing(),
             per_entity: IntMap::default(),
         }
     }
 }
 
 impl SceneBoundingBoxes {
-    pub fn update(&mut self, visualizers: &VisualizerCollection) {
+    pub fn update(&mut self, ui: &egui::Ui, visualizers: &VisualizerCollection) {
         re_tracing::profile_function!();
 
+        let previous = self.current;
         self.current = macaw::BoundingBox::nothing();
         self.per_entity.clear();
 
@@ -56,5 +64,67 @@ impl SceneBoundingBoxes {
         } else {
             self.accumulated = self.accumulated.union(self.current);
         }
+
+        // Update smoothed bounding box.
+        let discontinuity = detect_boundingbox_discontinuity(self.current, previous);
+        if !self.smoothed.is_finite() || self.smoothed.is_nothing() || discontinuity {
+            // Reset the smoothed bounding box if it's not valid or we detect a discontinuity.
+            self.smoothed = self.current;
+        } else {
+            let dt = ui.input(|input| input.stable_dt.at_most(0.1));
+
+            // Smooth the bounding box by moving center & size towards the current bounding box.
+            let reach_this_factor = 0.9;
+            let in_this_many_seconds = 0.2;
+            let smoothing_factor =
+                egui::emath::exponential_smooth_factor(reach_this_factor, in_this_many_seconds, dt);
+
+            self.smoothed = macaw::BoundingBox::from_center_size(
+                self.smoothed
+                    .center()
+                    .lerp(self.current.center(), smoothing_factor),
+                self.smoothed
+                    .size()
+                    .lerp(self.current.size(), smoothing_factor),
+            );
+
+            if self.smoothed.min.distance_squared(self.current.min) > 0.001
+                || self.smoothed.max.distance_squared(self.current.max) > 0.001
+            {
+                ui.ctx().request_repaint();
+            }
+        }
     }
+}
+
+fn detect_boundingbox_discontinuity(
+    current: macaw::BoundingBox,
+    previous: macaw::BoundingBox,
+) -> bool {
+    if !previous.is_finite() {
+        // Previous bounding box is not finite, so we can't compare.
+        return true;
+    }
+
+    // Is the size jumping a lot?
+    let current_size = current.size().length();
+    let previous_size = previous.size().length();
+    let size_change = (current_size - previous_size).abs();
+    let size_change_ratio = size_change / previous_size;
+    if size_change_ratio > 0.5 {
+        // Box size change by more than 50% since the previous frame.
+        return true;
+    }
+
+    // Did the center jump?
+    let current_center = current.center();
+    let previous_center = previous.center();
+    let center_change = current_center.distance(previous_center);
+    let center_change_ratio = center_change / previous_size;
+    if center_change_ratio > 0.5 {
+        // Center change by more than 50% of the previous size since the previous frame.
+        return true;
+    }
+
+    false
 }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -144,7 +144,6 @@ impl SpatialSpaceViewState {
             )
             .clicked()
         {
-            self.bounding_boxes.accumulated = self.bounding_boxes.current;
             self.bounding_boxes.smoothed = self.bounding_boxes.current;
             self.state_3d
                 .reset_camera(&self.bounding_boxes, scene_view_coordinates);

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -142,6 +142,7 @@ impl SpatialSpaceViewState {
             .clicked()
         {
             self.bounding_boxes.accumulated = self.bounding_boxes.current;
+            self.bounding_boxes.smoothed = self.bounding_boxes.current;
             self.state_3d
                 .reset_camera(&self.bounding_boxes, scene_view_coordinates);
         }

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -92,11 +92,12 @@ impl SpatialSpaceViewState {
     /// Updates the state with statistics from the latest system outputs.
     pub fn update_frame_statistics(
         &mut self,
+        ui: &egui::Ui,
         system_output: &re_viewer_context::SystemExecutionOutput,
     ) -> Result<(), SpaceViewSystemExecutionError> {
         re_tracing::profile_function!();
 
-        self.bounding_boxes.update(&system_output.view_systems);
+        self.bounding_boxes.update(ui, &system_output.view_systems);
 
         self.scene_num_primitives = system_output
             .context_systems

--- a/crates/re_space_view_spatial/src/ui.rs
+++ b/crates/re_space_view_spatial/src/ui.rs
@@ -12,6 +12,7 @@ use re_renderer::OutlineConfig;
 use re_space_view::{latest_at_with_blueprint_resolved_data, ScreenshotMode};
 use re_types::{
     archetypes::Pinhole,
+    blueprint::components::VisualBounds2D,
     components::{Colormap, DepthMeter, TensorData, ViewCoordinates},
     tensor_data::TensorDataMeaning,
     Loggable as _,
@@ -76,6 +77,8 @@ pub struct SpatialSpaceViewState {
 
     /// Pinhole component logged at the origin if any.
     pub pinhole_at_origin: Option<Pinhole>,
+
+    pub visual_bounds_2d: Option<VisualBounds2D>,
 }
 
 impl SpaceViewState for SpatialSpaceViewState {

--- a/crates/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/re_space_view_spatial/src/ui_2d.rs
@@ -40,7 +40,7 @@ fn ui_from_scene(
     view_id: SpaceViewId,
     response: &egui::Response,
     view_class: &SpatialSpaceView2D,
-    view_state: &SpatialSpaceViewState,
+    view_state: &mut SpatialSpaceViewState,
 ) -> RectTransform {
     let bounds_property = ViewProperty::from_archetype::<VisualBounds2D>(
         ctx.blueprint_db(),
@@ -51,6 +51,7 @@ fn ui_from_scene(
         .component_or_fallback(ctx, view_class, view_state)
         .ok_or_log_error()
         .unwrap_or_default();
+    view_state.visual_bounds_2d = Some(bounds);
     let mut bounds_rect: egui::Rect = bounds.into();
 
     // --------------------------------------------------------------------------

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -65,6 +65,7 @@ pub struct View3DState {
     pub show_axes: bool,
     pub show_bbox: bool,
     pub show_accumulated_bbox: bool,
+    pub show_smoothed_bbox: bool,
 
     eye_interact_fade_in: bool,
     eye_interact_fade_change_time: f64,
@@ -83,6 +84,7 @@ impl Default for View3DState {
             show_axes: false,
             show_bbox: false,
             show_accumulated_bbox: false,
+            show_smoothed_bbox: false,
             eye_interact_fade_in: false,
             eye_interact_fade_change_time: f64::NEG_INFINITY,
         }
@@ -660,6 +662,16 @@ impl SpatialSpaceView3D {
             line_builder
                 .batch("scene_bbox_accumulated")
                 .add_box_outline(&state.bounding_boxes.accumulated)
+                .map(|lines| {
+                    lines
+                        .radius(box_line_radius)
+                        .color(egui::Color32::from_gray(170))
+                });
+        }
+        if state.state_3d.show_smoothed_bbox {
+            line_builder
+                .batch("scene_bbox_smoothed")
+                .add_box_outline(&state.bounding_boxes.smoothed)
                 .map(|lines| {
                     lines
                         .radius(box_line_radius)

--- a/crates/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/re_space_view_spatial/src/ui_3d.rs
@@ -118,10 +118,10 @@ impl View3DState {
     ) -> ViewEye {
         // If the user has not interacted with the eye-camera yet, continue to
         // interpolate to the new default eye. This gives much better robustness
-        // with scenes that grow over time.
+        // with scenes that change over time.
         if self.last_eye_interaction.is_none() {
             self.interpolate_to_view_eye(default_eye(
-                &bounding_boxes.accumulated,
+                &bounding_boxes.current,
                 scene_view_coordinates,
             ));
         }
@@ -129,7 +129,7 @@ impl View3DState {
         // Detect live changes to view coordinates, and interpolate to the new up axis as needed.
         if scene_view_coordinates != self.scene_view_coordinates {
             self.interpolate_to_view_eye(default_eye(
-                &bounding_boxes.accumulated,
+                &bounding_boxes.current,
                 scene_view_coordinates,
             ));
         }
@@ -151,9 +151,9 @@ impl View3DState {
             }
         }
 
-        let view_eye = self.view_eye.get_or_insert_with(|| {
-            default_eye(&bounding_boxes.accumulated, scene_view_coordinates)
-        });
+        let view_eye = self
+            .view_eye
+            .get_or_insert_with(|| default_eye(&bounding_boxes.current, scene_view_coordinates));
 
         if self.spin {
             view_eye.rotate(egui::vec2(
@@ -855,7 +855,7 @@ fn show_projections_from_2d_space(
                         add_picking_ray(
                             line_builder,
                             ray,
-                            &state.bounding_boxes.accumulated,
+                            &state.bounding_boxes.smoothed,
                             thick_ray_length,
                             ray_color,
                         );

--- a/crates/re_space_view_spatial/src/view_2d.rs
+++ b/crates/re_space_view_spatial/src/view_2d.rs
@@ -248,7 +248,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         re_tracing::profile_function!();
 
         let state = state.downcast_mut::<SpatialSpaceViewState>()?;
-        state.update_frame_statistics(&system_output)?;
+        state.update_frame_statistics(ui, &system_output)?;
 
         self.view_2d(ctx, ui, state, query, system_output)
     }

--- a/crates/re_space_view_spatial/src/view_2d.rs
+++ b/crates/re_space_view_spatial/src/view_2d.rs
@@ -85,8 +85,18 @@ impl SpaceViewClass for SpatialSpaceView2D {
             .downcast_ref::<SpatialSpaceViewState>()
             .ok()
             .map(|state| {
-                let size = state.bounding_boxes.accumulated.size();
-                size.x / size.y
+                let (width, height) = state.visual_bounds_2d.map_or_else(
+                    || {
+                        let bbox = &state.bounding_boxes.smoothed;
+                        (
+                            (bbox.max.x - bbox.min.x).abs(),
+                            (bbox.max.y - bbox.min.y).abs(),
+                        )
+                    },
+                    |bounds| (bounds.x_range.len() as f32, bounds.y_range.len() as f32),
+                );
+
+                width / height
             })
     }
 

--- a/crates/re_space_view_spatial/src/view_2d.rs
+++ b/crates/re_space_view_spatial/src/view_2d.rs
@@ -93,7 +93,12 @@ impl SpaceViewClass for SpatialSpaceView2D {
                             (bbox.max.y - bbox.min.y).abs(),
                         )
                     },
-                    |bounds| (bounds.x_range.len() as f32, bounds.y_range.len() as f32),
+                    |bounds| {
+                        (
+                            bounds.x_range.abs_len() as f32,
+                            bounds.y_range.abs_len() as f32,
+                        )
+                    },
                 );
 
                 width / height

--- a/crates/re_space_view_spatial/src/view_2d_properties.rs
+++ b/crates/re_space_view_spatial/src/view_2d_properties.rs
@@ -54,10 +54,10 @@ impl TypedComponentFallbackProvider<VisualBounds2D> for SpatialSpaceView2D {
             .and_then(pinhole_resolution_rect)
             .unwrap_or_else(|| {
                 // TODO(emilk): if there is a single image in this view, use that as the default bounds
-                let scene_rect_accum = view_state.bounding_boxes.accumulated;
+                let scene_rect_smoothed = view_state.bounding_boxes.smoothed;
                 egui::Rect::from_min_max(
-                    scene_rect_accum.min.truncate().to_array().into(),
-                    scene_rect_accum.max.truncate().to_array().into(),
+                    scene_rect_smoothed.min.truncate().to_array().into(),
+                    scene_rect_smoothed.max.truncate().to_array().into(),
                 )
             });
 

--- a/crates/re_space_view_spatial/src/view_3d.rs
+++ b/crates/re_space_view_spatial/src/view_3d.rs
@@ -406,11 +406,6 @@ impl SpaceViewClass for SpatialSpaceView3D {
                 ui.re_checkbox(&mut state.state_3d.show_bbox, "Show bounding box")
                     .on_hover_text("Show the current scene bounding box");
                 ui.re_checkbox(
-                    &mut state.state_3d.show_accumulated_bbox,
-                    "Show accumulated bounding box",
-                )
-                .on_hover_text("Show bounding box accumulated over all rendered frames");
-                ui.re_checkbox(
                     &mut state.state_3d.show_smoothed_bbox,
                     "Show smoothed bounding box",
                 )

--- a/crates/re_space_view_spatial/src/view_3d.rs
+++ b/crates/re_space_view_spatial/src/view_3d.rs
@@ -410,6 +410,11 @@ impl SpaceViewClass for SpatialSpaceView3D {
                     "Show accumulated bounding box",
                 )
                 .on_hover_text("Show bounding box accumulated over all rendered frames");
+                ui.re_checkbox(
+                    &mut state.state_3d.show_smoothed_bbox,
+                    "Show smoothed bounding box",
+                )
+                .on_hover_text("Show a smoothed bounding box used for some heuristics");
             });
             ui.end_row();
 
@@ -435,7 +440,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         re_tracing::profile_function!();
 
         let state = state.downcast_mut::<SpatialSpaceViewState>()?;
-        state.update_frame_statistics(&system_output)?;
+        state.update_frame_statistics(ui, &system_output)?;
 
         self.view_3d(ctx, ui, state, query, system_output)
     }

--- a/crates/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/re_space_view_spatial/src/visualizers/cameras.rs
@@ -264,7 +264,7 @@ impl TypedComponentFallbackProvider<ImagePlaneDistance> for CamerasVisualizer {
             return Default::default();
         };
 
-        let scene_size = state.bounding_boxes.accumulated.size().length();
+        let scene_size = state.bounding_boxes.smoothed.size().length();
 
         if scene_size.is_finite() && scene_size > 0.0 {
             // Works pretty well for `examples/python/open_photogrammetry_format/open_photogrammetry_format.py --no-frames`

--- a/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -196,7 +196,7 @@ impl TypedComponentFallbackProvider<AxisLength> for Transform3DArrowsVisualizer 
 
         // If there is a finite bounding box, use the scene size to determine the axis length.
         if let Ok(state) = ctx.view_state.downcast_ref::<SpatialSpaceViewState>() {
-            let scene_size = state.bounding_boxes.accumulated.size().length();
+            let scene_size = state.bounding_boxes.smoothed.size().length();
 
             if scene_size.is_finite() && scene_size > 0.0 {
                 return (scene_size * 0.05).into();

--- a/crates/re_types/src/datatypes/range1d_ext.rs
+++ b/crates/re_types/src/datatypes/range1d_ext.rs
@@ -21,3 +21,11 @@ impl From<Range1D> for emath::Rangef {
         }
     }
 }
+
+impl Range1D {
+    /// Absolute length of the range.
+    #[inline]
+    pub fn len(&self) -> f64 {
+        (self.0[1] - self.0[0]).abs()
+    }
+}

--- a/crates/re_types/src/datatypes/range1d_ext.rs
+++ b/crates/re_types/src/datatypes/range1d_ext.rs
@@ -25,7 +25,7 @@ impl From<Range1D> for emath::Rangef {
 impl Range1D {
     /// Absolute length of the range.
     #[inline]
-    pub fn len(&self) -> f64 {
+    pub fn abs_len(&self) -> f64 {
         (self.0[1] - self.0[0]).abs()
     }
 }


### PR DESCRIPTION
### What

Introduce smoothed bounding box that we use in favor of `accumulated` bounding box in a bunch of places now.
Given how many issues we had historically with trying to find "max scene size" I decided to remove it completely.

The new smoothed bounding box interpolates the current box smoothly over time unless a discontinuity is detected in which case it will skip the transition.

We could do a "smooth accumulated" bounding box with the same approach: grow unless discontinuity is found but I refrained from exploring this.

https://github.com/rerun-io/rerun/assets/1220815/34f88402-126c-4b5f-968c-01f3323835a6




### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6791?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6791?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6791)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.