### PR TITLE
New code snippet for Transform3D demonstrating an animated hierarchy

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -9,6 +9,7 @@ namespace rerun.archetypes;
 /// A 3D transform.
 ///
 /// \example archetypes/transform3d_simple title="Variety of 3D transforms" image="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png"
+/// \example archetypes/transform3d_hierarchy title="Transform hierarchy" image="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png"
 table Transform3D (
   "attr.rust.derive": "PartialEq",
   "attr.docs.category": "Spatial 3D",

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -68,6 +68,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d_hierarchy").spawn()?;
 ///
+///     // TODO(#5521): log two space views as in the python example
+///
 ///     rec.set_time_seconds("sim_time", 0.0);
 ///
 ///     // Planetary motion is typically in the XY plane.
@@ -140,8 +142,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///             .from_parent(),
 ///         )?;
 ///     }
-///
-///     // TODO(#5521): log two space views as in the python example
 ///
 ///     Ok(())
 /// }

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -20,7 +20,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A 3D transform.
 ///
-/// ## Example
+/// ## Examples
 ///
 /// ### Variety of 3D transforms
 /// ```ignore
@@ -60,6 +60,99 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1024w.png">
 ///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png">
 ///   <img src="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/full.png" width="640">
+/// </picture>
+/// </center>
+///
+/// ### Transform hierarchy
+/// ```ignore
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d_hierarchy").spawn()?;
+///
+///     rec.set_time_seconds("sim_time", 0.0);
+///
+///     // Planetary motion is typically in the XY plane.
+///     rec.log_static("/", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
+///
+///     // Setup points, all are in the center of their own space:
+///     rec.log(
+///         "sun",
+///         &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+///             .with_radii([1.0])
+///             .with_colors([rerun::Color::from_rgb(255, 200, 10)]),
+///     )?;
+///     rec.log(
+///         "sun/planet",
+///         &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+///             .with_radii([0.4])
+///             .with_colors([rerun::Color::from_rgb(40, 80, 200)]),
+///     )?;
+///     rec.log(
+///         "sun/planet/moon",
+///         &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+///             .with_radii([0.15])
+///             .with_colors([rerun::Color::from_rgb(180, 180, 180)]),
+///     )?;
+///
+///     // Draw fixed paths where the planet & moon move.
+///     let d_planet = 6.0;
+///     let d_moon = 3.0;
+///     let angles = (0..=100).map(|i| i as f32 * 0.01 * std::f32::consts::TAU);
+///     let circle: Vec<_> = angles.map(|angle| [angle.sin(), angle.cos()]).collect();
+///     rec.log(
+///         "sun/planet_path",
+///         &rerun::LineStrips3D::new([rerun::LineStrip3D::from_iter(
+///             circle
+///                 .iter()
+///                 .map(|p| [p[0] * d_planet, p[1] * d_planet, 0.0]),
+///         )]),
+///     )?;
+///     rec.log(
+///         "sun/planet/moon_path",
+///         &rerun::LineStrips3D::new([rerun::LineStrip3D::from_iter(
+///             circle.iter().map(|p| [p[0] * d_moon, p[1] * d_moon, 0.0]),
+///         )]),
+///     )?;
+///
+///     // Movement via transforms.
+///     for i in 0..(6 * 120) {
+///         let time = i as f32 / 120.0;
+///         rec.set_time_seconds("sim_time", time);
+///         let r_moon = time * 5.0;
+///         let r_planet = time * 2.0;
+///
+///         rec.log(
+///             "sun/planet",
+///             &rerun::Transform3D::from_translation_rotation(
+///                 [r_planet.sin() * d_planet, r_planet.cos() * d_planet, 0.0],
+///                 rerun::RotationAxisAngle {
+///                     axis: [1.0, 0.0, 0.0].into(),
+///                     angle: rerun::Angle::Degrees(20.0),
+///                 },
+///             ),
+///         )?;
+///         rec.log(
+///             "sun/planet/moon",
+///             &rerun::Transform3D::from_translation([
+///                 r_moon.cos() * d_moon,
+///                 r_moon.sin() * d_moon,
+///                 0.0,
+///             ])
+///             .from_parent(),
+///         )?;
+///     }
+///
+///     // TODO(#5521): log two space views as in the python example
+///
+///     Ok(())
+/// }
+/// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png">
+///   <img src="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/full.png" width="640">
 /// </picture>
 /// </center>
 #[derive(Clone, Debug, PartialEq)]

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -20,7 +20,7 @@ A 3D transform.
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
  * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Transform3D.html)
 
