### PR TITLE
Fix permissions for `full-check` job

### DIFF
--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -8,7 +8,7 @@ name: "PR Comment"
 
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 defaults:
   run:

--- a/.github/workflows/on_pr_comment.yml
+++ b/.github/workflows/on_pr_comment.yml
@@ -17,7 +17,7 @@ defaults:
 permissions:
   contents: "read"
   id-token: "write"
-  issues: "write"
+  pull-requests: "write"
 
 jobs:
   parse-command:


### PR DESCRIPTION
### What

`mshick/add-pr-comment` needs the `pull-requests` scope: https://github.com/mshick/add-pr-comment#usage

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6822?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6822?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6822)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.