### PR TITLE
CLI command for compacting recordings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6412,9 +6412,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
+checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "tempfile"

--- a/crates/top/rerun/src/run.rs
+++ b/crates/top/rerun/src/run.rs
@@ -262,11 +262,15 @@ enum Command {
     /// Compacts the contents of an .rrd or .rbl file and writes the result to a new file.
     ///
     /// Use the usual environment variables to control the compaction thresholds:
-    /// * `RERUN_CHUNK_MAX_ROWS`
-    /// * `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`
-    /// * `RERUN_CHUNK_MAX_BYTES`
+    /// `RERUN_CHUNK_MAX_ROWS`,
+    /// `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`,
+    /// `RERUN_CHUNK_MAX_BYTES`.
+    ///
+    /// Example: `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun compact -i input.rrd -o output.rrd`
     Compact {
+        #[arg(short = 'i', long = "input", value_name = "src.rrd")]
         path_to_input_rrd: String,
+        #[arg(short = 'o', long = "output", value_name = "dst.rrd")]
         path_to_output_rrd: String,
     },
 

--- a/crates/top/rerun/src/run.rs
+++ b/crates/top/rerun/src/run.rs
@@ -259,6 +259,17 @@ enum Command {
     /// Print the contents of an .rrd or .rbl file.
     Print(PrintCommand),
 
+    /// Compacts the contents of an .rrd or .rbl file and writes the result to a new file.
+    ///
+    /// Use the usual environment variables to control the compaction thresholds:
+    /// * `RERUN_CHUNK_MAX_ROWS`
+    /// * `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`
+    /// * `RERUN_CHUNK_MAX_BYTES`
+    Compact {
+        path_to_input_rrd: String,
+        path_to_output_rrd: String,
+    },
+
     /// Reset the memory of the Rerun Viewer.
     ///
     /// Only run this if you're having trouble with the Viewer,
@@ -386,6 +397,15 @@ where
 
             Command::Print(print_command) => print_command.run(),
 
+            Command::Compact {
+                path_to_input_rrd,
+                path_to_output_rrd,
+            } => {
+                let path_to_input_rrd = PathBuf::from(path_to_input_rrd);
+                let path_to_output_rrd = PathBuf::from(path_to_output_rrd);
+                run_compact(&path_to_input_rrd, &path_to_output_rrd)
+            }
+
             #[cfg(feature = "native_viewer")]
             Command::Reset => re_viewer::reset_viewer_persistence(),
         }
@@ -467,7 +487,7 @@ fn run_compare(path_to_rrd1: &Path, path_to_rrd2: &Path, full_dump: bool) -> any
             let msg = msg.context("decode rrd message")?;
             stores
                 .entry(msg.store_id().clone())
-                .or_insert(re_entity_db::EntityDb::new(msg.store_id().clone()))
+                .or_insert_with(|| re_entity_db::EntityDb::new(msg.store_id().clone()))
                 .add(&msg)
                 .context("decode rrd file contents")?;
         }
@@ -535,6 +555,100 @@ fn run_compare(path_to_rrd1: &Path, path_to_rrd2: &Path, full_dump: bool) -> any
             ),
         );
     }
