### PR TITLE
Make default notebook widget size smaller and configurable

### DIFF
--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -23,7 +23,8 @@
     "\n",
     "import numpy as np\n",
     "import rerun as rr  # pip install rerun-sdk\n",
-    "import rerun.blueprint as rrb\n"
+    "import rerun.blueprint as rrb\n",
+    "import rerun.notebook as rrn\n"
    ]
   },
   {
@@ -241,6 +242,33 @@
     "rr.log(\"small_cube\", rr.Points3D(small_cube.positions, colors=small_cube.colors, radii=0.5))\n",
     "\n",
     "rr.notebook_show(width=400, height=400)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff84c840",
+   "metadata": {},
+   "source": [
+    "To update the default width and height, you can use the `rerun.notebook.set_default_size` function.\n",
+    "\n",
+    "Note that you do not need to initialize a recording to use this function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81157021",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rrn.set_default_size(width=400, height=400)\n",
+    "\n",
+    "rr.init(\"rerun_example_cube\")\n",
+    "\n",
+    "small_cube = build_color_grid(3, 3, 3, twist=0)\n",
+    "rr.log(\"small_cube\", rr.Points3D(small_cube.positions, colors=small_cube.colors, radii=0.5))\n",
+    "\n",
+    "rr.notebook_show()\n"
    ]
   },
   {

--- a/examples/python/notebook/cube.ipynb
+++ b/examples/python/notebook/cube.ipynb
@@ -23,8 +23,7 @@
     "\n",
     "import numpy as np\n",
     "import rerun as rr  # pip install rerun-sdk\n",
-    "import rerun.blueprint as rrb\n",
-    "import rerun.notebook as rrn\n"
+    "import rerun.blueprint as rrb\n"
    ]
   },
   {
@@ -261,14 +260,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rrn.set_default_size(width=400, height=400)\n",
+    "from rerun.notebook import set_default_size\n",
+    "\n",
+    "set_default_size(width=400, height=400)\n",
     "\n",
     "rr.init(\"rerun_example_cube\")\n",
     "\n",
     "small_cube = build_color_grid(3, 3, 3, twist=0)\n",
     "rr.log(\"small_cube\", rr.Points3D(small_cube.positions, colors=small_cube.colors, radii=0.5))\n",
     "\n",
-    "rr.notebook_show()\n"
+    "rr.notebook_show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "755957e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "set_default_size(width=640, height=480)"
    ]
   },
   {

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -12,8 +12,8 @@ from rerun import bindings
 
 from .recording_stream import RecordingStream, get_data_recording
 
-DEFAULT_WIDTH = 950
-DEFAULT_HEIGHT = 712
+DEFAULT_WIDTH = 640
+DEFAULT_HEIGHT = 480
 
 
 class Viewer:

--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -12,8 +12,30 @@ from rerun import bindings
 
 from .recording_stream import RecordingStream, get_data_recording
 
-DEFAULT_WIDTH = 640
-DEFAULT_HEIGHT = 480
+_default_width = 640
+_default_height = 480
+
+
+def set_default_size(*, width: int | None, height: int | None) -> None:
+    """
+    Set the default size for the viewer.
+
+    This will be used for any viewers created after this call.
+
+    Parameters
+    ----------
+    width : int
+        The width of the viewer in pixels.
+    height : int
+        The height of the viewer in pixels.
+
+    """
+
+    global _default_width, _default_height
+    if width is not None:
+        _default_width = width
+    if height is not None:
+        _default_height = height
 
 
 class Viewer:
@@ -26,8 +48,8 @@ class Viewer:
     def __init__(
         self,
         *,
-        width: int = DEFAULT_WIDTH,
-        height: int = DEFAULT_HEIGHT,
+        width: int | None = None,
+        height: int | None = None,
         blueprint: BlueprintLike | None = None,
         recording: RecordingStream | None = None,
     ):
@@ -74,8 +96,8 @@ class Viewer:
             self._recording.send_blueprint(blueprint)  # type: ignore[attr-defined]
 
         self._viewer = _Viewer(
-            width=width,
-            height=height,
+            width=width if width is not None else _default_width,
+            height=height if height is not None else _default_height,
         )
 
         bindings.set_callback_sink(
@@ -115,8 +137,8 @@ class Viewer:
 
 def notebook_show(
     *,
-    width: int = DEFAULT_WIDTH,
-    height: int = DEFAULT_HEIGHT,
+    width: int | None = None,
+    height: int | None = None,
     blueprint: BlueprintLike | None = None,
     recording: RecordingStream | None = None,
 ) -> None:


### PR DESCRIPTION
### What

- Part of https://github.com/rerun-io/rerun/issues/2289

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6827?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6827?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!

- [PR Build Summary](https://build.rerun.io/pr/6827)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.