-## Example
+## Examples
 
 ### Variety of 3D transforms
 
@@ -32,5 +32,17 @@ snippet: archetypes/transform3d_simple
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1024w.png">
   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png">
   <img src="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/full.png">
+</picture>
+
+### Transform hierarchy
+
+snippet: archetypes/transform3d_hierarchy
+
+<picture data-inline-viewer="snippets/transform3d_hierarchy">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png">
+  <img src="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/full.png">
 </picture>
 

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.cpp
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.cpp
@@ -1,0 +1,81 @@
+// Log different transforms between three arrows.
+
+#include <rerun.hpp>
+
+constexpr float TAU = 6.28318530717958647692528676655900577f;
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_transform3d_hierarchy");
+    rec.spawn().exit_on_failure();
+
+    rec.set_time_seconds("sim_time", 0.0);
+
+    // Planetary motion is typically in the XY plane.
+    rec.log_static("/", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
+
+    // Setup points, all are in the center of their own space:
+    rec.log(
+        "sun",
+        rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+            .with_radii({1.0f})
+            .with_colors({rerun::Color(255, 200, 10)})
+    );
+    rec.log(
+        "sun/planet",
+        rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+            .with_radii({0.4f})
+            .with_colors({rerun::Color(40, 80, 200)})
+    );
+    rec.log(
+        "sun/planet/moon",
+        rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+            .with_radii({0.15f})
+            .with_colors({rerun::Color(180, 180, 180)})
+    );
+
+    // Draw fixed paths where the planet & moon move.
+    float d_planet = 6.0f;
+    float d_moon = 3.0f;
+    std::vector<std::array<float, 3>> planet_path, moon_path;
+    for (int i = 0; i <= 100; i++) {
+        float angle = static_cast<float>(i) * 0.01f * TAU;
+        float circle_x = std::sin(angle);
+        float circle_y = std::cos(angle);
+        planet_path.push_back({circle_x * d_planet, circle_y * d_planet, 0.0f});
+        moon_path.push_back({circle_x * d_moon, circle_y * d_moon, 0.0f});
+    }
+    rec.log("sun/planet_path", rerun::LineStrips3D(rerun::LineStrip3D(planet_path)));
+    rec.log("sun/planet/moon_path", rerun::LineStrips3D(rerun::LineStrip3D(moon_path)));
+
+    // Movement via transforms.
+    for (int i = 0; i < 6 * 120; i++) {
+        float time = static_cast<float>(i) / 120.0f;
+        rec.set_time_seconds("sim_time", time);
+        float r_moon = time * 5.0f;
+        float r_planet = time * 2.0f;
+
+        rec.log(
+            "sun/planet",
+            rerun::Transform3D(
+                {std::sin(r_planet) * d_planet, std::cos(r_planet) * d_planet, 0.0f},
+                rerun::RotationAxisAngle{
+                    {1.0, 0.0f, 0.0f},
+                    rerun::Angle::degrees(20.0f),
+                }
+            )
+        );
+        rec.log(
+            "sun/planet/moon",
+            rerun::Transform3D(
+                {
+                    std::cos(r_moon) * d_moon,
+                    std::sin(r_moon) * d_moon,
+                    0.0f,
+                },
+                true
+            )
+        );
+    }
+
+    // TODO(#5521): log two space views as in the python example
+}

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.cpp
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.cpp
@@ -8,6 +8,8 @@ int main() {
     const auto rec = rerun::RecordingStream("rerun_example_transform3d_hierarchy");
     rec.spawn().exit_on_failure();
 
+    // TODO(#5521): log two space views as in the python example
+
     rec.set_time_seconds("sim_time", 0.0);
 
     // Planetary motion is typically in the XY plane.
@@ -76,6 +78,4 @@ int main() {
             )
         );
     }
