### PR TITLE
Update workflow permissions

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,6 +13,9 @@ on:
       - labeled
       - unlabeled
 
+# No permissions needed here
+# permissions:
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "write"
+  id-token: "write"
+  deployments: "write"
+
 jobs:
   checks:
     name: Checks

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -14,6 +14,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+  issues: "write"
+
 jobs:
   parse-command:
     if: |

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -12,6 +12,8 @@ on:
       - opened
       - synchronize
 
+permissions: write-all
+
 # These jobs use fairly short names as they are a prefix in the display hierarchy
 jobs:
   checks:

--- a/.github/workflows/on_pull_request_contrib.yml
+++ b/.github/workflows/on_pull_request_contrib.yml
@@ -13,6 +13,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: "read"
+
 jobs:
   checks:
     name: "Checks"

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -13,6 +13,8 @@ on:
         required: true
         type: string
 
+permissions: write-all
+
 jobs:
   checks:
     name: Checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ defaults:
   run:
     shell: bash
 
-permissions: # wants to push commits and create a PR
-  contents: write
-  id-token: write
+# wants to push commits and create a PR
+permissions: write-all
 
 jobs:
   # Re-entrancy:

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -47,21 +47,19 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+  id-token: "write"
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+
 jobs:
   # ---------------------------------------------------------------------------
 
   rs-benchmarks:
     name: Rust Criterion benchmarks
-
-    permissions:
-      # contents permission to update benchmark contents in gh-pages branch
-      contents: write
-      id-token: "write"
-      # deployments permission to deploy GitHub pages website
-      deployments: write
-
     runs-on: ubuntu-latest-16-cores
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -40,15 +40,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   rs-build-examples:
     name: Build Examples
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest-16-cores
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -34,15 +34,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   build:
     name: Build rerun_js
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest-16-cores
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -41,15 +41,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   rs-build-web-viewer:
     name: Build web viewer
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest-16-cores
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
+++ b/.github/workflows/reusable_bundle_and_upload_rerun_cpp.yml
@@ -22,19 +22,16 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   bundle-and-upload-rerun_cpp:
     name: Bundle and upload rerun_cpp_sdk.zip
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     container:
       image: rerunio/ci_docker:0.14.0 # Need container for arrow dependency.
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -38,6 +38,7 @@ defaults:
 permissions:
   contents: "read"
   id-token: "write"
+
 jobs:
   py-test-docs:
     name: Test Python Docs

--- a/.github/workflows/reusable_pip_index.yml
+++ b/.github/workflows/reusable_pip_index.yml
@@ -19,16 +19,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   pr-summary:
     name: Create a Pip Index file
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -18,17 +18,15 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+  pull-requests: "write"
+
 jobs:
   pr-summary:
     name: Create HTML summary for PR
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      pull-requests: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_publish_rerun_c.yml
+++ b/.github/workflows/reusable_publish_rerun_c.yml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   linux-arm64:
     name: "Linux-Arm64"

--- a/.github/workflows/reusable_publish_rerun_cli.yml
+++ b/.github/workflows/reusable_publish_rerun_cli.yml
@@ -15,6 +15,10 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   linux-arm64:
     name: "Linux-arm64"

--- a/.github/workflows/reusable_publish_wheels.yml
+++ b/.github/workflows/reusable_publish_wheels.yml
@@ -24,6 +24,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   get-commit-sha:
     name: Get Commit Sha

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -18,6 +18,10 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   publish-crates:
     name: "Publish Crates"

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -72,7 +72,7 @@ jobs:
         # 2. Install `rerun-sdk[notebook]` from the wheel again.
         #      This will not reinstall `rerun-sdk` or `rerun-notebook`, but it will
         #      properly install all dependencies.
-        # It's a mystery whether or not this installs the dependencies of the local wheel, or of the pypi-published package...
+        # It's a mystery whether or not this installs the dependencies of the local wheel, or of the pypi-published package…
         run: |
           pixi run -e wheel-test pip install \
               'rerun-sdk==${{ steps.get-version.outputs.wheel_version }}' \

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -19,19 +19,16 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   run-notebook:
     name: Run notebook
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     container:
       image: rerunio/ci_docker:0.14.0 # Required to run the wheel or we get "No matching distribution found for attrs>=23.1.0" during `pip install rerun-sdk`
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_sync_release_assets.yml
+++ b/.github/workflows/reusable_sync_release_assets.yml
@@ -23,16 +23,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "write"
+  id-token: "write"
+
 jobs:
   sync-assets:
     name: Upload assets from build.rerun.io
-
-    permissions:
-      contents: "write"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -18,17 +18,15 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+  pull-requests: "write"
+
 jobs:
   update-pr-body:
     name: Update PR body
-
-    permissions:
-      contents: "read"
-      id-token: "write"
-      pull-requests: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/reusable_upload_examples.yml
+++ b/.github/workflows/reusable_upload_examples.yml
@@ -34,15 +34,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   upload-web:
     name: Upload Examples to Google Cloud
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -35,15 +35,14 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: "read"
+  id-token: "write"
+
 jobs:
   upload-web:
     name: Upload web build to google cloud (wasm32 + wasm-bindgen)
-    permissions:
-      contents: "read"
-      id-token: "write"
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### What

GitHub forced us into an enterprise account, in which the default permissions for workflows are set to `none`. This updates the permissions of all jobs to restore their functionality, but the permissions are not as granular as they could be.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6803?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6803?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6803)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.