### PR TITLE
Forward Rust (de-)serialization of transparent datatypes

### DIFF
--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -109,6 +109,6 @@ impl ::re_types_core::Loggable for ActiveTab {
         Self: Sized,
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -82,11 +82,9 @@ impl ::re_types_core::Loggable for ActiveTab {
         "rerun.blueprint.components.ActiveTab".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::EntityPath::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -145,55 +145,7 @@ impl ::re_types_core::Loggable for ActiveTab {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.ActiveTab#tab")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt
-                        .map(|v| crate::datatypes::EntityPath(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.ActiveTab#tab")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.ActiveTab#tab")
-        .with_context("rerun.blueprint.components.ActiveTab")?)
+        crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/re_types/src/blueprint/components/active_tab.rs
@@ -89,53 +89,18 @@ impl ::re_types_core::Loggable for ActiveTab {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::EntityPath::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -110,6 +110,6 @@ impl ::re_types_core::Loggable for IncludedContent {
         Self: Sized,
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -83,11 +83,9 @@ impl ::re_types_core::Loggable for IncludedContent {
         "rerun.blueprint.components.IncludedContent".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::EntityPath::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/included_content.rs
+++ b/crates/re_types/src/blueprint/components/included_content.rs
@@ -90,53 +90,18 @@ impl ::re_types_core::Loggable for IncludedContent {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::EntityPath::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/interactive.rs
+++ b/crates/re_types/src/blueprint/components/interactive.rs
@@ -128,23 +128,7 @@ impl ::re_types_core::Loggable for Interactive {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.blueprint.components.Interactive#interactive")?
-            .into_iter()
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Bool(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.Interactive#interactive")
-            .with_context("rerun.blueprint.components.Interactive")?)
+        crate::datatypes::Bool::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/interactive.rs
+++ b/crates/re_types/src/blueprint/components/interactive.rs
@@ -87,38 +87,18 @@ impl ::re_types_core::Loggable for Interactive {
         DataType::Boolean
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            BooleanArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Bool::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/interactive.rs
+++ b/crates/re_types/src/blueprint/components/interactive.rs
@@ -80,11 +80,9 @@ impl ::re_types_core::Loggable for Interactive {
         "rerun.blueprint.components.Interactive".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Boolean
+        crate::datatypes::Bool::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/interactive.rs
+++ b/crates/re_types/src/blueprint/components/interactive.rs
@@ -107,6 +107,6 @@ impl ::re_types_core::Loggable for Interactive {
         Self: Sized,
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -128,23 +128,7 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<BooleanArray>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.blueprint.components.LockRangeDuringZoom#lock_range")?
-            .into_iter()
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Bool(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.LockRangeDuringZoom#lock_range")
-            .with_context("rerun.blueprint.components.LockRangeDuringZoom")?)
+        crate::datatypes::Bool::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -80,11 +80,9 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
         "rerun.blueprint.components.LockRangeDuringZoom".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Boolean
+        crate::datatypes::Bool::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -107,6 +107,6 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
         Self: Sized,
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -87,38 +87,18 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
         DataType::Boolean
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            BooleanArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Bool::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -87,11 +87,9 @@ impl ::re_types_core::Loggable for QueryExpression {
         "rerun.blueprint.components.QueryExpression".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -94,53 +94,18 @@ impl ::re_types_core::Loggable for QueryExpression {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::Utf8::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -150,54 +150,7 @@ impl ::re_types_core::Loggable for QueryExpression {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.QueryExpression#filter")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.QueryExpression#filter")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.QueryExpression#filter")
-        .with_context("rerun.blueprint.components.QueryExpression")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/re_types/src/blueprint/components/query_expression.rs
@@ -114,6 +114,6 @@ impl ::re_types_core::Loggable for QueryExpression {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -85,53 +85,18 @@ impl ::re_types_core::Loggable for SpaceViewClass {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::Utf8::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -78,11 +78,9 @@ impl ::re_types_core::Loggable for SpaceViewClass {
         "rerun.blueprint.components.SpaceViewClass".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for SpaceViewClass {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/re_types/src/blueprint/components/space_view_class.rs
@@ -141,54 +141,7 @@ impl ::re_types_core::Loggable for SpaceViewClass {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.SpaceViewClass#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.SpaceViewClass#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.SpaceViewClass#value")
-        .with_context("rerun.blueprint.components.SpaceViewClass")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
         Self: Sized,
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -141,55 +141,7 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.SpaceViewOrigin#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt
-                        .map(|v| crate::datatypes::EntityPath(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.SpaceViewOrigin#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.SpaceViewOrigin#value")
-        .with_context("rerun.blueprint.components.SpaceViewOrigin")?)
+        crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -85,53 +85,18 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::EntityPath::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/re_types/src/blueprint/components/space_view_origin.rs
@@ -78,11 +78,9 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
         "rerun.blueprint.components.SpaceViewOrigin".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::EntityPath::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -111,6 +111,6 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
         Self: Sized,
     {
         crate::blueprint::datatypes::TensorDimensionIndexSlider::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -129,17 +129,7 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::blueprint::datatypes::TensorDimensionIndexSlider::from_arrow_opt(arrow_data)
-                .with_context("rerun.blueprint.components.TensorDimensionIndexSlider#selection")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.blueprint.components.TensorDimensionIndexSlider#selection")
-                .with_context("rerun.blueprint.components.TensorDimensionIndexSlider")?,
-        )
+        crate::blueprint::datatypes::TensorDimensionIndexSlider::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -93,33 +93,20 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
         )]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
+        crate::blueprint::datatypes::TensorDimensionIndexSlider::to_arrow_opt(data.into_iter().map(
+            |datum| {
+                datum.map(|datum| match datum.into() {
+                    ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                    ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
                 })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::blueprint::datatypes::TensorDimensionIndexSlider::to_arrow_opt(data0)?
-            }
-        })
+            },
+        ))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -82,15 +82,9 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
         "rerun.blueprint.components.TensorDimensionIndexSlider".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![Field::new(
-            "dimension",
-            DataType::UInt32,
-            false,
-        )]))
+        crate::blueprint::datatypes::TensorDimensionIndexSlider::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -80,11 +80,9 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
         "rerun.blueprint.components.ViewerRecommendationHash".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::UInt64
+        crate::datatypes::UInt64::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -107,7 +107,7 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
         Self: Sized,
     {
         crate::datatypes::UInt64::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -115,7 +115,6 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
     where
         Self: Sized,
     {
-        crate::datatypes::UInt64::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::UInt64::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -138,33 +138,7 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<UInt64Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::UInt64;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.ViewerRecommendationHash#value")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::UInt64(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::UInt64::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -128,25 +128,8 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.blueprint.components.ViewerRecommendationHash#value")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::UInt64(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.ViewerRecommendationHash#value")
-            .with_context("rerun.blueprint.components.ViewerRecommendationHash")?)
+        crate::datatypes::UInt64::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -87,38 +87,18 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
         DataType::UInt64
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::UInt64::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -132,7 +112,6 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -134,17 +134,7 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::datatypes::VisibleTimeRange::from_arrow_opt(arrow_data)
-                .with_context("rerun.blueprint.components.VisibleTimeRange#value")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.blueprint.components.VisibleTimeRange#value")
-                .with_context("rerun.blueprint.components.VisibleTimeRange")?,
-        )
+        crate::datatypes::VisibleTimeRange::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -80,22 +80,9 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
         "rerun.blueprint.components.VisibleTimeRange".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new(
-                "timeline",
-                <crate::datatypes::Utf8>::arrow_datatype(),
-                false,
-            ),
-            Field::new(
-                "range",
-                <crate::datatypes::TimeRange>::arrow_datatype(),
-                false,
-            ),
-        ]))
+        crate::datatypes::VisibleTimeRange::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -98,33 +98,18 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::VisibleTimeRange::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::VisibleTimeRange::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/re_types/src/blueprint/components/visible_time_range.rs
@@ -107,6 +107,6 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
         Self: Sized,
     {
         crate::datatypes::VisibleTimeRange::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -99,33 +99,18 @@ impl ::re_types_core::Loggable for VisualBounds2D {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::Range2D::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::Range2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -135,15 +135,7 @@ impl ::re_types_core::Loggable for VisualBounds2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::Range2D::from_arrow_opt(arrow_data)
-            .with_context("rerun.blueprint.components.VisualBounds2D#range2d")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.blueprint.components.VisualBounds2D#range2d")
-            .with_context("rerun.blueprint.components.VisualBounds2D")?)
+        crate::datatypes::Range2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -108,6 +108,6 @@ impl ::re_types_core::Loggable for VisualBounds2D {
         Self: Sized,
     {
         crate::datatypes::Range2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -81,22 +81,9 @@ impl ::re_types_core::Loggable for VisualBounds2D {
         "rerun.blueprint.components.VisualBounds2D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new(
-                "x_range",
-                <crate::datatypes::Range1D>::arrow_datatype(),
-                false,
-            ),
-            Field::new(
-                "y_range",
-                <crate::datatypes::Range1D>::arrow_datatype(),
-                false,
-            ),
-        ]))
+        crate::datatypes::Range2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/axis_length.rs
+++ b/crates/re_types/src/components/axis_length.rs
@@ -78,11 +78,9 @@ impl ::re_types_core::Loggable for AxisLength {
         "rerun.components.AxisLength".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Float32
+        crate::datatypes::Float32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/axis_length.rs
+++ b/crates/re_types/src/components/axis_length.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for AxisLength {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,7 +113,6 @@ impl ::re_types_core::Loggable for AxisLength {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/axis_length.rs
+++ b/crates/re_types/src/components/axis_length.rs
@@ -126,25 +126,8 @@ impl ::re_types_core::Loggable for AxisLength {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.AxisLength#length")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Float32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.AxisLength#length")
-            .with_context("rerun.components.AxisLength")?)
+        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/axis_length.rs
+++ b/crates/re_types/src/components/axis_length.rs
@@ -85,38 +85,18 @@ impl ::re_types_core::Loggable for AxisLength {
         DataType::Float32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -130,7 +110,6 @@ impl ::re_types_core::Loggable for AxisLength {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/axis_length.rs
+++ b/crates/re_types/src/components/axis_length.rs
@@ -136,33 +136,7 @@ impl ::re_types_core::Loggable for AxisLength {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::Float32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.AxisLength#length")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Float32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Float32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -141,33 +141,7 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<UInt16Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::UInt16;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.ClassId#id")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::ClassId(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::ClassId::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -110,7 +110,7 @@ impl ::re_types_core::Loggable for ClassId {
         Self: Sized,
     {
         crate::datatypes::ClassId::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -118,6 +118,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        crate::datatypes::ClassId::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::ClassId::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -83,11 +83,9 @@ impl ::re_types_core::Loggable for ClassId {
         "rerun.components.ClassId".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::UInt16
+        crate::datatypes::ClassId::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -131,25 +131,8 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt16Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.ClassId#id")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::ClassId(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.ClassId#id")
-            .with_context("rerun.components.ClassId")?)
+        crate::datatypes::ClassId::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -90,38 +90,18 @@ impl ::re_types_core::Loggable for ClassId {
         DataType::UInt16
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::ClassId::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -135,7 +115,6 @@ impl ::re_types_core::Loggable for ClassId {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/class_id.rs
+++ b/crates/re_types/src/components/class_id.rs
@@ -141,7 +141,6 @@ impl ::re_types_core::Loggable for ClassId {
     where
         Self: Sized,
     {
-        crate::datatypes::ClassId::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::ClassId::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -81,11 +81,9 @@ impl ::re_types_core::Loggable for Color {
         "rerun.components.Color".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::UInt32
+        crate::datatypes::Rgba32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -139,7 +139,6 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        crate::datatypes::Rgba32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Rgba32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -108,7 +108,7 @@ impl ::re_types_core::Loggable for Color {
         Self: Sized,
     {
         crate::datatypes::Rgba32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -116,6 +116,6 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        crate::datatypes::Rgba32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Rgba32::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -139,33 +139,7 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<UInt32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::UInt32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Color#rgba")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Rgba32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Rgba32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -129,25 +129,8 @@ impl ::re_types_core::Loggable for Color {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.Color#rgba")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Rgba32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Color#rgba")
-            .with_context("rerun.components.Color")?)
+        crate::datatypes::Rgba32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/color.rs
+++ b/crates/re_types/src/components/color.rs
@@ -88,38 +88,18 @@ impl ::re_types_core::Loggable for Color {
         DataType::UInt32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Rgba32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -133,7 +113,6 @@ impl ::re_types_core::Loggable for Color {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -141,7 +141,6 @@ impl ::re_types_core::Loggable for FillRatio {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -141,33 +141,7 @@ impl ::re_types_core::Loggable for FillRatio {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::Float32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.FillRatio#value")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Float32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Float32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -110,7 +110,7 @@ impl ::re_types_core::Loggable for FillRatio {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -118,6 +118,6 @@ impl ::re_types_core::Loggable for FillRatio {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -83,11 +83,9 @@ impl ::re_types_core::Loggable for FillRatio {
         "rerun.components.FillRatio".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Float32
+        crate::datatypes::Float32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -90,38 +90,18 @@ impl ::re_types_core::Loggable for FillRatio {
         DataType::Float32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -135,7 +115,6 @@ impl ::re_types_core::Loggable for FillRatio {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/fill_ratio.rs
+++ b/crates/re_types/src/components/fill_ratio.rs
@@ -131,25 +131,8 @@ impl ::re_types_core::Loggable for FillRatio {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.FillRatio#value")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Float32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.FillRatio#value")
-            .with_context("rerun.components.FillRatio")?)
+        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -142,7 +142,6 @@ impl ::re_types_core::Loggable for GammaCorrection {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -91,38 +91,18 @@ impl ::re_types_core::Loggable for GammaCorrection {
         DataType::Float32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -136,7 +116,6 @@ impl ::re_types_core::Loggable for GammaCorrection {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -84,11 +84,9 @@ impl ::re_types_core::Loggable for GammaCorrection {
         "rerun.components.GammaCorrection".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Float32
+        crate::datatypes::Float32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -142,33 +142,7 @@ impl ::re_types_core::Loggable for GammaCorrection {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::Float32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.GammaCorrection#gamma")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Float32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Float32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -111,7 +111,7 @@ impl ::re_types_core::Loggable for GammaCorrection {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -119,6 +119,6 @@ impl ::re_types_core::Loggable for GammaCorrection {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/gamma_correction.rs
+++ b/crates/re_types/src/components/gamma_correction.rs
@@ -132,25 +132,8 @@ impl ::re_types_core::Loggable for GammaCorrection {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.GammaCorrection#gamma")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Float32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.GammaCorrection#gamma")
-            .with_context("rerun.components.GammaCorrection")?)
+        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/half_size2d.rs
+++ b/crates/re_types/src/components/half_size2d.rs
@@ -162,50 +162,7 @@ impl ::re_types_core::Loggable for HalfSize2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            2usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.HalfSize2D#xy")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 2usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.HalfSize2D#xy")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec2D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec2D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/half_size2d.rs
+++ b/crates/re_types/src/components/half_size2d.rs
@@ -152,76 +152,8 @@ impl ::re_types_core::Loggable for HalfSize2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.HalfSize2D#xy")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.HalfSize2D#xy")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec2D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.HalfSize2D#xy")
-        .with_context("rerun.components.HalfSize2D")?)
+        crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/half_size2d.rs
+++ b/crates/re_types/src/components/half_size2d.rs
@@ -109,7 +109,7 @@ impl ::re_types_core::Loggable for HalfSize2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -117,7 +117,6 @@ impl ::re_types_core::Loggable for HalfSize2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/half_size2d.rs
+++ b/crates/re_types/src/components/half_size2d.rs
@@ -92,57 +92,18 @@ impl ::re_types_core::Loggable for HalfSize2D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -156,7 +117,6 @@ impl ::re_types_core::Loggable for HalfSize2D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/half_size2d.rs
+++ b/crates/re_types/src/components/half_size2d.rs
@@ -82,14 +82,9 @@ impl ::re_types_core::Loggable for HalfSize2D {
         "rerun.components.HalfSize2D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            2usize,
-        )
+        crate::datatypes::Vec2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/half_size3d.rs
+++ b/crates/re_types/src/components/half_size3d.rs
@@ -162,50 +162,7 @@ impl ::re_types_core::Loggable for HalfSize3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            3usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.HalfSize3D#xyz")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 3usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.HalfSize3D#xyz")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec3D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec3D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/half_size3d.rs
+++ b/crates/re_types/src/components/half_size3d.rs
@@ -109,7 +109,7 @@ impl ::re_types_core::Loggable for HalfSize3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -117,7 +117,6 @@ impl ::re_types_core::Loggable for HalfSize3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/half_size3d.rs
+++ b/crates/re_types/src/components/half_size3d.rs
@@ -82,14 +82,9 @@ impl ::re_types_core::Loggable for HalfSize3D {
         "rerun.components.HalfSize3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            3usize,
-        )
+        crate::datatypes::Vec3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/half_size3d.rs
+++ b/crates/re_types/src/components/half_size3d.rs
@@ -92,57 +92,18 @@ impl ::re_types_core::Loggable for HalfSize3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(3usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -156,7 +117,6 @@ impl ::re_types_core::Loggable for HalfSize3D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/half_size3d.rs
+++ b/crates/re_types/src/components/half_size3d.rs
@@ -152,76 +152,8 @@ impl ::re_types_core::Loggable for HalfSize3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.HalfSize3D#xyz")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(3usize)
-                    .zip((3usize..).step_by(3usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.HalfSize3D#xyz")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 3usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec3D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.HalfSize3D#xyz")
-        .with_context("rerun.components.HalfSize3D")?)
+        crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/image_plane_distance.rs
+++ b/crates/re_types/src/components/image_plane_distance.rs
@@ -86,38 +86,18 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
         DataType::Float32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -131,7 +111,6 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/image_plane_distance.rs
+++ b/crates/re_types/src/components/image_plane_distance.rs
@@ -106,7 +106,7 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -114,7 +114,6 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/image_plane_distance.rs
+++ b/crates/re_types/src/components/image_plane_distance.rs
@@ -127,25 +127,8 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.ImagePlaneDistance#image_from_camera")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Float32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.ImagePlaneDistance#image_from_camera")
-            .with_context("rerun.components.ImagePlaneDistance")?)
+        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/image_plane_distance.rs
+++ b/crates/re_types/src/components/image_plane_distance.rs
@@ -79,11 +79,9 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
         "rerun.components.ImagePlaneDistance".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Float32
+        crate::datatypes::Float32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/image_plane_distance.rs
+++ b/crates/re_types/src/components/image_plane_distance.rs
@@ -137,33 +137,7 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::Float32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.ImagePlaneDistance#image_from_camera")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Float32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Float32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -153,7 +153,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        crate::datatypes::KeypointId::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::KeypointId::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -143,25 +143,8 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<UInt16Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.KeypointId#id")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::KeypointId(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.KeypointId#id")
-            .with_context("rerun.components.KeypointId")?)
+        crate::datatypes::KeypointId::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -102,38 +102,18 @@ impl ::re_types_core::Loggable for KeypointId {
         DataType::UInt16
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::KeypointId::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -147,7 +127,6 @@ impl ::re_types_core::Loggable for KeypointId {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -95,11 +95,9 @@ impl ::re_types_core::Loggable for KeypointId {
         "rerun.components.KeypointId".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::UInt16
+        crate::datatypes::KeypointId::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -153,33 +153,7 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<UInt16Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::UInt16;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.KeypointId#id")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::KeypointId(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::KeypointId::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/keypoint_id.rs
+++ b/crates/re_types/src/components/keypoint_id.rs
@@ -122,7 +122,7 @@ impl ::re_types_core::Loggable for KeypointId {
         Self: Sized,
     {
         crate::datatypes::KeypointId::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -130,6 +130,6 @@ impl ::re_types_core::Loggable for KeypointId {
     where
         Self: Sized,
     {
-        crate::datatypes::KeypointId::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::KeypointId::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -124,15 +124,7 @@ impl ::re_types_core::Loggable for Material {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::Material::from_arrow_opt(arrow_data)
-            .with_context("rerun.components.Material#material")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Material#material")
-            .with_context("rerun.components.Material")?)
+        crate::datatypes::Material::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -104,6 +104,6 @@ impl ::re_types_core::Loggable for Material {
         Self: Sized,
     {
         crate::datatypes::Material::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -77,15 +77,9 @@ impl ::re_types_core::Loggable for Material {
         "rerun.components.Material".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![Field::new(
-            "albedo_factor",
-            <crate::datatypes::Rgba32>::arrow_datatype(),
-            true,
-        )]))
+        crate::datatypes::Material::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/material.rs
+++ b/crates/re_types/src/components/material.rs
@@ -88,33 +88,18 @@ impl ::re_types_core::Loggable for Material {
         )]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::Material::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::Material::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -81,11 +81,9 @@ impl ::re_types_core::Loggable for MediaType {
         "rerun.components.MediaType".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -144,54 +144,7 @@ impl ::re_types_core::Loggable for MediaType {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.MediaType#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.MediaType#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.MediaType#value")
-        .with_context("rerun.components.MediaType")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/media_type.rs
+++ b/crates/re_types/src/components/media_type.rs
@@ -108,6 +108,6 @@ impl ::re_types_core::Loggable for MediaType {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -85,53 +85,18 @@ impl ::re_types_core::Loggable for Name {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::Utf8::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -78,11 +78,9 @@ impl ::re_types_core::Loggable for Name {
         "rerun.components.Name".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -141,54 +141,7 @@ impl ::re_types_core::Loggable for Name {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Name#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Name#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Name#value")
-        .with_context("rerun.components.Name")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/name.rs
+++ b/crates/re_types/src/components/name.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for Name {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/opacity.rs
+++ b/crates/re_types/src/components/opacity.rs
@@ -108,7 +108,7 @@ impl ::re_types_core::Loggable for Opacity {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -116,7 +116,6 @@ impl ::re_types_core::Loggable for Opacity {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/opacity.rs
+++ b/crates/re_types/src/components/opacity.rs
@@ -139,33 +139,7 @@ impl ::re_types_core::Loggable for Opacity {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = arrow_data
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .ok_or_else(|| {
-                    let expected = DataType::Float32;
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Opacity#opacity")?
-                .values()
-                .as_slice();
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Float32(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Float32::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/opacity.rs
+++ b/crates/re_types/src/components/opacity.rs
@@ -88,38 +88,18 @@ impl ::re_types_core::Loggable for Opacity {
         DataType::Float32
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            PrimitiveArray::new(
-                Self::arrow_datatype(),
-                data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .collect(),
-                data0_bitmap,
-            )
-            .boxed()
-        })
+        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -133,7 +113,6 @@ impl ::re_types_core::Loggable for Opacity {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/opacity.rs
+++ b/crates/re_types/src/components/opacity.rs
@@ -129,25 +129,8 @@ impl ::re_types_core::Loggable for Opacity {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(arrow_data
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .ok_or_else(|| {
-                let expected = Self::arrow_datatype();
-                let actual = arrow_data.data_type().clone();
-                DeserializationError::datatype_mismatch(expected, actual)
-            })
-            .with_context("rerun.components.Opacity#opacity")?
-            .into_iter()
-            .map(|opt| opt.copied())
-            .map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Float32(v)))
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Opacity#opacity")
-            .with_context("rerun.components.Opacity")?)
+        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/opacity.rs
+++ b/crates/re_types/src/components/opacity.rs
@@ -81,11 +81,9 @@ impl ::re_types_core::Loggable for Opacity {
         "rerun.components.Opacity".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Float32
+        crate::datatypes::Float32::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -141,15 +141,7 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
-            .with_context("rerun.components.OutOfTreeTransform3D#repr")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.OutOfTreeTransform3D#repr")
-            .with_context("rerun.components.OutOfTreeTransform3D")?)
+        crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -105,33 +105,18 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::Transform3D::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::Transform3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -109,6 +109,6 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
         Self: Sized,
     {
         crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/out_of_tree_transform3d.rs
+++ b/crates/re_types/src/components/out_of_tree_transform3d.rs
@@ -82,27 +82,9 @@ impl ::re_types_core::Loggable for OutOfTreeTransform3D {
         "rerun.components.OutOfTreeTransform3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Union(
-            std::sync::Arc::new(vec![
-                Field::new("_null_markers", DataType::Null, true),
-                Field::new(
-                    "TranslationAndMat3x3",
-                    <crate::datatypes::TranslationAndMat3x3>::arrow_datatype(),
-                    false,
-                ),
-                Field::new(
-                    "TranslationRotationScale",
-                    <crate::datatypes::TranslationRotationScale3D>::arrow_datatype(),
-                    false,
-                ),
-            ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
-            UnionMode::Dense,
-        )
+        crate::datatypes::Transform3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -167,50 +167,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            9usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.PinholeProjection#image_from_camera")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 9usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.PinholeProjection#image_from_camera")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Mat3x3(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Mat3x3::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -114,7 +114,7 @@ impl ::re_types_core::Loggable for PinholeProjection {
         Self: Sized,
     {
         crate::datatypes::Mat3x3::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -122,7 +122,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
-        crate::datatypes::Mat3x3::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Mat3x3::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -97,57 +97,18 @@ impl ::re_types_core::Loggable for PinholeProjection {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(9usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Mat3x3::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -161,7 +122,6 @@ impl ::re_types_core::Loggable for PinholeProjection {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -157,76 +157,8 @@ impl ::re_types_core::Loggable for PinholeProjection {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.PinholeProjection#image_from_camera")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(9usize)
-                    .zip((9usize..).step_by(9usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.PinholeProjection#image_from_camera")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 9usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Mat3x3(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.PinholeProjection#image_from_camera")
-        .with_context("rerun.components.PinholeProjection")?)
+        crate::datatypes::Mat3x3::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/pinhole_projection.rs
+++ b/crates/re_types/src/components/pinhole_projection.rs
@@ -87,14 +87,9 @@ impl ::re_types_core::Loggable for PinholeProjection {
         "rerun.components.PinholeProjection".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            9usize,
-        )
+        crate::datatypes::Mat3x3::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -158,50 +158,7 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            2usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.Position2D#xy")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 2usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Position2D#xy")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec2D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec2D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for Position2D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for Position2D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Position2D#xy")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Position2D#xy")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec2D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Position2D#xy")
-        .with_context("rerun.components.Position2D")?)
+        crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for Position2D {
         "rerun.components.Position2D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            2usize,
-        )
+        crate::datatypes::Vec2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/position2d.rs
+++ b/crates/re_types/src/components/position2d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for Position2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for Position2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for Position3D {
         "rerun.components.Position3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            3usize,
-        )
+        crate::datatypes::Vec3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -158,50 +158,7 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            3usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.Position3D#xyz")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 3usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Position3D#xyz")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec3D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec3D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Position3D#xyz")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(3usize)
-                    .zip((3usize..).step_by(3usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Position3D#xyz")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 3usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec3D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Position3D#xyz")
-        .with_context("rerun.components.Position3D")?)
+        crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for Position3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for Position3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/position3d.rs
+++ b/crates/re_types/src/components/position3d.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for Position3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(3usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for Position3D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for Range1D {
     where
         Self: Sized,
     {
-        crate::datatypes::Range1D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Range1D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for Range1D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float64,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Range1D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for Range1D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for Range1D {
         Self: Sized,
     {
         crate::datatypes::Range1D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for Range1D {
     where
         Self: Sized,
     {
-        crate::datatypes::Range1D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Range1D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for Range1D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Range1D#range")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float64Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float64;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Range1D#range")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Range1D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Range1D#range")
-        .with_context("rerun.components.Range1D")?)
+        crate::datatypes::Range1D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/range1d.rs
+++ b/crates/re_types/src/components/range1d.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for Range1D {
         "rerun.components.Range1D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float64, false)),
-            2usize,
-        )
+        crate::datatypes::Range1D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -159,50 +159,7 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            2usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.Resolution#resolution")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 2usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Resolution#resolution")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec2D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec2D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -106,7 +106,7 @@ impl ::re_types_core::Loggable for Resolution {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -114,7 +114,6 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -89,57 +89,18 @@ impl ::re_types_core::Loggable for Resolution {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -153,7 +114,6 @@ impl ::re_types_core::Loggable for Resolution {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -79,14 +79,9 @@ impl ::re_types_core::Loggable for Resolution {
         "rerun.components.Resolution".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            2usize,
-        )
+        crate::datatypes::Vec2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/resolution.rs
+++ b/crates/re_types/src/components/resolution.rs
@@ -149,76 +149,8 @@ impl ::re_types_core::Loggable for Resolution {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Resolution#resolution")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Resolution#resolution")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec2D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Resolution#resolution")
-        .with_context("rerun.components.Resolution")?)
+        crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -103,33 +103,18 @@ impl ::re_types_core::Loggable for Rotation3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::Rotation3D::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::Rotation3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -80,27 +80,9 @@ impl ::re_types_core::Loggable for Rotation3D {
         "rerun.components.Rotation3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Union(
-            std::sync::Arc::new(vec![
-                Field::new("_null_markers", DataType::Null, true),
-                Field::new(
-                    "Quaternion",
-                    <crate::datatypes::Quaternion>::arrow_datatype(),
-                    false,
-                ),
-                Field::new(
-                    "AxisAngle",
-                    <crate::datatypes::RotationAxisAngle>::arrow_datatype(),
-                    false,
-                ),
-            ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
-            UnionMode::Dense,
-        )
+        crate::datatypes::Rotation3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -107,6 +107,6 @@ impl ::re_types_core::Loggable for Rotation3D {
         Self: Sized,
     {
         crate::datatypes::Rotation3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/rotation3d.rs
+++ b/crates/re_types/src/components/rotation3d.rs
@@ -139,15 +139,7 @@ impl ::re_types_core::Loggable for Rotation3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::Rotation3D::from_arrow_opt(arrow_data)
-            .with_context("rerun.components.Rotation3D#repr")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Rotation3D#repr")
-            .with_context("rerun.components.Rotation3D")?)
+        crate::datatypes::Rotation3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -148,15 +148,7 @@ impl ::re_types_core::Loggable for TensorData {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::TensorData::from_arrow_opt(arrow_data)
-            .with_context("rerun.components.TensorData#data")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.TensorData#data")
-            .with_context("rerun.components.TensorData")?)
+        crate::datatypes::TensorData::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -90,26 +90,9 @@ impl ::re_types_core::Loggable for TensorData {
         "rerun.components.TensorData".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new(
-                "shape",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    <crate::datatypes::TensorDimension>::arrow_datatype(),
-                    false,
-                ))),
-                false,
-            ),
-            Field::new(
-                "buffer",
-                <crate::datatypes::TensorBuffer>::arrow_datatype(),
-                false,
-            ),
-        ]))
+        crate::datatypes::TensorData::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -117,6 +117,6 @@ impl ::re_types_core::Loggable for TensorData {
         Self: Sized,
     {
         crate::datatypes::TensorData::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_data.rs
+++ b/crates/re_types/src/components/tensor_data.rs
@@ -112,33 +112,18 @@ impl ::re_types_core::Loggable for TensorData {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::TensorData::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::TensorData::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/re_types/src/components/tensor_dimension_index_selection.rs
@@ -92,33 +92,20 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
+        crate::datatypes::TensorDimensionIndexSelection::to_arrow_opt(data.into_iter().map(
+            |datum| {
+                datum.map(|datum| match datum.into() {
+                    ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                    ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
                 })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::TensorDimensionIndexSelection::to_arrow_opt(data0)?
-            }
-        })
+            },
+        ))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/re_types/src/components/tensor_dimension_index_selection.rs
@@ -82,14 +82,9 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
         "rerun.components.TensorDimensionIndexSelection".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("dimension", DataType::UInt32, false),
-            Field::new("index", DataType::UInt64, false),
-        ]))
+        crate::datatypes::TensorDimensionIndexSelection::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/re_types/src/components/tensor_dimension_index_selection.rs
@@ -128,17 +128,7 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::datatypes::TensorDimensionIndexSelection::from_arrow_opt(arrow_data)
-                .with_context("rerun.components.TensorDimensionIndexSelection#selection")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.components.TensorDimensionIndexSelection#selection")
-                .with_context("rerun.components.TensorDimensionIndexSelection")?,
-        )
+        crate::datatypes::TensorDimensionIndexSelection::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/re_types/src/components/tensor_dimension_index_selection.rs
@@ -111,6 +111,6 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
         Self: Sized,
     {
         crate::datatypes::TensorDimensionIndexSelection::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/re_types/src/components/tensor_height_dimension.rs
@@ -88,33 +88,18 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::TensorDimensionSelection::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::TensorDimensionSelection::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/re_types/src/components/tensor_height_dimension.rs
@@ -124,17 +124,7 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
-                .with_context("rerun.components.TensorHeightDimension#dimension")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.components.TensorHeightDimension#dimension")
-                .with_context("rerun.components.TensorHeightDimension")?,
-        )
+        crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/re_types/src/components/tensor_height_dimension.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
         Self: Sized,
     {
         crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/re_types/src/components/tensor_height_dimension.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
         "rerun.components.TensorHeightDimension".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("dimension", DataType::UInt32, false),
-            Field::new("invert", DataType::Boolean, false),
-        ]))
+        crate::datatypes::TensorDimensionSelection::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/re_types/src/components/tensor_width_dimension.rs
@@ -124,17 +124,7 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
-                .with_context("rerun.components.TensorWidthDimension#dimension")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.components.TensorWidthDimension#dimension")
-                .with_context("rerun.components.TensorWidthDimension")?,
-        )
+        crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/re_types/src/components/tensor_width_dimension.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
         Self: Sized,
     {
         crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/re_types/src/components/tensor_width_dimension.rs
@@ -88,33 +88,18 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::TensorDimensionSelection::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::TensorDimensionSelection::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/re_types/src/components/tensor_width_dimension.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
         "rerun.components.TensorWidthDimension".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("dimension", DataType::UInt32, false),
-            Field::new("invert", DataType::Boolean, false),
-        ]))
+        crate::datatypes::TensorDimensionSelection::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -173,7 +173,6 @@ impl ::re_types_core::Loggable for Texcoord2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -93,14 +93,9 @@ impl ::re_types_core::Loggable for Texcoord2D {
         "rerun.components.Texcoord2D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            2usize,
-        )
+        crate::datatypes::Vec2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -173,50 +173,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            2usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.Texcoord2D#uv")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 2usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Texcoord2D#uv")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec2D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec2D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -163,76 +163,8 @@ impl ::re_types_core::Loggable for Texcoord2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Texcoord2D#uv")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Texcoord2D#uv")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec2D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Texcoord2D#uv")
-        .with_context("rerun.components.Texcoord2D")?)
+        crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -103,57 +103,18 @@ impl ::re_types_core::Loggable for Texcoord2D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -167,7 +128,6 @@ impl ::re_types_core::Loggable for Texcoord2D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/texcoord2d.rs
+++ b/crates/re_types/src/components/texcoord2d.rs
@@ -120,7 +120,7 @@ impl ::re_types_core::Loggable for Texcoord2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -128,6 +128,6 @@ impl ::re_types_core::Loggable for Texcoord2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -105,6 +105,6 @@ impl ::re_types_core::Loggable for Text {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -78,11 +78,9 @@ impl ::re_types_core::Loggable for Text {
         "rerun.components.Text".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -141,54 +141,7 @@ impl ::re_types_core::Loggable for Text {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Text#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Text#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Text#value")
-        .with_context("rerun.components.Text")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/text.rs
+++ b/crates/re_types/src/components/text.rs
@@ -85,53 +85,18 @@ impl ::re_types_core::Loggable for Text {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::Utf8::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -93,53 +93,18 @@ impl ::re_types_core::Loggable for TextLogLevel {
         DataType::Utf8
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                let offsets = arrow2::offset::Offsets::<i32>::try_from_lengths(
-                    data0
-                        .iter()
-                        .map(|opt| opt.as_ref().map(|datum| datum.0.len()).unwrap_or_default()),
-                )?
-                .into();
-                let inner_data: arrow2::buffer::Buffer<u8> = data0
-                    .into_iter()
-                    .flatten()
-                    .flat_map(|datum| datum.0 .0)
-                    .collect();
-
-                #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                unsafe {
-                    Utf8Array::<i32>::new_unchecked(
-                        Self::arrow_datatype(),
-                        offsets,
-                        inner_data,
-                        data0_bitmap,
-                    )
-                }
-                .boxed()
-            }
-        })
+        crate::datatypes::Utf8::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -86,11 +86,9 @@ impl ::re_types_core::Loggable for TextLogLevel {
         "rerun.components.TextLogLevel".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Utf8
+        crate::datatypes::Utf8::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -149,54 +149,7 @@ impl ::re_types_core::Loggable for TextLogLevel {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.TextLogLevel#value")?;
-            let arrow_data_buf = arrow_data.values();
-            let offsets = arrow_data.offsets();
-            arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
-                arrow_data.validity(),
-            )
-            .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end as usize > arrow_data_buf.len() {
-                        return Err(DeserializationError::offset_slice_oob(
-                            (start, end),
-                            arrow_data_buf.len(),
-                        ));
-                    }
-
-                    #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                    let data = unsafe { arrow_data_buf.clone().sliced_unchecked(start, len) };
-                    Ok(data)
-                })
-                .transpose()
-            })
-            .map(|res_or_opt| {
-                res_or_opt.map(|res_or_opt| {
-                    res_or_opt.map(|v| crate::datatypes::Utf8(::re_types_core::ArrowString(v)))
-                })
-            })
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.TextLogLevel#value")?
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.TextLogLevel#value")
-        .with_context("rerun.components.TextLogLevel")?)
+        crate::datatypes::Utf8::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/text_log_level.rs
+++ b/crates/re_types/src/components/text_log_level.rs
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for TextLogLevel {
         Self: Sized,
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -107,6 +107,6 @@ impl ::re_types_core::Loggable for Transform3D {
         Self: Sized,
     {
         crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -103,33 +103,18 @@ impl ::re_types_core::Loggable for Transform3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::datatypes::Transform3D::to_arrow_opt(data0)?
-            }
-        })
+        crate::datatypes::Transform3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -80,27 +80,9 @@ impl ::re_types_core::Loggable for Transform3D {
         "rerun.components.Transform3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Union(
-            std::sync::Arc::new(vec![
-                Field::new("_null_markers", DataType::Null, true),
-                Field::new(
-                    "TranslationAndMat3x3",
-                    <crate::datatypes::TranslationAndMat3x3>::arrow_datatype(),
-                    false,
-                ),
-                Field::new(
-                    "TranslationRotationScale",
-                    <crate::datatypes::TranslationRotationScale3D>::arrow_datatype(),
-                    false,
-                ),
-            ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32])),
-            UnionMode::Dense,
-        )
+        crate::datatypes::Transform3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/transform3d.rs
+++ b/crates/re_types/src/components/transform3d.rs
@@ -139,15 +139,7 @@ impl ::re_types_core::Loggable for Transform3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
-            .with_context("rerun.components.Transform3D#repr")?
-            .into_iter()
-            .map(|v| v.ok_or_else(DeserializationError::missing_data))
-            .map(|res| res.map(|v| Some(Self(v))))
-            .collect::<DeserializationResult<Vec<Option<_>>>>()
-            .with_context("rerun.components.Transform3D#repr")
-            .with_context("rerun.components.Transform3D")?)
+        crate::datatypes::Transform3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
         Self: Sized,
     {
         crate::datatypes::UVec3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for TriangleIndices {
     where
         Self: Sized,
     {
-        crate::datatypes::UVec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::UVec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for TriangleIndices {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.TriangleIndices#indices")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(3usize)
-                    .zip((3usize..).step_by(3usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.TriangleIndices#indices")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 3usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::UVec3D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.TriangleIndices#indices")
-        .with_context("rerun.components.TriangleIndices")?)
+        crate::datatypes::UVec3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for TriangleIndices {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(3usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::UInt32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::UVec3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for TriangleIndices {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -158,50 +158,7 @@ impl ::re_types_core::Loggable for TriangleIndices {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::UInt32, false)),
-                            3usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.TriangleIndices#indices")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 3usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.TriangleIndices#indices")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::UVec3D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::UVec3D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for TriangleIndices {
         "rerun.components.TriangleIndices".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::UInt32, false)),
-            3usize,
-        )
+        crate::datatypes::UVec3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/triangle_indices.rs
+++ b/crates/re_types/src/components/triangle_indices.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for TriangleIndices {
     where
         Self: Sized,
     {
-        crate::datatypes::UVec3D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::UVec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for Vector2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for Vector2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for Vector2D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(2usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec2D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for Vector2D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for Vector2D {
         "rerun.components.Vector2D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            2usize,
-        )
+        crate::datatypes::Vec2D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for Vector2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/vector2d.rs
+++ b/crates/re_types/src/components/vector2d.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for Vector2D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Vector2D#vector")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(2usize)
-                    .zip((2usize..).step_by(2usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Vector2D#vector")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 2usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec2D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Vector2D#vector")
-        .with_context("rerun.components.Vector2D")?)
+        crate::datatypes::Vec2D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for Vector3D {
         "rerun.components.Vector3D".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-            3usize,
-        )
+        crate::datatypes::Vec3D::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for Vector3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,6 +113,6 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for Vector3D {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.0).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(3usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::Float32,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Vec3D::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for Vector3D {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -158,7 +158,6 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| bytemuck::cast_vec(v))
     }
 }

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -158,50 +158,7 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                            3usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.components.Vector3D#vector")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 3usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Vector3D#vector")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|v| crate::datatypes::Vec3D(v))
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Vec3D::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types/src/components/vector3d.rs
+++ b/crates/re_types/src/components/vector3d.rs
@@ -148,76 +148,8 @@ impl ::re_types_core::Loggable for Vector3D {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.components.Vector3D#vector")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(3usize)
-                    .zip((3usize..).step_by(3usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<Float32Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::Float32;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.components.Vector3D#vector")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 3usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt.map(|res_or_opt| res_or_opt.map(|v| crate::datatypes::Vec3D(v)))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.components.Vector3D#vector")
-        .with_context("rerun.components.Vector3D")?)
+        crate::datatypes::Vec3D::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/datatypes/class_id.rs
+++ b/crates/re_types/src/datatypes/class_id.rs
@@ -142,4 +142,35 @@ impl ::re_types_core::Loggable for ClassId {
             .with_context("rerun.datatypes.ClassId#id")
             .with_context("rerun.datatypes.ClassId")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::UInt16;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.datatypes.ClassId#id")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/re_types/src/datatypes/keypoint_id.rs
@@ -144,4 +144,35 @@ impl ::re_types_core::Loggable for KeypointId {
             .with_context("rerun.datatypes.KeypointId#id")
             .with_context("rerun.datatypes.KeypointId")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<UInt16Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::UInt16;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.datatypes.KeypointId#id")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/mat3x3.rs
+++ b/crates/re_types/src/datatypes/mat3x3.rs
@@ -216,4 +216,52 @@ impl ::re_types_core::Loggable for Mat3x3 {
         .with_context("rerun.datatypes.Mat3x3#flat_columns")
         .with_context("rerun.datatypes.Mat3x3")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            9usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Mat3x3#flat_columns")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 9usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Mat3x3#flat_columns")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/mat4x4.rs
+++ b/crates/re_types/src/datatypes/mat4x4.rs
@@ -217,4 +217,52 @@ impl ::re_types_core::Loggable for Mat4x4 {
         .with_context("rerun.datatypes.Mat4x4#flat_columns")
         .with_context("rerun.datatypes.Mat4x4")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            16usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Mat4x4#flat_columns")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 16usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Mat4x4#flat_columns")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/quaternion.rs
+++ b/crates/re_types/src/datatypes/quaternion.rs
@@ -207,4 +207,52 @@ impl ::re_types_core::Loggable for Quaternion {
         .with_context("rerun.datatypes.Quaternion#xyzw")
         .with_context("rerun.datatypes.Quaternion")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            4usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Quaternion#xyzw")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 4usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Quaternion#xyzw")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/range1d.rs
+++ b/crates/re_types/src/datatypes/range1d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for Range1D {
         .with_context("rerun.datatypes.Range1D#range")
         .with_context("rerun.datatypes.Range1D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float64, false)),
+                            2usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Range1D#range")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float64Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float64;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Range1D#range")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/uvec2d.rs
+++ b/crates/re_types/src/datatypes/uvec2d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for UVec2D {
         .with_context("rerun.datatypes.UVec2D#xy")
         .with_context("rerun.datatypes.UVec2D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::UInt32, false)),
+                            2usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.UVec2D#xy")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<UInt32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::UInt32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.UVec2D#xy")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/uvec3d.rs
+++ b/crates/re_types/src/datatypes/uvec3d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for UVec3D {
         .with_context("rerun.datatypes.UVec3D#xyz")
         .with_context("rerun.datatypes.UVec3D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::UInt32, false)),
+                            3usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.UVec3D#xyz")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<UInt32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::UInt32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.UVec3D#xyz")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/uvec4d.rs
+++ b/crates/re_types/src/datatypes/uvec4d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for UVec4D {
         .with_context("rerun.datatypes.UVec4D#xyzw")
         .with_context("rerun.datatypes.UVec4D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::UInt32, false)),
+                            4usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.UVec4D#xyzw")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 4usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<UInt32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::UInt32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.UVec4D#xyzw")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/vec2d.rs
+++ b/crates/re_types/src/datatypes/vec2d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for Vec2D {
         .with_context("rerun.datatypes.Vec2D#xy")
         .with_context("rerun.datatypes.Vec2D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            2usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Vec2D#xy")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 2usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Vec2D#xy")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/vec3d.rs
+++ b/crates/re_types/src/datatypes/vec3d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for Vec3D {
         .with_context("rerun.datatypes.Vec3D#xyz")
         .with_context("rerun.datatypes.Vec3D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            3usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Vec3D#xyz")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 3usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Vec3D#xyz")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/datatypes/vec4d.rs
+++ b/crates/re_types/src/datatypes/vec4d.rs
@@ -205,4 +205,52 @@ impl ::re_types_core::Loggable for Vec4D {
         .with_context("rerun.datatypes.Vec4D#xyzw")
         .with_context("rerun.datatypes.Vec4D")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = {
+                let arrow_data = arrow_data
+                    .as_any()
+                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
+                    .ok_or_else(|| {
+                        let expected = DataType::FixedSizeList(
+                            std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
+                            4usize,
+                        );
+                        let actual = arrow_data.data_type().clone();
+                        DeserializationError::datatype_mismatch(expected, actual)
+                    })
+                    .with_context("rerun.datatypes.Vec4D#xyzw")?;
+                let arrow_data_inner = &**arrow_data.values();
+                bytemuck::cast_slice::<_, [_; 4usize]>(
+                    arrow_data_inner
+                        .as_any()
+                        .downcast_ref::<Float32Array>()
+                        .ok_or_else(|| {
+                            let expected = DataType::Float32;
+                            let actual = arrow_data_inner.data_type().clone();
+                            DeserializationError::datatype_mismatch(expected, actual)
+                        })
+                        .with_context("rerun.datatypes.Vec4D#xyzw")?
+                        .values()
+                        .as_slice(),
+                )
+            };
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -157,17 +157,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer1#single_required")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer1#single_required")
-                .with_context("rerun.testing.components.AffixFuzzer1")?,
-        )
+        crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -121,33 +121,18 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -76,49 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
         "rerun.testing.components.AffixFuzzer1".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("single_float_optional", DataType::Float32, true),
-            Field::new("single_string_required", DataType::Utf8, false),
-            Field::new("single_string_optional", DataType::Utf8, true),
-            Field::new(
-                "many_floats_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Float32,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new(
-                "many_strings_required",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                false,
-            ),
-            Field::new(
-                "many_strings_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new("flattened_scalar", DataType::Float32, false),
-            Field::new(
-                "almost_flattened_scalar",
-                <crate::testing::datatypes::FlattenedScalar>::arrow_datatype(),
-                false,
-            ),
-            Field::new("from_parent", DataType::Boolean, true),
-        ]))
+        crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer1.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -144,17 +144,7 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer3::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer14#single_required_union")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer14#single_required_union")
-                .with_context("rerun.testing.components.AffixFuzzer14")?,
-        )
+        crate::testing::datatypes::AffixFuzzer3::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -108,33 +108,18 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer3::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer3::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer14.rs
@@ -76,36 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
         "rerun.testing.components.AffixFuzzer14".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Union(
-            std::sync::Arc::new(vec![
-                Field::new("_null_markers", DataType::Null, true),
-                Field::new("degrees", DataType::Float32, false),
-                Field::new(
-                    "craziness",
-                    DataType::List(std::sync::Arc::new(Field::new(
-                        "item",
-                        <crate::testing::datatypes::AffixFuzzer1>::arrow_datatype(),
-                        false,
-                    ))),
-                    false,
-                ),
-                Field::new(
-                    "fixed_size_shenanigans",
-                    DataType::FixedSizeList(
-                        std::sync::Arc::new(Field::new("item", DataType::Float32, false)),
-                        3usize,
-                    ),
-                    false,
-                ),
-                Field::new("empty_variant", DataType::Null, true),
-            ]),
-            Some(std::sync::Arc::new(vec![0i32, 1i32, 2i32, 3i32, 4i32])),
-            UnionMode::Dense,
-        )
+        crate::testing::datatypes::AffixFuzzer3::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -123,17 +123,7 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer5::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer19#just_a_table_nothing_shady")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer19#just_a_table_nothing_shady")
-                .with_context("rerun.testing.components.AffixFuzzer19")?,
-        )
+        crate::testing::datatypes::AffixFuzzer5::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -76,15 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
         "rerun.testing.components.AffixFuzzer19".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![Field::new(
-            "single_optional_union",
-            <crate::testing::datatypes::AffixFuzzer4>::arrow_datatype(),
-            true,
-        )]))
+        crate::testing::datatypes::AffixFuzzer5::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -87,33 +87,18 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
         )]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer5::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer5::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer19.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer5::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -121,33 +121,18 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -157,17 +157,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer2#single_required")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer2#single_required")
-                .with_context("rerun.testing.components.AffixFuzzer2")?,
-        )
+        crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer2.rs
@@ -76,49 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
         "rerun.testing.components.AffixFuzzer2".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("single_float_optional", DataType::Float32, true),
-            Field::new("single_string_required", DataType::Utf8, false),
-            Field::new("single_string_optional", DataType::Utf8, true),
-            Field::new(
-                "many_floats_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Float32,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new(
-                "many_strings_required",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                false,
-            ),
-            Field::new(
-                "many_strings_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new("flattened_scalar", DataType::Float32, false),
-            Field::new(
-                "almost_flattened_scalar",
-                <crate::testing::datatypes::FlattenedScalar>::arrow_datatype(),
-                false,
-            ),
-            Field::new("from_parent", DataType::Boolean, true),
-        ]))
+        crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -94,33 +94,18 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer20::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer20::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -76,22 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
         "rerun.testing.components.AffixFuzzer20".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new(
-                "p",
-                <crate::testing::datatypes::PrimitiveComponent>::arrow_datatype(),
-                false,
-            ),
-            Field::new(
-                "s",
-                <crate::testing::datatypes::StringComponent>::arrow_datatype(),
-                false,
-            ),
-        ]))
+        crate::testing::datatypes::AffixFuzzer20::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -130,17 +130,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer20::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer20#nested_transparent")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer20#nested_transparent")
-                .with_context("rerun.testing.components.AffixFuzzer20")?,
-        )
+        crate::testing::datatypes::AffixFuzzer20::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer20.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer20::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -76,22 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
         "rerun.testing.components.AffixFuzzer21".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("single_half", DataType::Float16, false),
-            Field::new(
-                "many_halves",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Float16,
-                    false,
-                ))),
-                false,
-            ),
-        ]))
+        crate::testing::datatypes::AffixFuzzer21::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -94,33 +94,18 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer21::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer21::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -130,17 +130,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer21::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer21#nested_halves")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer21#nested_halves")
-                .with_context("rerun.testing.components.AffixFuzzer21")?,
-        )
+        crate::testing::datatypes::AffixFuzzer21::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer21.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer21::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -121,33 +121,18 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
         ]))
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                _ = data0_bitmap;
-                crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data0)?
-            }
-        })
+        crate::testing::datatypes::AffixFuzzer1::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -157,17 +157,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok(
-            crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-                .with_context("rerun.testing.components.AffixFuzzer3#single_required")?
-                .into_iter()
-                .map(|v| v.ok_or_else(DeserializationError::missing_data))
-                .map(|res| res.map(|v| Some(Self(v))))
-                .collect::<DeserializationResult<Vec<Option<_>>>>()
-                .with_context("rerun.testing.components.AffixFuzzer3#single_required")
-                .with_context("rerun.testing.components.AffixFuzzer3")?,
-        )
+        crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 }

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -76,49 +76,9 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
         "rerun.testing.components.AffixFuzzer3".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::Struct(std::sync::Arc::new(vec![
-            Field::new("single_float_optional", DataType::Float32, true),
-            Field::new("single_string_required", DataType::Utf8, false),
-            Field::new("single_string_optional", DataType::Utf8, true),
-            Field::new(
-                "many_floats_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Float32,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new(
-                "many_strings_required",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                false,
-            ),
-            Field::new(
-                "many_strings_optional",
-                DataType::List(std::sync::Arc::new(Field::new(
-                    "item",
-                    DataType::Utf8,
-                    false,
-                ))),
-                true,
-            ),
-            Field::new("flattened_scalar", DataType::Float32, false),
-            Field::new(
-                "almost_flattened_scalar",
-                <crate::testing::datatypes::FlattenedScalar>::arrow_datatype(),
-                false,
-            ),
-            Field::new("from_parent", DataType::Boolean, true),
-        ]))
+        crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/re_types/src/testing/components/affix_fuzzer3.rs
@@ -103,6 +103,6 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
         Self: Sized,
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 }

--- a/crates/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/re_types/src/testing/datatypes/primitive_component.rs
@@ -126,4 +126,35 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
             .with_context("rerun.testing.datatypes.PrimitiveComponent#value")
             .with_context("rerun.testing.datatypes.PrimitiveComponent")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use ::re_types_core::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::UInt32;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.testing.datatypes.PrimitiveComponent#value")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,7 +113,6 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
     where
         Self: Sized,
     {
-        crate::datatypes::Uuid::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -158,50 +158,7 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-                            16usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.blueprint.components.IncludedSpaceView#space_view_id")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 16usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt8Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt8;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.blueprint.components.IncludedSpaceView#space_view_id")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|bytes| crate::datatypes::Uuid { bytes })
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Uuid::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
         "rerun.blueprint.components.IncludedSpaceView".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-            16usize,
-        )
+        crate::datatypes::Uuid::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -91,57 +91,18 @@ impl ::re_types_core::Loggable for RootContainer {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.bytes).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(16usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::UInt8,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Uuid::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -155,7 +116,6 @@ impl ::re_types_core::Loggable for RootContainer {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -161,50 +161,7 @@ impl ::re_types_core::Loggable for RootContainer {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-                            16usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.blueprint.components.RootContainer#id")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 16usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt8Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt8;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.blueprint.components.RootContainer#id")?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|bytes| crate::datatypes::Uuid { bytes })
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Uuid::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -151,77 +151,8 @@ impl ::re_types_core::Loggable for RootContainer {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.RootContainer#id")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(16usize)
-                    .zip((16usize..).step_by(16usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt8Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt8;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context("rerun.blueprint.components.RootContainer#id")?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 16usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt
-                        .map(|res_or_opt| res_or_opt.map(|bytes| crate::datatypes::Uuid { bytes }))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.RootContainer#id")
-        .with_context("rerun.blueprint.components.RootContainer")?)
+        crate::datatypes::Uuid::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -81,14 +81,9 @@ impl ::re_types_core::Loggable for RootContainer {
         "rerun.blueprint.components.RootContainer".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-            16usize,
-        )
+        crate::datatypes::Uuid::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -108,7 +108,7 @@ impl ::re_types_core::Loggable for RootContainer {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -116,7 +116,6 @@ impl ::re_types_core::Loggable for RootContainer {
     where
         Self: Sized,
     {
-        crate::datatypes::Uuid::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -158,52 +158,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        if let Some(validity) = arrow_data.validity() {
-            if validity.unset_bits() != 0 {
-                return Err(DeserializationError::missing_data());
-            }
-        }
-        Ok({
-            let slice = {
-                let arrow_data = arrow_data
-                    .as_any()
-                    .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                    .ok_or_else(|| {
-                        let expected = DataType::FixedSizeList(
-                            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-                            16usize,
-                        );
-                        let actual = arrow_data.data_type().clone();
-                        DeserializationError::datatype_mismatch(expected, actual)
-                    })
-                    .with_context("rerun.blueprint.components.SpaceViewMaximized#space_view_id")?;
-                let arrow_data_inner = &**arrow_data.values();
-                bytemuck::cast_slice::<_, [_; 16usize]>(
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt8Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt8;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context(
-                            "rerun.blueprint.components.SpaceViewMaximized#space_view_id",
-                        )?
-                        .values()
-                        .as_slice(),
-                )
-            };
-            {
-                slice
-                    .iter()
-                    .copied()
-                    .map(|bytes| crate::datatypes::Uuid { bytes })
-                    .map(|v| Self(v))
-                    .collect::<Vec<_>>()
-            }
-        })
+        crate::datatypes::Uuid::from_arrow(arrow_data)
+            .map(|v| v.into_iter().map(|v| Self(v)).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -105,7 +105,7 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow_opt(arrow_data)
-            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
+            .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
     #[inline]
@@ -113,7 +113,6 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     where
         Self: Sized,
     {
-        crate::datatypes::Uuid::from_arrow(arrow_data)
-            .map(|v| v.into_iter().map(|v| Self(v)).collect())
+        crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -88,57 +88,18 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
         )
     }
 
-    #[allow(clippy::wildcard_imports)]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<::std::borrow::Cow<'a, Self>>>>,
     ) -> SerializationResult<Box<dyn arrow2::array::Array>>
     where
         Self: Clone + 'a,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, datatypes::*};
-        Ok({
-            let (somes, data0): (Vec<_>, Vec<_>) = data
-                .into_iter()
-                .map(|datum| {
-                    let datum: Option<::std::borrow::Cow<'a, Self>> = datum.map(Into::into);
-                    let datum = datum.map(|datum| datum.into_owned().0);
-                    (datum.is_some(), datum)
-                })
-                .unzip();
-            let data0_bitmap: Option<arrow2::bitmap::Bitmap> = {
-                let any_nones = somes.iter().any(|some| !*some);
-                any_nones.then(|| somes.into())
-            };
-            {
-                use arrow2::{buffer::Buffer, offset::OffsetsBuffer};
-                let data0_inner_data: Vec<_> = data0
-                    .into_iter()
-                    .map(|datum| datum.map(|datum| datum.bytes).unwrap_or_default())
-                    .flatten()
-                    .collect();
-                let data0_inner_bitmap: Option<arrow2::bitmap::Bitmap> =
-                    data0_bitmap.as_ref().map(|bitmap| {
-                        bitmap
-                            .iter()
-                            .map(|b| std::iter::repeat(b).take(16usize))
-                            .flatten()
-                            .collect::<Vec<_>>()
-                            .into()
-                    });
-                FixedSizeListArray::new(
-                    Self::arrow_datatype(),
-                    PrimitiveArray::new(
-                        DataType::UInt8,
-                        data0_inner_data.into_iter().collect(),
-                        data0_inner_bitmap,
-                    )
-                    .boxed(),
-                    data0_bitmap,
-                )
-                .boxed()
-            }
-        })
+        crate::datatypes::Uuid::to_arrow_opt(data.into_iter().map(|datum| {
+            datum.map(|datum| match datum.into() {
+                ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
+                ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
+            })
+        }))
     }
 
     #[allow(clippy::wildcard_imports)]
@@ -152,7 +113,6 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
             .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
     where

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -148,79 +148,8 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     where
         Self: Sized,
     {
-        use ::re_types_core::{Loggable as _, ResultExt as _};
-        use arrow2::{array::*, buffer::*, datatypes::*};
-        Ok({
-            let arrow_data = arrow_data
-                .as_any()
-                .downcast_ref::<arrow2::array::FixedSizeListArray>()
-                .ok_or_else(|| {
-                    let expected = Self::arrow_datatype();
-                    let actual = arrow_data.data_type().clone();
-                    DeserializationError::datatype_mismatch(expected, actual)
-                })
-                .with_context("rerun.blueprint.components.SpaceViewMaximized#space_view_id")?;
-            if arrow_data.is_empty() {
-                Vec::new()
-            } else {
-                let offsets = (0..)
-                    .step_by(16usize)
-                    .zip((16usize..).step_by(16usize).take(arrow_data.len()));
-                let arrow_data_inner = {
-                    let arrow_data_inner = &**arrow_data.values();
-                    arrow_data_inner
-                        .as_any()
-                        .downcast_ref::<UInt8Array>()
-                        .ok_or_else(|| {
-                            let expected = DataType::UInt8;
-                            let actual = arrow_data_inner.data_type().clone();
-                            DeserializationError::datatype_mismatch(expected, actual)
-                        })
-                        .with_context(
-                            "rerun.blueprint.components.SpaceViewMaximized#space_view_id",
-                        )?
-                        .into_iter()
-                        .map(|opt| opt.copied())
-                        .collect::<Vec<_>>()
-                };
-                arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets,
-                    arrow_data.validity(),
-                )
-                .map(|elem| {
-                    elem.map(|(start, end)| {
-                        debug_assert!(end - start == 16usize);
-                        if end as usize > arrow_data_inner.len() {
-                            return Err(DeserializationError::offset_slice_oob(
-                                (start, end),
-                                arrow_data_inner.len(),
-                            ));
-                        }
-
-                        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
-                        let data =
-                            unsafe { arrow_data_inner.get_unchecked(start as usize..end as usize) };
-                        let data = data.iter().cloned().map(Option::unwrap_or_default);
-
-                        // NOTE: Unwrapping cannot fail: the length must be correct.
-                        #[allow(clippy::unwrap_used)]
-                        Ok(array_init::from_iter(data).unwrap())
-                    })
-                    .transpose()
-                })
-                .map(|res_or_opt| {
-                    res_or_opt
-                        .map(|res_or_opt| res_or_opt.map(|bytes| crate::datatypes::Uuid { bytes }))
-                })
-                .collect::<DeserializationResult<Vec<Option<_>>>>()?
-            }
-            .into_iter()
-        }
-        .map(|v| v.ok_or_else(DeserializationError::missing_data))
-        .map(|res| res.map(|v| Some(Self(v))))
-        .collect::<DeserializationResult<Vec<Option<_>>>>()
-        .with_context("rerun.blueprint.components.SpaceViewMaximized#space_view_id")
-        .with_context("rerun.blueprint.components.SpaceViewMaximized")?)
+        crate::datatypes::Uuid::from_arrow_opt(arrow_data)
+            .map(|v| v.into_iter().map(|v| v.map(|v| Self(v))).collect())
     }
 
     #[allow(clippy::wildcard_imports)]

--- a/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -78,14 +78,9 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
         "rerun.blueprint.components.SpaceViewMaximized".into()
     }
 
-    #[allow(clippy::wildcard_imports)]
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        use arrow2::datatypes::*;
-        DataType::FixedSizeList(
-            std::sync::Arc::new(Field::new("item", DataType::UInt8, false)),
-            16usize,
-        )
+        crate::datatypes::Uuid::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(

--- a/crates/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/re_types_builder/src/codegen/rust/deserializer.rs
@@ -7,7 +7,7 @@ use crate::{
         arrow::{is_backed_by_arrow_buffer, quote_fqname_as_type_path, ArrowDataTypeTokenizer},
         util::{is_tuple_struct_from_obj, quote_comment},
     },
-    ArrowRegistry, Object, ObjectKind, Objects,
+    ArrowRegistry, Object, Objects,
 };
 
 // ---
@@ -1080,9 +1080,10 @@ fn quote_arrow_field_deserializer_buffer_slice(
 /// These optimizations require the outer type to be non-nullable and made up exclusively
 /// of primitive types.
 ///
-/// Nullabillity is kind of weird since it's technically a property of the field
-/// rather than the datatype. However, we know that Components can only be used
-/// by archetypes and as such should never be nullible.
+/// Note that nullabillity is kind of weird since it's technically a property of the field
+/// rather than the datatype.
+/// Components can only be used by archetypes so they should never be nullable, but for datatypes
+/// we might need both.
 ///
 /// This should always be checked before using [`quote_arrow_deserializer_buffer_slice`].
 pub fn should_optimize_buffer_slice_deserialize(
@@ -1090,7 +1091,7 @@ pub fn should_optimize_buffer_slice_deserialize(
     arrow_registry: &ArrowRegistry,
 ) -> bool {
     let is_arrow_transparent = obj.datatype.is_none();
-    if obj.kind == ObjectKind::Component && is_arrow_transparent {
+    if is_arrow_transparent {
         let typ = arrow_registry.get(&obj.fqname);
         let obj_field = &obj.fields[0];
         !obj_field.is_nullable && should_optimize_buffer_slice_deserialize_datatype(&typ)

--- a/crates/re_types_core/src/datatypes/float32.rs
+++ b/crates/re_types_core/src/datatypes/float32.rs
@@ -127,4 +127,35 @@ impl crate::Loggable for Float32 {
             .with_context("rerun.datatypes.Float32#value")
             .with_context("rerun.datatypes.Float32")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use crate::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::Float32;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.datatypes.Float32#value")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types_core/src/datatypes/time_int.rs
+++ b/crates/re_types_core/src/datatypes/time_int.rs
@@ -126,4 +126,35 @@ impl crate::Loggable for TimeInt {
             .with_context("rerun.datatypes.TimeInt#value")
             .with_context("rerun.datatypes.TimeInt")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use crate::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::Int64;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.datatypes.TimeInt#value")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }

--- a/crates/re_types_core/src/datatypes/uint32.rs
+++ b/crates/re_types_core/src/datatypes/uint32.rs
@@ -126,4 +126,35 @@ impl crate::Loggable for UInt32 {
             .with_context("rerun.datatypes.UInt32#value")
             .with_context("rerun.datatypes.UInt32")?)
     }
+
+    #[allow(clippy::wildcard_imports)]
+    #[inline]
+    fn from_arrow(arrow_data: &dyn arrow2::array::Array) -> DeserializationResult<Vec<Self>>
+    where
+        Self: Sized,
+    {
+        use crate::{Loggable as _, ResultExt as _};
+        use arrow2::{array::*, buffer::*, datatypes::*};
+        if let Some(validity) = arrow_data.validity() {
+            if validity.unset_bits() != 0 {
+                return Err(DeserializationError::missing_data());
+            }
+        }
+        Ok({
+            let slice = arrow_data
+                .as_any()
+                .downcast_ref::<UInt32Array>()
+                .ok_or_else(|| {
+                    let expected = DataType::UInt32;
+                    let actual = arrow_data.data_type().clone();
+                    DeserializationError::datatype_mismatch(expected, actual)
+                })
+                .with_context("rerun.datatypes.UInt32#value")?
+                .values()
+                .as_slice();
+            {
+                slice.iter().copied().map(|v| Self(v)).collect::<Vec<_>>()
+            }
+        })
+    }
 }


### PR DESCRIPTION
### What

Remove lots of redundant serialization code by forwarding transparent components to its datatypes:

* forward `from_arrow_opt` for fully transparent types
* forward `from_arrow` for fully transparent types
   * this requires us generating it for `datatypes`! 
   * the forwarding uses `bytemuck` when possible. Should be possible in more places, but the constraints are complicated so this isn't fully automated and depends on types being manually marked as `bytemuck::Pod`
         * would be really nice though if we could automate that. Almost everything we're dealing with _should_ be pod 🤔  
* forward `to_arrow_opt` for fully transparent types
* forward `arrow_datatype` for fully transparent types


@ reviewer: There's only two non-generated files:
* `crates/re_types_builder/src/codegen/rust/api.rs`: https://github.com/rerun-io/rerun/pull/6793/files#diff-4eb7d4aa8c72b1987ed00d1ad9c61782b9dd55d8b96a50a44156388fea8c67f9
* `crates/re_types_builder/src/codegen/rust/deserializer.rs`: https://github.com/rerun-io/rerun/pull/6793/files#diff-91844032ca93ef2e29de6a660674273bfd6e836b26ae58c83fef09dcd8db1076
Everything else is generated via those changes. You'll want to have a sampling of both datatypes & components.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6793?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6793?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6793)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.