### PR TITLE
Fork `macaw` as `re_math`

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -5,6 +5,7 @@
 [files]
 extend-exclude = [
   ".typos.toml",
+  "crates/utils/re_math/src/ray3.rs",            # Has a bunch of two-letter words
   "crates/viewer/re_ui/data/design_tokens.json",
   "crates/viewer/re_ui/src/design_tokens.rs",
   "examples/assets",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2959,17 +2959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "macaw"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e4daa18df16fd196b955e4bb16574641f39141fb3ea81b493a84b9439d17e6"
-dependencies = [
- "glam",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,7 +4706,6 @@ dependencies = [
  "gltf",
  "half 2.3.1",
  "itertools 0.13.0",
- "macaw",
  "never",
  "notify",
  "ordered-float",
@@ -4728,6 +4716,7 @@ dependencies = [
  "re_build_tools",
  "re_error",
  "re_log",
+ "re_math",
  "re_tracing",
  "serde",
  "slotmap",
@@ -4755,10 +4744,10 @@ dependencies = [
  "glam",
  "image",
  "itertools 0.13.0",
- "macaw",
  "pollster",
  "rand",
  "re_log",
+ "re_math",
  "re_renderer",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4928,7 +4917,6 @@ dependencies = [
  "egui",
  "glam",
  "itertools 0.13.0",
- "macaw",
  "mimalloc",
  "nohash-hasher",
  "once_cell",
@@ -4939,6 +4927,7 @@ dependencies = [
  "re_format",
  "re_log",
  "re_log_types",
+ "re_math",
  "re_query",
  "re_renderer",
  "re_space_view",
@@ -5308,7 +5297,6 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.13.0",
  "linked-hash-map",
- "macaw",
  "ndarray",
  "nohash-hasher",
  "once_cell",
@@ -5321,6 +5309,7 @@ dependencies = [
  "re_format",
  "re_log",
  "re_log_types",
+ "re_math",
  "re_query",
  "re_renderer",
  "re_smart_channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_math"
+version = "0.18.0-alpha.1+dev"
+dependencies = [
+ "glam",
+ "serde",
+]
+
+[[package]]
 name = "re_memory"
 version = "0.18.0-alpha.1+dev"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ re_error = { path = "crates/utils/re_error", version = "=0.18.0-alpha.1", defaul
 re_format = { path = "crates/utils/re_format", version = "=0.18.0-alpha.1", default-features = false }
 re_int_histogram = { path = "crates/utils/re_int_histogram", version = "=0.18.0-alpha.1", default-features = false }
 re_log = { path = "crates/utils/re_log", version = "=0.18.0-alpha.1", default-features = false }
+re_math = { path = "crates/utils/re_math", version = "=0.18.0-alpha.1", default-features = false }
 re_memory = { path = "crates/utils/re_memory", version = "=0.18.0-alpha.1", default-features = false }
 re_smart_channel = { path = "crates/utils/re_smart_channel", version = "=0.18.0-alpha.1", default-features = false }
 re_string_interner = { path = "crates/utils/re_string_interner", version = "=0.18.0-alpha.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"
-glam = "0.22" # glam update blocked by macaw
+glam = "0.22"
 glob = "0.3"
 gltf = "1.1"
 half = "2.3.1"
@@ -183,7 +183,6 @@ linked-hash-map = { version = "0.5", default-features = false }
 log = "0.4"
 log-once = "0.4"
 lz4_flex = "0.11"
-macaw = "0.18"
 memory-stats = "1.1"
 mimalloc = "=0.1.37" # TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
 mime = "0.3"

--- a/clippy.toml
+++ b/clippy.toml
@@ -45,6 +45,7 @@ disallowed-methods = [
   { path = "egui_extras::TableBody::row", reason = "`row` doesn't scale. Use `rows` instead." },
   { path = "glam::Vec2::normalize", reason = "normalize() can create NaNs. Use try_normalize or normalize_or_zero" },
   { path = "glam::Vec3::normalize", reason = "normalize() can create NaNs. Use try_normalize or normalize_or_zero" },
+  { path = "re_math::Ray::normalize", reason = "normalize() can create NaNs. Use try_normalize instead" },
   { path = "sha1::Digest::new", reason = "SHA1 is cryptographically broken" },
   { path = "std::env::temp_dir", reason = "Use the tempdir crate instead" },
   { path = "std::panic::catch_unwind", reason = "We compile with `panic = 'abort'`" },

--- a/crates/utils/re_math/Cargo.toml
+++ b/crates/utils/re_math/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "re_math"
+authors.workspace = true
+description = "3D math utilities built on glam"
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+
+[features]
+default = ["serde"]
+
+serde = ["dep:serde"]
+
+[dependencies]
+glam.workspace = true
+
+serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/utils/re_math/Cargo.toml
+++ b/crates/utils/re_math/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 
 
 [features]
-default = ["serde"]
+default = []
 
 serde = ["dep:serde"]
 

--- a/crates/utils/re_math/README.md
+++ b/crates/utils/re_math/README.md
@@ -1,0 +1,12 @@
+# re_math
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_math.svg)](https://crates.io/crates/re_math)
+[![Documentation](https://docs.rs/re_math/badge.svg)](https://docs.rs/re_math)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+3D math utilities built on [glam](https://crates.io/crates/glam).
+
+`re_math` was originally based on [macaw](https://crates.io/crates/macaw).

--- a/crates/utils/re_math/src/bounding_box.rs
+++ b/crates/utils/re_math/src/bounding_box.rs
@@ -29,7 +29,7 @@ impl BoundingBox {
 
     /// A [`BoundingBox`] that contains no points.
     ///
-    /// This is useful as the seed for bounding bounding boxes.
+    /// This is useful as the seed for bounding boxes.
     #[inline]
     pub fn nothing() -> Self {
         Self {
@@ -205,6 +205,7 @@ impl BoundingBox {
     }
 
     #[must_use]
+    #[inline]
     pub fn union(mut self, other: Self) -> Self {
         self.min = self.min.min(other.min);
         self.max = self.max.max(other.max);
@@ -214,6 +215,7 @@ impl BoundingBox {
     /// Returns the smallest volume that is covered by both `self` and `other`,
     /// or [`Self::nothing`] if the boxes are disjoint.
     #[must_use]
+    #[inline]
     pub fn intersection(mut self, other: Self) -> Self {
         let intersection = Self {
             min: self.min.max(other.min),

--- a/crates/utils/re_math/src/bounding_box.rs
+++ b/crates/utils/re_math/src/bounding_box.rs
@@ -312,8 +312,8 @@ mod test {
 
     #[test]
     fn test_bounding_box() {
-        use crate::Affine3A;
-        use crate::Quat;
+        use glam::{Affine3A, Quat};
+
         let bb = BoundingBox::from_min_max(Vec3::ZERO, Vec3::ZERO);
         assert!(bb.contains(Vec3::ZERO));
         assert!(bb.is_something());

--- a/crates/utils/re_math/src/bounding_box.rs
+++ b/crates/utils/re_math/src/bounding_box.rs
@@ -1,0 +1,329 @@
+use glam::{Affine3A, Quat, Vec3};
+
+use crate::{Conformal3, IsoTransform};
+
+/// A 3-dimensional axis-aligned bounding box
+#[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct BoundingBox {
+    /// Bounding box minimum (inclusive).
+    pub min: Vec3,
+
+    /// Bounding box maximum (inclusive).
+    pub max: Vec3,
+}
+
+impl core::fmt::Debug for BoundingBox {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:?} - {:?}", self.min, self.max)
+    }
+}
+
+#[allow(unused)]
+impl BoundingBox {
+    /// A [`BoundingBox`] that only contains [`Vec3::ZERO`].
+    pub const ZERO: Self = Self {
+        min: Vec3::ZERO,
+        max: Vec3::ZERO,
+    };
+
+    /// A [`BoundingBox`] that contains no points.
+    ///
+    /// This is useful as the seed for bounding bounding boxes.
+    #[inline]
+    pub fn nothing() -> Self {
+        Self {
+            min: Vec3::splat(core::f32::INFINITY),
+            max: Vec3::splat(core::f32::NEG_INFINITY),
+        }
+    }
+
+    /// A [`BoundingBox`] that contains every point.
+    #[inline]
+    pub fn everything() -> Self {
+        Self {
+            min: Vec3::splat(core::f32::NEG_INFINITY),
+            max: Vec3::splat(core::f32::INFINITY),
+        }
+    }
+
+    /// Create a bounding box from a minimum and maximum position.
+    #[inline]
+    pub fn from_min_max(min: Vec3, max: Vec3) -> Self {
+        Self { min, max }
+    }
+
+    #[inline]
+    pub fn from_min_size(min: Vec3, size: Vec3) -> Self {
+        Self {
+            min,
+            max: min + size,
+        }
+    }
+
+    /// Create a bounding box from a center position and a size.
+    pub fn from_center_size(center: Vec3, size: Vec3) -> Self {
+        Self::from_min_max(center - 0.5 * size, center + 0.5 * size)
+    }
+
+    /// Create a bounding box from an iterator of points that the bounding box will cover.
+    pub fn from_points(points: impl Iterator<Item = Vec3>) -> Self {
+        let mut bb = Self::nothing();
+        for p in points {
+            bb.extend(p);
+        }
+        bb
+    }
+
+    /// Returns the center point of the bounding box.
+    #[inline]
+    pub fn center(&self) -> Vec3 {
+        (self.min + self.max) * 0.5
+    }
+
+    /// Returns the 3D axis size of the bounding box.
+    #[inline]
+    pub fn size(&self) -> Vec3 {
+        self.max - self.min
+    }
+
+    /// Returns half the size (similar to a radius).
+    #[inline]
+    pub fn half_size(&self) -> Vec3 {
+        0.5 * (self.max - self.min)
+    }
+
+    /// Only correct for positively sized boxes.
+    pub fn volume(&self) -> f32 {
+        let s = self.size();
+        s.x * s.y * s.z
+    }
+
+    /// True if and only if there is at least one point for which `bb.contains(point)` is true.
+    ///
+    /// Will return `true` if [`Self::min`] == [`Self::max`].
+    /// The opposite of `is_nothing()`.
+    pub fn is_something(&self) -> bool {
+        self.min.x <= self.max.x && self.min.y <= self.max.y && self.min.z <= self.max.z
+    }
+
+    /// True if and only if there is no point for which `bb.contains(point)` is true.
+    ///
+    /// The opposite of `is_something()`.
+    pub fn is_nothing(&self) -> bool {
+        self.max.x < self.min.x || self.max.y < self.min.y || self.max.z < self.min.z
+    }
+
+    /// True if this box contains exactly one point.
+    ///
+    /// `true` if [`Self::min`] == [`Self::max`].
+    #[inline]
+    pub fn is_point(&self) -> bool {
+        self.min == self.max
+    }
+
+    /// Returns `true` if, and only if, all elements are finite.
+    ///
+    /// If any element is either `NaN`, positive or negative infinity, this will return `false`.
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.min.is_finite() && self.max.is_finite()
+    }
+
+    /// Returns `true` if any elements are `NaN`.
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.min.is_nan() || self.max.is_nan()
+    }
+
+    /// The eight corners of this bounding box.
+    pub fn corners(&self) -> [Vec3; 8] {
+        [
+            self.min,
+            Vec3::new(self.min.x, self.min.y, self.max.z),
+            Vec3::new(self.min.x, self.max.y, self.min.z),
+            Vec3::new(self.min.x, self.max.y, self.max.z),
+            Vec3::new(self.max.x, self.min.y, self.min.z),
+            Vec3::new(self.max.x, self.min.y, self.max.z),
+            Vec3::new(self.max.x, self.max.y, self.min.z),
+            self.max,
+        ]
+    }
+
+    /// The minimum radius of a sphere, centered at the origin, fully containing the box.
+    ///
+    /// Requires a well-formed box for the result to be valid.
+    pub fn bounding_sphere_radius(&self) -> f32 {
+        let mut max_dist_square = 0.0f32;
+        for corner in self.corners() {
+            max_dist_square = max_dist_square.max(corner.length_squared());
+        }
+        max_dist_square.sqrt()
+    }
+
+    /// The minimum radius of a sphere, centered at the bounding box, fully containing the box.
+    ///
+    /// Requires a well-formed box for the result to be valid.
+    pub fn centered_bounding_sphere_radius(&self) -> f32 {
+        let mut max_dist_square = 0.0f32;
+        let center = self.center();
+        for corner in self.corners() {
+            max_dist_square = max_dist_square.max((corner - center).length_squared());
+        }
+        max_dist_square.sqrt()
+    }
+
+    /// The twelve edges of this bounding box.
+    pub fn edges(&self) -> [[Vec3; 2]; 12] {
+        use glam::vec3;
+        let a = self.min;
+        let b = self.max;
+        [
+            // along X:
+            [vec3(a.x, a.y, a.z), vec3(b.x, a.y, a.z)],
+            [vec3(a.x, b.y, a.z), vec3(b.x, b.y, a.z)],
+            [vec3(a.x, a.y, b.z), vec3(b.x, a.y, b.z)],
+            [vec3(a.x, b.y, b.z), vec3(b.x, b.y, b.z)],
+            // along Y:
+            [vec3(a.x, a.y, a.z), vec3(a.x, b.y, a.z)],
+            [vec3(b.x, a.y, a.z), vec3(b.x, b.y, a.z)],
+            [vec3(a.x, a.y, b.z), vec3(a.x, b.y, b.z)],
+            [vec3(b.x, a.y, b.z), vec3(b.x, b.y, b.z)],
+            // along Z:
+            [vec3(a.x, a.y, a.z), vec3(a.x, a.y, b.z)],
+            [vec3(b.x, a.y, a.z), vec3(b.x, a.y, b.z)],
+            [vec3(a.x, b.y, a.z), vec3(a.x, b.y, b.z)],
+            [vec3(b.x, b.y, a.z), vec3(b.x, b.y, b.z)],
+        ]
+    }
+
+    /// Enlarge the box to include this point.
+    #[inline]
+    pub fn extend(&mut self, pos: Vec3) {
+        self.min = self.min.min(pos);
+        self.max = self.max.max(pos);
+    }
+
+    #[must_use]
+    pub fn union(mut self, other: Self) -> Self {
+        self.min = self.min.min(other.min);
+        self.max = self.max.max(other.max);
+        self
+    }
+
+    /// Returns the smallest volume that is covered by both `self` and `other`,
+    /// or [`Self::nothing`] if the boxes are disjoint.
+    #[must_use]
+    pub fn intersection(mut self, other: Self) -> Self {
+        let intersection = Self {
+            min: self.min.max(other.min),
+            max: self.max.min(other.max),
+        };
+        if intersection.is_nothing() {
+            Self::nothing()
+        } else {
+            intersection
+        }
+    }
+
+    /// Returns `true` if the point is within (or on the edge of) the box.
+    #[must_use]
+    pub fn contains(&self, point: Vec3) -> bool {
+        (self.min.x <= point.x && point.x <= self.max.x)
+            && (self.min.y <= point.y && point.y <= self.max.y)
+            && (self.min.z <= point.z && point.z <= self.max.z)
+    }
+
+    /// Expand with this much padding on each side.
+    #[must_use]
+    pub fn expanded(&self, padding: Vec3) -> Self {
+        Self {
+            min: self.min - padding,
+            max: self.max + padding,
+        }
+    }
+
+    /// Translate (move) the box by this much.
+    #[must_use]
+    pub fn translated(&self, translation: Vec3) -> Self {
+        Self {
+            min: self.min + translation,
+            max: self.max + translation,
+        }
+    }
+
+    /// Return a bounding box that contains this box after it has been rotated around [`Vec3::ZERO`].
+    ///
+    /// Note that the rotated bounding box is very likely larger than the original,
+    /// since it must be large enough to contain the now rotated box.
+    #[must_use]
+    pub fn rotated_around_origin(&self, q: &Quat) -> Self {
+        if self.is_nothing() {
+            Self::nothing()
+        } else {
+            // This can be optimized
+            Self::from_points(self.corners().iter().map(|&c| q.mul_vec3(c)))
+        }
+    }
+
+    /// Return a bounding box that contains this box after it has been transformed.
+    ///
+    /// Note that the rotated bounding box is very likely larger than the original,
+    /// since it must be large enough to contain the now rotated box.
+    #[must_use]
+    pub fn transform_iso(&self, m: &IsoTransform) -> Self {
+        if self.is_nothing() {
+            Self::nothing()
+        } else {
+            Self::from_points(self.corners().iter().map(|&c| m.transform_point3(c)))
+        }
+    }
+
+    /// Return a bounding box that contains this box after it has been transformed.
+    ///
+    /// Note that the rotated bounding box is very likely larger than the original,
+    /// since it must be large enough to contain the now rotated box.
+    #[must_use]
+    pub fn transform_affine3(&self, m: &Affine3A) -> Self {
+        if self.is_nothing() {
+            Self::nothing()
+        } else {
+            Self::from_points(self.corners().iter().map(|&c| m.transform_point3(c)))
+        }
+    }
+
+    /// Return a bounding box that contains this box after it has been transformed.
+    ///
+    /// Note that the rotated bounding box is very likely larger than the original,
+    /// since it must be large enough to contain the now rotated box.
+    #[must_use]
+    pub fn transform_conformal3(&self, m: &Conformal3) -> Self {
+        if self.is_nothing() {
+            Self::nothing()
+        } else {
+            Self::from_points(self.corners().iter().map(|&c| m.transform_point3(c)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_bounding_box() {
+        use crate::Affine3A;
+        use crate::Quat;
+        let bb = BoundingBox::from_min_max(Vec3::ZERO, Vec3::ZERO);
+        assert!(bb.contains(Vec3::ZERO));
+        assert!(bb.is_something());
+        assert!(!bb.is_nothing());
+        let bb_rotated =
+            bb.transform_affine3(&Affine3A::from_quat(Quat::from_axis_angle(Vec3::X, 0.5)));
+        assert_eq!(bb, bb_rotated);
+        let bb_translated =
+            bb.transform_affine3(&Affine3A::from_translation(Vec3::new(2.0, 3.0, 5.0)));
+        assert!(bb_translated.is_something());
+        assert!(bb_translated.contains(Vec3::new(2.0, 3.0, 5.0)));
+    }
+}

--- a/crates/utils/re_math/src/conformal.rs
+++ b/crates/utils/re_math/src/conformal.rs
@@ -59,7 +59,7 @@ impl Conformal3 {
 
     /// Returns this transform decomposed into scale, rotation, translation
     #[inline]
-    pub fn to_scale_rotation_translation(&self) -> (f32, Quat, Vec3) {
+    pub fn to_scale_rotation_translation(self) -> (f32, Quat, Vec3) {
         (self.scale(), self.rotation(), self.translation())
     }
 
@@ -108,7 +108,7 @@ impl Conformal3 {
 
     /// Returns this transform as an `Affine3A`
     #[inline]
-    pub fn to_affine3a(&self) -> Affine3A {
+    pub fn to_affine3a(self) -> Affine3A {
         Affine3A::from_scale_rotation_translation(
             Vec3::splat(self.scale()),
             self.rotation(),
@@ -354,6 +354,8 @@ mod test {
 
     #[test]
     fn test_inverse() {
+        #![allow(clippy::disallowed_methods)] // normalize
+
         use crate::Conformal3;
 
         let transform = Conformal3::from_scale_rotation_translation(

--- a/crates/utils/re_math/src/conformal.rs
+++ b/crates/utils/re_math/src/conformal.rs
@@ -1,8 +1,6 @@
-use glam::Affine3A;
-use glam::Mat4;
-use glam::Vec3A;
+use glam::{Affine3A, Mat4, Quat, Vec3, Vec3A, Vec4, Vec4Swizzles};
 
-use crate::{IsoTransform, Quat, Vec3, Vec3Ext, Vec4, Vec4Swizzles};
+use crate::{IsoTransform, Vec3Ext};
 
 /// Represents a transform with translation + rotation + uniform scale.
 ///
@@ -98,7 +96,7 @@ impl Conformal3 {
     /// Will attempt to create a `Conformal3` from an `Affine3A`. Assumes no shearing and uniform scaling.
     /// If the affine transform contains shearing or non-uniform scaling it will be lost.
     #[inline]
-    pub fn from_affine3a_lossy(transform: &crate::Affine3A) -> Self {
+    pub fn from_affine3a_lossy(transform: &Affine3A) -> Self {
         let (scale, rotation, translation) = transform.to_scale_rotation_translation();
         Self {
             translation_and_scale: translation.extend(scale.mean()),
@@ -217,7 +215,6 @@ impl Conformal3 {
     /// For a view coordinate system with `+X=right`, `+Y=up` and `+Z=back`.
     ///
     /// Will return [`None`] if any argument is zero, non-finite, or if forward and up are colinear.
-    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
     #[inline]
     pub fn look_at_rh(eye: Vec3, target: Vec3, up: Vec3) -> Option<Self> {
         IsoTransform::look_at_rh(eye, target, up).map(Self::from_iso_transform)
@@ -295,7 +292,7 @@ impl From<Conformal3> for Mat4 {
     }
 }
 
-impl From<Conformal3> for crate::Affine3A {
+impl From<Conformal3> for Affine3A {
     #[inline]
     fn from(c: Conformal3) -> Self {
         c.to_affine3a()

--- a/crates/utils/re_math/src/conformal.rs
+++ b/crates/utils/re_math/src/conformal.rs
@@ -1,0 +1,375 @@
+use glam::Affine3A;
+use glam::Mat4;
+use glam::Vec3A;
+
+use crate::{IsoTransform, Quat, Vec3, Vec3Ext, Vec4, Vec4Swizzles};
+
+/// Represents a transform with translation + rotation + uniform scale.
+///
+/// Preserves local angles.
+/// Scale and rotation will be applied first, then translation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Conformal3 {
+    translation_and_scale: Vec4,
+    rotation: Quat,
+}
+
+impl Conformal3 {
+    /// The identity transform: doesn't transform at all. Like multiplying with `1`.
+    pub const IDENTITY: Self = Self {
+        translation_and_scale: Vec4::W,
+        rotation: Quat::IDENTITY,
+    };
+
+    #[inline]
+    /// A transform that first rotates and scales around the origin and then moves all points by a set amount.
+    ///
+    /// Equivalent to `Conformal3::from_translation(translation) * (Conformal3::from_scale(rotation) * Conformal3::from_quat(scale))`.
+    ///
+    /// The given rotation should be normalized.
+    pub fn from_scale_rotation_translation(scale: f32, rotation: Quat, translation: Vec3) -> Self {
+        Self {
+            translation_and_scale: translation.extend(scale),
+            rotation,
+        }
+    }
+
+    /// A transform that first rotates around the origin and then moves all points by a set amount.
+    ///
+    /// Equivalent to `Conformal3::from_translation(translation) * Conformal3::from_quat(rotation)`.
+    ///
+    /// The given rotation should be normalized.
+    #[inline]
+    pub fn from_rotation_translation(rotation: Quat, translation: Vec3) -> Self {
+        Self {
+            translation_and_scale: translation.extend(1.0),
+            rotation,
+        }
+    }
+
+    /// A pure translation without any rotation or scale.
+    #[inline]
+    pub fn from_translation(translation: Vec3) -> Self {
+        Self {
+            translation_and_scale: translation.extend(1.0),
+            rotation: Quat::IDENTITY,
+        }
+    }
+
+    /// Returns this transform decomposed into scale, rotation, translation
+    #[inline]
+    pub fn to_scale_rotation_translation(&self) -> (f32, Quat, Vec3) {
+        (self.scale(), self.rotation(), self.translation())
+    }
+
+    /// A pure rotation without any translation or scale.
+    #[inline]
+    pub fn from_quat(rotation: Quat) -> Self {
+        Self::from_scale_rotation_translation(1.0, rotation, Vec3::ZERO)
+    }
+
+    /// A pure scale without any translation or rotation.
+    #[inline]
+    pub fn from_scale(scale: f32) -> Self {
+        Self::from_scale_rotation_translation(scale, Quat::IDENTITY, Vec3::ZERO)
+    }
+
+    /// Returns the inverse of this transform. `my_transform * my_transform.inverse() = Conformal3::IDENITTY`
+    #[inline]
+    pub fn inverse(&self) -> Self {
+        let inv_scale = self.inv_scale();
+        let inv_rotation = self.rotation.inverse();
+        let inv_translation = inv_scale * (inv_rotation * -self.translation());
+        Self::from_scale_rotation_translation(inv_scale, inv_rotation, inv_translation)
+    }
+
+    /// Returns self normalized.
+    /// You generally don't need to call this unless you've multiplied A LOT of `Conformal3`.
+    #[inline]
+    #[must_use]
+    pub fn normalize(&self) -> Self {
+        let scale = self.scale();
+        let rotation = self.rotation().normalize();
+        let translation = self.translation();
+        Self::from_scale_rotation_translation(scale, rotation, translation)
+    }
+
+    /// Will attempt to create a `Conformal3` from an `Affine3A`. Assumes no shearing and uniform scaling.
+    /// If the affine transform contains shearing or non-uniform scaling it will be lost.
+    #[inline]
+    pub fn from_affine3a_lossy(transform: &crate::Affine3A) -> Self {
+        let (scale, rotation, translation) = transform.to_scale_rotation_translation();
+        Self {
+            translation_and_scale: translation.extend(scale.mean()),
+            rotation: rotation.normalize(),
+        }
+    }
+
+    /// Returns this transform as an `Affine3A`
+    #[inline]
+    pub fn to_affine3a(&self) -> Affine3A {
+        Affine3A::from_scale_rotation_translation(
+            Vec3::splat(self.scale()),
+            self.rotation(),
+            self.translation(),
+        )
+    }
+
+    /// Returns this transform as a `Mat4`
+    #[inline]
+    pub fn to_mat4(self) -> Mat4 {
+        Mat4::from_scale_rotation_translation(
+            Vec3::splat(self.scale()),
+            self.rotation(),
+            self.translation(),
+        )
+    }
+
+    /// Transform a `Vec3` using translation, rotation, scale.
+    #[inline]
+    pub fn transform_point3(&self, value: Vec3) -> Vec3 {
+        self.translation() + self.scale() * (self.rotation() * value)
+    }
+
+    /// Transform a `Vec3A` using translation, rotation, scale.
+    #[inline]
+    pub fn transform_point3a(&self, value: Vec3A) -> Vec3A {
+        Vec3A::from(self.translation()) + self.scale() * (self.rotation() * value)
+    }
+
+    /// Transform a `Vec3` using only rotation and scale.
+    #[inline]
+    pub fn transform_vector3(&self, value: Vec3) -> Vec3 {
+        self.scale() * (self.rotation() * value)
+    }
+
+    /// Transform a `Vec3A` using only rotation and scale.
+    #[inline]
+    pub fn transform_vector3a(&self, value: Vec3A) -> Vec3A {
+        self.scale() * (self.rotation() * value)
+    }
+
+    /// Returns the rotation
+    #[inline]
+    pub fn rotation(&self) -> Quat {
+        self.rotation
+    }
+
+    /// Sets the rotation
+    #[inline]
+    pub fn set_rotation(&mut self, rotation: Quat) {
+        self.rotation = rotation;
+    }
+
+    /// Returns the translation
+    #[inline]
+    pub fn translation(&self) -> Vec3 {
+        self.translation_and_scale.xyz()
+    }
+
+    /// Returns the translation and scale as a `Vec4`
+    #[inline]
+    pub fn translation_and_scale(&self) -> Vec4 {
+        self.translation_and_scale
+    }
+
+    /// Sets the translation
+    #[inline]
+    pub fn set_translation(&mut self, translation: Vec3) {
+        let scale = self.scale();
+        self.translation_and_scale = translation.extend(scale);
+    }
+
+    /// Returns the scale
+    #[inline]
+    pub fn scale(&self) -> f32 {
+        self.translation_and_scale.w
+    }
+
+    /// Returns the scale inverse
+    #[inline]
+    pub fn inv_scale(&self) -> f32 {
+        if self.scale() == 0.0 {
+            f32::INFINITY
+        } else {
+            1.0 / self.scale()
+        }
+    }
+
+    /// Sets the scale
+    #[inline]
+    pub fn set_scale(&mut self, scale: f32) {
+        self.translation_and_scale.w = scale;
+    }
+
+    /// Builds a `Conformal3` from an `IsoTransform` (rotation, translation).
+    #[inline]
+    pub fn from_iso_transform(t: IsoTransform) -> Self {
+        Self::from_rotation_translation(t.rotation(), t.translation())
+    }
+
+    /// Creates a right-handed view transform using a camera position,
+    /// a point to look at, and an up direction.
+    ///
+    /// The result transforms from world coordinates to view coordinates.
+    ///
+    /// For a view coordinate system with `+X=right`, `+Y=up` and `+Z=back`.
+    ///
+    /// Will return [`None`] if any argument is zero, non-finite, or if forward and up are colinear.
+    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
+    #[inline]
+    pub fn look_at_rh(eye: Vec3, target: Vec3, up: Vec3) -> Option<Self> {
+        IsoTransform::look_at_rh(eye, target, up).map(Self::from_iso_transform)
+    }
+
+    /// Returns `true` if, and only if, all components are finite.
+    ///
+    /// If any component is either `NaN`, positive or negative infinity, this will return `false`.
+    pub fn is_finite(&self) -> bool {
+        self.translation_and_scale.is_finite() && self.rotation.is_finite()
+    }
+}
+
+impl core::ops::Mul for &Conformal3 {
+    type Output = Conformal3;
+
+    #[inline]
+    fn mul(self, rhs: &Conformal3) -> Conformal3 {
+        let translation = self.transform_point3(rhs.translation());
+        let rotation = self.rotation() * rhs.rotation();
+        let scale = self.scale() * rhs.scale();
+        Conformal3::from_scale_rotation_translation(scale, rotation, translation)
+    }
+}
+
+impl core::ops::Mul<Conformal3> for &Conformal3 {
+    type Output = Conformal3;
+
+    #[inline]
+    fn mul(self, rhs: Conformal3) -> Conformal3 {
+        self.mul(&rhs)
+    }
+}
+
+impl core::ops::Mul for Conformal3 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        (&self).mul(&rhs)
+    }
+}
+
+impl core::ops::Mul<Conformal3> for IsoTransform {
+    type Output = Conformal3;
+
+    #[inline]
+    fn mul(self, rhs: Conformal3) -> Conformal3 {
+        Conformal3::from_iso_transform(self).mul(rhs)
+    }
+}
+
+impl core::ops::Mul<IsoTransform> for Conformal3 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: IsoTransform) -> Self {
+        self.mul(Self::from_iso_transform(rhs))
+    }
+}
+
+/// Identity transform
+impl Default for Conformal3 {
+    /// Identity transform
+    #[inline]
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
+impl From<Conformal3> for Mat4 {
+    #[inline]
+    fn from(c: Conformal3) -> Self {
+        c.to_mat4()
+    }
+}
+
+impl From<Conformal3> for crate::Affine3A {
+    #[inline]
+    fn from(c: Conformal3) -> Self {
+        c.to_affine3a()
+    }
+}
+
+impl From<IsoTransform> for Conformal3 {
+    #[inline]
+    fn from(c: IsoTransform) -> Self {
+        Self::from_iso_transform(c)
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Debug for Conformal3 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let (axis, angle) = self.rotation().to_axis_angle();
+        let translation = self.translation();
+        let scale = self.scale();
+        f.debug_struct("Conformal3")
+            .field(
+                "translation",
+                &format!("[{} {} {}]", translation[0], translation[1], translation[2]),
+            )
+            .field(
+                "rotation",
+                &format!(
+                    "{:.1}° around [{} {} {}]",
+                    angle.to_degrees(),
+                    axis[0],
+                    axis[1],
+                    axis[2],
+                ),
+            )
+            .field("scale", &format!("{}", scale))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn approx_eq_transform(a: Conformal3, b: Conformal3) -> bool {
+        let max_abs_diff = 1e-6;
+        a.translation().abs_diff_eq(b.translation(), max_abs_diff)
+            && a.rotation().abs_diff_eq(b.rotation(), max_abs_diff)
+            && ((a.scale() - b.scale()).abs() < max_abs_diff)
+    }
+
+    macro_rules! assert_approx_eq_transform {
+        ($a: expr, $b: expr) => {
+            assert!(approx_eq_transform($a, $b), "{:#?} != {:#?}", $a, $b,);
+        };
+    }
+
+    #[test]
+    fn test_inverse() {
+        use crate::Conformal3;
+
+        let transform = Conformal3::from_scale_rotation_translation(
+            2.0,
+            Quat::from_rotation_y(std::f32::consts::PI),
+            Vec3::ONE,
+        );
+        let identity = transform * transform.inverse();
+        assert_approx_eq_transform!(identity, Conformal3::IDENTITY);
+
+        let transform = Conformal3::from_scale_rotation_translation(
+            10.0,
+            Quat::from_axis_angle(Vec3::ONE.normalize(), 1.234),
+            Vec3::new(1.0, 2.0, 3.0),
+        );
+        let identity = transform * transform.inverse();
+        assert_approx_eq_transform!(identity, Conformal3::IDENTITY);
+    }
+}

--- a/crates/utils/re_math/src/float_ext.rs
+++ b/crates/utils/re_math/src/float_ext.rs
@@ -1,0 +1,49 @@
+/// Extensions to floating-point primitives.
+///
+/// Adds additional math-related functionality to floats
+pub trait FloatExt {
+    /// Returns `0.0` if `value < self` and 1.0 otherwise.
+    ///
+    /// Similar to glsl's step(edge, x), which translates into edge.step(x)
+    #[must_use]
+    fn step(self, value: Self) -> Self;
+
+    /// Selects between `less` and `greater_or_equal` based on the result of `value < self`
+    #[must_use]
+    fn step_select(self, value: Self, less: Self, greater_or_equal: Self) -> Self;
+
+    /// Performs a linear interpolation between `self` and `other` using `a` to weight between them.
+    /// The return value is computed as `self * (1−a) + other * a`.
+    #[must_use]
+    fn lerp(self, other: Self, a: Self) -> Self;
+
+    /// Clamp `self` within the range `[0.0, 1.0]`
+    #[must_use]
+    fn saturate(self) -> Self;
+}
+
+impl FloatExt for f32 {
+    fn step(self, value: Self) -> Self {
+        if value < self {
+            0.0
+        } else {
+            1.0
+        }
+    }
+
+    fn step_select(self, value: Self, less: Self, greater_or_equal: Self) -> Self {
+        if value < self {
+            less
+        } else {
+            greater_or_equal
+        }
+    }
+
+    fn lerp(self, other: Self, a: Self) -> Self {
+        self + (other - self) * a
+    }
+
+    fn saturate(self) -> Self {
+        self.clamp(0.0, 1.0)
+    }
+}

--- a/crates/utils/re_math/src/iso_transform.rs
+++ b/crates/utils/re_math/src/iso_transform.rs
@@ -1,8 +1,4 @@
-use glam::Affine3A;
-use glam::Mat4;
-use glam::Quat;
-use glam::Vec3;
-use glam::Vec3A;
+use glam::{Affine3A, Mat4, Quat, Vec3, Vec3A};
 
 /// An isometric transform represented by translation * rotation.
 ///
@@ -87,7 +83,6 @@ impl IsoTransform {
     /// # Panics
     ///
     /// Will panic if the determinant of `t` is zero and the `assert` feature is enabled.
-    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
     #[inline]
     pub fn from_mat4(t: &Mat4) -> Option<Self> {
         let (scale3, rotation, translation) = t.to_scale_rotation_translation();
@@ -104,7 +99,6 @@ impl IsoTransform {
     /// For a view coordinate system with `+X=right`, `+Y=up` and `+Z=back`.
     ///
     /// Will return [`None`] if any argument is zero, non-finite, or if forward and up are colinear.
-    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
     #[inline]
     pub fn look_at_rh(eye: Vec3, target: Vec3, up: Vec3) -> Option<Self> {
         use crate::QuatExt;
@@ -267,7 +261,7 @@ impl core::ops::Mul<IsoTransform> for Mat4 {
     }
 }
 
-impl From<IsoTransform> for crate::Affine3A {
+impl From<IsoTransform> for Affine3A {
     #[inline]
     fn from(iso: IsoTransform) -> Self {
         Self::from_rotation_translation(iso.rotation(), iso.translation())

--- a/crates/utils/re_math/src/iso_transform.rs
+++ b/crates/utils/re_math/src/iso_transform.rs
@@ -355,6 +355,8 @@ mod test {
 
     #[test]
     fn transform() {
+        #![allow(clippy::disallowed_methods)] // normalize
+
         let t = [
             IsoTransform {
                 translation: Vec3A::new(0.0, 0.0, 0.0),

--- a/crates/utils/re_math/src/iso_transform.rs
+++ b/crates/utils/re_math/src/iso_transform.rs
@@ -1,0 +1,505 @@
+use glam::Affine3A;
+use glam::Mat4;
+use glam::Quat;
+use glam::Vec3;
+use glam::Vec3A;
+
+/// An isometric transform represented by translation * rotation.
+///
+/// An isometric transform conserves distances and angles.
+///
+/// The operations are applied right-to-left, so when transforming a point
+/// it will first be rotated and finally translated.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct IsoTransform {
+    /// Normalized
+    rotation: Quat,
+
+    /// Final translation. This is where the input origin will end up,
+    /// so for many circumstances this can be thought of as the position.
+    translation: Vec3A,
+}
+
+/// Identity transform
+impl Default for IsoTransform {
+    /// Identity transform
+    #[inline]
+    fn default() -> Self {
+        Self::IDENTITY
+    }
+}
+
+impl IsoTransform {
+    // ------------------------------------------------------------------------
+    // Constructors:
+
+    /// The identity transform: doesn't transform at all. Like multiplying with `1`.
+    pub const IDENTITY: Self = Self {
+        rotation: Quat::IDENTITY,
+        translation: Vec3A::ZERO,
+    };
+
+    /// A transform that first rotates around the origin and then moves all points by a set amount.
+    ///
+    /// Equivalent to `IsoTransform::from_translation(translation) * IsoTransform::from_quat(rotation)`.
+    ///
+    /// The given rotation should be normalized.
+    #[inline]
+    pub fn from_rotation_translation(rotation: Quat, translation: Vec3) -> Self {
+        Self {
+            rotation,
+            translation: translation.into(),
+        }
+    }
+
+    /// A rotation around a given point
+    #[inline]
+    pub fn from_rotation_around_point(rotation: Quat, point: Vec3) -> Self {
+        Self::from_rotation_translation(rotation, point) * Self::from_translation(-point)
+    }
+
+    /// A pure rotation without any translation.
+    ///
+    /// The given rotation should be normalized.
+    #[inline]
+    pub fn from_quat(rotation: Quat) -> Self {
+        Self {
+            rotation,
+            translation: Vec3A::ZERO,
+        }
+    }
+
+    /// A pure translation without any rotation.
+    #[inline]
+    pub fn from_translation(translation: Vec3) -> Self {
+        Self {
+            rotation: Quat::IDENTITY,
+            translation: translation.into(),
+        }
+    }
+
+    /// Tries to convert a 4x4 matrix to a [`IsoTransform`].
+    ///
+    /// This may return [`None`] as a [`Mat4`] can represent things that a [`IsoTransform`] cannot,
+    /// such as scale, shearing and projection.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the determinant of `t` is zero and the `assert` feature is enabled.
+    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
+    #[inline]
+    pub fn from_mat4(t: &Mat4) -> Option<Self> {
+        let (scale3, rotation, translation) = t.to_scale_rotation_translation();
+        scale3
+            .abs_diff_eq(Vec3::splat(1.0), 1e-4)
+            .then(|| Self::from_rotation_translation(rotation, translation))
+    }
+
+    /// Creates a right-handed view transform using a camera position,
+    /// a point to look at, and an up direction.
+    ///
+    /// The result transforms from world coordinates to view coordinates.
+    ///
+    /// For a view coordinate system with `+X=right`, `+Y=up` and `+Z=back`.
+    ///
+    /// Will return [`None`] if any argument is zero, non-finite, or if forward and up are colinear.
+    #[cfg(not(target_arch = "spirv"))] // TODO: large Options in rust-gpu
+    #[inline]
+    pub fn look_at_rh(eye: Vec3, target: Vec3, up: Vec3) -> Option<Self> {
+        use crate::QuatExt;
+        let rotation = Quat::rotate_negative_z_towards(target - eye, up)?;
+        Some(Self::from_quat(rotation.inverse()) * Self::from_translation(-eye))
+    }
+
+    // ------------------------------------------------------------------------
+    // Accessors:
+
+    #[inline]
+    pub fn rotation(&self) -> Quat {
+        self.rotation
+    }
+
+    #[inline]
+    pub fn set_rotation(&mut self, rotation: Quat) {
+        self.rotation = rotation;
+    }
+
+    #[inline]
+    pub fn translation(&self) -> Vec3 {
+        self.translation.into()
+    }
+
+    #[inline]
+    pub fn set_translation(&mut self, translation: Vec3) {
+        self.translation = translation.into();
+    }
+
+    /// True if every value is finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.translation.is_finite() && self.rotation.is_finite()
+    }
+
+    /// Returns `true` if any elements are `NaN`.
+    #[inline]
+    pub fn is_nan(&self) -> bool {
+        self.translation.is_nan() || self.rotation.is_nan()
+    }
+
+    // ------------------------------------------------------------------------
+    // Conversions:
+
+    /// Convert to an equivalent `Mat4` transformation matrix.
+    #[inline]
+    pub fn to_mat4(self) -> Mat4 {
+        Mat4::from_rotation_translation(self.rotation, self.translation())
+    }
+
+    // ------------------------------------------------------------------------
+    // Operations:
+
+    /// Get the transform that undoes this transform so that `t.inverse() * t == IDENTITY`.
+    #[inline]
+    #[must_use]
+    pub fn inverse(&self) -> Self {
+        let inv_rotation = self.rotation.inverse();
+        Self {
+            rotation: inv_rotation,
+            translation: inv_rotation * -self.translation,
+        }
+    }
+
+    /// Returns self normalized.
+    /// You generally don't need to call this unless you've multiplied A LOT of `IsoTransforms`.
+    #[inline]
+    #[must_use]
+    pub fn normalize(&self) -> Self {
+        Self {
+            rotation: self.rotation.normalize(),
+            translation: self.translation,
+        }
+    }
+
+    /// Rotate and translate a point.
+    #[inline]
+    pub fn transform_point3(&self, p: Vec3) -> Vec3 {
+        (self.translation + self.rotation.mul_vec3a(p.into())).into()
+    }
+
+    /// Rotate a vector.
+    #[inline]
+    pub fn transform_vector3(&self, v: Vec3) -> Vec3 {
+        self.rotation.mul_vec3a(v.into()).into()
+    }
+}
+
+/// iso * iso -> iso
+impl core::ops::Mul for &IsoTransform {
+    type Output = IsoTransform;
+
+    #[inline]
+    fn mul(self, rhs: &IsoTransform) -> IsoTransform {
+        IsoTransform {
+            rotation: self.rotation * rhs.rotation,
+            translation: self.translation + self.rotation.mul_vec3a(rhs.translation),
+        }
+    }
+}
+
+/// iso * iso -> iso
+impl core::ops::Mul<IsoTransform> for &IsoTransform {
+    type Output = IsoTransform;
+
+    #[inline]
+    fn mul(self, rhs: IsoTransform) -> IsoTransform {
+        self.mul(&rhs)
+    }
+}
+
+/// iso * iso -> iso
+impl core::ops::Mul for IsoTransform {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        (&self).mul(&rhs)
+    }
+}
+
+/// iso * affine3a -> affine3a
+impl core::ops::Mul<Affine3A> for IsoTransform {
+    type Output = Affine3A;
+
+    #[inline]
+    fn mul(self, rhs: Affine3A) -> Affine3A {
+        Affine3A::from(self).mul(rhs)
+    }
+}
+
+/// affine3a * iso -> affine3a
+impl core::ops::Mul<IsoTransform> for Affine3A {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: IsoTransform) -> Self {
+        self.mul(Self::from(rhs))
+    }
+}
+
+/// mat4 * iso -> mat4
+impl core::ops::Mul<Mat4> for IsoTransform {
+    type Output = Mat4;
+
+    #[inline]
+    fn mul(self, rhs: Mat4) -> Mat4 {
+        self.to_mat4().mul(rhs)
+    }
+}
+
+/// iso * mat4 -> mat4
+impl core::ops::Mul<IsoTransform> for Mat4 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: IsoTransform) -> Self {
+        self.mul(rhs.to_mat4())
+    }
+}
+
+impl From<IsoTransform> for crate::Affine3A {
+    #[inline]
+    fn from(iso: IsoTransform) -> Self {
+        Self::from_rotation_translation(iso.rotation(), iso.translation())
+    }
+}
+
+impl From<IsoTransform> for Mat4 {
+    #[inline]
+    fn from(t: IsoTransform) -> Self {
+        t.to_mat4()
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Debug for IsoTransform {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let (axis, angle) = self.rotation.to_axis_angle();
+        f.debug_struct("IsoTransform")
+            .field(
+                "translation",
+                &format!(
+                    "[{} {} {}]",
+                    self.translation[0], self.translation[1], self.translation[2]
+                ),
+            )
+            .field(
+                "rotation",
+                &format!(
+                    "{:.1}° around [{} {} {}]",
+                    angle.to_degrees(),
+                    axis[0],
+                    axis[1],
+                    axis[2],
+                ),
+            )
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const MAX_ERR: f32 = 1e-5;
+
+    fn approx_eq_vec3(a: Vec3, b: Vec3) -> bool {
+        a.abs_diff_eq(b, MAX_ERR)
+    }
+
+    fn approx_eq_quat(a: Quat, b: Quat) -> bool {
+        a.abs_diff_eq(b, MAX_ERR) || a.abs_diff_eq(-b, MAX_ERR)
+    }
+
+    fn approx_eq_transform(a: IsoTransform, b: IsoTransform) -> bool {
+        approx_eq_vec3(a.translation(), b.translation()) && approx_eq_quat(a.rotation, b.rotation)
+    }
+
+    macro_rules! assert_approx_eq_vec3 {
+        ($a: expr, $b: expr) => {
+            assert!(
+                approx_eq_vec3($a, $b),
+                "[{} {} {}] != [{} {} {}], abs-diff: {:?}",
+                $a[0],
+                $a[1],
+                $a[2],
+                $b[0],
+                $b[1],
+                $b[2],
+                ($a - $b).abs(),
+            );
+        };
+    }
+
+    macro_rules! assert_approx_eq_mat4 {
+        ($a: expr, $b: expr) => {
+            assert!($a.abs_diff_eq($b, MAX_ERR), "Mat4 {:?} vs {:?}", $a, $b,);
+        };
+    }
+
+    macro_rules! assert_approx_eq_transform {
+        ($a: expr, $b: expr) => {
+            assert!(approx_eq_transform($a, $b), "{:#?} != {:#?}", $a, $b,);
+        };
+    }
+
+    #[test]
+    fn transform() {
+        let t = [
+            IsoTransform {
+                translation: Vec3A::new(0.0, 0.0, 0.0),
+                rotation: Quat::IDENTITY,
+            },
+            IsoTransform {
+                translation: Vec3A::new(0.0, 0.0, 0.0),
+                rotation: Quat::from_axis_angle(
+                    Vec3::new(0.0, 1.0, 0.0).normalize(),
+                    core::f32::consts::PI / 6.0,
+                ),
+            },
+            IsoTransform {
+                translation: Vec3A::new(0.7, 1.2, 3.4),
+                rotation: Quat::from_axis_angle(
+                    Vec3::new(0.3, -0.5, -0.4).normalize(),
+                    1.618 * core::f32::consts::PI,
+                ),
+            },
+            IsoTransform {
+                translation: Vec3A::new(-3.6, 4.2, -0.7654321),
+                rotation: Quat::from_axis_angle(
+                    Vec3::new(-0.8, -0.1, 0.2).normalize(),
+                    0.321 * core::f32::consts::PI,
+                ),
+            },
+        ];
+
+        for &t in &t {
+            test_single_transform(t);
+        }
+
+        for &a in &t {
+            for &b in &t {
+                test_transform_mul(a, b);
+            }
+        }
+    }
+
+    fn test_single_transform(t: IsoTransform) {
+        #[cfg(feature = "std")]
+        eprintln!("-------------------------------------------\nTesting {t:?}",);
+
+        assert_approx_eq_transform!(t, IsoTransform::from_mat4(&t.to_mat4()).unwrap());
+        assert_approx_eq_transform!(t, t.inverse().inverse());
+        assert_approx_eq_transform!(t.inverse() * t, IsoTransform::IDENTITY);
+        assert_approx_eq_transform!(t * t.inverse(), IsoTransform::IDENTITY);
+        assert_approx_eq_mat4!(t.to_mat4().inverse(), t.inverse().to_mat4());
+
+        for p in points() {
+            assert_approx_eq_vec3!(t.transform_vector3(p), t.to_mat4().transform_vector3(p));
+            assert_approx_eq_vec3!(t.transform_point3(p), t.to_mat4().transform_point3(p));
+
+            assert_approx_eq_vec3!(
+                t.inverse().transform_vector3(p),
+                t.inverse().to_mat4().transform_vector3(p)
+            );
+            assert_approx_eq_vec3!(
+                t.inverse().transform_point3(p),
+                t.inverse().to_mat4().transform_point3(p)
+            );
+
+            assert_approx_eq_vec3!(
+                t.inverse().transform_vector3(p),
+                t.to_mat4().inverse().transform_vector3(p)
+            );
+            assert_approx_eq_vec3!(
+                t.inverse().transform_point3(p),
+                t.to_mat4().inverse().transform_point3(p)
+            );
+        }
+    }
+
+    fn test_transform_mul(a: IsoTransform, b: IsoTransform) {
+        #[cfg(feature = "std")]
+        eprintln!("-------------------------------------------\nTesting {a:?} x {b:?}",);
+
+        assert_approx_eq_transform!(
+            a * b,
+            IsoTransform::from_mat4(&(a.to_mat4() * b.to_mat4())).unwrap()
+        );
+        assert_approx_eq_mat4!((a * b).to_mat4(), a.to_mat4() * b.to_mat4());
+        for p in points() {
+            assert_approx_eq_vec3!(
+                (a * b).transform_vector3(p),
+                a.transform_vector3(b.transform_vector3(p))
+            );
+            assert_approx_eq_vec3!(
+                (a * b).transform_point3(p),
+                a.transform_point3(b.transform_point3(p))
+            );
+        }
+    }
+
+    fn points() -> Vec<Vec3> {
+        vec![
+            Vec3::X,
+            Vec3::Y,
+            Vec3::Z,
+            Vec3::new(0.1, 0.2, 0.3),
+            Vec3::new(-4.5, -3.17, 0.43),
+        ]
+    }
+
+    #[test]
+    fn unsupported_from_mat4() {
+        // converting a skewed matrix to IsoTransform should result in None
+        assert_eq!(
+            IsoTransform::from_mat4(
+                &(Mat4::from_scale(Vec3::new(1.0, 2.0, 1.0))
+                    * Mat4::from_rotation_z(std::f32::consts::FRAC_PI_3))
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_rotate_around() {
+        use std::f32::consts::TAU;
+        let center = Vec3::new(1.0, 2.0, 3.0);
+        let t = IsoTransform::from_rotation_around_point(Quat::from_rotation_z(TAU / 4.0), center);
+
+        assert_approx_eq_vec3!(t.transform_point3(center + Vec3::X), center + Vec3::Y);
+    }
+
+    #[test]
+    fn test_look_at() {
+        {
+            let eye = Vec3::new(0.0, 2.0, 0.0);
+            let center = Vec3::new(10.0, 2.0, 0.0);
+            let up = Vec3::new(0.0, 1.0, 0.0);
+            let transform = IsoTransform::look_at_rh(eye, center, up).unwrap();
+            assert_approx_eq_vec3!(
+                transform.transform_point3(center),
+                Vec3::new(0.0, 0.0, -10.0)
+            );
+        }
+
+        {
+            let eye = Vec3::new(0.0, 0.0, -5.0);
+            let center = Vec3::new(0.0, 0.0, 0.0);
+            let up = Vec3::new(1.0, 0.0, 0.0);
+            let transform = IsoTransform::look_at_rh(eye, center, up).unwrap();
+            let point = Vec3::new(1.0, 0.0, 0.0);
+            assert_approx_eq_vec3!(transform.transform_point3(point), Vec3::new(0.0, 1.0, -5.0));
+        }
+    }
+}

--- a/crates/utils/re_math/src/lib.rs
+++ b/crates/utils/re_math/src/lib.rs
@@ -1,0 +1,100 @@
+//! An opinionated 3D math library built on [`glam`](https://github.com/bitshifter/glam-rs).
+//!
+//! `re_math` was originally based on [macaw](https://crates.io/crates/macaw).
+
+mod bounding_box;
+mod conformal;
+mod float_ext;
+mod iso_transform;
+mod mesh_gen;
+mod plane3;
+mod quat_ext;
+mod ray3;
+mod utils;
+mod vec2_ext;
+mod vec3_ext;
+mod vec4_ext;
+
+pub use self::bounding_box::*;
+pub use self::conformal::*;
+pub use self::float_ext::*;
+pub use self::iso_transform::*;
+pub use self::plane3::*;
+pub use self::ray3::*;
+pub use self::utils::*;
+pub use self::vec2_ext::Vec2Ext;
+pub use self::vec3_ext::Vec3Ext;
+pub use self::vec4_ext::Vec4Ext;
+
+pub use mesh_gen::*;
+pub use quat_ext::*;
+
+/// Prelude module with extension traits
+pub mod prelude {
+    pub use crate::FloatExt;
+    pub use crate::Vec2Ext;
+    pub use crate::Vec2Swizzles;
+    pub use crate::Vec3Ext;
+    pub use crate::Vec3Swizzles;
+    pub use crate::Vec4Ext;
+    pub use crate::Vec4Swizzles;
+
+    pub use crate::QuatExt;
+}
+
+// Re-export main glam types.
+// i32
+pub use glam::ivec2;
+pub use glam::ivec3;
+pub use glam::IVec2;
+pub use glam::IVec3;
+pub use glam::IVec4;
+// u32
+pub use glam::uvec2;
+pub use glam::uvec3;
+pub use glam::uvec4;
+pub use glam::UVec2;
+pub use glam::UVec3;
+pub use glam::UVec4;
+// f32
+pub use glam::mat2;
+pub use glam::mat3;
+pub use glam::mat3a;
+pub use glam::mat4;
+pub use glam::quat;
+pub use glam::vec2;
+pub use glam::vec3;
+pub use glam::vec3a;
+pub use glam::vec4;
+pub use glam::Affine3A;
+pub use glam::Mat2;
+pub use glam::Mat3;
+pub use glam::Mat3A;
+pub use glam::Mat4;
+pub use glam::Quat;
+pub use glam::Vec2;
+pub use glam::Vec3;
+pub use glam::Vec3A;
+pub use glam::Vec4;
+// f64
+pub use glam::dmat2;
+pub use glam::dmat3;
+pub use glam::dmat4;
+pub use glam::dquat;
+pub use glam::dvec2;
+pub use glam::dvec3;
+pub use glam::dvec4;
+pub use glam::DAffine2;
+pub use glam::DAffine3;
+pub use glam::DMat2;
+pub use glam::DMat3;
+pub use glam::DMat4;
+pub use glam::DQuat;
+pub use glam::DVec2;
+pub use glam::DVec3;
+pub use glam::DVec4;
+// other
+pub use glam::EulerRot;
+pub use glam::Vec2Swizzles;
+pub use glam::Vec3Swizzles;
+pub use glam::Vec4Swizzles;

--- a/crates/utils/re_math/src/lib.rs
+++ b/crates/utils/re_math/src/lib.rs
@@ -15,86 +15,30 @@ mod vec2_ext;
 mod vec3_ext;
 mod vec4_ext;
 
-pub use self::bounding_box::*;
-pub use self::conformal::*;
-pub use self::float_ext::*;
-pub use self::iso_transform::*;
-pub use self::plane3::*;
-pub use self::ray3::*;
-pub use self::utils::*;
-pub use self::vec2_ext::Vec2Ext;
-pub use self::vec3_ext::Vec3Ext;
-pub use self::vec4_ext::Vec4Ext;
-
-pub use mesh_gen::*;
-pub use quat_ext::*;
+pub use self::{
+    bounding_box::BoundingBox,
+    conformal::Conformal3,
+    float_ext::FloatExt,
+    iso_transform::IsoTransform,
+    mesh_gen::MeshGen,
+    plane3::Plane3,
+    quat_ext::QuatExt,
+    ray3::Ray3,
+    utils::{lerp, remap, remap_clamp},
+    vec2_ext::Vec2Ext,
+    vec3_ext::Vec3Ext,
+    vec4_ext::Vec4Ext,
+};
 
 /// Prelude module with extension traits
 pub mod prelude {
     pub use crate::FloatExt;
-    pub use crate::Vec2Ext;
-    pub use crate::Vec2Swizzles;
-    pub use crate::Vec3Ext;
-    pub use crate::Vec3Swizzles;
-    pub use crate::Vec4Ext;
-    pub use crate::Vec4Swizzles;
-
     pub use crate::QuatExt;
-}
+    pub use crate::Vec2Ext;
+    pub use crate::Vec3Ext;
+    pub use crate::Vec4Ext;
 
-// Re-export main glam types.
-// i32
-pub use glam::ivec2;
-pub use glam::ivec3;
-pub use glam::IVec2;
-pub use glam::IVec3;
-pub use glam::IVec4;
-// u32
-pub use glam::uvec2;
-pub use glam::uvec3;
-pub use glam::uvec4;
-pub use glam::UVec2;
-pub use glam::UVec3;
-pub use glam::UVec4;
-// f32
-pub use glam::mat2;
-pub use glam::mat3;
-pub use glam::mat3a;
-pub use glam::mat4;
-pub use glam::quat;
-pub use glam::vec2;
-pub use glam::vec3;
-pub use glam::vec3a;
-pub use glam::vec4;
-pub use glam::Affine3A;
-pub use glam::Mat2;
-pub use glam::Mat3;
-pub use glam::Mat3A;
-pub use glam::Mat4;
-pub use glam::Quat;
-pub use glam::Vec2;
-pub use glam::Vec3;
-pub use glam::Vec3A;
-pub use glam::Vec4;
-// f64
-pub use glam::dmat2;
-pub use glam::dmat3;
-pub use glam::dmat4;
-pub use glam::dquat;
-pub use glam::dvec2;
-pub use glam::dvec3;
-pub use glam::dvec4;
-pub use glam::DAffine2;
-pub use glam::DAffine3;
-pub use glam::DMat2;
-pub use glam::DMat3;
-pub use glam::DMat4;
-pub use glam::DQuat;
-pub use glam::DVec2;
-pub use glam::DVec3;
-pub use glam::DVec4;
-// other
-pub use glam::EulerRot;
-pub use glam::Vec2Swizzles;
-pub use glam::Vec3Swizzles;
-pub use glam::Vec4Swizzles;
+    pub use glam::Vec2Swizzles;
+    pub use glam::Vec3Swizzles;
+    pub use glam::Vec4Swizzles;
+}

--- a/crates/utils/re_math/src/mesh_gen.rs
+++ b/crates/utils/re_math/src/mesh_gen.rs
@@ -1,0 +1,224 @@
+use crate::IsoTransform;
+use crate::Vec3;
+use std::ops::Range;
+
+/// Raw mesh generator. Only generates positions, normals and an index buffer.
+///
+/// Composable - to create a composite mesh, just repeatedly call the various
+/// generation functions. Each one will return the range of vertices added, so if you
+/// have parallel arrays of things like colors, you know how many to push.
+#[derive(Default)]
+pub struct MeshGen {
+    pub positions: Vec<Vec3>,
+    pub normals: Vec<Vec3>,
+    pub indices: Vec<u32>,
+}
+
+fn transform_points(points: &mut [Vec3], transform: IsoTransform) {
+    if transform != IsoTransform::IDENTITY {
+        for point in points {
+            *point = transform.transform_point3(*point);
+        }
+    }
+}
+
+fn transform_vectors(vectors: &mut [Vec3], transform: IsoTransform) {
+    if transform != IsoTransform::IDENTITY {
+        for vector in vectors {
+            *vector = transform.transform_vector3(*vector);
+        }
+    }
+}
+
+impl MeshGen {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn push_cube(&mut self, half_size: Vec3, transform: IsoTransform) -> Range<usize> {
+        let s = half_size;
+
+        let index_offset = self.positions.len() as u32;
+
+        //
+        //      a +--------------+ b
+        //       /|             /|
+        //      / |            / |
+        //   c *--+-----------*  | d
+        //     |  |           |  |
+        //     |  |           |  |
+        //     |  |           |  |
+        //   e |  +-----------+--+ f
+        //     | /            | /
+        //     |/             |/
+        //   g *--------------* h
+        let mut positions = vec![
+            Vec3::new(s.x, -s.y, s.z),   // g
+            Vec3::new(s.x, -s.y, -s.z),  // e
+            Vec3::new(s.x, s.y, -s.z),   // a
+            Vec3::new(s.x, s.y, s.z),    // c
+            Vec3::new(-s.x, -s.y, s.z),  // h
+            Vec3::new(-s.x, -s.y, -s.z), // f
+            Vec3::new(-s.x, s.y, -s.z),  // b
+            Vec3::new(-s.x, s.y, s.z),   // d
+        ];
+
+        let mut indices: Vec<u32> = vec![
+            4, 0, 3, 4, 3, 7, 0, 1, 2, 0, 2, 3, 1, 5, 6, 1, 6, 2, 5, 4, 7, 5, 7, 6, 7, 3, 2, 7, 2,
+            6, 0, 5, 1, 0, 4, 5,
+        ];
+
+        let mut normals = {
+            let face_normals: Vec<Vec3> = indices
+                .chunks(3)
+                .map(|i| {
+                    let p = positions[i[0] as usize];
+                    let a = positions[i[1] as usize] - p;
+                    let b = positions[i[2] as usize] - p;
+                    a.cross(b).normalize()
+                })
+                .collect::<Vec<_>>();
+
+            positions = indices
+                .iter()
+                .map(|i| positions[*i as usize])
+                .collect::<Vec<_>>();
+
+            indices = (0..36_u32).map(|x| x + index_offset).collect::<Vec<_>>();
+
+            indices
+                .iter()
+                .map(|i| face_normals[((i - index_offset) / 3) as usize])
+                .collect::<Vec<Vec3>>()
+        };
+
+        let index_offset = index_offset as usize;
+        let out_range = index_offset..(index_offset + positions.len());
+
+        transform_points(&mut positions, transform);
+        transform_vectors(&mut normals, transform);
+
+        self.positions.extend(positions);
+        self.normals.extend(normals);
+        self.indices.extend(indices);
+
+        out_range
+    }
+
+    /// Creates a lat-long sphere.
+    pub fn push_sphere(
+        &mut self,
+        radius: f32,
+        subdivision_x: usize,
+        subdivision_y: usize,
+        transform: IsoTransform,
+    ) -> Range<usize> {
+        self.push_capsule(radius, 0.0, subdivision_x, subdivision_y, transform)
+    }
+
+    /// Create a lat-long capsule mesh. Can also be used to create spheres
+    /// by setting `length_y` = 0.
+    ///
+    /// Instead of coloring the sphere here, especially if you're using boxes with
+    /// multiple colors, consider making it white (`ColorRgba8([255, 255, 255, 255)`)
+    /// and using `MeshStyle` Tint to color the box. This applies both to the scene
+    /// and world APIs.
+    ///
+    /// If `subdivision_x` or `subdivision_y` are less than 3 they will be overridden
+    /// to 3. This is done as a lower subdivision will result in a mesh that is not
+    /// visible when rendered.
+    pub fn push_capsule(
+        &mut self,
+        radius: f32,
+        length_y: f32,
+        subdivision_x: usize,
+        subdivision_y: usize,
+        transform: IsoTransform,
+    ) -> Range<usize> {
+        let index_offset = self.positions.len() as u32;
+
+        let subdivision_x = 3.max(subdivision_x as u32);
+        let subdivision_y = 3.max(subdivision_y as u32);
+
+        let delta_x = 2.0 * std::f32::consts::PI / subdivision_x as f32;
+        let delta_y = std::f32::consts::PI / subdivision_y as f32;
+
+        let mut positions = vec![];
+        let mut normals = vec![];
+
+        let middle = subdivision_y / 2;
+
+        // North pole. Consider it negative and go towards positive.
+        positions.push(Vec3::new(0.0, -radius, 0.0));
+        normals.push(Vec3::new(0.0, -1.0, 0.0));
+
+        // Stripes, including the middle
+        for y in 1..subdivision_y {
+            let angle_y = delta_y * y as f32;
+            let y_offset = if y >= middle { length_y } else { 0.0 };
+            // TODO: The middle stripe on capsules should really be a whole extra ring.
+            // Still looks "good enough" with enough tessellation, but should be fixed.
+            // let midstripe = y == middle || y == middle + 1;
+            for x in 0..subdivision_x {
+                let angle_x = delta_x * x as f32;
+
+                let mut pos = Vec3::new(
+                    angle_x.cos() * angle_y.sin(),
+                    -angle_y.cos(),
+                    angle_x.sin() * angle_y.sin(),
+                );
+                normals.push(pos);
+
+                pos *= radius;
+                pos.y += y_offset;
+
+                positions.push(pos);
+            }
+        }
+        // South pole.
+        positions.push(Vec3::new(0.0, radius + length_y, 0.0));
+        normals.push(Vec3::new(0.0, 1.0, 0.0));
+
+        let mut indices: Vec<u32> = vec![];
+        // North cap
+        for i in 0..subdivision_x {
+            indices.push(index_offset);
+            indices.push(index_offset + 1 + i);
+            indices.push(index_offset + 1 + (i + 1) % subdivision_x);
+        }
+
+        // Stripes
+        for y in 0..subdivision_y - 2 {
+            for x in 0..subdivision_x {
+                let b = index_offset + 1 + y * subdivision_x + x;
+                let b_next = index_offset + 1 + y * subdivision_x + (x + 1) % subdivision_x;
+                indices.push(b);
+                indices.push(b + subdivision_x);
+                indices.push(b_next);
+                indices.push(b_next);
+                indices.push(b + subdivision_x);
+                indices.push(b_next + subdivision_x);
+            }
+        }
+
+        // South cap
+        let b = 1 + (subdivision_y - 2) * subdivision_x + index_offset;
+        for i in 0..subdivision_x {
+            indices.push(b + (i + 1) % subdivision_x);
+            indices.push(b + i);
+            indices.push(b + subdivision_x);
+        }
+
+        let index_offset = index_offset as usize;
+        let out_range = index_offset..(index_offset + positions.len());
+
+        transform_points(&mut positions, transform);
+        transform_vectors(&mut normals, transform);
+
+        self.positions.extend(positions);
+        self.normals.extend(normals);
+        self.indices.extend(indices);
+
+        out_range
+    }
+}

--- a/crates/utils/re_math/src/mesh_gen.rs
+++ b/crates/utils/re_math/src/mesh_gen.rs
@@ -1,6 +1,8 @@
-use crate::IsoTransform;
-use crate::Vec3;
 use std::ops::Range;
+
+use glam::Vec3;
+
+use crate::IsoTransform;
 
 /// Raw mesh generator. Only generates positions, normals and an index buffer.
 ///

--- a/crates/utils/re_math/src/mesh_gen.rs
+++ b/crates/utils/re_math/src/mesh_gen.rs
@@ -36,6 +36,8 @@ impl MeshGen {
     }
 
     pub fn push_cube(&mut self, half_size: Vec3, transform: IsoTransform) -> Range<usize> {
+        #![allow(clippy::disallowed_methods)] // Use of normalize fine as long as the input is not degenerate.
+
         let s = half_size;
 
         let index_offset = self.positions.len() as u32;

--- a/crates/utils/re_math/src/mesh_gen.rs
+++ b/crates/utils/re_math/src/mesh_gen.rs
@@ -160,7 +160,7 @@ impl MeshGen {
         for y in 1..subdivision_y {
             let angle_y = delta_y * y as f32;
             let y_offset = if y >= middle { length_y } else { 0.0 };
-            // TODO: The middle stripe on capsules should really be a whole extra ring.
+            // TODO(emilk): The middle stripe on capsules should really be a whole extra ring.
             // Still looks "good enough" with enough tessellation, but should be fixed.
             // let midstripe = y == middle || y == middle + 1;
             for x in 0..subdivision_x {

--- a/crates/utils/re_math/src/plane3.rs
+++ b/crates/utils/re_math/src/plane3.rs
@@ -25,11 +25,13 @@ impl Plane3 {
         normal: Vec3::Z,
         d: 0.0,
     };
+
     /// The Y^Z plane with normal = +X
     pub const YZ: Self = Self {
         normal: Vec3::X,
         d: 0.0,
     };
+
     /// The Z^X plane with normal = +Y
     pub const ZX: Self = Self {
         normal: Vec3::Y,

--- a/crates/utils/re_math/src/plane3.rs
+++ b/crates/utils/re_math/src/plane3.rs
@@ -1,4 +1,4 @@
-use crate::Vec3;
+use glam::{Vec3, Vec4};
 
 /// A 3-dimensional plane primitive.
 ///
@@ -10,11 +10,11 @@ use crate::Vec3;
 ///
 /// A point `point` is on the plane when `plane.normal.dot(point) + plane.d = 0`.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(not(target_arch = "spirv"), derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Plane3 {
     /// Normal vector
     pub normal: Vec3,
+
     /// Distance
     pub d: f32,
 }
@@ -98,7 +98,7 @@ impl Plane3 {
 
     /// The distance to a point `[x, y, z, 1]` is the dot product of the point and this.
     #[inline]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(&self) -> Vec4 {
         self.normal.extend(self.d)
     }
 }

--- a/crates/utils/re_math/src/plane3.rs
+++ b/crates/utils/re_math/src/plane3.rs
@@ -1,0 +1,119 @@
+use crate::Vec3;
+
+/// A 3-dimensional plane primitive.
+///
+/// Represented by a normal and the signed distance from the origin to the plane.
+///
+/// This representation can specify any possible plane in 3D space using 4 parameters
+/// (disregarding floating point precision). There are duplicate representations caused
+/// by negating both parameters, but that's fine - you could view it as an oriented plane.
+///
+/// A point `point` is on the plane when `plane.normal.dot(point) + plane.d = 0`.
+#[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(not(target_arch = "spirv"), derive(Debug))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Plane3 {
+    /// Normal vector
+    pub normal: Vec3,
+    /// Distance
+    pub d: f32,
+}
+
+impl Plane3 {
+    /// The X^Y plane with normal = +Z
+    pub const XY: Self = Self {
+        normal: Vec3::Z,
+        d: 0.0,
+    };
+    /// The Y^Z plane with normal = +X
+    pub const YZ: Self = Self {
+        normal: Vec3::X,
+        d: 0.0,
+    };
+    /// The Z^X plane with normal = +Y
+    pub const ZX: Self = Self {
+        normal: Vec3::Y,
+        d: 0.0,
+    };
+
+    /// From the plane normal and a distance `d` so that for all points on the plane:
+    /// `normal.dot(point) + d = 0`.
+    #[inline]
+    pub fn from_normal_dist(normal: Vec3, d: f32) -> Self {
+        Self { normal, d }
+    }
+
+    /// From the plane normal and a point on the plane.
+    #[inline]
+    pub fn from_normal_point(normal: Vec3, point: Vec3) -> Self {
+        Self {
+            normal,
+            d: -normal.dot(point),
+        }
+    }
+
+    /// Get normalized plane
+    #[inline]
+    #[must_use]
+    pub fn normalized(&self) -> Self {
+        let inv_len = self.normal.length_recip();
+        Self {
+            normal: self.normal * inv_len,
+            d: self.d * inv_len,
+        }
+    }
+
+    /// Computes the distance between the plane and the point p.
+    /// The returned distance is only correct if the plane is normalized or the distance is zero.
+    #[inline]
+    pub fn distance(&self, p: Vec3) -> f32 {
+        self.normal.dot(p) + self.d
+    }
+
+    /// The bool is whether the plane was hit or not.
+    ///
+    /// If false, the ray was either perpendicular to the plane, or the ray shot away from the plane.
+    ///
+    /// The returned f32 is the t value so you can easily compute the
+    /// intersection point through "origin + dir * t".
+    pub fn intersect_ray(&self, origin: Vec3, dir: Vec3) -> (bool, f32) {
+        let denom = dir.dot(self.normal);
+        if denom == 0.0 {
+            (false, 0.0)
+        } else {
+            let t = -(origin.dot(self.normal) + self.d) / denom;
+            if t < 0.0 {
+                (false, t)
+            } else {
+                (true, t)
+            }
+        }
+    }
+
+    /// True if every value is finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.normal.is_finite() && self.d.is_finite()
+    }
+
+    /// The distance to a point `[x, y, z, 1]` is the dot product of the point and this.
+    #[inline]
+    pub fn as_vec4(&self) -> crate::Vec4 {
+        self.normal.extend(self.d)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_plane3() {
+        #![allow(clippy::float_cmp)]
+        let point = Vec3::new(2.0, 3.0, 4.0);
+        let p = Plane3::from_normal_point(Vec3::new(2.0, 0.0, 0.0), point);
+        assert_eq!(p.distance(point), 0.0);
+        let p = p.normalized();
+        assert_eq!(p.distance(point), 0.0);
+    }
+}

--- a/crates/utils/re_math/src/quat_ext.rs
+++ b/crates/utils/re_math/src/quat_ext.rs
@@ -1,0 +1,100 @@
+use crate::Quat;
+use crate::Vec3;
+
+/// Extensions to [`Quat`]
+pub trait QuatExt: Sized {
+    /// Return a Quaternion that rotates -Z to the `forward` direction,
+    /// using `up` to control roll, so that +Y will approximately point in the `up` direction.
+    ///
+    /// Will return [`None`] if either argument is zero, non-finite, or if they are colinear.
+    ///
+    /// This is generally what you want to use to construct a view-rotation when -Z is forward and +Y is up (this is what Ark uses!).
+    fn rotate_negative_z_towards(forward: Vec3, up: Vec3) -> Option<Quat>;
+
+    /// Return a Quaternion that rotates +Z to the `forward` direction,
+    /// using `up` to control roll, so that +Y will approximately point in the `up` direction.
+    ///
+    /// Will return [`None`] if either argument is zero, non-finite, or if they are colinear.
+    ///
+    /// This is generally what you want to use to construct a view-rotation when +Z is forward and +Y is up.
+    fn rotate_positive_z_towards(forward: Vec3, up: Vec3) -> Option<Quat>;
+}
+
+impl QuatExt for Quat {
+    fn rotate_negative_z_towards(forward: Vec3, up: Vec3) -> Option<Quat> {
+        let forward = forward.normalize_or_zero();
+        let side = forward.cross(up).normalize_or_zero(); // `side` is right in a right-handed system
+        let up = side.cross(forward);
+
+        if forward != Vec3::ZERO && side != Vec3::ZERO && up != Vec3::ZERO {
+            Some(Self::from_mat3(&glam::Mat3::from_cols(side, up, -forward)))
+        } else {
+            None
+        }
+    }
+
+    fn rotate_positive_z_towards(forward: Vec3, up: Vec3) -> Option<Quat> {
+        let forward = forward.normalize_or_zero();
+        let side = up.cross(forward).normalize_or_zero(); // `side` is left in a right-handed system
+        let up = forward.cross(side);
+
+        if forward != Vec3::ZERO && side != Vec3::ZERO && up != Vec3::ZERO {
+            Some(Self::from_mat3(&glam::Mat3::from_cols(side, up, forward)))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_rotate_negative_z_towards() {
+        let desired_fwd = Vec3::new(1.0, 2.0, 3.0).normalize();
+        let desired_up = Vec3::new(4.0, 5.0, 6.0).normalize();
+
+        let rot = Quat::rotate_negative_z_towards(desired_fwd, desired_up).unwrap();
+
+        let rotated_z = rot * -Vec3::Z;
+        assert!(
+            (rotated_z - desired_fwd).length() < 1e-5,
+            "Expected to rotate -Z to {}, but got {}",
+            desired_fwd,
+            rotated_z,
+        );
+
+        let rotated_y = rot * Vec3::Y;
+        assert!(
+            rotated_y.dot(desired_up) >= 0.0,
+            "Expected to rotate +Y to point approximately towards {}, but got {}",
+            desired_up,
+            rotated_y,
+        );
+    }
+
+    #[test]
+    fn test_rotate_positive_z_towards() {
+        let desired_fwd = Vec3::new(1.0, 2.0, 3.0).normalize();
+        let desired_up = Vec3::new(4.0, 5.0, 6.0).normalize();
+
+        let rot = Quat::rotate_positive_z_towards(desired_fwd, desired_up).unwrap();
+
+        let rotated_z = rot * Vec3::Z;
+        assert!(
+            (rotated_z - desired_fwd).length() < 1e-5,
+            "Expected to rotate +Z to {}, but got {}",
+            desired_fwd,
+            rotated_z,
+        );
+
+        let rotated_y = rot * Vec3::Y;
+        assert!(
+            rotated_y.dot(desired_up) >= 0.0,
+            "Expected to rotate +Y to point approximately towards {}, but got {}",
+            desired_up,
+            rotated_y,
+        );
+    }
+}

--- a/crates/utils/re_math/src/quat_ext.rs
+++ b/crates/utils/re_math/src/quat_ext.rs
@@ -1,5 +1,4 @@
-use crate::Quat;
-use crate::Vec3;
+use glam::{Quat, Vec3};
 
 /// Extensions to [`Quat`]
 pub trait QuatExt: Sized {

--- a/crates/utils/re_math/src/quat_ext.rs
+++ b/crates/utils/re_math/src/quat_ext.rs
@@ -52,6 +52,8 @@ mod test {
 
     #[test]
     fn test_rotate_negative_z_towards() {
+        #![allow(clippy::disallowed_methods)] // normalize
+
         let desired_fwd = Vec3::new(1.0, 2.0, 3.0).normalize();
         let desired_up = Vec3::new(4.0, 5.0, 6.0).normalize();
 
@@ -60,22 +62,20 @@ mod test {
         let rotated_z = rot * -Vec3::Z;
         assert!(
             (rotated_z - desired_fwd).length() < 1e-5,
-            "Expected to rotate -Z to {}, but got {}",
-            desired_fwd,
-            rotated_z,
+            "Expected to rotate -Z to {desired_fwd}, but got {rotated_z}"
         );
 
         let rotated_y = rot * Vec3::Y;
         assert!(
             rotated_y.dot(desired_up) >= 0.0,
-            "Expected to rotate +Y to point approximately towards {}, but got {}",
-            desired_up,
-            rotated_y,
+            "Expected to rotate +Y to point approximately towards {desired_up}, but got {rotated_y}",
         );
     }
 
     #[test]
     fn test_rotate_positive_z_towards() {
+        #![allow(clippy::disallowed_methods)] // normalize
+
         let desired_fwd = Vec3::new(1.0, 2.0, 3.0).normalize();
         let desired_up = Vec3::new(4.0, 5.0, 6.0).normalize();
 
@@ -84,17 +84,13 @@ mod test {
         let rotated_z = rot * Vec3::Z;
         assert!(
             (rotated_z - desired_fwd).length() < 1e-5,
-            "Expected to rotate +Z to {}, but got {}",
-            desired_fwd,
-            rotated_z,
+            "Expected to rotate +Z to {desired_fwd}, but got {rotated_z}",
         );
 
         let rotated_y = rot * Vec3::Y;
         assert!(
             rotated_y.dot(desired_up) >= 0.0,
-            "Expected to rotate +Y to point approximately towards {}, but got {}",
-            desired_up,
-            rotated_y,
+            "Expected to rotate +Y to point approximately towards {desired_up}, but got {rotated_y}",
         );
     }
 }

--- a/crates/utils/re_math/src/ray3.rs
+++ b/crates/utils/re_math/src/ray3.rs
@@ -1,4 +1,4 @@
-use crate::Vec3;
+use glam::Vec3;
 
 /// A ray in 3-dimensional space: a line through space with a starting point and a direction.
 ///
@@ -182,7 +182,6 @@ impl core::ops::Mul<Ray3> for glam::Mat4 {
     }
 }
 
-#[cfg(not(target_arch = "spirv"))]
 impl std::fmt::Debug for Ray3 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Ray3")

--- a/crates/utils/re_math/src/ray3.rs
+++ b/crates/utils/re_math/src/ray3.rs
@@ -1,0 +1,180 @@
+use crate::Vec3;
+
+/// A ray in 3-dimensional space: a line through space with a starting point and a direction.
+///
+/// Any point on the ray can be found through the formula `origin + t * dir`,
+/// where t is a non-negative floating point value, which represents the distance
+/// along the ray.
+#[derive(Clone, Copy, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ray3 {
+    /// Start of the ray
+    pub origin: Vec3,
+    /// Direction of the ray, normalized
+    pub dir: Vec3,
+}
+
+impl Ray3 {
+    /// An invalid ray, starting at the origin and going nowhere.
+    pub const ZERO: Self = Self {
+        origin: Vec3::ZERO,
+        dir: Vec3::ZERO,
+    };
+
+    /// `dir` should be normalized
+    #[inline]
+    pub fn from_origin_dir(origin: Vec3, dir: Vec3) -> Self {
+        Self { origin, dir }
+    }
+
+    /// Get normalized ray (where `dir.len() == 1`).
+    #[inline]
+    #[must_use]
+    pub fn normalize(&self) -> Self {
+        Self {
+            origin: self.origin,
+            dir: self.dir.normalize(),
+        }
+    }
+
+    /// Returns a new ray that has had its origin moved a given distance forwards along the ray.
+    ///
+    /// If the ray direction is normalized then the `t` parameter corresponds to the world space distance it moves.
+    #[inline]
+    #[must_use]
+    pub fn offset_along_ray(&self, t: f32) -> Self {
+        Self {
+            origin: self.origin + self.dir * t,
+            dir: self.dir,
+        }
+    }
+
+    /// True if every value is finite
+    #[inline]
+    pub fn is_finite(&self) -> bool {
+        self.origin.is_finite() && self.dir.is_finite()
+    }
+
+    #[inline]
+    pub fn point_along(&self, t: f32) -> Vec3 {
+        self.origin + t * self.dir
+    }
+
+    /// Returns the line segment where `self` and `other` are the closest to each other.
+    /// If the rays are parallel then non-finite points are returned.
+    pub fn closest_points(&self, other: &Self) -> (Vec3, Vec3) {
+        // https://en.wikipedia.org/wiki/Skew_lines#Nearest_Points
+        let (self_t, other_t) = self.closest_ts(other);
+        (self.point_along(self_t), other.point_along(other_t))
+    }
+
+    /// Returns the distance along both rays which together form
+    /// line segment where `self` and `other` are the closest to each other.
+    /// If the rays are parallel then non-finite values are returned.
+    pub fn closest_ts(&self, other: &Self) -> (f32, f32) {
+        // https://en.wikipedia.org/wiki/Skew_lines#Nearest_Points
+        let (a, b) = (self, other);
+        let n = a.dir.cross(b.dir);
+        let n_a = a.dir.cross(n);
+        let n_b = b.dir.cross(n);
+        let a_t = (b.origin - a.origin).dot(n_b) / a.dir.dot(n_b);
+        let b_t = (a.origin - b.origin).dot(n_a) / b.dir.dot(n_a);
+        (a_t, b_t)
+    }
+
+    /// Returns the point where the ray intersects the plane.
+    /// Returns non-finite result of the ray and plane are parallel.
+    pub fn intersects_plane(&self, plane: crate::Plane3) -> Vec3 {
+        let (ro, rd) = (self.origin, self.dir);
+        let (pn, pd) = (plane.normal, plane.d);
+        // p = ro + t * rd
+        // p.dot(pn) + pd = 0
+        // (ro + t * rd).dot(pn) + pd = 0
+        // ro.dot(pn) + t * rd.dot(pn) + pd = 0
+        // t * rd.dot(pn) = -(ro.dot(pn) + pd)
+        // t = -(ro.dot(pn) + pd) / rd.dot(pn)
+        let t = -(ro.dot(pn) + pd) / rd.dot(pn);
+        ro + t * rd
+
+        // alternate implementation:
+        //     let point = self.to_line().intersects_plane(plane);
+        //     (point.truncate() / point.w).into()
+    }
+
+    // Returns the distance along the ray that is closest to the given point.
+    // The returned `t` can be negative.
+    #[inline]
+    pub fn closest_t_to_point(&self, point: Vec3) -> f32 {
+        self.dir.dot(point - self.origin)
+    }
+
+    /// Returns the point along the ray that is closest to the given point.
+    /// The returned point may be "behind" the ray origin.
+    #[inline]
+    pub fn closest_point_to_point(&self, point: Vec3) -> Vec3 {
+        self.origin + self.dir * self.dir.dot(point - self.origin)
+    }
+}
+
+impl core::ops::Mul<Ray3> for crate::IsoTransform {
+    type Output = Ray3;
+
+    fn mul(self, rhs: Ray3) -> Ray3 {
+        Ray3 {
+            origin: self.transform_point3(rhs.origin),
+            dir: self.transform_vector3(rhs.dir),
+        }
+    }
+}
+
+impl core::ops::Mul<Ray3> for crate::Conformal3 {
+    type Output = Ray3;
+
+    fn mul(self, rhs: Ray3) -> Ray3 {
+        Ray3 {
+            origin: self.transform_point3(rhs.origin),
+            dir: self.transform_vector3(rhs.dir),
+        }
+    }
+}
+
+impl core::ops::Mul<Ray3> for glam::Affine3A {
+    type Output = Ray3;
+
+    fn mul(self, rhs: Ray3) -> Ray3 {
+        Ray3 {
+            origin: self.transform_point3(rhs.origin),
+            dir: self.transform_vector3(rhs.dir).normalize(),
+        }
+    }
+}
+
+impl core::ops::Mul<Ray3> for glam::Mat4 {
+    type Output = Ray3;
+
+    fn mul(self, rhs: Ray3) -> Ray3 {
+        Ray3 {
+            origin: self.transform_point3(rhs.origin),
+            dir: self.transform_vector3(rhs.dir).normalize(),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "spirv"))]
+impl std::fmt::Debug for Ray3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Ray3")
+            .field(
+                "origin",
+                &format!(
+                    "[{:.3} {:.3} {:.3}]",
+                    self.origin[0], self.origin[1], self.origin[2]
+                ),
+            )
+            .field(
+                "dir",
+                &format!("[{:.2} {:.2} {:.2}]", self.dir[0], self.dir[1], self.dir[2]),
+            )
+            .finish()
+    }
+}

--- a/crates/utils/re_math/src/ray3.rs
+++ b/crates/utils/re_math/src/ray3.rs
@@ -28,13 +28,31 @@ impl Ray3 {
     }
 
     /// Get normalized ray (where `dir.len() == 1`).
+    ///
+    /// Assumes the direction is finite and non-zero.
+    ///
+    /// See also: [`Self::try_normalize`].
     #[inline]
     #[must_use]
     pub fn normalize(&self) -> Self {
+        #![allow(clippy::disallowed_methods)]
         Self {
             origin: self.origin,
             dir: self.dir.normalize(),
         }
+    }
+
+    /// Get normalized ray (where `dir.len() == 1`).
+    ///
+    /// If the direction was zero or non-finite,
+    /// this will return `None`.
+    #[inline]
+    #[must_use]
+    pub fn try_normalize(&self) -> Option<Self> {
+        self.dir.try_normalize().map(|dir| Self {
+            origin: self.origin,
+            dir,
+        })
     }
 
     /// Returns a new ray that has had its origin moved a given distance forwards along the ray.
@@ -142,6 +160,8 @@ impl core::ops::Mul<Ray3> for glam::Affine3A {
     type Output = Ray3;
 
     fn mul(self, rhs: Ray3) -> Ray3 {
+        #![allow(clippy::disallowed_methods)] // normalize - if we want an ergonomic mul, we cannot have it be fallible. As long as the transform is not degenerate, we are fine
+
         Ray3 {
             origin: self.transform_point3(rhs.origin),
             dir: self.transform_vector3(rhs.dir).normalize(),
@@ -153,6 +173,8 @@ impl core::ops::Mul<Ray3> for glam::Mat4 {
     type Output = Ray3;
 
     fn mul(self, rhs: Ray3) -> Ray3 {
+        #![allow(clippy::disallowed_methods)] // normalize - if we want an ergonomic mul, we cannot have it be fallible. As long as the transform is not degenerate, we are fine
+
         Ray3 {
             origin: self.transform_point3(rhs.origin),
             dir: self.transform_vector3(rhs.dir).normalize(),

--- a/crates/utils/re_math/src/ray3.rs
+++ b/crates/utils/re_math/src/ray3.rs
@@ -10,6 +10,7 @@ use glam::Vec3;
 pub struct Ray3 {
     /// Start of the ray
     pub origin: Vec3,
+
     /// Direction of the ray, normalized
     pub dir: Vec3,
 }

--- a/crates/utils/re_math/src/utils.rs
+++ b/crates/utils/re_math/src/utils.rs
@@ -1,0 +1,78 @@
+use core::ops::Add;
+use core::ops::Mul;
+use core::ops::RangeInclusive;
+
+/// Linear interpolation between a range
+pub fn lerp<T>(range: RangeInclusive<T>, t: f32) -> T
+where
+    f32: Mul<T, Output = T>,
+    T: Add<T, Output = T> + Copy,
+{
+    (1.0 - t) * *range.start() + t * *range.end()
+}
+
+/// Remap a value from one range to another, e.g. do a linear transform.
+///
+/// # Example
+///
+/// ```
+/// # use macaw::remap;
+/// let ocean_height = remap(0.2, -1.0..=1.0, 2.0..=3.1);
+/// ```
+///
+/// # From range requirement
+///
+/// The range has to be from a low value to a high value, such as 0..=1.0, NOT 1.0..=0.0.
+/// If it is outside of that range the results will be undefined
+pub fn remap(x: f32, from: RangeInclusive<f32>, to: RangeInclusive<f32>) -> f32 {
+    let t = (x - from.start()) / (from.end() - from.start());
+    lerp(to, t)
+}
+
+/// Remap a value from one range to another, clamps the input value to be in the from range first.
+///
+/// # Example
+///
+/// ```
+/// # use macaw::remap_clamp;
+/// let ocean_height = remap_clamp(0.2, -1.0..=1.0, 2.0..=3.1);
+/// ```
+///
+/// # From range requirement
+///
+/// The range has to be from a low value to a high value, such as 0..=1.0, NOT 1.0..=0.0.
+/// If it is outside of that range the results will be undefined
+pub fn remap_clamp(x: f32, from: RangeInclusive<f32>, to: RangeInclusive<f32>) -> f32 {
+    if x <= *from.start() {
+        *to.start()
+    } else if *from.end() <= x {
+        *to.end()
+    } else {
+        let t = (x - from.start()) / (from.end() - from.start());
+        // Ensure no numerical inaccurcies sneak in:
+        if 1.0 <= t {
+            *to.end()
+        } else {
+            lerp(to, t)
+        }
+    }
+}
+
+#[allow(clippy::float_cmp)]
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn remapping() {
+        // verify simple case
+        assert_eq!(remap(0.2, -1.0..=1.0, -2.0..=2.0), 0.4000001);
+        assert_eq!(remap_clamp(0.2, -1.0..=1.0, -2.0..=2.0), 0.4000001);
+        // out of range
+        assert_eq!(remap(3.0, -1.0..=1.0, -2.0..=2.0), 6.0);
+        assert_eq!(remap_clamp(3.0, -1.0..=1.0, -2.0..=2.0), 2.0);
+        // invalid remapping
+        assert!(remap(0.0, 0.0..=0.0, -2.0..=2.0).is_nan());
+        assert_eq!(remap_clamp(0.0, 0.0..=0.0, -2.0..=2.0), -2.0);
+    }
+}

--- a/crates/utils/re_math/src/utils.rs
+++ b/crates/utils/re_math/src/utils.rs
@@ -16,7 +16,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use macaw::remap;
+/// # use re_math::remap;
 /// let ocean_height = remap(0.2, -1.0..=1.0, 2.0..=3.1);
 /// ```
 ///
@@ -34,7 +34,7 @@ pub fn remap(x: f32, from: RangeInclusive<f32>, to: RangeInclusive<f32>) -> f32 
 /// # Example
 ///
 /// ```
-/// # use macaw::remap_clamp;
+/// # use re_math::remap_clamp;
 /// let ocean_height = remap_clamp(0.2, -1.0..=1.0, 2.0..=3.1);
 /// ```
 ///

--- a/crates/utils/re_math/src/vec2_ext.rs
+++ b/crates/utils/re_math/src/vec2_ext.rs
@@ -1,9 +1,6 @@
 use super::prelude::*;
-use super::vec2;
-use super::Vec2;
 
-#[cfg(target_arch = "spirv")]
-use num_traits::Float;
+use glam::{vec2, Vec2};
 
 /// Extensions to [`Vec2`]
 ///

--- a/crates/utils/re_math/src/vec2_ext.rs
+++ b/crates/utils/re_math/src/vec2_ext.rs
@@ -1,0 +1,121 @@
+use super::prelude::*;
+use super::vec2;
+use super::Vec2;
+
+#[cfg(target_arch = "spirv")]
+use num_traits::Float;
+
+/// Extensions to [`Vec2`]
+///
+/// Adds additional functionality to [`Vec2`] that [`glam`] doesn't have.
+pub trait Vec2Ext {
+    /// `x: cos(angle), y: sin(angle)` (in radians)
+    #[must_use]
+    fn from_angle(angle: f32) -> Self;
+
+    /// Angle of the vector: `y.atan2(x)`
+    #[must_use]
+    fn angle(&self) -> f32;
+
+    /// For element `i` of `self`, return `v[i].trunc()`
+    #[must_use]
+    fn trunc(self) -> Self;
+
+    /// For element `i` of the return value, returns 0.0 if `value[i] < self[i]` and 1.0 otherwise.
+    ///
+    /// Similar to glsl's step(edge, x), which translates into edge.step(x)
+    #[must_use]
+    fn step(self, value: Self) -> Self;
+
+    /// Selects between `true` and `false` based on the result of `value[i] < self[i]`
+    #[must_use]
+    fn step_select(self, value: Self, true_: Self, false_: Self) -> Self;
+
+    /// Return only the fractional parts of each component.
+    #[must_use]
+    fn fract(self) -> Self;
+
+    /// Clamp all components of `self` to the range `[0.0, 1.0]`
+    #[must_use]
+    fn saturate(self) -> Self;
+
+    /// Get the mean value of the two components
+    #[must_use]
+    fn mean(self) -> f32;
+
+    /// Returns true if both components of the vector is the same within an absolute difference of `max_abs_diff`
+    #[must_use]
+    fn has_equal_components(self, max_abs_diff: f32) -> bool;
+}
+
+impl Vec2Ext for Vec2 {
+    #[inline]
+    fn trunc(self) -> Self {
+        vec2(self.x.trunc(), self.y.trunc())
+    }
+
+    fn from_angle(angle: f32) -> Self {
+        Self::new(angle.cos(), angle.sin())
+    }
+
+    fn angle(&self) -> f32 {
+        self.y.atan2(self.x)
+    }
+
+    fn step(self, value: Self) -> Self {
+        vec2(self.x.step(value.x), self.y.step(value.y))
+    }
+
+    fn step_select(self, value: Self, less: Self, greater_or_equal: Self) -> Self {
+        vec2(
+            self.x.step_select(value.x, less.x, greater_or_equal.x),
+            self.y.step_select(value.y, less.y, greater_or_equal.y),
+        )
+    }
+
+    fn fract(self) -> Self {
+        vec2(self.x.fract(), self.y.fract())
+    }
+
+    fn saturate(self) -> Self {
+        vec2(self.x.saturate(), self.y.saturate())
+    }
+
+    fn mean(self) -> f32 {
+        (self.x + self.y) / 2.0
+    }
+
+    fn has_equal_components(self, max_abs_diff: f32) -> bool {
+        (self.x - self.y).abs() < max_abs_diff
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mean() {
+        assert!((Vec2::ONE.mean() - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_mean_2() {
+        assert!((vec2(1.0, 3.0).mean() - 2.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_has_equal_components() {
+        assert!(Vec2::ONE.has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_2() {
+        assert!(vec2(0.0, 0.00001).has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_3() {
+        assert!(!vec2(1.0, 0.0).has_equal_components(0.0001));
+    }
+}

--- a/crates/utils/re_math/src/vec3_ext.rs
+++ b/crates/utils/re_math/src/vec3_ext.rs
@@ -1,9 +1,6 @@
-use super::prelude::*;
-use super::vec3;
-use super::Vec3;
+use glam::{vec3, Vec3};
 
-#[cfg(target_arch = "spirv")]
-use num_traits::Float;
+use super::prelude::*;
 
 /// Extensions to [`Vec3`]
 ///

--- a/crates/utils/re_math/src/vec3_ext.rs
+++ b/crates/utils/re_math/src/vec3_ext.rs
@@ -1,0 +1,193 @@
+use super::prelude::*;
+use super::vec3;
+use super::Vec3;
+
+#[cfg(target_arch = "spirv")]
+use num_traits::Float;
+
+/// Extensions to [`Vec3`]
+///
+/// Adds additional functionality to [`Vec3`] that [`glam`] doesn't have.
+pub trait Vec3Ext {
+    /// For element `i` of `self`, return `v[i].trunc()`
+    #[must_use]
+    fn trunc(self) -> Self;
+
+    /// For element `i` of the return value, returns 0.0 if `value[i] < self[i]` and 1.0 otherwise.
+    ///
+    /// Similar to glsl's step(edge, x), which translates into edge.step(x)
+    #[must_use]
+    fn step(self, value: Self) -> Self;
+
+    /// Selects between `true` and `false` based on the result of `value[i] < self[i]`
+    #[must_use]
+    fn step_select(self, value: Self, true_: Self, false_: Self) -> Self;
+
+    /// Return only the fractional parts of each component.
+    #[must_use]
+    fn fract(self) -> Self;
+
+    /// Clamp all components of `self` to the range `[0.0, 1.0]`
+    #[must_use]
+    fn saturate(self) -> Self;
+
+    /// Square root of all three components.
+    #[must_use]
+    fn sqrt(self) -> Self;
+
+    /// Natural logarithm of all three components.
+    #[must_use]
+    fn ln(self) -> Self;
+
+    /// The reflection of a incident vector and surface normal.
+    #[must_use]
+    fn reflect(self, normal: Self) -> Self;
+
+    /// Get the mean value of all three components
+    #[must_use]
+    fn mean(self) -> f32;
+
+    /// Returns true if all components of the vector is the same within an absolute difference of `max_abs_diff`
+    #[must_use]
+    fn has_equal_components(self, max_abs_diff: f32) -> bool;
+}
+
+impl Vec3Ext for Vec3 {
+    /// For element `i` of `self`, return `v[i].trunc()`
+    #[inline]
+    fn trunc(self) -> Self {
+        vec3(self.x.trunc(), self.y.trunc(), self.z.trunc())
+    }
+
+    fn step(self, value: Self) -> Self {
+        vec3(
+            self.x.step(value.x),
+            self.y.step(value.y),
+            self.z.step(value.z),
+        )
+    }
+
+    fn step_select(self, value: Self, less: Self, greater_or_equal: Self) -> Self {
+        vec3(
+            self.x.step_select(value.x, less.x, greater_or_equal.x),
+            self.y.step_select(value.y, less.y, greater_or_equal.y),
+            self.z.step_select(value.z, less.z, greater_or_equal.z),
+        )
+    }
+
+    fn fract(self) -> Self {
+        vec3(self.x.fract(), self.y.fract(), self.z.fract())
+    }
+
+    fn saturate(self) -> Self {
+        vec3(self.x.saturate(), self.y.saturate(), self.z.saturate())
+    }
+
+    fn sqrt(self) -> Self {
+        vec3(self.x.sqrt(), self.y.sqrt(), self.z.sqrt())
+    }
+
+    fn ln(self) -> Self {
+        vec3(self.x.ln(), self.y.ln(), self.z.ln())
+    }
+
+    fn reflect(self, normal: Self) -> Self {
+        self - 2.0 * normal * self.dot(normal)
+    }
+
+    fn mean(self) -> f32 {
+        (self.x + self.y + self.z) / 3.0
+    }
+
+    fn has_equal_components(self, max_abs_diff: f32) -> bool {
+        (self.x - self.y).abs() < max_abs_diff
+            && (self.y - self.z).abs() < max_abs_diff
+            && (self.x - self.z).abs() < max_abs_diff
+    }
+}
+
+/// Coordinate system extension to [`Vec3`]
+///
+/// This crate is opinionated  with what coordinate system it uses and this adds
+/// additional functions to access the coordinate system axis
+///
+/// The exact coordinate system we use is right-handed with +X = right, +Y = up, -Z = forward, +Z = back
+pub trait CoordinateSystem {
+    /// A unit length vector pointing in the canonical up direction.
+    fn up() -> Self;
+
+    /// A unit length vector pointing in the canonical down direction.
+    fn down() -> Self;
+
+    /// A unit length vector pointing in the canonical right direction.
+    ///
+    /// This is the right hand side of a first person character.
+    fn right() -> Self;
+
+    /// A unit length vector pointing in the canonical left direction.
+    fn left() -> Self;
+
+    /// A unit length vector pointing in the canonical forward direction.
+    ///
+    /// This is the direction a character faces, or a car drives towards.
+    fn forward() -> Self;
+
+    /// A unit length vector pointing in the canonical back direction.
+    fn back() -> Self;
+}
+
+impl CoordinateSystem for Vec3 {
+    fn up() -> Self {
+        Self::new(0.0, 1.0, 0.0)
+    }
+
+    fn down() -> Self {
+        Self::new(0.0, -1.0, 0.0)
+    }
+
+    fn right() -> Self {
+        Self::new(1.0, 0.0, 0.0)
+    }
+
+    fn left() -> Self {
+        Self::new(-1.0, 0.0, 0.0)
+    }
+
+    fn forward() -> Self {
+        Self::new(0.0, 0.0, -1.0)
+    }
+
+    fn back() -> Self {
+        Self::new(0.0, 0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mean() {
+        assert!((Vec3::ONE.mean() - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_mean_2() {
+        assert!((vec3(1.0, 2.0, 3.0).mean() - 2.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_has_equal_components() {
+        assert!(Vec3::ONE.has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_2() {
+        assert!(vec3(0.0, 0.00001, -0.00001).has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_3() {
+        assert!(!vec3(1.0, 0.0, 0.0).has_equal_components(0.0001));
+    }
+}

--- a/crates/utils/re_math/src/vec3_ext.rs
+++ b/crates/utils/re_math/src/vec3_ext.rs
@@ -105,7 +105,7 @@ impl Vec3Ext for Vec3 {
 
 /// Coordinate system extension to [`Vec3`]
 ///
-/// This crate is opinionated  with what coordinate system it uses and this adds
+/// This crate is opinionated with what coordinate system it uses and this adds
 /// additional functions to access the coordinate system axis
 ///
 /// The exact coordinate system we use is right-handed with +X = right, +Y = up, -Z = forward, +Z = back

--- a/crates/utils/re_math/src/vec4_ext.rs
+++ b/crates/utils/re_math/src/vec4_ext.rs
@@ -1,0 +1,143 @@
+use super::prelude::*;
+use super::uvec4;
+use super::vec4;
+use super::UVec4;
+use super::Vec4;
+
+#[cfg(target_arch = "spirv")]
+use num_traits::Float;
+
+/// Extensions to [`Vec4`]
+///
+/// Adds additional functionality to [`Vec4`] that [`glam`] doesn't have.
+pub trait Vec4Ext {
+    /// For element `i` of `self`, return `v[i].trunc()`
+    #[must_use]
+    fn trunc(self) -> Self;
+
+    /// For element `i` of the return value, returns 0.0 if `value[i] < self[i]` and 1.0 otherwise.
+    ///
+    /// Similar to glsl's step(edge, x), which translates into edge.step(x)
+    #[must_use]
+    fn step(self, value: Self) -> Self;
+
+    /// Selects between `true` and `false` based on the result of `value[i] < self[i]`
+    #[must_use]
+    fn step_select(self, value: Self, true_: Self, false_: Self) -> Self;
+
+    /// Return only the fractional parts of each component.
+    #[must_use]
+    fn fract(self) -> Self;
+
+    /// Return the square root of each component.
+    #[must_use]
+    fn sqrt(self) -> Self;
+
+    /// Raw transmute each component to u32.
+    #[must_use]
+    fn to_bits(self) -> UVec4;
+
+    /// Get the mean value of all four components
+    #[must_use]
+    fn mean(self) -> f32;
+
+    /// Returns true if all components of the vector is the same within an absolute difference of `max_abs_diff`
+    #[must_use]
+    fn has_equal_components(self, max_abs_diff: f32) -> bool;
+}
+
+impl Vec4Ext for Vec4 {
+    #[inline]
+    fn trunc(self) -> Self {
+        vec4(
+            self.x.trunc(),
+            self.y.trunc(),
+            self.z.trunc(),
+            self.w.trunc(),
+        )
+    }
+
+    fn step(self, value: Self) -> Self {
+        vec4(
+            self.x.step(value.x),
+            self.y.step(value.y),
+            self.z.step(value.z),
+            self.w.step(value.z),
+        )
+    }
+
+    fn step_select(self, value: Self, less: Self, greater_or_equal: Self) -> Self {
+        vec4(
+            self.x.step_select(value.x, less.x, greater_or_equal.x),
+            self.y.step_select(value.y, less.y, greater_or_equal.y),
+            self.z.step_select(value.z, less.z, greater_or_equal.z),
+            self.w.step_select(value.w, less.w, greater_or_equal.w),
+        )
+    }
+
+    #[inline]
+    fn fract(self) -> Self {
+        vec4(
+            self.x.fract(),
+            self.y.fract(),
+            self.z.fract(),
+            self.w.fract(),
+        )
+    }
+
+    fn sqrt(self) -> Self {
+        vec4(self.x.sqrt(), self.y.sqrt(), self.z.sqrt(), self.w.sqrt())
+    }
+
+    fn to_bits(self) -> UVec4 {
+        uvec4(
+            self.x.to_bits(),
+            self.y.to_bits(),
+            self.z.to_bits(),
+            self.w.to_bits(),
+        )
+    }
+
+    fn mean(self) -> f32 {
+        (self.x + self.y + self.z + self.w) / 4.0
+    }
+
+    fn has_equal_components(self, max_abs_diff: f32) -> bool {
+        (self.x - self.y).abs() < max_abs_diff
+            && (self.y - self.z).abs() < max_abs_diff
+            && (self.x - self.z).abs() < max_abs_diff
+            && (self.w - self.x).abs() < max_abs_diff
+            && (self.w - self.y).abs() < max_abs_diff
+            && (self.w - self.z).abs() < max_abs_diff
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_mean() {
+        assert!((Vec4::ONE.mean() - 1.0).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_mean_2() {
+        assert!((vec4(1.0, 2.0, 3.0, 4.0).mean() - 2.5).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_has_equal_components() {
+        assert!(Vec4::ONE.has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_2() {
+        assert!(vec4(0.0, 0.00001, -0.00001, 0.0).has_equal_components(0.001));
+    }
+
+    #[test]
+    fn test_has_equal_components_3() {
+        assert!(!vec4(1.0, 0.0, 0.0, 0.0).has_equal_components(0.0001));
+    }
+}

--- a/crates/utils/re_math/src/vec4_ext.rs
+++ b/crates/utils/re_math/src/vec4_ext.rs
@@ -1,11 +1,6 @@
-use super::prelude::*;
-use super::uvec4;
-use super::vec4;
-use super::UVec4;
-use super::Vec4;
+use glam::{uvec4, vec4, UVec4, Vec4};
 
-#[cfg(target_arch = "spirv")]
-use num_traits::Float;
+use super::prelude::*;
 
 /// Extensions to [`Vec4`]
 ///

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -50,6 +50,7 @@ serde = ["dep:serde"]
 [dependencies]
 re_error.workspace = true
 re_log.workspace = true
+re_math.workspace = true
 re_tracing.workspace = true
 
 ahash.workspace = true
@@ -64,7 +65,6 @@ enumset.workspace = true
 glam = { workspace = true, features = ["bytemuck"] }
 half = { workspace = true, features = ["bytemuck"] }
 itertools = { workspace = true }
-macaw.workspace = true
 never.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true

--- a/crates/viewer/re_renderer/src/importer/mod.rs
+++ b/crates/viewer/re_renderer/src/importer/mod.rs
@@ -7,7 +7,7 @@ pub mod gltf;
 #[cfg(feature = "import-stl")]
 pub mod stl;
 
-use macaw::Vec3Ext as _;
+use re_math::Vec3Ext as _;
 
 use crate::renderer::MeshInstance;
 
@@ -21,8 +21,8 @@ pub fn to_uniform_scale(scale: glam::Vec3) -> f32 {
     }
 }
 
-pub fn calculate_bounding_box(instances: &[MeshInstance]) -> macaw::BoundingBox {
-    macaw::BoundingBox::from_points(
+pub fn calculate_bounding_box(instances: &[MeshInstance]) -> re_math::BoundingBox {
+    re_math::BoundingBox::from_points(
         instances
             .iter()
             .filter_map(|mesh_instance| {

--- a/crates/viewer/re_renderer/src/line_drawable_builder.rs
+++ b/crates/viewer/re_renderer/src/line_drawable_builder.rs
@@ -356,7 +356,7 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
     #[inline]
     pub fn add_box_outline(
         &mut self,
-        bbox: &macaw::BoundingBox,
+        bbox: &re_math::BoundingBox,
     ) -> Option<LineStripBuilder<'_, 'ctx>> {
         if !bbox.is_something() || !bbox.is_finite() {
             return None;

--- a/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
@@ -168,7 +168,7 @@ pub struct DepthCloud {
 
 impl DepthCloud {
     /// World-space bounding-box.
-    pub fn world_space_bbox(&self) -> macaw::BoundingBox {
+    pub fn world_space_bbox(&self) -> re_math::BoundingBox {
         let max_depth = self.max_depth_in_world;
         let w = self.depth_dimensions.x as f32;
         let h = self.depth_dimensions.y as f32;
@@ -184,7 +184,7 @@ impl DepthCloud {
         let focal_length = glam::vec2(intrinsics.col(0).x, intrinsics.col(1).y);
         let offset = intrinsics.col(2).truncate();
 
-        let mut bbox = macaw::BoundingBox::nothing();
+        let mut bbox = re_math::BoundingBox::nothing();
 
         for corner in corners {
             let depth = corner.z;

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -119,7 +119,7 @@ pub struct MeshInstance {
     pub mesh: Option<Arc<Mesh>>,
 
     /// Where this instance is placed in world space and how its oriented & scaled.
-    pub world_from_mesh: macaw::Affine3A,
+    pub world_from_mesh: glam::Affine3A,
 
     /// Per-instance (as opposed to per-material/mesh!) tint color that is added to the albedo texture.
     /// Alpha channel is currently unused.
@@ -137,7 +137,7 @@ impl Default for MeshInstance {
         Self {
             gpu_mesh: GpuMeshHandle::Invalid,
             mesh: None,
-            world_from_mesh: macaw::Affine3A::IDENTITY,
+            world_from_mesh: glam::Affine3A::IDENTITY,
             additive_tint: Color32::TRANSPARENT,
             outline_mask_ids: OutlineMaskPreference::NONE,
             picking_layer_id: PickingLayerId::default(),

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -192,7 +192,7 @@ pub struct TargetConfiguration {
 
     /// The viewport resolution in physical pixels.
     pub resolution_in_pixel: [u32; 2],
-    pub view_from_world: macaw::IsoTransform,
+    pub view_from_world: re_math::IsoTransform,
     pub projection_from_view: Projection,
 
     /// Defines a viewport transformation from the projected space to the final image space.

--- a/crates/viewer/re_renderer_examples/2d.rs
+++ b/crates/viewer/re_renderer_examples/2d.rs
@@ -298,7 +298,7 @@ impl framework::Example for Render2D {
                     TargetConfiguration {
                         name: "2D".into(),
                         resolution_in_pixel: splits[0].resolution_in_pixel,
-                        view_from_world: macaw::IsoTransform::IDENTITY,
+                        view_from_world: re_math::IsoTransform::IDENTITY,
                         projection_from_view: Projection::Orthographic {
                             camera_mode:
                                 view_builder::OrthographicCameraMode::TopLeftCornerAndExtendZ,
@@ -336,7 +336,7 @@ impl framework::Example for Render2D {
                     view_builder::TargetConfiguration {
                         name: "3D".into(),
                         resolution_in_pixel: splits[1].resolution_in_pixel,
-                        view_from_world: macaw::IsoTransform::look_at_rh(
+                        view_from_world: re_math::IsoTransform::look_at_rh(
                             camera_position,
                             camera_rotation_center,
                             glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/Cargo.toml
+++ b/crates/viewer/re_renderer_examples/Cargo.toml
@@ -39,6 +39,7 @@ path = "picking.rs"
 
 [dependencies]
 re_log = { workspace = true, features = ["setup"] }
+re_math.workspace = true
 re_renderer = { workspace = true, features = ["import-obj", "import-gltf"] }
 
 ahash.workspace = true
@@ -47,7 +48,6 @@ bytemuck.workspace = true
 glam.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
-macaw.workspace = true
 pollster.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 web-time.workspace = true

--- a/crates/viewer/re_renderer_examples/depth_cloud.rs
+++ b/crates/viewer/re_renderer_examples/depth_cloud.rs
@@ -20,7 +20,7 @@ use std::f32::consts::TAU;
 
 use glam::Vec3;
 use itertools::Itertools;
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 use re_renderer::{
     renderer::{
         ColormappedTexture, DepthCloud, DepthCloudDrawData, DepthClouds, DrawData,

--- a/crates/viewer/re_renderer_examples/depth_offset.rs
+++ b/crates/viewer/re_renderer_examples/depth_offset.rs
@@ -102,7 +102,7 @@ impl framework::Example for Render2D {
             view_builder::TargetConfiguration {
                 name: "3D".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     glam::Vec3::Z * 2.0 * self.distance_scale,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -8,8 +8,8 @@ use std::f32::consts::TAU;
 use framework::Example;
 use glam::Vec3;
 use itertools::Itertools;
-use macaw::IsoTransform;
 use rand::Rng;
+use re_math::IsoTransform;
 
 use re_renderer::{
     renderer::{

--- a/crates/viewer/re_renderer_examples/outlines.rs
+++ b/crates/viewer/re_renderer_examples/outlines.rs
@@ -57,7 +57,7 @@ impl framework::Example for Outlines {
             TargetConfiguration {
                 name: "OutlinesDemo".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     camera_position,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/picking.rs
+++ b/crates/viewer/re_renderer_examples/picking.rs
@@ -128,7 +128,7 @@ impl framework::Example for Picking {
             TargetConfiguration {
                 name: "OutlinesDemo".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     camera_position,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_space_view_spatial/Cargo.toml
+++ b/crates/viewer/re_space_view_spatial/Cargo.toml
@@ -26,6 +26,7 @@ re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
+re_math = { workspace = true, features = ["serde"] }
 re_query.workspace = true
 re_renderer = { workspace = true, features = [
   "import-gltf",
@@ -46,7 +47,6 @@ bytemuck.workspace = true
 egui = { workspace = true, features = ["serde"] }
 glam.workspace = true
 itertools.workspace = true
-macaw = { workspace = true, features = ["with_serde"] }
 nohash-hasher.workspace = true
 once_cell.workspace = true
 serde.workspace = true

--- a/crates/viewer/re_space_view_spatial/src/eye.rs
+++ b/crates/viewer/re_space_view_spatial/src/eye.rs
@@ -1,5 +1,7 @@
 use egui::{lerp, NumExt as _, Rect};
-use macaw::{vec3, IsoTransform, Mat4, Quat, Vec3};
+use glam::{vec3, Mat4, Quat, Vec3};
+
+use re_math::IsoTransform;
 
 use re_space_view::controls::{
     RuntimeModifiers, DRAG_PAN3D_BUTTON, ROLL_MOUSE, ROLL_MOUSE_ALT, ROLL_MOUSE_MODIFIER,
@@ -85,7 +87,7 @@ impl Eye {
 
     /// Picking ray for a given pointer in the parent space
     /// (i.e. prior to camera transform, "world" space)
-    pub fn picking_ray(&self, screen_rect: Rect, pointer: glam::Vec2) -> macaw::Ray3 {
+    pub fn picking_ray(&self, screen_rect: Rect, pointer: glam::Vec2) -> re_math::Ray3 {
         if let Some(fov_y) = self.fov_y {
             let (w, h) = (screen_rect.width(), screen_rect.height());
             let aspect_ratio = w / h;
@@ -95,7 +97,7 @@ impl Eye {
             let ray_dir = self
                 .world_from_rub_view
                 .transform_vector3(glam::vec3(px, py, -1.0));
-            macaw::Ray3::from_origin_dir(self.pos_in_world(), ray_dir.normalize_or_zero())
+            re_math::Ray3::from_origin_dir(self.pos_in_world(), ray_dir.normalize_or_zero())
         } else {
             // The ray originates on the camera plane, not from the camera position
             let ray_dir = self.world_from_rub_view.rotation().mul_vec3(glam::Vec3::Z);
@@ -104,7 +106,7 @@ impl Eye {
                 + self.world_from_rub_view.rotation().mul_vec3(glam::Vec3::Y) * pointer.y
                 + ray_dir * self.near();
 
-            macaw::Ray3::from_origin_dir(origin, ray_dir)
+            re_math::Ray3::from_origin_dir(origin, ray_dir)
         }
     }
 

--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -15,7 +15,7 @@ pub struct LoadedMesh {
     // Can't do that right now because it's too hard to pass the render context through.
     pub mesh_instances: Vec<re_renderer::renderer::MeshInstance>,
 
-    bbox: macaw::BoundingBox,
+    bbox: re_math::BoundingBox,
 }
 
 impl LoadedMesh {
@@ -149,7 +149,7 @@ impl LoadedMesh {
 
         let bbox = {
             re_tracing::profile_scope!("bbox");
-            macaw::BoundingBox::from_points(vertex_positions.iter().copied())
+            re_math::BoundingBox::from_points(vertex_positions.iter().copied())
         };
 
         let albedo = if let Some(albedo_texture) = &albedo_texture {
@@ -197,7 +197,7 @@ impl LoadedMesh {
         &self.name
     }
 
-    pub fn bbox(&self) -> macaw::BoundingBox {
+    pub fn bbox(&self) -> re_math::BoundingBox {
         self.bbox
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/picking.rs
+++ b/crates/viewer/re_space_view_spatial/src/picking.rs
@@ -73,7 +73,7 @@ pub struct PickingContext {
     pub pointer_in_space2d: glam::Vec2,
 
     /// The picking ray used. Given in the coordinates of the space the picking is performed in.
-    pub ray_in_world: macaw::Ray3,
+    pub ray_in_world: re_math::Ray3,
 }
 
 impl PickingContext {
@@ -257,7 +257,7 @@ fn picking_textured_rects<'a>(
             continue; // extent_u and extent_v are parallel. Shouldn't happen.
         };
 
-        let rect_plane = macaw::Plane3::from_normal_point(normal, rect.top_left_corner_position);
+        let rect_plane = re_math::Plane3::from_normal_point(normal, rect.top_left_corner_position);
 
         // TODO(andreas): Interaction radius is currently ignored for rects.
         let (intersect, t) =

--- a/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
+++ b/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
@@ -8,22 +8,22 @@ use crate::visualizers::SpatialViewVisualizerData;
 #[derive(Clone)]
 pub struct SceneBoundingBoxes {
     /// Overall bounding box of the scene for the current query.
-    pub current: macaw::BoundingBox,
+    pub current: re_math::BoundingBox,
 
     /// A bounding box that smoothly transitions to the current bounding box.
     ///
     /// If discontinuities are detected, this bounding box will be reset immediately to the current bounding box.
-    pub smoothed: macaw::BoundingBox,
+    pub smoothed: re_math::BoundingBox,
 
     /// Per-entity bounding boxes for the current query.
-    pub per_entity: IntMap<EntityPathHash, macaw::BoundingBox>,
+    pub per_entity: IntMap<EntityPathHash, re_math::BoundingBox>,
 }
 
 impl Default for SceneBoundingBoxes {
     fn default() -> Self {
         Self {
-            current: macaw::BoundingBox::nothing(),
-            smoothed: macaw::BoundingBox::nothing(),
+            current: re_math::BoundingBox::nothing(),
+            smoothed: re_math::BoundingBox::nothing(),
             per_entity: IntMap::default(),
         }
     }
@@ -34,7 +34,7 @@ impl SceneBoundingBoxes {
         re_tracing::profile_function!();
 
         let previous = self.current;
-        self.current = macaw::BoundingBox::nothing();
+        self.current = re_math::BoundingBox::nothing();
         self.per_entity.clear();
 
         for visualizer in visualizers.iter() {
@@ -79,7 +79,7 @@ impl SceneBoundingBoxes {
             let new_smoothed_size = self.smoothed.size().lerp(current_size, smoothing_factor);
 
             self.smoothed =
-                macaw::BoundingBox::from_center_size(new_smoothed_center, new_smoothed_size);
+                re_math::BoundingBox::from_center_size(new_smoothed_center, new_smoothed_size);
 
             let current_diagonal_length = current_size.length();
             let sameness_threshold = current_diagonal_length * (0.1 / 100.0); // 0.1% of the diagonal.
@@ -94,8 +94,8 @@ impl SceneBoundingBoxes {
 }
 
 fn detect_boundingbox_discontinuity(
-    current: macaw::BoundingBox,
-    previous: macaw::BoundingBox,
+    current: re_math::BoundingBox,
+    previous: re_math::BoundingBox,
 ) -> bool {
     if !previous.is_finite() {
         // Previous bounding box is not finite, so we can't compare.

--- a/crates/viewer/re_space_view_spatial/src/space_camera_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/space_camera_3d.rs
@@ -1,5 +1,5 @@
 use glam::Vec3;
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 
 use re_log_types::EntityPath;
 use re_types::archetypes::Pinhole;

--- a/crates/viewer/re_space_view_spatial/src/ui.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use egui::{epaint::util::OrderedFloat, text::TextWrapping, NumExt, WidgetText};
-use macaw::BoundingBox;
+use re_math::BoundingBox;
 
 use re_data_ui::{
     item_ui, show_zoomed_image_region, show_zoomed_image_region_area_outline, DataUi,

--- a/crates/viewer/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_2d.rs
@@ -1,5 +1,5 @@
 use egui::{emath::RectTransform, pos2, vec2, Align2, Color32, Pos2, Rect, Shape, Vec2};
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 
 use re_entity_db::EntityPath;
 use re_log::ResultExt as _;
@@ -371,7 +371,7 @@ fn setup_target_config(
     let focal_length = 2.0 / (1.0 / focal_length.x() + 1.0 / focal_length.y()); // harmonic mean (lack of anamorphic support)
 
     // Position the camera looking straight at the principal point:
-    let view_from_world = macaw::IsoTransform::look_at_rh(
+    let view_from_world = re_math::IsoTransform::look_at_rh(
         pinhole.principal_point().extend(-focal_length),
         pinhole.principal_point().extend(0.0),
         -glam::Vec3::Y,

--- a/crates/viewer/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_3d.rs
@@ -1,9 +1,11 @@
 use egui::{emath::RectTransform, NumExt as _};
 use glam::Affine3A;
-use macaw::{BoundingBox, Quat, Vec3};
+use glam::{Quat, Vec3};
+use web_time::Instant;
+
+use re_math::BoundingBox;
 use re_ui::ContextExt;
 use re_viewport_blueprint::ViewProperty;
-use web_time::Instant;
 
 use re_log_types::EntityPath;
 use re_renderer::{
@@ -520,7 +522,7 @@ impl SpatialSpaceView3D {
             let axis_length = 1.0; // The axes are also a measuring stick
             crate::visualizers::add_axis_arrows(
                 &mut line_builder,
-                macaw::Affine3A::IDENTITY,
+                glam::Affine3A::IDENTITY,
                 None,
                 axis_length,
                 re_renderer::OutlineMaskPreference::NONE,
@@ -837,7 +839,7 @@ fn show_projections_from_2d_space(
                     let origin = cam.position();
 
                     if let Some(dir) = (stop_in_world - origin).try_normalize() {
-                        let ray = macaw::Ray3::from_origin_dir(origin, dir);
+                        let ray = re_math::Ray3::from_origin_dir(origin, dir);
 
                         let thick_ray_length = (stop_in_world - origin).length();
                         add_picking_ray(
@@ -864,7 +866,7 @@ fn show_projections_from_2d_space(
                 {
                     let cam_to_pos = *pos - tracked_camera.position();
                     let distance = cam_to_pos.length();
-                    let ray = macaw::Ray3::from_origin_dir(
+                    let ray = re_math::Ray3::from_origin_dir(
                         tracked_camera.position(),
                         cam_to_pos / distance,
                     );
@@ -884,7 +886,7 @@ fn show_projections_from_2d_space(
 
 fn add_picking_ray(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
-    ray: macaw::Ray3,
+    ray: re_math::Ray3,
     scene_bbox: &BoundingBox,
     thick_ray_length: f32,
     ray_color: egui::Color32,
@@ -908,7 +910,7 @@ fn add_picking_ray(
 }
 
 fn default_eye(
-    bounding_box: &macaw::BoundingBox,
+    bounding_box: &re_math::BoundingBox,
     scene_view_coordinates: Option<ViewCoordinates>,
 ) -> ViewEye {
     // Defaults to RFU.

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -78,7 +78,7 @@ impl Arrows2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
 
             let origins =
                 clamped(data.origins, num_instances).chain(std::iter::repeat(&Position2D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -78,7 +78,7 @@ impl Arrows3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
 
             let origins =
                 clamped(data.origins, num_instances).chain(std::iter::repeat(&Position3D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -127,7 +127,7 @@ impl Boxes2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
 
             let centers =
                 clamped(data.centers, num_instances).chain(std::iter::repeat(&Position2D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -74,7 +74,7 @@ impl Boxes3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
 
             let centers =
                 clamped(data.centers, num_instances).chain(std::iter::repeat(&Position3D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
@@ -67,7 +67,7 @@ impl CamerasVisualizer {
             self.space_cameras.push(SpaceCamera3D {
                 ent_path: ent_path.clone(),
                 pinhole_view_coordinates,
-                world_from_camera: macaw::IsoTransform::IDENTITY,
+                world_from_camera: re_math::IsoTransform::IDENTITY,
                 pinhole: Some(pinhole.clone()),
                 picture_plane_distance: frustum_length,
             });
@@ -86,7 +86,7 @@ impl CamerasVisualizer {
             let world_from_parent = ent_path
                 .parent()
                 .and_then(|parent_path| transforms.reference_from_entity(&parent_path))
-                .unwrap_or(macaw::Affine3A::IDENTITY);
+                .unwrap_or(glam::Affine3A::IDENTITY);
 
             // Then combine it with the transform at the entity itself, if there is one.
             if let Some(transform_at_entity) = transform_at_entity {
@@ -99,7 +99,7 @@ impl CamerasVisualizer {
         // If this transform is not representable as an `IsoTransform` we can't display it yet.
         // This would happen if the camera is under another camera or under a transform with non-uniform scale.
         let Some(world_from_camera_rigid_iso) =
-            macaw::IsoTransform::from_mat4(&world_from_camera_rigid.into())
+            re_math::IsoTransform::from_mat4(&world_from_camera_rigid.into())
         else {
             return;
         };

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -76,7 +76,7 @@ impl Lines2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
             for (i, (strip, radius, &color)) in
                 itertools::izip!(data.strips, radii, &colors).enumerate()
             {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -78,7 +78,7 @@ impl Lines3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::nothing();
 
             let mut num_rendered_strips = 0usize;
             for (i, (strip, radius, &color)) in

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -118,7 +118,7 @@ impl Points2DVisualizer {
                 }
             }
 
-            let obj_space_bounding_box = macaw::BoundingBox::from_points(positions.iter().copied());
+            let obj_space_bounding_box = re_math::BoundingBox::from_points(positions.iter().copied());
             self.data.add_bounding_box(
                 entity_path.hash(),
                 obj_space_bounding_box,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -123,7 +123,7 @@ impl Points3DVisualizer {
                 }
             }
 
-            let obj_space_bounding_box = macaw::BoundingBox::from_points(positions.iter().copied());
+            let obj_space_bounding_box = re_math::BoundingBox::from_points(positions.iter().copied());
             self.data.add_bounding_box(
                 entity_path.hash(),
                 obj_space_bounding_box,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -81,7 +81,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
             // Only add the center to the bounding box - the lines may be dependent on the bounding box, causing a feedback loop otherwise.
             self.0.add_bounding_box(
                 data_result.entity_path.hash(),
-                macaw::BoundingBox::ZERO,
+                re_math::BoundingBox::ZERO,
                 world_from_obj,
             );
 
@@ -123,7 +123,7 @@ const AXIS_COLOR_Z: Color32 = Color32::from_rgb(80, 80, 255);
 
 pub fn add_axis_arrows(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
-    world_from_obj: macaw::Affine3A,
+    world_from_obj: glam::Affine3A,
     ent_path: Option<&EntityPath>,
     axis_length: f32,
     outline_mask_ids: re_renderer::OutlineMaskPreference,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
@@ -8,7 +8,7 @@ use crate::view_kind::SpatialSpaceViewKind;
 /// Each spatial scene element is expected to fill an instance of this struct with its data.
 pub struct SpatialViewVisualizerData {
     pub ui_labels: Vec<UiLabel>,
-    pub bounding_boxes: Vec<(EntityPathHash, macaw::BoundingBox)>,
+    pub bounding_boxes: Vec<(EntityPathHash, re_math::BoundingBox)>,
     pub preferred_view_kind: Option<SpatialSpaceViewKind>,
 }
 
@@ -24,7 +24,7 @@ impl SpatialViewVisualizerData {
     pub fn add_bounding_box(
         &mut self,
         entity: EntityPathHash,
-        bbox: macaw::BoundingBox,
+        bbox: re_math::BoundingBox,
         world_from_obj: glam::Affine3A,
     ) {
         self.bounding_boxes
@@ -40,7 +40,7 @@ impl SpatialViewVisualizerData {
         re_tracing::profile_function!();
         self.add_bounding_box(
             entity,
-            macaw::BoundingBox::from_points(points),
+            re_math::BoundingBox::from_points(points),
             world_from_obj,
         );
     }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/textured_rect.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/textured_rect.rs
@@ -88,12 +88,12 @@ pub fn tensor_to_textured_rect(
 
 pub fn bounding_box_for_textured_rect(
     textured_rect: &renderer::TexturedRect,
-) -> macaw::BoundingBox {
+) -> re_math::BoundingBox {
     let left_top = textured_rect.top_left_corner_position;
     let extent_u = textured_rect.extent_u;
     let extent_v = textured_rect.extent_v;
 
-    macaw::BoundingBox::from_points(
+    re_math::BoundingBox::from_points(
         [
             left_top,
             left_top + extent_u,

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -19,14 +19,15 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_chunk_store.workspace = true
 re_chunk.workspace = true
 re_data_source.workspace = true
-re_chunk_store.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
 re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
+re_math.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_smart_channel.workspace = true
@@ -50,7 +51,6 @@ half.workspace = true
 indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
 linked-hash-map.workspace = true
-macaw.workspace = true
 ndarray.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -174,7 +174,7 @@ pub fn render_image(
     let target_config = re_renderer::view_builder::TargetConfiguration {
         name: debug_name.into(),
         resolution_in_pixel,
-        view_from_world: macaw::IsoTransform::from_translation(-top_left_position.extend(0.0)),
+        view_from_world: re_math::IsoTransform::from_translation(-top_left_position.extend(0.0)),
         projection_from_view: re_renderer::view_builder::Projection::Orthographic {
             camera_mode: re_renderer::view_builder::OrthographicCameraMode::TopLeftCornerAndExtendZ,
             vertical_world_size: space_from_pixel * resolution_in_pixel[1] as f32,


### PR DESCRIPTION
### What
[macaw](https://crates.io/crates/macaw) (which I was one of the main contributors at Embark) is no longer maintained. This is holding us back from updating `glam`:

* https://github.com/rerun-io/rerun/issues/6467

`macaw` was never published as repository anywhere, so I just copied the code from it (it's Apache2/MIT) and modernized it slightly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
