### PR TITLE
CLI refactor: introduce `rerun rrd <compare|print|compact>` subscommand

### DIFF
--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -141,8 +141,8 @@ impl crate::DataUi for EntityDb {
 
                         This compaction process is an ephemeral, in-memory optimization of the Rerun viewer.\
                         It will not modify the recording itself: use the `Save` command of the viewer, or the \
-                        `rerun compact` CLI tool if you wish to persist the compacted results, which will make \
-                        future runs cheaper.
+                        `rerun rrd compact` CLI tool if you wish to persist the compacted results, which will \
+                        make future runs cheaper.
                         ",
                         re_format::format_uint(chunk_max_rows),
                         re_format::format_uint(chunk_max_rows_if_unsorted),

--- a/rerun_py/tests/unit/test_binary_stream.py
+++ b/rerun_py/tests/unit/test_binary_stream.py
@@ -61,7 +61,7 @@ def test_binary_stream() -> None:
                 f.write(data)
 
         subprocess.run(
-            ["rerun", "compare", f"{tmpdir}/output_A.rrd", f"{tmpdir}/output_B.rrd"],
+            ["rerun", "rrd", "compare", f"{tmpdir}/output_A.rrd", f"{tmpdir}/output_B.rrd"],
             check=True,
         )
 

--- a/scripts/roundtrip_utils.py
+++ b/scripts/roundtrip_utils.py
@@ -98,7 +98,7 @@ def cmake_build(target: str, release: bool) -> None:
 
 
 def run_comparison(rrd0_path: str, rrd1_path: str, full_dump: bool) -> None:
-    cmd = ["rerun", "compare"]
+    cmd = ["rerun", "rrd", "compare"]
     if full_dump:
         cmd += ["--full-dump"]
     cmd += [rrd0_path, rrd1_path]


### PR DESCRIPTION
Title.

```
$ rerun rrd --help
Usage: rerun rrd <COMMAND>

Commands:
  compare  Compares the data between 2 .rrd files, returning a successful shell exit code if they match
  print    Print the contents of an .rrd or .rbl file
  compact  Compacts the contents of an .rrd or .rbl file and writes the result to a new file
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```

- DNM: Requires #6860 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6861?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6861?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6861)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.