### PR TITLE
rust-analyzer: configuration overhaul

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,8 @@
         "cargo",
         "clippy",
         "--message-format=json",
+        // We shouldn't need this, except we do based on my empirical testing.
+        "--target-dir=target_ra",
     ],
     "rust-analyzer.cargo.buildScripts.invocationLocation": "workspace",
     "rust-analyzer.cargo.buildScripts.invocationStrategy": "per_workspace",
@@ -28,6 +30,8 @@
         "check",
         "--quiet",
         "--message-format=json",
+        // We shouldn't need this, except we do based on my empirical testing.
+        "--target-dir=target_ra",
     ],
     // Our build scripts are generating code.
     // Having Rust Analyzer do this while doing other builds can lead to catastrophic failures.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,28 +8,26 @@
     "files.autoGuessEncoding": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
-    // Whether `--workspace` should be passed to `cargo check`.
-    // If false, `-p <package>` will be passed instead.
+    // Whether `--workspace` should be passed to `cargo check`. If false, `-p <package>` will be passed instead.
     "rust-analyzer.check.workspace": false,
-    // don't share a cargo lock with rust-analyzer.
-    // see https://github.com/rerun-io/rerun/pull/519 for rationale
+    "rust-analyzer.cargo.allTargets": true,
+    // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.cargo.targetDir": "target_ra",
+    "rust-analyzer.check.invocationLocation": "workspace",
+    "rust-analyzer.check.invocationStrategy": "per_workspace",
     "rust-analyzer.check.overrideCommand": [
         "cargo",
         "clippy",
-        "--target-dir=target_ra",
         "--message-format=json",
-        "--all-targets",
-        "--all-features" // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer
     ],
+    "rust-analyzer.cargo.buildScripts.invocationLocation": "workspace",
+    "rust-analyzer.cargo.buildScripts.invocationStrategy": "per_workspace",
     "rust-analyzer.cargo.buildScripts.overrideCommand": [
         "cargo",
         "check",
         "--quiet",
-        "--target-dir=target_ra",
-        "--workspace",
         "--message-format=json",
-        "--all-targets",
-        "--all-features", // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer
     ],
     // Our build scripts are generating code.
     // Having Rust Analyzer do this while doing other builds can lead to catastrophic failures.
@@ -38,14 +36,17 @@
     "rust-analyzer.cargo.extraEnv": {
         "IS_IN_RERUN_WORKSPACE": "yes"
     },
-    "python.analysis.extraPaths": [
-        "rerun_py/rerun_sdk"
-    ],
+    "rust-analyzer.showUnlinkedFileNotification": false,
+    // Uncomment the following option and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
+    // Don't forget to put it in a comment again before committing.
+    // "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools", // Use cmake-tools to grab configs.
     "C_Cpp.autoAddFileAssociations": false,
     "cmake.buildDirectory": "${workspaceRoot}/build/debug",
     "cmake.generator": "Ninja", // Use Ninja, just like we do in our just/pixi command.
-    "rust-analyzer.showUnlinkedFileNotification": false,
+    "python.analysis.extraPaths": [
+        "rerun_py/rerun_sdk"
+    ],
     "ruff.format.args": [
         "--config=rerun_py/pyproject.toml"
     ],
@@ -68,8 +69,5 @@
     },
     "[yaml]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    // Uncomment the following option and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
-    // Don't forget to put it in a comment again before committing.
-    // "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,6 +40,7 @@
     "rust-analyzer.cargo.extraEnv": {
         "IS_IN_RERUN_WORKSPACE": "yes"
     },
+    "rust-analyzer.diagnostics.enable": false, // False positives
     "rust-analyzer.showUnlinkedFileNotification": false,
     // Uncomment the following option and restart rust-analyzer to get it to check code behind `cfg(target_arch=wasm32)`.
     // Don't forget to put it in a comment again before committing.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,13 +8,15 @@
     "files.autoGuessEncoding": true,
     "files.insertFinalNewline": true,
     "files.trimTrailingWhitespace": true,
+    // Whether `--workspace` should be passed to `cargo check`.
+    // If false, `-p <package>` will be passed instead.
+    "rust-analyzer.check.workspace": false,
     // don't share a cargo lock with rust-analyzer.
     // see https://github.com/rerun-io/rerun/pull/519 for rationale
     "rust-analyzer.check.overrideCommand": [
         "cargo",
         "clippy",
         "--target-dir=target_ra",
-        "--workspace",
         "--message-format=json",
         "--all-targets",
         "--all-features" // --all-features will set the `__ci` feature flag, which stops re_web_viewer_server/build.rs from building the web viewer


### PR DESCRIPTION
Config overhaul for `rust-analyzer`, using many of the newly available toys.
For the VSCode peoples in the crowd. Others will know what to do!

Most importantly, this should stop checking the entire workspace on every save, and instead only the relevant package, which should be a massive quality of life boost.

Leaving that drafted while I get some soak time with it myself.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6854?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6854?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6854)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.