+
+    Ok(())
+}
+
+fn run_compact(path_to_input_rrd: &Path, path_to_output_rrd: &Path) -> anyhow::Result<()> {
+    use re_entity_db::EntityDb;
+    use re_log_types::StoreId;
+
+    let rrd_in =
+        std::fs::File::open(path_to_input_rrd).with_context(|| format!("{path_to_input_rrd:?}"))?;
+    let rrd_in_size = rrd_in.metadata().ok().map(|md| md.len());
+
+    let file_size_to_string = |size: Option<u64>| {
+        size.map_or_else(
+            || "<unknown>".to_owned(),
+            |size| re_format::format_bytes(size as _),
+        )
+    };
+
+    use re_viewer::external::re_chunk_store::ChunkStoreConfig;
+    let mut store_config = ChunkStoreConfig::from_env().unwrap_or_default();
+    // NOTE: We're doing headless, there's no point in running subscribers, it will just
+    // (massively) slow us down.
+    store_config.enable_changelog = false;
+
+    re_log::info!(
+        src = ?path_to_input_rrd,
+        src_size_bytes = %file_size_to_string(rrd_in_size),
+        dst = ?path_to_output_rrd,
+        max_num_rows = %re_format::format_uint(store_config.chunk_max_rows),
+        max_num_bytes = %re_format::format_bytes(store_config.chunk_max_bytes as _),
+        "compaction started"
+    );
+
+    let now = std::time::Instant::now();
+
+    let mut entity_dbs: std::collections::HashMap<StoreId, EntityDb> = Default::default();
+    let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
+    let decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_in)?;
+    let version = decoder.version();
+    for msg in decoder {
+        let msg = msg.context("decode rrd message")?;
+        entity_dbs
+            .entry(msg.store_id().clone())
+            .or_insert_with(|| {
+                re_entity_db::EntityDb::with_store_config(
+                    msg.store_id().clone(),
+                    store_config.clone(),
+                )
+            })
+            .add(&msg)
+            .context("decode rrd file contents")?;
+    }
+
+    anyhow::ensure!(
+        !entity_dbs.is_empty(),
+        "no recordings found in rrd/rbl file"
+    );
+
+    let mut rrd_out = std::fs::File::create(path_to_output_rrd)
+        .with_context(|| format!("{path_to_input_rrd:?}"))?;
+
+    let messages: Result<Vec<Vec<LogMsg>>, _> = entity_dbs
+        .into_values()
+        .map(|entity_db| entity_db.to_messages(None /* time selection */))
+        .collect();
+    let messages = messages?;
+    let messages = messages.iter().flatten();
+
+    let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
+    re_log_encoding::encoder::encode(version, encoding_options, messages, &mut rrd_out)
+        .context("Message encode")?;
+
+    let rrd_out_size = rrd_out.metadata().ok().map(|md| md.len());
+
+    let compaction_ratio =
+        if let (Some(rrd_in_size), Some(rrd_out_size)) = (rrd_in_size, rrd_out_size) {
+            format!(
+                "{:3.3}%",
+                100.0 - rrd_out_size as f64 / (rrd_in_size as f64 + f64::EPSILON) * 100.0
+            )
+        } else {
+            "N/A".to_owned()
+        };
+
+    re_log::info!(
+        src = ?path_to_input_rrd,
+        src_size_bytes = %file_size_to_string(rrd_in_size),
+        dst = ?path_to_output_rrd,
+        dst_size_bytes = %file_size_to_string(rrd_out_size),
+        time = ?now.elapsed(),
+        compaction_ratio,
+        "compaction finished"
+    );
 
     Ok(())
 }
@@ -738,10 +852,10 @@ fn run_impl(
             && (args.port == args.web_viewer_port.0 || args.port == args.ws_server_port.0)
         {
             anyhow::bail!(
-                    "Trying to spawn a websocket server on {}, but this port is \
-                    already used by the server we're connecting to. Please specify a different port.",
-                    args.port
-                );
+                "Trying to spawn a websocket server on {}, but this port is \
+                already used by the server we're connecting to. Please specify a different port.",
+                args.port
+            );
         }
 
         #[cfg(feature = "server")]

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -139,9 +139,10 @@ impl crate::DataUi for EntityDb {
                         * {}
                         * {}
 
-                        This compaction process is an ephemeral, in-memory optimization of the Rerun viewer.
-                        It will not modify the recording itself: use the `Save` command if you wish to persist \
-                        the compacted results, which will make future runs cheaper.\
+                        This compaction process is an ephemeral, in-memory optimization of the Rerun viewer.\
+                        It will not modify the recording itself: use the `Save` command of the viewer, or the \
+                        `rerun compact` CLI tool if you wish to persist the compacted results, which will make \
+                        future runs cheaper.
                         ",
                         re_format::format_uint(chunk_max_rows),
                         re_format::format_uint(chunk_max_rows_if_unsorted),


### PR DESCRIPTION
Title.

```
$ rerun compact --help

Compacts the contents of an .rrd or .rbl file and writes the result to a new file.

Use the usual environment variables to control the compaction thresholds: `RERUN_CHUNK_MAX_ROWS`, `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`, `RERUN_CHUNK_MAX_BYTES`.

Example: `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun compact -i input.rrd -o output.rrd`

Usage: rerun compact --input <src.rrd> --output <dst.rrd>

Options:
  -i, --input <src.rrd>


  -o, --output <dst.rrd>


  -h, --help
          Print help (see a summary with '-h')
```

```
$ rerun compact -i plot_stress_5x10_50k_2khz.rrd -o /tmp/out.rrd
[2024-07-11T10:55:09Z INFO  rerun::run] compaction started src="plot_stress_5x10_50k_2khz.rrd" src_size_bytes=261 MiB dst="/tmp/out.rrd" max_num_rows=1 024 max_num_bytes=8.0 MiB
[2024-07-11T10:55:16Z INFO  rerun::run] compaction finished src="plot_stress_5x10_50k_2khz.rrd" src_size_bytes=261 MiB dst="/tmp/out.rrd" dst_size_bytes=94.3 MiB time=7.376564451s compaction_ratio="63.895%"
```

- DNM: Requires #6858 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6860?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6860?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6860)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.