-
-    // TODO(#5521): log two space views as in the python example
 }

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -1,0 +1,53 @@
+"""Logs a transforms transform hierarchy."""
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+
+rr.init("rerun_example_transform3d_hierarchy", spawn=True)
+
+rr.set_time_seconds("sim_time", 0)
+
+# Planetary motion is typically in the XY plane.
+rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+
+# Setup points, all are in the center of their own space:
+# TODO(#1361): Should use spheres instead of points.
+rr.log("sun", rr.Points3D([0.0, 0.0, 0.0], radii=1.0, colors=[255, 200, 10]))
+rr.log("sun/planet", rr.Points3D([0.0, 0.0, 0.0], radii=0.4, colors=[40, 80, 200]))
+rr.log("sun/planet/moon", rr.Points3D([0.0, 0.0, 0.0], radii=0.15, colors=[180, 180, 180]))
+
+# Draw fixed paths where the planet & moon move.
+d_planet = 6.0
+d_moon = 3.0
+angles = np.arange(0.0, 1.01, 0.01) * np.pi * 2
+circle = np.array([np.sin(angles), np.cos(angles), angles * 0.0]).transpose()
+rr.log("sun/planet_path", rr.LineStrips3D(circle * d_planet))
+rr.log("sun/planet/moon_path", rr.LineStrips3D(circle * d_moon))
+
+# Movement via transforms.
+for i in range(0, 6 * 120):
+    time = i / 120.0
+    rr.set_time_seconds("sim_time", time)
+    r_moon = time * 5.0
+    r_planet = time * 2.0
+
+    rr.log(
+        "sun/planet",
+        rr.Transform3D(
+            translation=[np.sin(r_planet) * d_planet, np.cos(r_planet) * d_planet, 0.0],
+            rotation=rr.RotationAxisAngle(axis=(1, 0, 0), degrees=20),
+        ),
+    )
+    rr.log(
+        "sun/planet/moon",
+        rr.Transform3D(
+            translation=[np.cos(r_moon) * d_moon, np.sin(r_moon) * d_moon, 0.0],
+            from_parent=True,
+        ),
+    )
+
+# One space with the sun in the center, and another one with the planet.
+rr.send_blueprint(
+    rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
+)

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.py
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.py
@@ -6,6 +6,11 @@ import rerun.blueprint as rrb
 
 rr.init("rerun_example_transform3d_hierarchy", spawn=True)
 
+# One space with the sun in the center, and another one with the planet.
+rr.send_blueprint(
+    rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
+)
+
 rr.set_time_seconds("sim_time", 0)
 
 # Planetary motion is typically in the XY plane.
@@ -46,8 +51,3 @@ for i in range(0, 6 * 120):
             from_parent=True,
         ),
     )
-
-# One space with the sun in the center, and another one with the planet.
-rr.send_blueprint(
-    rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
-)

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.rs
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.rs
@@ -3,6 +3,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d_hierarchy").spawn()?;
 
+    // TODO(#5521): log two space views as in the python example
+
     rec.set_time_seconds("sim_time", 0.0);
 
     // Planetary motion is typically in the XY plane.
@@ -75,8 +77,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .from_parent(),
         )?;
     }
-
-    // TODO(#5521): log two space views as in the python example
 
     Ok(())
 }

