### PR TITLE
Add blueprint backwards compat check

### DIFF
--- a/tests/python/release_checklist/check_blueprint_bw_compat.py
+++ b/tests/python/release_checklist/check_blueprint_bw_compat.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+README = """
+# Blueprint backwards compatibility
+
+Updating your Rerun version should never result in indecipherable Blueprint errors.
+
+Even in the case of irrecoverable ABI changes, we should make sure that the end-user has
+a pleasant experience (i.e., in the worst case, the blueprint is ignored, with a warning).
+
+## Checks
+
+#### Step 1: instantiate blueprints from previous release
+
+* Install the latest official Rerun release in a virtual env: `pip install --force rerun-sdk`.
+* Clear all your blueprint data: `rerun reset`.
+* Start Rerun and check in Menu > About that you are indeed running the version you think
+  you're running.
+* Open all demos available in the welcome screen.
+* Play around long enough for the blueprints to be saved to disk (a few seconds).
+    * You can check whether that's the case by listing the contents of:
+          - Linux: `/home/UserName/.local/share/rerun`
+          - macOS: `/Users/UserName/Library/Application Support/rerun`
+          - Windows: `C:\\Users\\UserName\\AppData\\Roaming\\rerun`
+          - Web: local storage
+
+#### Step 2: load blueprints from previous release into new one
+
+* Install the about-to-released Rerun version in a virtual env: `pip install --force rerun-sdk=whatever`.
+* Start Rerun and check in Menu > About that you are indeed running the version you think
+  you're running.
+* Open all demos available in the welcome screen.
+
+#### Step 3: does it look okay?
+
+There are two acceptable outcomes here:
+- The blueprints worked as-is. :+1:
+- The blueprints completely or partially failed to load, but a clear warning explaining what's
+  going on was shown to the user.
+
+Anything else is a failure (e.g. deserialization failure spam).
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(
+        args,
+        f"{os.path.basename(__file__)}",
+        recording_id=uuid4(),
+        default_blueprint=rrb.Grid(rrb.TextDocumentView(origin="readme")),
+    )
+
+    log_readme()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)

--- a/tests/python/release_checklist/check_blueprint_bw_compat.py
+++ b/tests/python/release_checklist/check_blueprint_bw_compat.py
@@ -41,7 +41,7 @@ a pleasant experience (i.e., in the worst case, the blueprint is ignored, with a
 #### Step 3: does it look okay?
 
 There are two acceptable outcomes here:
-- The blueprints worked as-is. :+1:
+- The blueprints worked as-is. 👍
 - The blueprints completely or partially failed to load, but a clear warning explaining what's
   going on was shown to the user.
 

--- a/tests/python/release_checklist/check_notebook.py
+++ b/tests/python/release_checklist/check_notebook.py
@@ -23,7 +23,7 @@ def run(args: Namespace) -> None:
         args,
         f"{os.path.basename(__file__)}",
         recording_id=uuid4(),
-        default_blueprint=rrb.Grid(rrb.Spatial2DView(origin="/"), rrb.TextDocumentView(origin="readme")),
+        default_blueprint=rrb.Grid(rrb.TextDocumentView(origin="readme")),
     )
 
     log_readme()


### PR DESCRIPTION
Successfully ran through it for `0.16.1` -> `0.17.0-rc.2`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
