### PR TITLE
Fix query benchmarks overflow

### DIFF
--- a/crates/re_query/benches/latest_at.rs
+++ b/crates/re_query/benches/latest_at.rs
@@ -190,7 +190,7 @@ pub fn build_some_strings(len: usize) -> Vec<Text> {
 
     (0..len)
         .map(|_| {
-            let ilen: usize = rng.gen_range(0..10000);
+            let ilen: usize = rng.gen_range(0..100);
             let s: String = rand::thread_rng()
                 .sample_iter(&rand::distributions::Alphanumeric)
                 .take(ilen)


### PR DESCRIPTION
These benchmarks used to be `DataRow`-based, i.e. the rows didn't share any memory.

Now that these are `Chunk`-based, the memory for all strings is shared, and therefore cannot be more than 4gig total.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6806?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6806?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6806)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.