--- a/docs/snippets/all/archetypes/transform3d_hierarchy.rs
+++ b/docs/snippets/all/archetypes/transform3d_hierarchy.rs
@@ -1,0 +1,82 @@
+//! Log different transforms between three arrows.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_transform3d_hierarchy").spawn()?;
+
+    rec.set_time_seconds("sim_time", 0.0);
+
+    // Planetary motion is typically in the XY plane.
+    rec.log_static("/", &rerun::ViewCoordinates::RIGHT_HAND_Z_UP)?;
+
+    // Setup points, all are in the center of their own space:
+    rec.log(
+        "sun",
+        &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+            .with_radii([1.0])
+            .with_colors([rerun::Color::from_rgb(255, 200, 10)]),
+    )?;
+    rec.log(
+        "sun/planet",
+        &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+            .with_radii([0.4])
+            .with_colors([rerun::Color::from_rgb(40, 80, 200)]),
+    )?;
+    rec.log(
+        "sun/planet/moon",
+        &rerun::Points3D::new([[0.0, 0.0, 0.0]])
+            .with_radii([0.15])
+            .with_colors([rerun::Color::from_rgb(180, 180, 180)]),
+    )?;
+
+    // Draw fixed paths where the planet & moon move.
+    let d_planet = 6.0;
+    let d_moon = 3.0;
+    let angles = (0..=100).map(|i| i as f32 * 0.01 * std::f32::consts::TAU);
+    let circle: Vec<_> = angles.map(|angle| [angle.sin(), angle.cos()]).collect();
+    rec.log(
+        "sun/planet_path",
+        &rerun::LineStrips3D::new([rerun::LineStrip3D::from_iter(
+            circle
+                .iter()
+                .map(|p| [p[0] * d_planet, p[1] * d_planet, 0.0]),
+        )]),
+    )?;
+    rec.log(
+        "sun/planet/moon_path",
+        &rerun::LineStrips3D::new([rerun::LineStrip3D::from_iter(
+            circle.iter().map(|p| [p[0] * d_moon, p[1] * d_moon, 0.0]),
+        )]),
+    )?;
+
+    // Movement via transforms.
+    for i in 0..(6 * 120) {
+        let time = i as f32 / 120.0;
+        rec.set_time_seconds("sim_time", time);
+        let r_moon = time * 5.0;
+        let r_planet = time * 2.0;
+
+        rec.log(
+            "sun/planet",
+            &rerun::Transform3D::from_translation_rotation(
+                [r_planet.sin() * d_planet, r_planet.cos() * d_planet, 0.0],
+                rerun::RotationAxisAngle {
+                    axis: [1.0, 0.0, 0.0].into(),
+                    angle: rerun::Angle::Degrees(20.0),
+                },
+            ),
+        )?;
+        rec.log(
+            "sun/planet/moon",
+            &rerun::Transform3D::from_translation([
+                r_moon.cos() * d_moon,
+                r_moon.sin() * d_moon,
+                0.0,
+            ])
+            .from_parent(),
+        )?;
+    }
+
+    // TODO(#5521): log two space views as in the python example
+
+    Ok(())
+}

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -115,7 +115,7 @@ def main() -> None:
         print("----------------------------------------------------------")
         print("Build rerun_c & rerun_cpp…")
         start_time = time.time()
