### PR TITLE
Implement on-write `Chunk` compaction

### DIFF
--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -266,7 +266,7 @@ mod tests {
             .with_component_batch(row_id1, timepoint1.clone(), &MyIndex::from_iter(0..10))
             .build()?;
 
-        view.on_events(&[store.insert_chunk(&Arc::new(chunk1))?.unwrap()]);
+        view.on_events(&store.insert_chunk(&Arc::new(chunk1))?);
 
         similar_asserts::assert_eq!(
             GlobalCounts::new(
@@ -311,7 +311,7 @@ mod tests {
                 .build()?
         };
 
-        view.on_events(&[store.insert_chunk(&Arc::new(chunk2))?.unwrap()]);
+        view.on_events(&store.insert_chunk(&Arc::new(chunk2))?);
 
         similar_asserts::assert_eq!(
             GlobalCounts::new(
@@ -360,7 +360,7 @@ mod tests {
                 .build()?
         };
 
-        view.on_events(&[store.insert_chunk(&Arc::new(chunk3))?.unwrap()]);
+        view.on_events(&store.insert_chunk(&Arc::new(chunk3))?);
 
         similar_asserts::assert_eq!(
             GlobalCounts::new(

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -44,6 +44,17 @@ pub mod external {
 pub enum ChunkStoreError {
     #[error("Chunks must be sorted before insertion in the chunk store")]
     UnsortedChunk,
+
+    #[error(transparent)]
+    Chunk(#[from] re_chunk::ChunkError),
+
+    /// Error when parsing configuration from environment.
+    #[error("Failed to parse config: '{name}={value}': {err}")]
+    ParseConfig {
+        name: &'static str,
+        value: String,
+        err: Box<dyn std::error::Error + Send + Sync>,
+    },
 }
 
 pub type ChunkStoreResult<T> = ::std::result::Result<T, ChunkStoreError>;

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -101,7 +101,7 @@ impl ChunkStoreConfig {
     };
 
     /// Environment variable to configure [`Self::enable_changelog`].
-    pub const ENV_ENABLE_CHANGELOG: &'static str = "RERUN_ENABLE_CHANGELOG";
+    pub const ENV_STORE_ENABLE_CHANGELOG: &'static str = "RERUN_STORE_ENABLE_CHANGELOG";
 
     /// Environment variable to configure [`Self::chunk_max_bytes`].
     pub const ENV_CHUNK_MAX_BYTES: &'static str = "RERUN_CHUNK_MAX_BYTES";
@@ -126,14 +126,14 @@ impl ChunkStoreConfig {
     /// Returns a copy of `self`, overriding existing fields with values from the environment if
     /// they are present.
     ///
-    /// See [`Self::ENV_ENABLE_CHANGELOG`], [`Self::ENV_CHUNK_MAX_BYTES`], [`Self::ENV_CHUNK_MAX_ROWS`]
+    /// See [`Self::ENV_STORE_ENABLE_CHANGELOG`], [`Self::ENV_CHUNK_MAX_BYTES`], [`Self::ENV_CHUNK_MAX_ROWS`]
     /// and [`Self::ENV_CHUNK_MAX_ROWS_IF_UNSORTED`].
     pub fn apply_env(&self) -> ChunkStoreResult<Self> {
         let mut new = self.clone();
 
-        if let Ok(s) = std::env::var(Self::ENV_ENABLE_CHANGELOG) {
+        if let Ok(s) = std::env::var(Self::ENV_STORE_ENABLE_CHANGELOG) {
             new.enable_changelog = s.parse().map_err(|err| ChunkStoreError::ParseConfig {
-                name: Self::ENV_ENABLE_CHANGELOG,
+                name: Self::ENV_STORE_ENABLE_CHANGELOG,
                 value: s.clone(),
                 err: Box::new(err),
             })?;
@@ -171,7 +171,7 @@ impl ChunkStoreConfig {
 #[test]
 fn chunk_store_config() {
     // Detect breaking changes in our environment variables.
-    std::env::set_var("RERUN_ENABLE_CHANGELOG", "false");
+    std::env::set_var("RERUN_STORE_ENABLE_CHANGELOG", "false");
     std::env::set_var("RERUN_CHUNK_MAX_BYTES", "42");
     std::env::set_var("RERUN_CHUNK_MAX_ROWS", "666");
     std::env::set_var("RERUN_CHUNK_MAX_ROWS_IF_UNSORTED", "999");

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -9,14 +9,80 @@ use re_chunk::{Chunk, ChunkId, RowId};
 use re_log_types::{EntityPath, StoreId, TimeInt, Timeline};
 use re_types_core::ComponentName;
 
-use crate::ChunkStoreChunkStats;
+use crate::{ChunkStoreChunkStats, ChunkStoreError, ChunkStoreResult};
 
 // ---
 
-// TODO(cmc): empty for now but soon will contain compaction settings, so preemptively
-// avoid breaking changes everywhere.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ChunkStoreConfig {}
+pub struct ChunkStoreConfig {
+    /// If `true` (the default), the store will emit events when its contents are modified in
+    /// any way (insertion, GC), that can be subscribed to.
+    ///
+    /// Leaving this disabled can lead to major performance improvements on the ingestion path
+    /// in some workloads, provided that the subscribers aren't needed (e.g. headless mode).
+    pub enable_changelog: bool,
+
+    /// What is the threshold, in bytes, after which a [`Chunk`] cannot be compacted any further?
+    ///
+    /// This is a multi-dimensional trade-off:
+    /// * Larger chunks lead to less fixed overhead introduced by metadata, indices and such. Good.
+    /// * Larger chunks lead to slower query execution on some unhappy paths. Bad.
+    /// * Larger chunks lead to slower and slower compaction as chunks grow larger. Bad.
+    /// * Larger chunks lead to coarser garbage collection. Good or bad depending on use case.
+    /// * Larger chunks lead to less precision in e.g. the time panel. Bad.
+    ///
+    /// Empirical testing shows that the space overhead gains rapidly diminish beyond ~1000 rows,
+    /// which is the default row threshold.
+    /// The default byte threshold is set to 8MiB, which is a reasonable unit of work when e.g.
+    /// sending chunks over the network.
+    pub chunk_max_bytes: u64,
+
+    /// What is the threshold, in rows, after which a [`Chunk`] cannot be compacted any further?
+    ///
+    /// This specifically applies to time-sorted chunks.
+    /// See also [`ChunkStoreConfig::chunk_max_rows_if_unsorted`].
+    ///
+    /// This is a multi-dimensional trade-off:
+    /// * Larger chunks lead to less fixed overhead caused to metadata, indices and such. Good.
+    /// * Larger chunks lead to slower query execution in unhappy paths. Bad.
+    /// * Larger chunks lead to slower and slower compaction as chunks grow larger. Bad.
+    /// * Larger chunks lead to coarser garbage collection. Bad.
+    /// * Larger chunks lead to less precision in e.g. the time panel. Bad.
+    ///
+    /// Empirical testing shows that the space overhead gains rapidly diminish beyond ~1000 rows,
+    /// which is the default row threshold.
+    /// The default byte threshold is set to 8MiB, which is a reasonable unit of work when e.g.
+    /// sending chunks over the network.
+    pub chunk_max_rows: u64,
+
+    /// What is the threshold, in rows, after which a [`Chunk`] cannot be compacted any further?
+    ///
+    /// This specifically applies to _non_ time-sorted chunks.
+    /// See also [`ChunkStoreConfig::chunk_max_rows`].
+    ///
+    /// This is a multi-dimensional trade-off:
+    /// * Larger chunks lead to less fixed overhead caused to metadata, indices and such. Good.
+    /// * Larger chunks lead to slower query execution in unhappy paths. Bad.
+    /// * Larger chunks lead to slower and slower compaction as chunks grow larger. Bad.
+    /// * Larger chunks lead to coarser garbage collection. Bad.
+    /// * Larger chunks lead to less precision in e.g. the time panel. Bad.
+    ///
+    /// Empirical testing shows that the space overhead gains rapidly diminish beyond ~1000 rows,
+    /// which is the default row threshold.
+    /// The default byte threshold is set to 8MiB, which is a reasonable unit of work when e.g.
+    /// sending chunks over the network.
+    pub chunk_max_rows_if_unsorted: u64,
+    //
+    // TODO(cmc): It could make sense to have time-range-based thresholds in here, since the time
+    // range covered by a chunk has direct effects on A) the complexity of backward walks and
+    // B) in downstream subscribers (e.g. the precision of the time panel).
+    //
+    // In practice this is highly recording-dependent, and would require either to make it
+    // user-configurable per-recording, or use heuristics to compute it on the fly.
+    //
+    // The added complexity just isn't worth it at the moment.
+    // Maybe at some point.
+}
 
 impl Default for ChunkStoreConfig {
     #[inline]
@@ -26,7 +92,100 @@ impl Default for ChunkStoreConfig {
 }
 
 impl ChunkStoreConfig {
-    pub const DEFAULT: Self = Self {};
+    /// Default configuration, applicable to most use cases, according to empirical testing.
+    pub const DEFAULT: Self = Self {
+        enable_changelog: true,
+        chunk_max_bytes: 8 * 1024 * 1024,
+        chunk_max_rows: 1024,
+        chunk_max_rows_if_unsorted: 256,
+    };
+
+    /// Environment variable to configure [`Self::enable_changelog`].
+    pub const ENV_ENABLE_CHANGELOG: &'static str = "RERUN_ENABLE_CHANGELOG";
+
+    /// Environment variable to configure [`Self::chunk_max_bytes`].
+    pub const ENV_CHUNK_MAX_BYTES: &'static str = "RERUN_CHUNK_MAX_BYTES";
+
+    /// Environment variable to configure [`Self::chunk_max_rows`].
+    pub const ENV_CHUNK_MAX_ROWS: &'static str = "RERUN_CHUNK_MAX_ROWS";
+
+    /// Environment variable to configure [`Self::chunk_max_rows_if_unsorted`].
+    //
+    // NOTE: Shared with the same env-var on the batcher side, for consistency.
+    pub const ENV_CHUNK_MAX_ROWS_IF_UNSORTED: &'static str = "RERUN_CHUNK_MAX_ROWS_IF_UNSORTED";
+
+    /// Creates a new `ChunkStoreConfig` using the default values, optionally overridden
+    /// through the environment.
+    ///
+    /// See [`Self::apply_env`].
+    #[inline]
+    pub fn from_env() -> ChunkStoreResult<Self> {
+        Self::default().apply_env()
+    }
+
+    /// Returns a copy of `self`, overriding existing fields with values from the environment if
+    /// they are present.
+    ///
+    /// See [`Self::ENV_ENABLE_CHANGELOG`], [`Self::ENV_CHUNK_MAX_BYTES`], [`Self::ENV_CHUNK_MAX_ROWS`]
+    /// and [`Self::ENV_CHUNK_MAX_ROWS_IF_UNSORTED`].
+    pub fn apply_env(&self) -> ChunkStoreResult<Self> {
+        let mut new = self.clone();
+
+        if let Ok(s) = std::env::var(Self::ENV_ENABLE_CHANGELOG) {
+            new.enable_changelog = s.parse().map_err(|err| ChunkStoreError::ParseConfig {
+                name: Self::ENV_ENABLE_CHANGELOG,
+                value: s.clone(),
+                err: Box::new(err),
+            })?;
+        }
+
+        if let Ok(s) = std::env::var(Self::ENV_CHUNK_MAX_BYTES) {
+            new.chunk_max_bytes = s.parse().map_err(|err| ChunkStoreError::ParseConfig {
+                name: Self::ENV_CHUNK_MAX_BYTES,
+                value: s.clone(),
+                err: Box::new(err),
+            })?;
+        }
+
+        if let Ok(s) = std::env::var(Self::ENV_CHUNK_MAX_ROWS) {
+            new.chunk_max_rows = s.parse().map_err(|err| ChunkStoreError::ParseConfig {
+                name: Self::ENV_CHUNK_MAX_ROWS,
+                value: s.clone(),
+                err: Box::new(err),
+            })?;
+        }
+
+        if let Ok(s) = std::env::var(Self::ENV_CHUNK_MAX_ROWS_IF_UNSORTED) {
+            new.chunk_max_rows_if_unsorted =
+                s.parse().map_err(|err| ChunkStoreError::ParseConfig {
+                    name: Self::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
+                    value: s.clone(),
+                    err: Box::new(err),
+                })?;
+        }
+
+        Ok(new)
+    }
+}
+
+#[test]
+fn chunk_store_config() {
+    // Detect breaking changes in our environment variables.
+    std::env::set_var("RERUN_ENABLE_CHANGELOG", "false");
+    std::env::set_var("RERUN_CHUNK_MAX_BYTES", "42");
+    std::env::set_var("RERUN_CHUNK_MAX_ROWS", "666");
+    std::env::set_var("RERUN_CHUNK_MAX_ROWS_IF_UNSORTED", "999");
+
+    let config = ChunkStoreConfig::from_env().unwrap();
+
+    let expected = ChunkStoreConfig {
+        enable_changelog: false,
+        chunk_max_bytes: 42,
+        chunk_max_rows: 666,
+        chunk_max_rows_if_unsorted: 999,
+    };
+
+    assert_eq!(expected, config);
 }
 
 // ---

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -1,12 +1,14 @@
 use std::{collections::BTreeSet, sync::Arc};
 
+use ahash::HashMap;
 use arrow2::array::{Array as _, ListArray as ArrowListArray};
 use itertools::Itertools as _;
 
 use re_chunk::{Chunk, EntityPath, RowId};
+use re_types_core::SizeBytes as _;
 
 use crate::{
-    store::ChunkIdSetPerTime, ChunkStore, ChunkStoreChunkStats, ChunkStoreDiff, ChunkStoreDiffKind,
+    store::ChunkIdSetPerTime, ChunkStore, ChunkStoreChunkStats, ChunkStoreConfig, ChunkStoreDiff,
     ChunkStoreError, ChunkStoreEvent, ChunkStoreResult,
 };
 
@@ -25,17 +27,14 @@ impl ChunkStore {
     /// * Trying to insert an unsorted chunk ([`Chunk::is_sorted`]) will fail with an error.
     /// * Inserting a duplicated [`ChunkId`] will result in a no-op.
     /// * Inserting an empty [`Chunk`] will result in a no-op.
-    pub fn insert_chunk(
-        &mut self,
-        chunk: &Arc<Chunk>,
-    ) -> ChunkStoreResult<Option<ChunkStoreEvent>> {
+    pub fn insert_chunk(&mut self, chunk: &Arc<Chunk>) -> ChunkStoreResult<Vec<ChunkStoreEvent>> {
         if self.chunks_per_chunk_id.contains_key(&chunk.id()) {
             // We assume that chunk IDs are unique, and that reinserting a chunk has no effect.
             re_log::warn_once!(
                 "Chunk #{} was inserted more than once (this has no effect)",
                 chunk.id()
             );
-            return Ok(None);
+            return Ok(Vec::new());
         }
 
         if !chunk.is_sorted() {
@@ -43,21 +42,16 @@ impl ChunkStore {
         }
 
         let Some(row_id_range) = chunk.row_id_range() else {
-            return Ok(None);
+            return Ok(Vec::new());
         };
 
         re_tracing::profile_function!(format!("{}", row_id_range.0));
 
         self.insert_id += 1;
 
-        self.chunks_per_chunk_id.insert(chunk.id(), chunk.clone());
-        self.chunk_ids_per_min_row_id
-            .entry(row_id_range.0)
-            .or_default()
-            .push(chunk.id());
-
-        if chunk.is_static() {
+        let (chunk, diffs) = if chunk.is_static() {
             // Static data: make sure to keep the most recent chunk available for each component column.
+            re_tracing::profile_scope!("static");
 
             let row_id_range_per_component = chunk.row_id_range_per_component();
 
@@ -100,48 +94,108 @@ impl ChunkStore {
             }
 
             self.static_chunks_stats += ChunkStoreChunkStats::from_chunk(chunk);
+
+            (
+                Arc::clone(chunk),
+                vec![ChunkStoreDiff::addition(Arc::clone(chunk))],
+            )
         } else {
             // Temporal data: just index the chunk on every dimension of interest.
+            re_tracing::profile_scope!("temporal");
 
-            let temporal_chunk_ids_per_timeline = self
-                .temporal_chunk_ids_per_entity
-                .entry(chunk.entity_path().clone())
-                .or_default();
+            let (elected_chunk, chunk_or_compacted) = {
+                re_tracing::profile_scope!("election");
 
-            // NOTE: We must make sure to use the time range of each specific component column
-            // here, or we open ourselves to nasty edge cases.
-            //
-            // See the `latest_at_sparse_component_edge_case` test.
-            for (timeline, time_range_per_component) in chunk.time_range_per_component() {
-                let temporal_chunk_ids_per_component =
-                    temporal_chunk_ids_per_timeline.entry(timeline).or_default();
+                let elected_chunk = self.find_and_elect_compaction_candidate(chunk);
 
-                for (component_name, time_range) in time_range_per_component {
-                    let temporal_chunk_ids_per_time = temporal_chunk_ids_per_component
-                        .entry(component_name)
-                        .or_default();
+                let chunk_or_compacted = if let Some(elected_chunk) = &elected_chunk {
+                    let chunk_rowid_min = chunk.row_id_range().map(|(min, _)| min);
+                    let elected_rowid_min = elected_chunk.row_id_range().map(|(min, _)| min);
 
-                    // See `ChunkIdSetPerTime::max_interval_length`'s documentation.
-                    temporal_chunk_ids_per_time.max_interval_length = u64::max(
-                        temporal_chunk_ids_per_time.max_interval_length,
-                        time_range.abs_length(),
+                    let mut compacted = if elected_rowid_min < chunk_rowid_min {
+                        elected_chunk.concatenated(chunk)?
+                    } else {
+                        chunk.concatenated(elected_chunk)?
+                    };
+
+                    compacted.sort_if_unsorted();
+
+                    re_log::trace!(
+                        "compacted {} ({} rows) and {} ({} rows) together, resulting in {} ({} rows)",
+                        chunk.id(),
+                        re_format::format_uint(chunk.num_rows()),
+                        elected_chunk.id(),
+                        re_format::format_uint(elected_chunk.num_rows()),
+                        compacted.id(),
+                        re_format::format_uint(compacted.num_rows()),
                     );
 
-                    temporal_chunk_ids_per_time
-                        .per_start_time
-                        .entry(time_range.min())
-                        .or_default()
-                        .insert(chunk.id());
-                    temporal_chunk_ids_per_time
-                        .per_end_time
-                        .entry(time_range.max())
-                        .or_default()
-                        .insert(chunk.id());
+                    Arc::new(compacted)
+                } else {
+                    Arc::clone(chunk)
+                };
+
+                (elected_chunk, chunk_or_compacted)
+            };
+
+            {
+                re_tracing::profile_scope!("insertion");
+
+                let temporal_chunk_ids_per_timeline = self
+                    .temporal_chunk_ids_per_entity
+                    .entry(chunk_or_compacted.entity_path().clone())
+                    .or_default();
+
+                // NOTE: We must make sure to use the time range of each specific component column
+                // here, or we open ourselves to nasty edge cases.
+                //
+                // See the `latest_at_sparse_component_edge_case` test.
+                for (timeline, time_range_per_component) in
+                    chunk_or_compacted.time_range_per_component()
+                {
+                    let temporal_chunk_ids_per_component =
+                        temporal_chunk_ids_per_timeline.entry(timeline).or_default();
+
+                    for (component_name, time_range) in time_range_per_component {
+                        let temporal_chunk_ids_per_time = temporal_chunk_ids_per_component
+                            .entry(component_name)
+                            .or_default();
+
+                        // See `ChunkIdSetPerTime::max_interval_length`'s documentation.
+                        temporal_chunk_ids_per_time.max_interval_length = u64::max(
+                            temporal_chunk_ids_per_time.max_interval_length,
+                            time_range.abs_length(),
+                        );
+
+                        temporal_chunk_ids_per_time
+                            .per_start_time
+                            .entry(time_range.min())
+                            .or_default()
+                            .insert(chunk_or_compacted.id());
+                        temporal_chunk_ids_per_time
+                            .per_end_time
+                            .entry(time_range.max())
+                            .or_default()
+                            .insert(chunk_or_compacted.id());
+                    }
                 }
             }
 
-            self.temporal_chunks_stats += ChunkStoreChunkStats::from_chunk(chunk);
-        }
+            self.temporal_chunks_stats += ChunkStoreChunkStats::from_chunk(&chunk_or_compacted);
+
+            let mut diffs = vec![ChunkStoreDiff::addition(Arc::clone(&chunk_or_compacted))];
+            if let Some(elected_chunk) = &elected_chunk {
+                diffs.extend(self.remove_chunk(elected_chunk.id()));
+            }
+
+            (chunk_or_compacted, diffs)
+        };
+
+        self.chunks_per_chunk_id.insert(chunk.id(), chunk.clone());
+        self.chunk_ids_per_min_row_id
+            .entry(row_id_range.0)
+            .or_default()
+            .push(chunk.id());
 
         for (&component_name, list_array) in chunk.components() {
             self.type_registry.insert(
@@ -150,29 +204,145 @@ impl ChunkStore {
             );
         }
 
-        let event = ChunkStoreEvent {
-            store_id: self.id.clone(),
-            store_generation: self.generation(),
-            event_id: self
-                .event_id
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-            diff: ChunkStoreDiff::addition(Arc::clone(chunk)),
+        let events = if self.config.enable_changelog {
+            let events: Vec<_> = diffs
+                .into_iter()
+                .map(|diff| ChunkStoreEvent {
+                    store_id: self.id.clone(),
+                    store_generation: self.generation(),
+                    event_id: self
+                        .event_id
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+                    diff,
+                })
+                .collect();
+
+            Self::on_events(&events);
+
+            events
+        } else {
+            Vec::new()
         };
 
-        {
-            let events = &[event.clone()];
+        Ok(events)
+    }
 
-            if cfg!(debug_assertions) {
-                let any_event_other_than_addition = events
-                    .iter()
-                    .any(|e| e.kind != ChunkStoreDiffKind::Addition);
-                assert!(!any_event_other_than_addition);
+    /// Finds the most appropriate candidate for compaction.
+    ///
+    /// The algorithm is simple: for each incoming [`Chunk`], we take a look at its future neighbors.
+    /// Each neighbor is a potential candidate for compaction.
+    ///
+    /// Because the chunk is going to be inserted into many different indices -- for each of its timelines
+    /// and components -- it will have many direct neighbors.
+    /// Everytime we encounter a neighbor, it earns points.
+    ///
+    /// The neighbor with the most points at the end of the process is elected.
+    fn find_and_elect_compaction_candidate(&mut self, chunk: &Arc<Chunk>) -> Option<Arc<Chunk>> {
+        re_tracing::profile_function!();
+
+        let mut candidates_below_threshold: HashMap<ChunkId, bool> = HashMap::default();
+        let mut check_if_chunk_below_threshold =
+            |store: &Self, candidate_chunk_id: ChunkId| -> bool {
+                let ChunkStoreConfig {
+                    enable_changelog: _,
+                    chunk_max_bytes,
+                    chunk_max_rows,
+                    chunk_max_rows_if_unsorted,
+                } = store.config;
+
+                *candidates_below_threshold
+                    .entry(candidate_chunk_id)
+                    .or_insert_with(|| {
+                        store.chunks_per_chunk_id.get(&candidate_chunk_id).map_or(
+                            false,
+                            |candidate| {
+                                let total_bytes =
+                                    chunk.total_size_bytes() + candidate.total_size_bytes();
+                                let is_below_bytes_threshold = total_bytes <= chunk_max_bytes;
+
+                                let total_rows = (chunk.num_rows() + candidate.num_rows()) as u64;
+                                let is_below_rows_threshold = if candidate.is_time_sorted() {
+                                    total_rows <= chunk_max_rows
+                                } else {
+                                    total_rows <= chunk_max_rows_if_unsorted
+                                };
+
+                                is_below_bytes_threshold && is_below_rows_threshold
+                            },
+                        )
+                    })
+            };
+
+        let mut candidates: HashMap<ChunkId, u64> = HashMap::default();
+
+        let temporal_chunk_ids_per_timeline = self
+            .temporal_chunk_ids_per_entity
+            .get(chunk.entity_path())?;
+
+        for (timeline, time_range_per_component) in chunk.time_range_per_component() {
+            let Some(temporal_chunk_ids_per_component) =
+                temporal_chunk_ids_per_timeline.get(&timeline)
+            else {
+                continue;
+            };
+
+            for (component_name, time_range) in time_range_per_component {
+                let Some(temporal_chunk_ids_per_time) =
+                    temporal_chunk_ids_per_component.get(&component_name)
+                else {
+                    continue;
+                };
+
+                {
+                    // Direct neighbors (before): 1 point each.
+                    if let Some((_data_time, chunk_id_set)) = temporal_chunk_ids_per_time
+                        .per_start_time
+                        .range(..time_range.min())
+                        .next_back()
+                    {
+                        for &chunk_id in chunk_id_set {
+                            if check_if_chunk_below_threshold(self, chunk_id) {
+                                *candidates.entry(chunk_id).or_default() += 1;
+                            }
+                        }
+                    }
+
+                    // Direct neighbors (after): 1 point each.
+                    if let Some((_data_time, chunk_id_set)) = temporal_chunk_ids_per_time
+                        .per_start_time
+                        .range(time_range.max().inc()..)
+                        .next()
+                    {
+                        for &chunk_id in chunk_id_set {
+                            if check_if_chunk_below_threshold(self, chunk_id) {
+                                *candidates.entry(chunk_id).or_default() += 1;
+                            }
+                        }
+                    }
+
+                    let chunk_id_set = temporal_chunk_ids_per_time
+                        .per_start_time
+                        .get(&time_range.min());
+
+                    // Shared start times: 2 points each.
+                    for chunk_id in chunk_id_set.iter().flat_map(|set| set.iter().copied()) {
+                        if check_if_chunk_below_threshold(self, chunk_id) {
+                            *candidates.entry(chunk_id).or_default() += 2;
+                        }
+                    }
+                }
             }
-
-            Self::on_events(events);
         }
 
-        Ok(Some(event))
+        debug_assert!(!candidates.contains_key(&chunk.id()));
+
+        let mut candidates = candidates.into_iter().collect_vec();
+        candidates.sort_by_key(|(_chunk_id, points)| *points);
+        candidates.reverse();
+
+        candidates
+            .into_iter()
+            .find_map(|(chunk_id, _points)| self.chunks_per_chunk_id.get(&chunk_id).map(Arc::clone))
     }
 
     /// Unconditionally drops all the data for a given `entity_path`.
@@ -272,5 +442,128 @@ impl ChunkStore {
                 diff,
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use re_chunk::Timeline;
+    use re_log_types::example_components::MyPoint;
+
+    use super::*;
+
+    // TODO(cmc): We could have more test coverage here, especially regarding thresholds etc.
+    // For now the development and maintenance cost doesn't seem to be worth it.
+    // We can re-assess later if things turns out to be shaky in practice.
+
+    #[test]
+    fn compaction_simple() -> anyhow::Result<()> {
+        re_log::setup_logging();
+
+        let mut store = ChunkStore::new(
+            re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+            Default::default(),
+        );
+
+        let entity_path = EntityPath::from("this/that");
+
+        let row_id1 = RowId::new();
+        let row_id2 = RowId::new();
+        let row_id3 = RowId::new();
+        let row_id4 = RowId::new();
+        let row_id5 = RowId::new();
+        let row_id6 = RowId::new();
+        let row_id7 = RowId::new();
+        let row_id8 = RowId::new();
+        let row_id9 = RowId::new();
+        let row_id10 = RowId::new();
+
+        let timepoint1 = [(Timeline::new_sequence("frame"), 1)];
+        let timepoint2 = [(Timeline::new_sequence("frame"), 3)];
+        let timepoint3 = [(Timeline::new_sequence("frame"), 5)];
+        let timepoint4 = [(Timeline::new_sequence("frame"), 7)];
+        let timepoint5 = [(Timeline::new_sequence("frame"), 9)];
+
+        let points1 = &[MyPoint::new(1.0, 1.0)];
+        let points2 = &[MyPoint::new(2.0, 2.0)];
+        let points3 = &[MyPoint::new(3.0, 3.0)];
+        let points4 = &[MyPoint::new(4.0, 4.0)];
+        let points5 = &[MyPoint::new(5.0, 5.0)];
+
+        let chunk1 = Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id1, timepoint1, [points1 as _])
+            .with_component_batches(row_id2, timepoint2, [points2 as _])
+            .with_component_batches(row_id3, timepoint3, [points3 as _])
+            .build()?;
+        let chunk2 = Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id4, timepoint4, [points4 as _])
+            .with_component_batches(row_id5, timepoint5, [points5 as _])
+            .build()?;
+        let chunk3 = Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id6, timepoint1, [points1 as _])
+            .with_component_batches(row_id7, timepoint2, [points2 as _])
+            .with_component_batches(row_id8, timepoint3, [points3 as _])
+            .build()?;
+        let chunk4 = Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id9, timepoint4, [points4 as _])
+            .with_component_batches(row_id10, timepoint5, [points5 as _])
+            .build()?;
+
+        let chunk1 = Arc::new(chunk1);
+        let chunk2 = Arc::new(chunk2);
+        let chunk3 = Arc::new(chunk3);
+        let chunk4 = Arc::new(chunk4);
+
+        eprintln!("---\n{store}\ninserting {}", chunk1.id());
+
+        store.insert_chunk(&chunk1)?;
+
+        eprintln!("---\n{store}\ninserting {}", chunk2.id());
+
+        store.insert_chunk(&chunk2)?;
+
+        eprintln!("---\n{store}\ninserting {}", chunk3.id());
+
+        store.insert_chunk(&chunk3)?;
+
+        eprintln!("---\n{store}\ninserting {}", chunk4.id());
+
+        store.insert_chunk(&chunk4)?;
+
+        eprintln!("---\n{store}");
+
+        let got = store
+            .chunks_per_chunk_id
+            .first_key_value()
+            .map(|(_id, chunk)| chunk)
+            .unwrap();
+
+        let expected = Chunk::builder_with_id(got.id(), entity_path.clone())
+            .with_component_batches(row_id1, timepoint1, [points1 as _])
+            .with_component_batches(row_id2, timepoint2, [points2 as _])
+            .with_component_batches(row_id3, timepoint3, [points3 as _])
+            .with_component_batches(row_id4, timepoint4, [points4 as _])
+            .with_component_batches(row_id5, timepoint5, [points5 as _])
+            .with_component_batches(row_id6, timepoint1, [points1 as _])
+            .with_component_batches(row_id7, timepoint2, [points2 as _])
+            .with_component_batches(row_id8, timepoint3, [points3 as _])
+            .with_component_batches(row_id9, timepoint4, [points4 as _])
+            .with_component_batches(row_id10, timepoint5, [points5 as _])
+            .build()?;
+
+        assert_eq!(1, store.chunks_per_chunk_id.len());
+        assert_eq!(
+            expected,
+            **got,
+            "{}",
+            similar_asserts::SimpleDiff::from_str(
+                &format!("{expected}"),
+                &format!("{got}"),
+                "expected",
+                "got",
+            ),
+        );
+
+        Ok(())
     }
 }

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -6,7 +6,8 @@ use rand::Rng as _;
 
 use re_chunk::{Chunk, ChunkId, ComponentName, LatestAtQuery, RowId, TimeInt, TimePoint};
 use re_chunk_store::{
-    ChunkStore, ChunkStoreDiffKind, GarbageCollectionOptions, GarbageCollectionTarget,
+    ChunkStore, ChunkStoreConfig, ChunkStoreDiffKind, GarbageCollectionOptions,
+    GarbageCollectionTarget,
 };
 use re_log_types::{
     build_frame_nr, build_log_time,
@@ -51,7 +52,11 @@ fn simple() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        Default::default(),
+        ChunkStoreConfig {
+            chunk_max_bytes: 0,
+            chunk_max_rows: 0,
+            ..ChunkStoreConfig::DEFAULT
+        },
     );
 
     for _ in 0..2 {
@@ -211,7 +216,11 @@ fn protected() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        Default::default(),
+        ChunkStoreConfig {
+            chunk_max_bytes: 0,
+            chunk_max_rows: 0,
+            ..ChunkStoreConfig::DEFAULT
+        },
     );
 
     let entity_path = EntityPath::from("this/that");

--- a/crates/store/re_entity_db/src/time_histogram_per_timeline.rs
+++ b/crates/store/re_entity_db/src/time_histogram_per_timeline.rs
@@ -100,12 +100,13 @@ impl TimeHistogramPerTimeline {
                 });
         } else {
             for &(timeline, times) in times_per_timeline {
-                let histogram = self.times.entry(timeline).or_default();
-                for &time in times {
-                    histogram.decrement(time, n);
-                }
-                if histogram.is_empty() {
-                    self.times.remove(&timeline);
+                if let Some(histo) = self.times.get_mut(&timeline) {
+                    for &time in times {
+                        histo.decrement(time, n);
+                    }
+                    if histo.is_empty() {
+                        self.times.remove(&timeline);
+                    }
                 }
             }
         }

--- a/crates/store/re_log_types/src/time_point/time_int.rs
+++ b/crates/store/re_log_types/src/time_point/time_int.rs
@@ -115,6 +115,24 @@ impl TimeInt {
             None => f64::MIN,
         }
     }
+
+    /// Always returns [`Self::STATIC`] for [`Self::STATIC`].
+    #[inline]
+    pub fn inc(&self) -> Self {
+        match self.0 {
+            Some(t) => Self::new_temporal(t.get().saturating_add(1)),
+            None => *self,
+        }
+    }
+
+    /// Always returns [`Self::STATIC`] for [`Self::STATIC`].
+    #[inline]
+    pub fn dec(&self) -> Self {
+        match self.0 {
+            Some(t) => Self::new_temporal(t.get().saturating_sub(1)),
+            None => *self,
+        }
+    }
 }
 
 impl TryFrom<i64> for TimeInt {

--- a/crates/store/re_query/benches/latest_at.rs
+++ b/crates/store/re_query/benches/latest_at.rs
@@ -254,7 +254,7 @@ fn insert_chunks<'a>(msgs: impl Iterator<Item = &'a Arc<Chunk>>) -> (Caches, Chu
     let mut caches = Caches::new(&store);
 
     msgs.for_each(|chunk| {
-        caches.on_events(&[store.insert_chunk(chunk).unwrap().unwrap()]);
+        caches.on_events(&store.insert_chunk(chunk).unwrap());
     });
 
     (caches, store)

--- a/crates/store/re_query/tests/latest_at.rs
+++ b/crates/store/re_query/tests/latest_at.rs
@@ -545,7 +545,7 @@ fn static_invalidation() {
 // ---
 
 fn insert_and_react(store: &mut ChunkStore, caches: &mut Caches, chunk: &Arc<Chunk>) {
-    caches.on_events(&[store.insert_chunk(chunk).unwrap().unwrap()]);
+    caches.on_events(&store.insert_chunk(chunk).unwrap());
 }
 
 fn query_and_compare(

--- a/crates/store/re_query/tests/range.rs
+++ b/crates/store/re_query/tests/range.rs
@@ -1017,7 +1017,7 @@ fn concurrent_multitenant_edge_case2() {
 // // ---
 
 fn insert_and_react(store: &mut ChunkStore, caches: &mut Caches, chunk: &Arc<Chunk>) {
-    caches.on_events(&[store.insert_chunk(chunk).unwrap().unwrap()]);
+    caches.on_events(&store.insert_chunk(chunk).unwrap());
 }
 
 fn query_and_compare(


### PR DESCRIPTION
`Chunk`s will now be compacted as they are written to the store, provided an appropriate candidate can be found.

When a `Chunk` gets written to the store, it will be merged with one of its direct neighbors, whichever is deemed more appropriate.
The algorithm to find and elect compaction candidates is very simple for now, being mostly focused on the happy path case.

When a merge happens, two events gets fired for the write instead of one: one addition for the new compacted chunk, and one deletion for the pre-existing chunk that got merged with the new incoming chunk, in that order.

Some numbers:
```
 273.74 MB plot_stress_5x10_50k_2khz.rrd
 105.77 MB plot_stress_5x10_50k_2khz_compacted_256_rows_inf_bytes.rrd
 100.94 MB plot_stress_5x10_50k_2khz_compacted_512_rows_inf_bytes.rrd
  98.73 MB plot_stress_5x10_50k_2khz_compacted_1024_rows_inf_bytes.rrd
  97.85 MB plot_stress_5x10_50k_2khz_compacted_2048_rows_inf_bytes.rrd
  97.21 MB plot_stress_5x10_50k_2khz_compacted_4096_rows_inf_bytes.rrd
```
which is pretty much optimal given our current data model.

Because event subscribers are now by far the main bottleneck on the ingestion path, this PR introduces a toggle to disable subscribers, which is very useful when running in headless mode (e.g. our CLI tools).
This will be used in an upcoming PR.

- Fixes #6812 
- DNM: Requires #6857 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6858?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6858?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6858)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.