### PR TITLE
Use "N-dimensional" instead of "rank-N" in docstrings and error messages

### DIFF
--- a/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/bar_chart.fbs
@@ -18,7 +18,7 @@ table BarChart (
 ) {
   // --- Required ---
 
-  /// The values. Should always be a rank-1 tensor.
+  /// The values. Should always be a 1-dimensional tensor (i.e. a vector).
   values: rerun.components.TensorData ("attr.rerun.component_required", required, order: 1000);
 
   // --- Optional ---

--- a/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/depth_image.fbs
@@ -25,7 +25,7 @@ table DepthImage (
 ) {
   // --- Required ---
 
-  /// The depth-image data. Should always be a rank-2 tensor.
+  /// The depth-image data. Should always be a 2-dimensional tensor.
   data: rerun.components.TensorData ("attr.rerun.component_required", order: 1000);
 
   // --- Optional ---

--- a/crates/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/image.fbs
@@ -40,7 +40,7 @@ table Image (
 ) {
   // --- Required ---
 
-  /// The image data. Should always be a rank-2 or rank-3 tensor.
+  /// The image data. Should always be a 2- or 3-dimensional tensor.
   data: rerun.components.TensorData ("attr.rerun.component_required", order: 1000);
 
   // --- Optional ---

--- a/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
+++ b/crates/re_types/definitions/rerun/archetypes/segmentation_image.fbs
@@ -33,7 +33,7 @@ table SegmentationImage (
 ) {
   // --- Required ---
 
-  /// The image data. Should always be a rank-2 tensor.
+  /// The image data. Should always be a 2-dimensional tensor.
   data: rerun.components.TensorData ("attr.rerun.component_required", order: 1000);
 
   // --- Optional ---

--- a/crates/re_types/src/archetypes/bar_chart.rs
+++ b/crates/re_types/src/archetypes/bar_chart.rs
@@ -52,7 +52,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct BarChart {
-    /// The values. Should always be a rank-1 tensor.
+    /// The values. Should always be a 1-dimensional tensor (i.e. a vector).
     pub values: crate::components::TensorData,
 
     /// The color of the bar chart

--- a/crates/re_types/src/archetypes/depth_image.rs
+++ b/crates/re_types/src/archetypes/depth_image.rs
@@ -69,7 +69,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct DepthImage {
-    /// The depth-image data. Should always be a rank-2 tensor.
+    /// The depth-image data. Should always be a 2-dimensional tensor.
     pub data: crate::components::TensorData,
 
     /// An optional floating point value that specifies how long a meter is in the native depth units.

--- a/crates/re_types/src/archetypes/image.rs
+++ b/crates/re_types/src/archetypes/image.rs
@@ -70,7 +70,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct Image {
-    /// The image data. Should always be a rank-2 or rank-3 tensor.
+    /// The image data. Should always be a 2- or 3-dimensional tensor.
     pub data: crate::components::TensorData,
 
     /// Opacity of the image, useful for layering several images.

--- a/crates/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/re_types/src/archetypes/segmentation_image.rs
@@ -74,7 +74,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct SegmentationImage {
-    /// The image data. Should always be a rank-2 tensor.
+    /// The image data. Should always be a 2-dimensional tensor.
     pub data: crate::components::TensorData,
 
     /// Opacity of the image, useful for layering the segmentation image on top of another image.

--- a/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
+++ b/rerun_cpp/src/rerun/archetypes/bar_chart.hpp
@@ -37,7 +37,7 @@ namespace rerun::archetypes {
     /// }
     /// ```
     struct BarChart {
-        /// The values. Should always be a rank-1 tensor.
+        /// The values. Should always be a 1-dimensional tensor (i.e. a vector).
         rerun::components::TensorData values;
 
         /// The color of the bar chart

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -73,7 +73,7 @@ namespace rerun::archetypes {
     /// }
     /// ```
     struct DepthImage {
-        /// The depth-image data. Should always be a rank-2 tensor.
+        /// The depth-image data. Should always be a 2-dimensional tensor.
         rerun::components::TensorData data;
 
         /// An optional floating point value that specifies how long a meter is in the native depth units.

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -117,7 +117,7 @@ namespace rerun::archetypes {
         /// New depth image from height/width and tensor buffer.
         ///
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// \param buffer
         /// The tensor buffer containing the depth image data.
@@ -129,14 +129,14 @@ namespace rerun::archetypes {
         /// \param data_
         /// The tensor buffer containing the depth image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2.
+        /// Calls `Error::handle()` if the tensor is not 2-dimensional
         explicit DepthImage(components::TensorData data_);
 
         /// New depth image from dimensions and pointer to depth image data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
         /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
         /// Determines the number of elements expected to be in `data`.
         /// \param data_

--- a/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
@@ -3,6 +3,8 @@
 
 #include "../collection_adapter_builtins.hpp"
 
+#include <sstream>
+
 namespace rerun::archetypes {
 
 #ifdef EDIT_EXTENSION
@@ -45,7 +47,9 @@ namespace rerun::archetypes {
     DepthImage::DepthImage(components::TensorData data_) : data(std::move(data_)) {
         auto& shape = data.data.shape;
         if (shape.size() != 2) {
-            Error(ErrorCode::InvalidTensorDimension, "Shape must be rank 2.").handle();
+            std::stringstream ss;
+            ss << "Expected 2-dimensional tensor, got " << shape.size() << " dimensions.";
+            Error(ErrorCode::InvalidTensorDimension, ss.str()).handle();
             return;
         }
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
@@ -11,7 +11,7 @@ namespace rerun::archetypes {
     /// New depth image from height/width and tensor buffer.
     ///
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// \param buffer
     /// The tensor buffer containing the depth image data.
@@ -23,14 +23,14 @@ namespace rerun::archetypes {
     /// \param data_
     /// The tensor buffer containing the depth image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2.
+    /// Calls `Error::handle()` if the tensor is not 2-dimensional
     explicit DepthImage(components::TensorData data_);
 
     /// New depth image from dimensions and pointer to depth image data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
     /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
     /// Determines the number of elements expected to be in `data`.
     /// \param data_

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -73,7 +73,7 @@ namespace rerun::archetypes {
     /// }
     /// ```
     struct Image {
-        /// The image data. Should always be a rank-2 or rank-3 tensor.
+        /// The image data. Should always be a 2- or 3-dimensional tensor.
         rerun::components::TensorData data;
 
         /// Opacity of the image, useful for layering several images.

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -98,7 +98,7 @@ namespace rerun::archetypes {
         /// New Image from height/width/channel and tensor buffer.
         ///
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
         /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
         /// \param buffer
         /// The tensor buffer containing the image data.
@@ -110,14 +110,14 @@ namespace rerun::archetypes {
         /// \param data_
         /// The tensor buffer containing the image data.
         /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2 or 3.
+        /// Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
         explicit Image(rerun::components::TensorData data_);
 
         /// New image from dimensions and pointer to image data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
         /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
         /// Determines the number of elements expected to be in `data`.
         /// \param data_

--- a/rerun_cpp/src/rerun/archetypes/image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image_ext.cpp
@@ -14,7 +14,7 @@ namespace rerun::archetypes {
     /// New Image from height/width/channel and tensor buffer.
     ///
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
     /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
     /// \param buffer
     /// The tensor buffer containing the image data.
@@ -26,14 +26,14 @@ namespace rerun::archetypes {
     /// \param data_
     /// The tensor buffer containing the image data.
     /// Sets the dimension names to "height",  "width" and "channel" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2 or 3.
+    /// Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
     explicit Image(rerun::components::TensorData data_);
 
     /// New image from dimensions and pointer to image data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2 or 3.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2- or 3-dimensional.
     /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
     /// Determines the number of elements expected to be in `data`.
     /// \param data_

--- a/rerun_cpp/src/rerun/archetypes/image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image_ext.cpp
@@ -3,6 +3,8 @@
 
 #include "../collection_adapter_builtins.hpp"
 
+#include <sstream>
+
 // Uncomment for better auto-complete while editing the extension.
 // #define EDIT_EXTENSION
 
@@ -48,11 +50,9 @@ namespace rerun::archetypes {
     Image::Image(rerun::components::TensorData data_) : data(std::move(data_)) {
         auto& shape = data.data.shape;
         if (shape.size() != 2 && shape.size() != 3) {
-            Error(
-                ErrorCode::InvalidTensorDimension,
-                "Image shape is expected to be either rank 2 or 3."
-            )
-                .handle();
+            std::stringstream ss;
+            ss << "Expected 2- or 3-dimensional tensor, got " << shape.size() << " dimensions.";
+            Error(ErrorCode::InvalidTensorDimension, ss.str()).handle();
             return;
         }
         if (shape.size() == 3 && shape[2].size != 1 && shape[2].size != 3 && shape[2].size != 4) {

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -98,7 +98,7 @@ namespace rerun::archetypes {
         /// New segmentation image from height/width and tensor buffer.
         ///
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
         /// Sets the dimension names to "height" and "width" if they are not specified.
         /// \param buffer
         /// The tensor buffer containing the segmentation image data.
@@ -112,14 +112,14 @@ namespace rerun::archetypes {
         /// \param data_
         /// The tensor buffer containing the segmentation image data.
         /// Sets the dimension names to "height" and "width" if they are not specified.
-        /// Calls `Error::handle()` if the shape is not rank 2.
+        /// Calls `Error::handle()` if the tensor is not 2-dimensional
         explicit SegmentationImage(components::TensorData data_);
 
         /// New segmentation image from dimensions and pointer to segmentation image data.
         ///
         /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
         /// \param shape
-        /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+        /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
         /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
         /// Determines the number of elements expected to be in `data`.
         /// \param data_

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -72,7 +72,7 @@ namespace rerun::archetypes {
     /// }
     /// ```
     struct SegmentationImage {
-        /// The image data. Should always be a rank-2 tensor.
+        /// The image data. Should always be a 2-dimensional tensor.
         rerun::components::TensorData data;
 
         /// Opacity of the image, useful for layering the segmentation image on top of another image.

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
@@ -3,6 +3,8 @@
 #include "../collection_adapter_builtins.hpp"
 #include "../error.hpp"
 
+#include <sstream>
+
 namespace rerun::archetypes {
 
 #if 0
@@ -45,7 +47,9 @@ namespace rerun::archetypes {
     SegmentationImage::SegmentationImage(components::TensorData data_) : data(std::move(data_)) {
         auto& shape = data.data.shape;
         if (shape.size() != 2) {
-            Error(ErrorCode::InvalidTensorDimension, "Shape must be rank 2.").handle();
+            std::stringstream ss;
+            ss << "Expected 2-dimensional tensor, got " << shape.size() << " dimensions.";
+            Error(ErrorCode::InvalidTensorDimension, ss.str()).handle();
             return;
         }
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
@@ -11,7 +11,7 @@ namespace rerun::archetypes {
     /// New segmentation image from height/width and tensor buffer.
     ///
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
     /// Sets the dimension names to "height" and "width" if they are not specified.
     /// \param buffer
     /// The tensor buffer containing the segmentation image data.
@@ -23,14 +23,14 @@ namespace rerun::archetypes {
     /// \param data_
     /// The tensor buffer containing the segmentation image data.
     /// Sets the dimension names to "height" and "width" if they are not specified.
-    /// Calls `Error::handle()` if the shape is not rank 2.
+    /// Calls `Error::handle()` if the tensor is not 2-dimensional
     explicit SegmentationImage(components::TensorData data_);
 
     /// New segmentation image from dimensions and pointer to segmentation image data.
     ///
     /// Type must be one of the types supported by `rerun::datatypes::TensorData`.
     /// \param shape
-    /// Shape of the image. Calls `Error::handle()` if the shape is not rank 2.
+    /// Shape of the image. Calls `Error::handle()` if the tensor is not 2-dimensional
     /// Sets the dimension names to "height", "width" and "channel" if they are not specified.
     /// Determines the number of elements expected to be in `data`.
     /// \param data_

--- a/rerun_cpp/tests/archetypes/image.cpp
+++ b/rerun_cpp/tests/archetypes/image.cpp
@@ -7,7 +7,7 @@ using namespace rerun::archetypes;
 #define TEST_TAG "[image][archetypes]"
 
 SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
-    GIVEN("tensor data with correct rank 2 shape") {
+    GIVEN("tensor data with correct 2-dimensional shape") {
         rerun::datatypes::TensorData data({3, 7}, std::vector<uint8_t>(3 * 7, 0));
         THEN("no error occurs on image construction") {
             auto image = check_logged_error([&] { return Image(std::move(data)); });
@@ -22,7 +22,7 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
             }
         }
     }
-    GIVEN("tensor data with correct rank 3 shape") {
+    GIVEN("tensor data with correct 3-dimensional shape") {
         rerun::datatypes::TensorData data({3, 7, 3}, std::vector<uint8_t>(3 * 7 * 3, 0));
         THEN("no error occurs on image construction") {
             auto image = check_logged_error([&] { return Image(std::move(data)); });
@@ -38,7 +38,7 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
             }
         }
     }
-    GIVEN("tensor data with incorrect rank 3 shape") {
+    GIVEN("tensor data with incorrect 3-dimensional shape") {
         rerun::datatypes::TensorData data({3, 7, 2}, std::vector<uint8_t>(3 * 7 * 2, 0));
         THEN("a warning occurs on image construction") {
             auto image = check_logged_error(
@@ -72,7 +72,7 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
         }
     }
 
-    GIVEN("tensor data with too high rank") {
+    GIVEN("tensor data with too high dimensionality") {
         rerun::datatypes::TensorData data(
             {
                 {
@@ -103,7 +103,7 @@ SCENARIO("Image archetype can be created from tensor data." TEST_TAG) {
         }
     }
 
-    GIVEN("tensor data with too low rank") {
+    GIVEN("tensor data with too low dimensionality") {
         rerun::datatypes::TensorData data(
             {
                 rerun::datatypes::TensorDimension(1, "dr robotnik"),

--- a/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
+++ b/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
@@ -46,7 +46,7 @@ void run_image_tests() {
         }
     }
 
-    GIVEN("tensor data with too high rank") {
+    GIVEN("tensor data with too high dimensionality") {
         rerun::datatypes::TensorData data(
             {
                 {
@@ -75,7 +75,7 @@ void run_image_tests() {
         }
     }
 
-    GIVEN("tensor data with too low rank") {
+    GIVEN("tensor data with too low dimensionality") {
         rerun::datatypes::TensorData data(
             {
                 rerun::datatypes::TensorDimension(1, "dr robotnik"),

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart.py
@@ -54,7 +54,7 @@ class BarChart(BarChartExt, Archetype):
         Parameters
         ----------
         values:
-            The values. Should always be a rank-1 tensor.
+            The values. Should always be a 1-dimensional tensor (i.e. a vector).
         color:
             The color of the bar chart
 
@@ -84,7 +84,7 @@ class BarChart(BarChartExt, Archetype):
         metadata={"component": "required"},
         converter=BarChartExt.values__field_converter_override,  # type: ignore[misc]
     )
-    # The values. Should always be a rank-1 tensor.
+    # The values. Should always be a 1-dimensional tensor (i.e. a vector).
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/depth_image.py
@@ -80,7 +80,7 @@ class DepthImage(DepthImageExt, Archetype):
         Parameters
         ----------
         data:
-            The depth-image data. Should always be a rank-2 tensor.
+            The depth-image data. Should always be a 2-dimensional tensor.
         meter:
             An optional floating point value that specifies how long a meter is in the native depth units.
 
@@ -137,7 +137,7 @@ class DepthImage(DepthImageExt, Archetype):
         metadata={"component": "required"},
         converter=DepthImageExt.data__field_converter_override,  # type: ignore[misc]
     )
-    # The depth-image data. Should always be a rank-2 tensor.
+    # The depth-image data. Should always be a 2-dimensional tensor.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -82,7 +82,7 @@ class Image(ImageExt, Archetype):
         Parameters
         ----------
         data:
-            The image data. Should always be a rank-2 or rank-3 tensor.
+            The image data. Should always be a 2- or 3-dimensional tensor.
         opacity:
             Opacity of the image, useful for layering several images.
 
@@ -119,7 +119,7 @@ class Image(ImageExt, Archetype):
         metadata={"component": "required"},
         converter=ImageExt.data__field_converter_override,  # type: ignore[misc]
     )
-    # The image data. Should always be a rank-2 or rank-3 tensor.
+    # The image data. Should always be a 2- or 3-dimensional tensor.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/segmentation_image.py
@@ -79,7 +79,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         Parameters
         ----------
         data:
-            The image data. Should always be a rank-2 tensor.
+            The image data. Should always be a 2-dimensional tensor.
         opacity:
             Opacity of the image, useful for layering the segmentation image on top of another image.
 
@@ -116,7 +116,7 @@ class SegmentationImage(SegmentationImageExt, Archetype):
         metadata={"component": "required"},
         converter=SegmentationImageExt.data__field_converter_override,  # type: ignore[misc]
     )
-    # The image data. Should always be a rank-2 tensor.
+    # The image data. Should always be a 2-dimensional tensor.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5254

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
