### PR TITLE
`Chunk` concatenation primitives

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -24,6 +24,9 @@ pub enum ChunkError {
     Malformed { reason: String },
 
     #[error(transparent)]
+    Arrow(#[from] arrow2::error::Error),
+
+    #[error(transparent)]
     Serialization(#[from] SerializationError),
 }
 
@@ -898,8 +901,6 @@ impl re_types_core::SizeBytes for ChunkTimeline {
             + time_range.heap_size_bytes()
     }
 }
-
-// TODO(cmc): methods to merge chunks (compaction).
 
 // --- Sanity checks ---
 

--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -9,6 +9,7 @@ mod chunk;
 mod id;
 mod iter;
 mod latest_at;
+mod merge;
 mod range;
 mod shuffle;
 mod slice;

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -29,13 +29,6 @@ impl Chunk {
             });
         }
 
-        if cr.is_empty() {
-            return Ok(cl.clone());
-        }
-        if cl.is_empty() {
-            return Ok(cr.clone());
-        }
-
         let Some((_cl0, cl1)) = cl.row_id_range() else {
             return Ok(cr.clone()); // `cl` is empty (`cr` might be too, that's fine)
         };

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -1,0 +1,784 @@
+use std::collections::BTreeMap;
+
+use arrow2::array::{
+    Array as ArrowArray, ListArray as ArrowListArray, PrimitiveArray as ArrowPrimitiveArray,
+    StructArray as ArrowStructArray,
+};
+use itertools::{izip, Itertools};
+
+use crate::{Chunk, ChunkError, ChunkId, ChunkResult, ChunkTimeline};
+
+// ---
+
+impl Chunk {
+    /// Concatenates two `Chunk`s into a new one.
+    ///
+    /// The order of the arguments matter: `self`'s contents will precede `rhs`' contents in the
+    /// returned `Chunk`.
+    ///
+    /// This will return an error if the chunks are not [concatenable].
+    ///
+    /// [concatenable]: [`Chunk::concatenable`]
+    pub fn concatenated(&self, rhs: &Self) -> ChunkResult<Self> {
+        let cl = self;
+        let cr = rhs;
+
+        if !cl.concatenable(cr) {
+            return Err(ChunkError::Malformed {
+                reason: "cannot concatenate incompatible Chunks:\n{cl}\n{cr}".to_owned(),
+            });
+        }
+
+        if cr.is_empty() {
+            return Ok(cl.clone());
+        }
+        if cl.is_empty() {
+            return Ok(cr.clone());
+        }
+
+        let Some((_cl0, cl1)) = cl.row_id_range() else {
+            return Ok(cr.clone()); // `cl` is empty (`cr` might be too, that's fine)
+        };
+        let Some((cr0, _cr1)) = cr.row_id_range() else {
+            return Ok(cl.clone());
+        };
+
+        let is_sorted = cl.is_sorted && cr.is_sorted && cl1 <= cr0;
+
+        let row_ids = arrow2::compute::concatenate::concatenate(&[&cl.row_ids, &cr.row_ids])?;
+        #[allow(clippy::unwrap_used)] // concatenating 2 RowId arrays must yield another RowId array
+        let row_ids = row_ids
+            .as_any()
+            .downcast_ref::<ArrowStructArray>()
+            .unwrap()
+            .clone();
+
+        // NOTE: We know they are the same set, and they are in a btree => we can zip them.
+        let timelines = izip!(self.timelines.iter(), rhs.timelines.iter())
+            .filter_map(
+                |((lhs_timeline, lhs_time_chunk), (rhs_timeline, rhs_time_chunk))| {
+                    debug_assert_eq!(lhs_timeline, rhs_timeline);
+                    lhs_time_chunk
+                        .concatenated(rhs_time_chunk)
+                        .map(|time_chunk| (*lhs_timeline, time_chunk))
+                },
+            )
+            .collect();
+
+        // First pass: concat right onto left.
+        let mut components: BTreeMap<_, _> = self
+            .components
+            .iter()
+            .filter_map(|(component_name, lhs_list_array)| {
+                if let Some(rhs_list_array) = rhs.components.get(component_name) {
+                    let list_array = arrow2::compute::concatenate::concatenate(&[
+                        lhs_list_array,
+                        rhs_list_array,
+                    ])
+                    .ok()?;
+                    let list_array = list_array
+                        .as_any()
+                        .downcast_ref::<ArrowListArray<i32>>()?
+                        .clone();
+                    Some((*component_name, list_array))
+                } else {
+                    Some((
+                        *component_name,
+                        crate::util::pad_list_array_back(
+                            lhs_list_array,
+                            self.num_rows() + rhs.num_rows(),
+                        ),
+                    ))
+                }
+            })
+            .collect();
+
+        // Second pass: concat left onto right, where necessary.
+        components.extend(
+            rhs.components
+                .iter()
+                .filter_map(|(component_name, rhs_list_array)| {
+                    if components.contains_key(component_name) {
+                        // Already did that one during the first pass.
+                        return None;
+                    }
+
+                    if let Some(lhs_list_array) = self.components.get(component_name) {
+                        let list_array = arrow2::compute::concatenate::concatenate(&[
+                            lhs_list_array,
+                            rhs_list_array,
+                        ])
+                        .ok()?;
+                        let list_array = list_array
+                            .as_any()
+                            .downcast_ref::<ArrowListArray<i32>>()?
+                            .clone();
+                        Some((*component_name, list_array))
+                    } else {
+                        Some((
+                            *component_name,
+                            crate::util::pad_list_array_front(
+                                rhs_list_array,
+                                self.num_rows() + rhs.num_rows(),
+                            ),
+                        ))
+                    }
+                })
+                .collect_vec(),
+        );
+
+        let chunk = Self {
+            id: ChunkId::new(),
+            entity_path: cl.entity_path.clone(),
+            heap_size_bytes: Default::default(),
+            is_sorted,
+            row_ids,
+            timelines,
+            components,
+        };
+
+        chunk.sanity_check()?;
+
+        Ok(chunk)
+    }
+
+    /// Returns `true` if `self` and `rhs` overlap on their `RowId` range.
+    #[inline]
+    pub fn overlaps_on_row_id(&self, rhs: &Self) -> bool {
+        let cl = self;
+        let cr = rhs;
+
+        let Some((cl0, cl1)) = cl.row_id_range() else {
+            return false;
+        };
+        let Some((cr0, cr1)) = cr.row_id_range() else {
+            return false;
+        };
+
+        cl0 <= cr1 && cr0 <= cl1
+    }
+
+    /// Returns `true` if `self` and `rhs` overlap on any of their time range(s).
+    ///
+    /// This does not imply that they share the same exact set of timelines.
+    #[inline]
+    pub fn overlaps_on_time(&self, rhs: &Self) -> bool {
+        self.timelines.iter().any(|(timeline, cl_time_chunk)| {
+            if let Some(cr_time_chunk) = rhs.timelines.get(timeline) {
+                cl_time_chunk
+                    .time_range()
+                    .intersects(cr_time_chunk.time_range())
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Returns `true` if both chunks share the same entity path.
+    #[inline]
+    pub fn same_entity_paths(&self, rhs: &Self) -> bool {
+        self.entity_path() == rhs.entity_path()
+    }
+
+    /// Returns `true` if both chunks contains the same set of timelines.
+    #[inline]
+    pub fn same_timelines(&self, rhs: &Self) -> bool {
+        self.timelines.len() == rhs.timelines.len()
+            && self.timelines.keys().collect_vec() == rhs.timelines.keys().collect_vec()
+    }
+
+    /// Returns `true` if both chunks share the same datatypes for the components that
+    /// _they have in common_.
+    #[inline]
+    pub fn same_datatypes(&self, rhs: &Self) -> bool {
+        self.components
+            .iter()
+            .all(|(component_name, lhs_list_array)| {
+                if let Some(rhs_list_array) = rhs.components.get(component_name) {
+                    lhs_list_array.data_type() == rhs_list_array.data_type()
+                } else {
+                    true
+                }
+            })
+    }
+
+    /// Returns true if two chunks are concatenable.
+    ///
+    /// To be concatenable, two chunks must:
+    /// * Share the same entity path.
+    /// * Share the same exact set of timelines.
+    /// * Use the same datatypes for the components they have in common.
+    #[inline]
+    pub fn concatenable(&self, rhs: &Self) -> bool {
+        self.same_entity_paths(rhs) && self.same_timelines(rhs) && self.same_datatypes(rhs)
+    }
+}
+
+impl ChunkTimeline {
+    /// Concatenates two `ChunkTimeline`s into a new one.
+    ///
+    /// The order of the arguments matter: `self`'s contents will precede `rhs`' contents in the
+    /// returned `ChunkTimeline`.
+    ///
+    /// This will return `None` if the time chunks do not share the same timeline.
+    pub fn concatenated(&self, rhs: &Self) -> Option<Self> {
+        if self.timeline != rhs.timeline {
+            return None;
+        }
+
+        let is_sorted =
+            self.is_sorted && rhs.is_sorted && self.time_range.max() <= rhs.time_range.min();
+
+        let time_range = self.time_range.union(rhs.time_range);
+
+        let times = arrow2::compute::concatenate::concatenate(&[&self.times, &rhs.times]).ok()?;
+        let times = times
+            .as_any()
+            .downcast_ref::<ArrowPrimitiveArray<i64>>()?
+            .clone();
+
+        Some(Self {
+            timeline: self.timeline,
+            times,
+            is_sorted,
+            time_range,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoint64};
+    use re_types_core::Loggable;
+
+    use crate::{Chunk, RowId, Timeline};
+
+    #[test]
+    fn homogeneous() -> anyhow::Result<()> {
+        let entity_path = "my/entity";
+
+        let row_id1 = RowId::new();
+        let row_id2 = RowId::new();
+        let row_id3 = RowId::new();
+        let row_id4 = RowId::new();
+        let row_id5 = RowId::new();
+
+        let timepoint1 = [
+            (Timeline::log_time(), 1000),
+            (Timeline::new_sequence("frame"), 1),
+        ];
+        let timepoint2 = [
+            (Timeline::log_time(), 1032),
+            (Timeline::new_sequence("frame"), 3),
+        ];
+        let timepoint3 = [
+            (Timeline::log_time(), 1064),
+            (Timeline::new_sequence("frame"), 5),
+        ];
+        let timepoint4 = [
+            (Timeline::log_time(), 1096),
+            (Timeline::new_sequence("frame"), 7),
+        ];
+        let timepoint5 = [
+            (Timeline::log_time(), 1128),
+            (Timeline::new_sequence("frame"), 9),
+        ];
+
+        let points1 = &[MyPoint::new(1.0, 1.0), MyPoint::new(2.0, 2.0)];
+        let points3 = &[
+            MyPoint::new(3.0, 3.0),
+            MyPoint::new(4.0, 4.0),
+            MyPoint::new(5.0, 5.0),
+        ];
+        let points5 = &[MyPoint::new(6.0, 7.0)];
+
+        let colors2 = &[MyColor::from_rgb(1, 1, 1)];
+        let colors4 = &[MyColor::from_rgb(2, 2, 2), MyColor::from_rgb(3, 3, 3)];
+
+        let labels2 = &[
+            MyLabel("a".into()),
+            MyLabel("b".into()),
+            MyLabel("c".into()),
+        ];
+        let labels5 = &[MyLabel("d".into())];
+
+        let chunk1 = Chunk::builder(entity_path.into())
+            .with_component_batches(row_id1, timepoint1, [points1 as _])
+            .with_component_batches(row_id2, timepoint2, [colors2 as _, labels2 as _])
+            .with_component_batches(row_id3, timepoint3, [points3 as _])
+            .build()?;
+
+        let chunk2 = Chunk::builder(entity_path.into())
+            .with_component_batches(row_id4, timepoint4, [colors4 as _])
+            .with_component_batches(row_id5, timepoint5, [points5 as _, labels5 as _])
+            .build()?;
+
+        eprintln!("chunk1:\n{chunk1}");
+        eprintln!("chunk2:\n{chunk2}");
+
+        {
+            assert!(chunk1.concatenable(&chunk2));
+
+            let got = chunk1.concatenated(&chunk2).unwrap();
+            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+                .with_sparse_component_batches(
+                    row_id1,
+                    timepoint1,
+                    [
+                        (MyPoint::name(), Some(points1 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id2,
+                    timepoint2,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors2 as _)),
+                        (MyLabel::name(), Some(labels2 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id3,
+                    timepoint3,
+                    [
+                        (MyPoint::name(), Some(points3 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id4,
+                    timepoint4,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors4 as _)),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id5,
+                    timepoint5,
+                    [
+                        (MyPoint::name(), Some(points5 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels5 as _)),
+                    ],
+                )
+                .build()?;
+
+            eprintln!("got:\n{got}");
+            eprintln!("expected:\n{expected}");
+
+            assert_eq!(
+                expected,
+                got,
+                "{}",
+                similar_asserts::SimpleDiff::from_str(
+                    &format!("{got}"),
+                    &format!("{expected}"),
+                    "got",
+                    "expected",
+                ),
+            );
+
+            assert!(got.is_sorted());
+            assert!(got.is_time_sorted());
+        }
+        {
+            assert!(chunk2.concatenable(&chunk1));
+
+            let got = chunk2.concatenated(&chunk1).unwrap();
+            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+                .with_sparse_component_batches(
+                    row_id4,
+                    timepoint4,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors4 as _)),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id5,
+                    timepoint5,
+                    [
+                        (MyPoint::name(), Some(points5 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels5 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id1,
+                    timepoint1,
+                    [
+                        (MyPoint::name(), Some(points1 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id2,
+                    timepoint2,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors2 as _)),
+                        (MyLabel::name(), Some(labels2 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id3,
+                    timepoint3,
+                    [
+                        (MyPoint::name(), Some(points3 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), None),
+                    ],
+                )
+                .build()?;
+
+            eprintln!("got:\n{got}");
+            eprintln!("expected:\n{expected}");
+
+            assert_eq!(
+                expected,
+                got,
+                "{}",
+                similar_asserts::SimpleDiff::from_str(
+                    &format!("{got}"),
+                    &format!("{expected}"),
+                    "got",
+                    "expected",
+                ),
+            );
+
+            assert!(!got.is_sorted());
+            assert!(!got.is_time_sorted());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn heterogeneous() -> anyhow::Result<()> {
+        let entity_path = "my/entity";
+
+        let row_id1 = RowId::new();
+        let row_id2 = RowId::new();
+        let row_id3 = RowId::new();
+        let row_id4 = RowId::new();
+        let row_id5 = RowId::new();
+
+        let timepoint1 = [
+            (Timeline::log_time(), 1000),
+            (Timeline::new_sequence("frame"), 1),
+        ];
+        let timepoint2 = [
+            (Timeline::log_time(), 1032),
+            (Timeline::new_sequence("frame"), 3),
+        ];
+        let timepoint3 = [
+            (Timeline::log_time(), 1064),
+            (Timeline::new_sequence("frame"), 5),
+        ];
+        let timepoint4 = [
+            (Timeline::log_time(), 1096),
+            (Timeline::new_sequence("frame"), 7),
+        ];
+        let timepoint5 = [
+            (Timeline::log_time(), 1128),
+            (Timeline::new_sequence("frame"), 9),
+        ];
+
+        let points1 = &[MyPoint::new(1.0, 1.0), MyPoint::new(2.0, 2.0)];
+        let points3 = &[MyPoint::new(6.0, 7.0)];
+
+        let colors4 = &[MyColor::from_rgb(1, 1, 1)];
+        let colors5 = &[MyColor::from_rgb(2, 2, 2), MyColor::from_rgb(3, 3, 3)];
+
+        let labels1 = &[MyLabel("a".into())];
+        let labels2 = &[MyLabel("b".into())];
+        let labels3 = &[MyLabel("c".into())];
+        let labels4 = &[MyLabel("d".into())];
+        let labels5 = &[MyLabel("e".into())];
+
+        let chunk1 = Chunk::builder(entity_path.into())
+            .with_component_batches(row_id1, timepoint1, [points1 as _, labels1 as _])
+            .with_component_batches(row_id2, timepoint2, [labels2 as _])
+            .with_component_batches(row_id3, timepoint3, [points3 as _, labels3 as _])
+            .build()?;
+
+        let chunk2 = Chunk::builder(entity_path.into())
+            .with_component_batches(row_id4, timepoint4, [colors4 as _, labels4 as _])
+            .with_component_batches(row_id5, timepoint5, [colors5 as _, labels5 as _])
+            .build()?;
+
+        eprintln!("chunk1:\n{chunk1}");
+        eprintln!("chunk2:\n{chunk2}");
+
+        {
+            assert!(chunk1.concatenable(&chunk2));
+
+            let got = chunk1.concatenated(&chunk2).unwrap();
+            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+                .with_sparse_component_batches(
+                    row_id1,
+                    timepoint1,
+                    [
+                        (MyPoint::name(), Some(points1 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels1 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id2,
+                    timepoint2,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels2 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id3,
+                    timepoint3,
+                    [
+                        (MyPoint::name(), Some(points3 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels3 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id4,
+                    timepoint4,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors4 as _)),
+                        (MyLabel::name(), Some(labels4 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id5,
+                    timepoint5,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors5 as _)),
+                        (MyLabel::name(), Some(labels5 as _)),
+                    ],
+                )
+                .build()?;
+
+            eprintln!("got:\n{got}");
+            eprintln!("expected:\n{expected}");
+
+            assert_eq!(
+                expected,
+                got,
+                "{}",
+                similar_asserts::SimpleDiff::from_str(
+                    &format!("{got}"),
+                    &format!("{expected}"),
+                    "got",
+                    "expected",
+                ),
+            );
+
+            assert!(got.is_sorted());
+            assert!(got.is_time_sorted());
+        }
+        {
+            assert!(chunk2.concatenable(&chunk1));
+
+            let got = chunk2.concatenated(&chunk1).unwrap();
+            let expected = Chunk::builder_with_id(got.id(), entity_path.into())
+                .with_sparse_component_batches(
+                    row_id4,
+                    timepoint4,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors4 as _)),
+                        (MyLabel::name(), Some(labels4 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id5,
+                    timepoint5,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), Some(colors5 as _)),
+                        (MyLabel::name(), Some(labels5 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id1,
+                    timepoint1,
+                    [
+                        (MyPoint::name(), Some(points1 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels1 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id2,
+                    timepoint2,
+                    [
+                        (MyPoint::name(), None),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels2 as _)),
+                    ],
+                )
+                .with_sparse_component_batches(
+                    row_id3,
+                    timepoint3,
+                    [
+                        (MyPoint::name(), Some(points3 as _)),
+                        (MyColor::name(), None),
+                        (MyLabel::name(), Some(labels3 as _)),
+                    ],
+                )
+                .build()?;
+
+            eprintln!("got:\n{got}");
+            eprintln!("expected:\n{expected}");
+
+            assert_eq!(
+                expected,
+                got,
+                "{}",
+                similar_asserts::SimpleDiff::from_str(
+                    &format!("{got}"),
+                    &format!("{expected}"),
+                    "got",
+                    "expected",
+                ),
+            );
+
+            assert!(!got.is_sorted());
+            assert!(!got.is_time_sorted());
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn malformed() -> anyhow::Result<()> {
+        // Different entity paths
+        {
+            let entity_path1 = "ent1";
+            let entity_path2 = "ent2";
+
+            let row_id1 = RowId::new();
+            let row_id2 = RowId::new();
+
+            let timepoint1 = [
+                (Timeline::log_time(), 1000),
+                (Timeline::new_sequence("frame"), 1),
+            ];
+            let timepoint2 = [
+                (Timeline::log_time(), 1032),
+                (Timeline::new_sequence("frame"), 3),
+            ];
+
+            let points1 = &[MyPoint::new(1.0, 1.0)];
+            let points2 = &[MyPoint::new(2.0, 2.0)];
+
+            let chunk1 = Chunk::builder(entity_path1.into())
+                .with_component_batches(row_id1, timepoint1, [points1 as _])
+                .build()?;
+
+            let chunk2 = Chunk::builder(entity_path2.into())
+                .with_component_batches(row_id2, timepoint2, [points2 as _])
+                .build()?;
+
+            assert!(matches!(
+                chunk1.concatenated(&chunk2),
+                Err(ChunkError::Malformed { .. })
+            ));
+            assert!(matches!(
+                chunk2.concatenated(&chunk1),
+                Err(ChunkError::Malformed { .. })
+            ));
+        }
+
+        // Different timelines
+        {
+            let entity_path = "ent";
+
+            let row_id1 = RowId::new();
+            let row_id2 = RowId::new();
+
+            let timepoint1 = [(Timeline::new_sequence("frame"), 1)];
+            let timepoint2 = [(Timeline::log_time(), 1032)];
+
+            let points1 = &[MyPoint::new(1.0, 1.0)];
+            let points2 = &[MyPoint::new(2.0, 2.0)];
+
+            let chunk1 = Chunk::builder(entity_path.into())
+                .with_component_batches(row_id1, timepoint1, [points1 as _])
+                .build()?;
+
+            let chunk2 = Chunk::builder(entity_path.into())
+                .with_component_batches(row_id2, timepoint2, [points2 as _])
+                .build()?;
+
+            assert!(matches!(
+                chunk1.concatenated(&chunk2),
+                Err(ChunkError::Malformed { .. })
+            ));
+            assert!(matches!(
+                chunk2.concatenated(&chunk1),
+                Err(ChunkError::Malformed { .. })
+            ));
+        }
+
+        // Different datatypes
+        {
+            let entity_path = "ent";
+
+            let row_id1 = RowId::new();
+            let row_id2 = RowId::new();
+
+            let timepoint1 = [(Timeline::new_sequence("frame"), 1)];
+            let timepoint2 = [(Timeline::new_sequence("frame"), 2)];
+
+            let points32bit =
+                <MyPoint as re_types_core::LoggableBatch>::to_arrow(&MyPoint::new(1.0, 1.0))?;
+            let points64bit =
+                <MyPoint64 as re_types_core::LoggableBatch>::to_arrow(&MyPoint64::new(1.0, 1.0))?;
+
+            let chunk1 = Chunk::builder(entity_path.into())
+                .with_row(
+                    row_id1,
+                    timepoint1,
+                    [
+                        (MyPoint::name(), points32bit), //
+                    ],
+                )
+                .build()?;
+
+            let chunk2 = Chunk::builder(entity_path.into())
+                .with_row(
+                    row_id2,
+                    timepoint2,
+                    [
+                        (MyPoint::name(), points64bit), //
+                    ],
+                )
+                .build()?;
+
+            assert!(matches!(
+                chunk1.concatenated(&chunk2),
+                Err(ChunkError::Malformed { .. })
+            ));
+            assert!(matches!(
+                chunk2.concatenated(&chunk1),
+                Err(ChunkError::Malformed { .. })
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -23,6 +23,16 @@ impl Chunk {
         self.is_sorted
     }
 
+    /// Is the chunk ascendingly sorted by time, for all of its timelines?
+    ///
+    /// This is O(1) (cached).
+    #[inline]
+    pub fn is_time_sorted(&self) -> bool {
+        self.timelines
+            .values()
+            .all(|time_chunk| time_chunk.is_sorted())
+    }
+
     /// Like [`Self::is_sorted`], but actually checks the entire dataset rather than relying on the
     /// cached value.
     ///

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -98,6 +98,99 @@ pub fn sparse_list_array_to_dense_list_array(
     )
 }
 
+/// Pads a `ListArray` by pushing null values to its back.
+pub fn pad_list_array_back(
+    list_array: &ArrowListArray<i32>,
+    target_len: usize,
+) -> ArrowListArray<i32> {
+    let missing_len = target_len.saturating_sub(list_array.len());
+    if missing_len == 0 {
+        return list_array.clone();
+    }
+
+    let datatype = list_array.data_type().clone();
+
+    let offsets = {
+        #[allow(clippy::unwrap_used)] // yes, these are indeed lengths
+        ArrowOffsets::try_from_lengths(
+            list_array
+                .iter()
+                .map(|array| array.map_or(0, |array| array.len()))
+                .chain(std::iter::repeat(0).take(missing_len)),
+        )
+        .unwrap()
+    };
+
+    let values = list_array.values().clone();
+
+    let validity = {
+        if let Some(validity) = list_array.validity() {
+            #[allow(clippy::from_iter_instead_of_collect)]
+            ArrowBitmap::from_iter(
+                validity
+                    .iter()
+                    .chain(std::iter::repeat(false).take(missing_len)),
+            )
+        } else {
+            #[allow(clippy::from_iter_instead_of_collect)]
+            ArrowBitmap::from_iter(
+                std::iter::repeat(true)
+                    .take(list_array.len())
+                    .chain(std::iter::repeat(false).take(missing_len)),
+            )
+        }
+    };
+
+    ArrowListArray::new(datatype, offsets.into(), values, Some(validity))
+}
+
+/// Pads a `ListArray` by pushing null values to its front.
+pub fn pad_list_array_front(
+    list_array: &ArrowListArray<i32>,
+    target_len: usize,
+) -> ArrowListArray<i32> {
+    let missing_len = target_len.saturating_sub(list_array.len());
+    if missing_len == 0 {
+        return list_array.clone();
+    }
+
+    let datatype = list_array.data_type().clone();
+
+    let offsets = {
+        #[allow(clippy::unwrap_used)] // yes, these are indeed lengths
+        ArrowOffsets::try_from_lengths(
+            std::iter::repeat(0).take(missing_len).chain(
+                list_array
+                    .iter()
+                    .map(|array| array.map_or(0, |array| array.len())),
+            ),
+        )
+        .unwrap()
+    };
+
+    let values = list_array.values().clone();
+
+    let validity = {
+        if let Some(validity) = list_array.validity() {
+            #[allow(clippy::from_iter_instead_of_collect)]
+            ArrowBitmap::from_iter(
+                std::iter::repeat(false)
+                    .take(missing_len)
+                    .chain(validity.iter()),
+            )
+        } else {
+            #[allow(clippy::from_iter_instead_of_collect)]
+            ArrowBitmap::from_iter(
+                std::iter::repeat(false)
+                    .take(missing_len)
+                    .chain(std::iter::repeat(true).take(list_array.len())),
+            )
+        }
+    };
+
+    ArrowListArray::new(datatype, offsets.into(), values, Some(validity))
+}
+
 /// Applies a filter kernel to the given `array`.
 ///
 /// Takes care of up- and down-casting the data back and forth on behalf of the caller.

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -98,7 +98,9 @@ pub fn sparse_list_array_to_dense_list_array(
     )
 }
 
-/// Pads a `ListArray` by pushing null values to its back.
+/// Create a new `ListArray` of target length by appending null values to its back.
+///
+/// This will share the same child data array buffer, but will create new offset and validity buffers.
 pub fn pad_list_array_back(
     list_array: &ArrowListArray<i32>,
     target_len: usize,
@@ -144,7 +146,9 @@ pub fn pad_list_array_back(
     ArrowListArray::new(datatype, offsets.into(), values, Some(validity))
 }
 
-/// Pads a `ListArray` by pushing null values to its front.
+/// Create a new `ListArray` of target length by appending null values to its front.
+///
+/// This will share the same child data array buffer, but will create new offset and validity buffers.
 pub fn pad_list_array_front(
     list_array: &ArrowListArray<i32>,
     target_len: usize,


### PR DESCRIPTION
Introduces a toolbox to efficiently merge `Chunk`s together.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6857?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6857?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6857)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.