### PR TITLE
Display compaction information in the recording UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4445,6 +4445,7 @@ dependencies = [
  "re_ui",
  "re_viewer_context",
  "rfd",
+ "unindent",
 ]
 
 [[package]]

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -43,10 +43,10 @@ pub struct ChunkStoreConfig {
     /// See also [`ChunkStoreConfig::chunk_max_rows_if_unsorted`].
     ///
     /// This is a multi-dimensional trade-off:
-    /// * Larger chunks lead to less fixed overhead caused to metadata, indices and such. Good.
-    /// * Larger chunks lead to slower query execution in unhappy paths. Bad.
+    /// * Larger chunks lead to less fixed overhead introduced by metadata, indices and such. Good.
+    /// * Larger chunks lead to slower query execution on some unhappy paths. Bad.
     /// * Larger chunks lead to slower and slower compaction as chunks grow larger. Bad.
-    /// * Larger chunks lead to coarser garbage collection. Bad.
+    /// * Larger chunks lead to coarser garbage collection. Good or bad depending on use case.
     /// * Larger chunks lead to less precision in e.g. the time panel. Bad.
     ///
     /// Empirical testing shows that the space overhead gains rapidly diminish beyond ~1000 rows,
@@ -61,10 +61,10 @@ pub struct ChunkStoreConfig {
     /// See also [`ChunkStoreConfig::chunk_max_rows`].
     ///
     /// This is a multi-dimensional trade-off:
-    /// * Larger chunks lead to less fixed overhead caused to metadata, indices and such. Good.
-    /// * Larger chunks lead to slower query execution in unhappy paths. Bad.
+    /// * Larger chunks lead to less fixed overhead introduced by metadata, indices and such. Good.
+    /// * Larger chunks lead to slower query execution on some unhappy paths. Bad.
     /// * Larger chunks lead to slower and slower compaction as chunks grow larger. Bad.
-    /// * Larger chunks lead to coarser garbage collection. Bad.
+    /// * Larger chunks lead to coarser garbage collection. Good or bad depending on use case.
     /// * Larger chunks lead to less precision in e.g. the time panel. Bad.
     ///
     /// Empirical testing shows that the space overhead gains rapidly diminish beyond ~1000 rows,

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -45,3 +45,4 @@ egui.workspace = true
 image.workspace = true
 itertools.workspace = true
 rfd.workspace = true
+unindent.workspace = true

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -1,3 +1,4 @@
+use re_chunk_store::ChunkStoreConfig;
 use re_entity_db::EntityDb;
 use re_log_types::StoreKind;
 use re_types::SizeBytes;
@@ -98,6 +99,58 @@ impl crate::DataUi for EntityDb {
                          If you hover an entity in the streams view (bottom panel) you can see the \
                          size of individual entities.",
                     );
+                ui.end_row();
+            }
+
+            {
+                let &ChunkStoreConfig {
+                    enable_changelog: _,
+                    chunk_max_bytes,
+                    chunk_max_rows,
+                    chunk_max_rows_if_unsorted,
+                } = self.store().config();
+
+                ui.grid_left_hand_label("Compaction");
+                ui.label(format!(
+                    "{} rows ({} if unsorted) or {}",
+                    re_format::format_uint(chunk_max_rows),
+                    re_format::format_uint(chunk_max_rows_if_unsorted),
+                    re_format::format_bytes(chunk_max_bytes as _),
+                ))
+                .on_hover_text(
+                    unindent::unindent(&format!("\
+                        The current compaction configuration for this recording is to merge chunks until they \
+                        reach either a maximum of {} rows ({} if unsorted) or {}, whichever comes first.
+
+                        The viewer compacts chunks together as they come in, in order to find the right \
+                        balance between space and compute overhead.
+                        This is not to be confused with the SDK's batcher, which does a similar job, with \
+                        different goals and constraints, on the logging side (SDK).
+                        These two functions (SDK batcher & viewer compactor) complement each other.
+
+                        Higher thresholds generally translate to better space overhead, but require more compute \
+                        for both ingestion and queries.
+                        Lower thresholds generally translate to worse space overhead, but faster ingestion times
+                        and more responsive queries.
+                        This is a broad oversimplification -- use the defaults if unsure, they fit most workfloads well.
+
+                        To modify the current configuration, set these environment variables before starting the viewer:
+                        * {}
+                        * {}
+                        * {}
+
+                        This compaction process is an ephemeral, in-memory optimization of the Rerun viewer.
+                        It will not modify the recording itself: use the `Save` command if you wish to persist \
+                        the compacted results, which will make future runs cheaper.\
+                        ",
+                        re_format::format_uint(chunk_max_rows),
+                        re_format::format_uint(chunk_max_rows_if_unsorted),
+                        re_format::format_bytes(chunk_max_bytes as _),
+                        ChunkStoreConfig::ENV_CHUNK_MAX_ROWS,
+                        ChunkStoreConfig::ENV_CHUNK_MAX_ROWS_IF_UNSORTED,
+                        ChunkStoreConfig::ENV_CHUNK_MAX_BYTES,
+                    )),
+                );
                 ui.end_row();
             }
 


### PR DESCRIPTION
Title.

![image](https://github.com/rerun-io/rerun/assets/2910679/7f8a4291-c5e6-460f-842a-1b325ac91e9d)


- DNM: Requires #6858 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6859?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6859?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6859)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.