-        run(["pixi", "run", "cpp-build-snippets"])
+        run(["pixi", "run", "-e", "cpp", "cpp-build-snippets"])
         elapsed = time.time() - start_time
         print(f"rerun-sdk for C++ built in {elapsed:.1f} seconds")
         print("")

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -135,7 +135,9 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
-
+"archetypes/transform3d_hierarchy" = [ # Uses a lot of trignometry which is suprisingly easy to get the same on Rust & C++, but not on Python/Numpy
+  "py",
+]
 
 # `$config_dir` will be replaced with the absolute path of `docs/snippets`.
 [extra_args]

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -135,7 +135,7 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
-"archetypes/transform3d_hierarchy" = [ # Uses a lot of trignometry which is suprisingly easy to get the same on Rust & C++, but not on Python/Numpy
+"archetypes/transform3d_hierarchy" = [ # Uses a lot of trigonometry which is surprisingly easy to get the same on Rust & C++, but not on Python/Numpy
   "py",
 ]
 

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -20,7 +20,7 @@
 namespace rerun::archetypes {
     /// **Archetype**: A 3D transform.
     ///
-    /// ## Example
+    /// ## Examples
     ///
     /// ### Variety of 3D transforms
     /// ![image](https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/full.png)
@@ -50,6 +50,91 @@ namespace rerun::archetypes {
     ///         )
     ///     );
     ///     rec.log("base/rotated_scaled", arrow);
+    /// }
+    /// ```
+    ///
+    /// ### Transform hierarchy
+    /// ![image](https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/full.png)
+    ///
+    /// ```cpp
+    /// #include <rerun.hpp>
+    ///
+    /// constexpr float TAU = 6.28318530717958647692528676655900577f;
+    ///
+    /// int main() {
+    ///     const auto rec = rerun::RecordingStream("rerun_example_transform3d_hierarchy");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     rec.set_time_seconds("sim_time", 0.0);
+    ///
+    ///     // Planetary motion is typically in the XY plane.
+    ///     rec.log_static("/", rerun::ViewCoordinates::RIGHT_HAND_Z_UP);
+    ///
+    ///     // Setup points, all are in the center of their own space:
+    ///     rec.log(
+    ///         "sun",
+    ///         rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+    ///             .with_radii({1.0f})
+    ///             .with_colors({rerun::Color(255, 200, 10)})
+    ///     );
+    ///     rec.log(
+    ///         "sun/planet",
+    ///         rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+    ///             .with_radii({0.4f})
+    ///             .with_colors({rerun::Color(40, 80, 200)})
+    ///     );
+    ///     rec.log(
+    ///         "sun/planet/moon",
+    ///         rerun::Points3D({{0.0f, 0.0f, 0.0f}})
+    ///             .with_radii({0.15f})
+    ///             .with_colors({rerun::Color(180, 180, 180)})
+    ///     );
+    ///
+    ///     // Draw fixed paths where the planet & moon move.
+    ///     float d_planet = 6.0f;
+    ///     float d_moon = 3.0f;
+    ///     std::vector<std::array<float, 3>> planet_path, moon_path;
+    ///     for (int i = 0; i <= 100; i++) {
+    ///         float angle = static_cast<float>(i) * 0.01f * TAU;
+    ///         float circle_x = std::sin(angle);
+    ///         float circle_y = std::cos(angle);
+    ///         planet_path.push_back({circle_x * d_planet, circle_y * d_planet, 0.0f});
+    ///         moon_path.push_back({circle_x * d_moon, circle_y * d_moon, 0.0f});
+    ///     }
+    ///     rec.log("sun/planet_path", rerun::LineStrips3D(rerun::LineStrip3D(planet_path)));
+    ///     rec.log("sun/planet/moon_path", rerun::LineStrips3D(rerun::LineStrip3D(moon_path)));
+    ///
+    ///     // Movement via transforms.
+    ///     for (int i = 0; i <6 * 120; i++) {
+    ///         float time = static_cast<float>(i) / 120.0f;
+    ///         rec.set_time_seconds("sim_time", time);
+    ///         float r_moon = time * 5.0f;
+    ///         float r_planet = time * 2.0f;
+    ///
+    ///         rec.log(
+    ///             "sun/planet",
+    ///             rerun::Transform3D(
+    ///                 {std::sin(r_planet) * d_planet, std::cos(r_planet) * d_planet, 0.0f},
+    ///                 rerun::RotationAxisAngle{
+    ///                     {1.0, 0.0f, 0.0f},
+    ///                     rerun::Angle::degrees(20.0f),
+    ///                 }
+    ///             )
+    ///         );
+    ///         rec.log(
+    ///             "sun/planet/moon",
+    ///             rerun::Transform3D(
+    ///                 {
+    ///                     std::cos(r_moon) * d_moon,
+    ///                     std::sin(r_moon) * d_moon,
+    ///                     0.0f,
+    ///                 },
+    ///                 true
+    ///             )
+    ///         );
+    ///     }
+    ///
+    ///     // TODO(#5521): log two space views as in the python example
     /// }
     /// ```
     struct Transform3D {

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -65,6 +65,8 @@ namespace rerun::archetypes {
     ///     const auto rec = rerun::RecordingStream("rerun_example_transform3d_hierarchy");
     ///     rec.spawn().exit_on_failure();
     ///
+    ///     // TODO(#5521): log two space views as in the python example
+    ///
     ///     rec.set_time_seconds("sim_time", 0.0);
     ///
     ///     // Planetary motion is typically in the XY plane.
@@ -133,8 +135,6 @@ namespace rerun::archetypes {
     ///             )
     ///         );
     ///     }
-    ///
-    ///     // TODO(#5521): log two space views as in the python example
     /// }
     /// ```
     struct Transform3D {

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -66,6 +66,11 @@ class Transform3D(Transform3DExt, Archetype):
 
     rr.init("rerun_example_transform3d_hierarchy", spawn=True)
 
+    # One space with the sun in the center, and another one with the planet.
+    rr.send_blueprint(
+        rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
+    )
+
     rr.set_time_seconds("sim_time", 0)
 
     # Planetary motion is typically in the XY plane.
@@ -106,11 +111,6 @@ class Transform3D(Transform3DExt, Archetype):
                 from_parent=True,
             ),
         )
-
-    # One space with the sun in the center, and another one with the planet.
-    rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
-    )
     ```
     <center>
     <picture>

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -21,8 +21,8 @@ class Transform3D(Transform3DExt, Archetype):
     """
     **Archetype**: A 3D transform.
 
-    Example
-    -------
+    Examples
+    --------
     ### Variety of 3D transforms:
     ```python
     from math import pi
@@ -55,6 +55,70 @@ class Transform3D(Transform3DExt, Archetype):
       <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1024w.png">
       <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png">
       <img src="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/full.png" width="640">
+    </picture>
+    </center>
+
+    ### Transform hierarchy:
+    ```python
+    import numpy as np
+    import rerun as rr
+    import rerun.blueprint as rrb
+
+    rr.init("rerun_example_transform3d_hierarchy", spawn=True)
+
+    rr.set_time_seconds("sim_time", 0)
+
+    # Planetary motion is typically in the XY plane.
+    rr.log("/", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+
+    # Setup points, all are in the center of their own space:
+    # TODO(#1361): Should use spheres instead of points.
+    rr.log("sun", rr.Points3D([0.0, 0.0, 0.0], radii=1.0, colors=[255, 200, 10]))
+    rr.log("sun/planet", rr.Points3D([0.0, 0.0, 0.0], radii=0.4, colors=[40, 80, 200]))
+    rr.log("sun/planet/moon", rr.Points3D([0.0, 0.0, 0.0], radii=0.15, colors=[180, 180, 180]))
+
+    # Draw fixed paths where the planet & moon move.
+    d_planet = 6.0
+    d_moon = 3.0
+    angles = np.arange(0.0, 1.01, 0.01) * np.pi * 2
+    circle = np.array([np.sin(angles), np.cos(angles), angles * 0.0]).transpose()
+    rr.log("sun/planet_path", rr.LineStrips3D(circle * d_planet))
+    rr.log("sun/planet/moon_path", rr.LineStrips3D(circle * d_moon))
+
+    # Movement via transforms.
+    for i in range(0, 6 * 120):
+        time = i / 120.0
+        rr.set_time_seconds("sim_time", time)
+        r_moon = time * 5.0
+        r_planet = time * 2.0
+
+        rr.log(
+            "sun/planet",
+            rr.Transform3D(
+                translation=[np.sin(r_planet) * d_planet, np.cos(r_planet) * d_planet, 0.0],
+                rotation=rr.RotationAxisAngle(axis=(1, 0, 0), degrees=20),
+            ),
+        )
+        rr.log(
+            "sun/planet/moon",
+            rr.Transform3D(
+                translation=[np.cos(r_moon) * d_moon, np.sin(r_moon) * d_moon, 0.0],
+                from_parent=True,
+            ),
+        )
+
+    # One space with the sun in the center, and another one with the planet.
+    rr.send_blueprint(
+        rrb.Horizontal(rrb.Spatial3DView(origin="sun"), rrb.Spatial3DView(origin="sun/planet", contents="sun/**"))
+    )
+    ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png">
+      <img src="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/full.png" width="640">
     </picture>
     </center>
 

--- a/tests/python/test_api/test_api.py
+++ b/tests/python/test_api/test_api.py
@@ -245,84 +245,6 @@ def run_log_cleared() -> None:
     rr.log("null_test/rect/1", rr.Boxes2D(array=[10, 5, 4, 4], array_format=rr.Box2DFormat.XYWH))
 
 
-def transforms_rigid_3d() -> None:
-    rr.set_time_seconds("sim_time", 0)
-
-    sun_to_planet_distance = 6.0
-    planet_to_moon_distance = 3.0
-    rotation_speed_planet = 2.0
-    rotation_speed_moon = 5.0
-
-    # Planetary motion is typically in the XY plane.
-    rr.log("transforms3d", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-    rr.log("transforms3d/sun", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-    rr.log("transforms3d/sun/planet", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-    rr.log("transforms3d/sun/planet/moon", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
-
-    # All are in the center of their own space:
-    rr.log("transforms3d/sun", rr.Points3D([0.0, 0.0, 0.0], radii=1.0, colors=[255, 200, 10]))
-    rr.log("transforms3d/sun/planet", rr.Points3D([0.0, 0.0, 0.0], radii=0.4, colors=[40, 80, 200]))
-    rr.log("transforms3d/sun/planet/moon", rr.Points3D([0.0, 0.0, 0.0], radii=0.15, colors=[180, 180, 180]))
-
-    # "dust" around the "planet" (and inside, don't care)
-    # distribution is quadratically higher in the middle
-    radii = np.random.rand(200) * planet_to_moon_distance * 0.5
-    angles = np.random.rand(200) * math.tau
-    height = np.power(np.random.rand(200), 0.2) * 0.5 - 0.5
-    rr.log(
-        "transforms3d/sun/planet/dust",
-        rr.Points3D(
-            np.array([np.sin(angles) * radii, np.cos(angles) * radii, height]).transpose(),
-            colors=[80, 80, 80],
-            radii=0.025,
-        ),
-    )
-
-    # paths where the planet & moon move
-    angles = np.arange(0.0, 1.01, 0.01) * math.tau
-    circle = np.array([np.sin(angles), np.cos(angles), angles * 0.0]).transpose()
-    rr.log(
-        "transforms3d/sun/planet_path",
-        rr.LineStrips3D(
-            circle * sun_to_planet_distance,
-        ),
-    )
-    rr.log(
-        "transforms3d/sun/planet/moon_path",
-        rr.LineStrips3D(
-            circle * planet_to_moon_distance,
-        ),
-    )
-
-    # movement via transforms
-    for i in range(0, 6 * 120):
-        time = i / 120.0
-        rr.set_time_seconds("sim_time", time)
-
-        rr.log(
-            "transforms3d/sun/planet",
-            rr.Transform3D(
-                translation=[
-                    math.sin(time * rotation_speed_planet) * sun_to_planet_distance,
-                    math.cos(time * rotation_speed_planet) * sun_to_planet_distance,
-                    0.0,
-                ],
-                rotation=rr.RotationAxisAngle(axis=(1, 0, 0), degrees=20),
-            ),
-        )
-        rr.log(
-            "transforms3d/sun/planet/moon",
-            rr.Transform3D(
-                translation=[
-                    math.cos(time * rotation_speed_moon) * planet_to_moon_distance,
-                    math.sin(time * rotation_speed_moon) * planet_to_moon_distance,
-                    0.0,
-                ],
-                from_parent=True,
-            ),
-        )
-
-
 def run_bounding_box() -> None:
     rr.set_time_seconds("sim_time", 0)
     rr.log(
@@ -441,7 +363,6 @@ def main() -> None:
         "small_image": small_image,
         "text": run_text_logs,
         "transforms": transforms,
-        "transforms_rigid_3d": transforms_rigid_3d,
     }
 
     parser = argparse.ArgumentParser(description="Logs rich data using the Rerun SDK.")


### PR DESCRIPTION
### What

* Part of testing for https://github.com/rerun-io/rerun/issues/6831
* Part of https://github.com/rerun-io/rerun/issues/3210

![image](https://github.com/rerun-io/rerun/assets/1220815/51c07c54-515d-4667-8a55-27fe889c4d19)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6851?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6851?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6851)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.