### PR TITLE
Update to glam 0.28 & replace `macaw` with fork `re_math`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.22.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2956,17 +2956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
 dependencies = [
  "twox-hash",
-]
-
-[[package]]
-name = "macaw"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e4daa18df16fd196b955e4bb16574641f39141fb3ea81b493a84b9439d17e6"
-dependencies = [
- "glam",
- "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -4636,6 +4625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_math"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999db5029a2879efeddb538f2e486aabf33adf7a0b3708c6df5c1cae13b3af49"
+dependencies = [
+ "glam",
+ "serde",
+]
+
+[[package]]
 name = "re_memory"
 version = "0.18.0-alpha.1+dev"
 dependencies = [
@@ -4709,7 +4708,6 @@ dependencies = [
  "gltf",
  "half 2.3.1",
  "itertools 0.13.0",
- "macaw",
  "never",
  "notify",
  "ordered-float",
@@ -4720,6 +4718,7 @@ dependencies = [
  "re_build_tools",
  "re_error",
  "re_log",
+ "re_math",
  "re_tracing",
  "serde",
  "slotmap",
@@ -4747,10 +4746,10 @@ dependencies = [
  "glam",
  "image",
  "itertools 0.13.0",
- "macaw",
  "pollster",
  "rand",
  "re_log",
+ "re_math",
  "re_renderer",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4920,7 +4919,6 @@ dependencies = [
  "egui",
  "glam",
  "itertools 0.13.0",
- "macaw",
  "mimalloc",
  "nohash-hasher",
  "once_cell",
@@ -4931,6 +4929,7 @@ dependencies = [
  "re_format",
  "re_log",
  "re_log_types",
+ "re_math",
  "re_query",
  "re_renderer",
  "re_space_view",
@@ -5300,7 +5299,6 @@ dependencies = [
  "indexmap 2.1.0",
  "itertools 0.13.0",
  "linked-hash-map",
- "macaw",
  "ndarray",
  "nohash-hasher",
  "once_cell",
@@ -5313,6 +5311,7 @@ dependencies = [
  "re_format",
  "re_log",
  "re_log_types",
+ "re_math",
  "re_query",
  "re_renderer",
  "re_smart_channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,10 @@ re_viewport = { path = "crates/viewer/re_viewport", version = "=0.18.0-alpha.1",
 re_viewport_blueprint = { path = "crates/viewer/re_viewport_blueprint", version = "=0.18.0-alpha.1", default-features = false }
 re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = "=0.18.0-alpha.1", default-features = false }
 
+# Rerun crates in other repos:
+ewebsock = "0.6.0"
+re_math = "0.20.0"
+
 # egui-crates:
 ecolor = "0.28.1"
 eframe = { version = "0.28.1", default-features = false, features = [
@@ -159,13 +163,12 @@ document-features = "0.2.8"
 ehttp = "0.5.0"
 enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
-ewebsock = "0.6.0"
 fixed = { version = "1.17", default-features = false }
 flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"
-glam = "0.22" # glam update blocked by macaw
+glam = "0.28"
 glob = "0.3"
 gltf = "1.1"
 half = "2.3.1"
@@ -182,7 +185,6 @@ linked-hash-map = { version = "0.5", default-features = false }
 log = "0.4"
 log-once = "0.4"
 lz4_flex = "0.11"
-macaw = "0.18"
 memory-stats = "1.1"
 mimalloc = "=0.1.37" # TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
 mime = "0.3"

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -50,6 +50,7 @@ serde = ["dep:serde"]
 [dependencies]
 re_error.workspace = true
 re_log.workspace = true
+re_math.workspace = true
 re_tracing.workspace = true
 
 ahash.workspace = true
@@ -64,7 +65,6 @@ enumset.workspace = true
 glam = { workspace = true, features = ["bytemuck"] }
 half = { workspace = true, features = ["bytemuck"] }
 itertools = { workspace = true }
-macaw.workspace = true
 never.workspace = true
 ordered-float.workspace = true
 parking_lot.workspace = true

--- a/crates/viewer/re_renderer/src/importer/mod.rs
+++ b/crates/viewer/re_renderer/src/importer/mod.rs
@@ -7,7 +7,7 @@ pub mod gltf;
 #[cfg(feature = "import-stl")]
 pub mod stl;
 
-use macaw::Vec3Ext as _;
+use re_math::Vec3Ext as _;
 
 use crate::renderer::MeshInstance;
 
@@ -21,8 +21,8 @@ pub fn to_uniform_scale(scale: glam::Vec3) -> f32 {
     }
 }
 
-pub fn calculate_bounding_box(instances: &[MeshInstance]) -> macaw::BoundingBox {
-    macaw::BoundingBox::from_points(
+pub fn calculate_bounding_box(instances: &[MeshInstance]) -> re_math::BoundingBox {
+    re_math::BoundingBox::from_points(
         instances
             .iter()
             .filter_map(|mesh_instance| {

--- a/crates/viewer/re_renderer/src/line_drawable_builder.rs
+++ b/crates/viewer/re_renderer/src/line_drawable_builder.rs
@@ -356,7 +356,7 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
     #[inline]
     pub fn add_box_outline(
         &mut self,
-        bbox: &macaw::BoundingBox,
+        bbox: &re_math::BoundingBox,
     ) -> Option<LineStripBuilder<'_, 'ctx>> {
         if !bbox.is_something() || !bbox.is_finite() {
             return None;

--- a/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
@@ -168,7 +168,7 @@ pub struct DepthCloud {
 
 impl DepthCloud {
     /// World-space bounding-box.
-    pub fn world_space_bbox(&self) -> macaw::BoundingBox {
+    pub fn world_space_bbox(&self) -> re_math::BoundingBox {
         let max_depth = self.max_depth_in_world;
         let w = self.depth_dimensions.x as f32;
         let h = self.depth_dimensions.y as f32;
@@ -184,7 +184,7 @@ impl DepthCloud {
         let focal_length = glam::vec2(intrinsics.col(0).x, intrinsics.col(1).y);
         let offset = intrinsics.col(2).truncate();
 
-        let mut bbox = macaw::BoundingBox::nothing();
+        let mut bbox = re_math::BoundingBox::NOTHING;
 
         for corner in corners {
             let depth = corner.z;

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -119,7 +119,7 @@ pub struct MeshInstance {
     pub mesh: Option<Arc<Mesh>>,
 
     /// Where this instance is placed in world space and how its oriented & scaled.
-    pub world_from_mesh: macaw::Affine3A,
+    pub world_from_mesh: glam::Affine3A,
 
     /// Per-instance (as opposed to per-material/mesh!) tint color that is added to the albedo texture.
     /// Alpha channel is currently unused.
@@ -137,7 +137,7 @@ impl Default for MeshInstance {
         Self {
             gpu_mesh: GpuMeshHandle::Invalid,
             mesh: None,
-            world_from_mesh: macaw::Affine3A::IDENTITY,
+            world_from_mesh: glam::Affine3A::IDENTITY,
             additive_tint: Color32::TRANSPARENT,
             outline_mask_ids: OutlineMaskPreference::NONE,
             picking_layer_id: PickingLayerId::default(),

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -192,7 +192,7 @@ pub struct TargetConfiguration {
 
     /// The viewport resolution in physical pixels.
     pub resolution_in_pixel: [u32; 2],
-    pub view_from_world: macaw::IsoTransform,
+    pub view_from_world: re_math::IsoTransform,
     pub projection_from_view: Projection,
 
     /// Defines a viewport transformation from the projected space to the final image space.

--- a/crates/viewer/re_renderer_examples/2d.rs
+++ b/crates/viewer/re_renderer_examples/2d.rs
@@ -298,7 +298,7 @@ impl framework::Example for Render2D {
                     TargetConfiguration {
                         name: "2D".into(),
                         resolution_in_pixel: splits[0].resolution_in_pixel,
-                        view_from_world: macaw::IsoTransform::IDENTITY,
+                        view_from_world: re_math::IsoTransform::IDENTITY,
                         projection_from_view: Projection::Orthographic {
                             camera_mode:
                                 view_builder::OrthographicCameraMode::TopLeftCornerAndExtendZ,
@@ -336,7 +336,7 @@ impl framework::Example for Render2D {
                     view_builder::TargetConfiguration {
                         name: "3D".into(),
                         resolution_in_pixel: splits[1].resolution_in_pixel,
-                        view_from_world: macaw::IsoTransform::look_at_rh(
+                        view_from_world: re_math::IsoTransform::look_at_rh(
                             camera_position,
                             camera_rotation_center,
                             glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/Cargo.toml
+++ b/crates/viewer/re_renderer_examples/Cargo.toml
@@ -39,6 +39,7 @@ path = "picking.rs"
 
 [dependencies]
 re_log = { workspace = true, features = ["setup"] }
+re_math.workspace = true
 re_renderer = { workspace = true, features = ["import-obj", "import-gltf"] }
 
 ahash.workspace = true
@@ -47,7 +48,6 @@ bytemuck.workspace = true
 glam.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
-macaw.workspace = true
 pollster.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 web-time.workspace = true

--- a/crates/viewer/re_renderer_examples/depth_cloud.rs
+++ b/crates/viewer/re_renderer_examples/depth_cloud.rs
@@ -20,7 +20,7 @@ use std::f32::consts::TAU;
 
 use glam::Vec3;
 use itertools::Itertools;
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 use re_renderer::{
     renderer::{
         ColormappedTexture, DepthCloud, DepthCloudDrawData, DepthClouds, DrawData,

--- a/crates/viewer/re_renderer_examples/depth_offset.rs
+++ b/crates/viewer/re_renderer_examples/depth_offset.rs
@@ -102,7 +102,7 @@ impl framework::Example for Render2D {
             view_builder::TargetConfiguration {
                 name: "3D".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     glam::Vec3::Z * 2.0 * self.distance_scale,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -8,8 +8,8 @@ use std::f32::consts::TAU;
 use framework::Example;
 use glam::Vec3;
 use itertools::Itertools;
-use re_math::IsoTransform;
 use rand::Rng;
+use re_math::IsoTransform;
 
 use re_renderer::{
     renderer::{

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -8,7 +8,7 @@ use std::f32::consts::TAU;
 use framework::Example;
 use glam::Vec3;
 use itertools::Itertools;
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 use rand::Rng;
 
 use re_renderer::{

--- a/crates/viewer/re_renderer_examples/outlines.rs
+++ b/crates/viewer/re_renderer_examples/outlines.rs
@@ -57,7 +57,7 @@ impl framework::Example for Outlines {
             TargetConfiguration {
                 name: "OutlinesDemo".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     camera_position,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_renderer_examples/picking.rs
+++ b/crates/viewer/re_renderer_examples/picking.rs
@@ -128,7 +128,7 @@ impl framework::Example for Picking {
             TargetConfiguration {
                 name: "OutlinesDemo".into(),
                 resolution_in_pixel: resolution,
-                view_from_world: macaw::IsoTransform::look_at_rh(
+                view_from_world: re_math::IsoTransform::look_at_rh(
                     camera_position,
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,

--- a/crates/viewer/re_space_view_spatial/Cargo.toml
+++ b/crates/viewer/re_space_view_spatial/Cargo.toml
@@ -26,6 +26,7 @@ re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
+re_math = { workspace = true, features = ["serde"] }
 re_query.workspace = true
 re_renderer = { workspace = true, features = [
   "import-gltf",
@@ -46,7 +47,6 @@ bytemuck.workspace = true
 egui = { workspace = true, features = ["serde"] }
 glam.workspace = true
 itertools.workspace = true
-macaw = { workspace = true, features = ["with_serde"] }
 nohash-hasher.workspace = true
 once_cell.workspace = true
 serde.workspace = true

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -152,7 +152,7 @@ impl ViewContextSystem for TransformContext {
                 }
                 Ok(None) => {}
                 Ok(Some(parent_from_child)) => {
-                    reference_from_ancestor = reference_from_ancestor * parent_from_child.inverse();
+                    reference_from_ancestor *= parent_from_child.inverse();
                 }
             }
 

--- a/crates/viewer/re_space_view_spatial/src/eye.rs
+++ b/crates/viewer/re_space_view_spatial/src/eye.rs
@@ -1,5 +1,7 @@
 use egui::{lerp, NumExt as _, Rect};
-use macaw::{vec3, IsoTransform, Mat4, Quat, Vec3};
+use glam::{vec3, Mat4, Quat, Vec3};
+
+use re_math::IsoTransform;
 
 use re_space_view::controls::{
     RuntimeModifiers, DRAG_PAN3D_BUTTON, ROLL_MOUSE, ROLL_MOUSE_ALT, ROLL_MOUSE_MODIFIER,
@@ -85,7 +87,7 @@ impl Eye {
 
     /// Picking ray for a given pointer in the parent space
     /// (i.e. prior to camera transform, "world" space)
-    pub fn picking_ray(&self, screen_rect: Rect, pointer: glam::Vec2) -> macaw::Ray3 {
+    pub fn picking_ray(&self, screen_rect: Rect, pointer: glam::Vec2) -> re_math::Ray3 {
         if let Some(fov_y) = self.fov_y {
             let (w, h) = (screen_rect.width(), screen_rect.height());
             let aspect_ratio = w / h;
@@ -95,7 +97,7 @@ impl Eye {
             let ray_dir = self
                 .world_from_rub_view
                 .transform_vector3(glam::vec3(px, py, -1.0));
-            macaw::Ray3::from_origin_dir(self.pos_in_world(), ray_dir.normalize_or_zero())
+            re_math::Ray3::from_origin_dir(self.pos_in_world(), ray_dir.normalize_or_zero())
         } else {
             // The ray originates on the camera plane, not from the camera position
             let ray_dir = self.world_from_rub_view.rotation().mul_vec3(glam::Vec3::Z);
@@ -104,7 +106,7 @@ impl Eye {
                 + self.world_from_rub_view.rotation().mul_vec3(glam::Vec3::Y) * pointer.y
                 + ray_dir * self.near();
 
-            macaw::Ray3::from_origin_dir(origin, ray_dir)
+            re_math::Ray3::from_origin_dir(origin, ray_dir)
         }
     }
 

--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -15,7 +15,7 @@ pub struct LoadedMesh {
     // Can't do that right now because it's too hard to pass the render context through.
     pub mesh_instances: Vec<re_renderer::renderer::MeshInstance>,
 
-    bbox: macaw::BoundingBox,
+    bbox: re_math::BoundingBox,
 }
 
 impl LoadedMesh {
@@ -149,7 +149,7 @@ impl LoadedMesh {
 
         let bbox = {
             re_tracing::profile_scope!("bbox");
-            macaw::BoundingBox::from_points(vertex_positions.iter().copied())
+            re_math::BoundingBox::from_points(vertex_positions.iter().copied())
         };
 
         let albedo = if let Some(albedo_texture) = &albedo_texture {
@@ -197,7 +197,7 @@ impl LoadedMesh {
         &self.name
     }
 
-    pub fn bbox(&self) -> macaw::BoundingBox {
+    pub fn bbox(&self) -> re_math::BoundingBox {
         self.bbox
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/picking.rs
+++ b/crates/viewer/re_space_view_spatial/src/picking.rs
@@ -73,7 +73,7 @@ pub struct PickingContext {
     pub pointer_in_space2d: glam::Vec2,
 
     /// The picking ray used. Given in the coordinates of the space the picking is performed in.
-    pub ray_in_world: macaw::Ray3,
+    pub ray_in_world: re_math::Ray3,
 }
 
 impl PickingContext {
@@ -257,7 +257,7 @@ fn picking_textured_rects<'a>(
             continue; // extent_u and extent_v are parallel. Shouldn't happen.
         };
 
-        let rect_plane = macaw::Plane3::from_normal_point(normal, rect.top_left_corner_position);
+        let rect_plane = re_math::Plane3::from_normal_point(normal, rect.top_left_corner_position);
 
         // TODO(andreas): Interaction radius is currently ignored for rects.
         let (intersect, t) =

--- a/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
+++ b/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
@@ -8,22 +8,22 @@ use crate::visualizers::SpatialViewVisualizerData;
 #[derive(Clone)]
 pub struct SceneBoundingBoxes {
     /// Overall bounding box of the scene for the current query.
-    pub current: macaw::BoundingBox,
+    pub current: re_math::BoundingBox,
 
     /// A bounding box that smoothly transitions to the current bounding box.
     ///
     /// If discontinuities are detected, this bounding box will be reset immediately to the current bounding box.
-    pub smoothed: macaw::BoundingBox,
+    pub smoothed: re_math::BoundingBox,
 
     /// Per-entity bounding boxes for the current query.
-    pub per_entity: IntMap<EntityPathHash, macaw::BoundingBox>,
+    pub per_entity: IntMap<EntityPathHash, re_math::BoundingBox>,
 }
 
 impl Default for SceneBoundingBoxes {
     fn default() -> Self {
         Self {
-            current: macaw::BoundingBox::nothing(),
-            smoothed: macaw::BoundingBox::nothing(),
+            current: re_math::BoundingBox::NOTHING,
+            smoothed: re_math::BoundingBox::NOTHING,
             per_entity: IntMap::default(),
         }
     }
@@ -34,7 +34,7 @@ impl SceneBoundingBoxes {
         re_tracing::profile_function!();
 
         let previous = self.current;
-        self.current = macaw::BoundingBox::nothing();
+        self.current = re_math::BoundingBox::NOTHING;
         self.per_entity.clear();
 
         for visualizer in visualizers.iter() {
@@ -79,7 +79,7 @@ impl SceneBoundingBoxes {
             let new_smoothed_size = self.smoothed.size().lerp(current_size, smoothing_factor);
 
             self.smoothed =
-                macaw::BoundingBox::from_center_size(new_smoothed_center, new_smoothed_size);
+                re_math::BoundingBox::from_center_size(new_smoothed_center, new_smoothed_size);
 
             let current_diagonal_length = current_size.length();
             let sameness_threshold = current_diagonal_length * (0.1 / 100.0); // 0.1% of the diagonal.
@@ -94,8 +94,8 @@ impl SceneBoundingBoxes {
 }
 
 fn detect_boundingbox_discontinuity(
-    current: macaw::BoundingBox,
-    previous: macaw::BoundingBox,
+    current: re_math::BoundingBox,
+    previous: re_math::BoundingBox,
 ) -> bool {
     if !previous.is_finite() {
         // Previous bounding box is not finite, so we can't compare.

--- a/crates/viewer/re_space_view_spatial/src/space_camera_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/space_camera_3d.rs
@@ -1,5 +1,5 @@
 use glam::Vec3;
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 
 use re_log_types::EntityPath;
 use re_types::archetypes::Pinhole;

--- a/crates/viewer/re_space_view_spatial/src/ui.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use egui::{epaint::util::OrderedFloat, text::TextWrapping, NumExt, WidgetText};
-use macaw::BoundingBox;
+use re_math::BoundingBox;
 
 use re_data_ui::{
     item_ui, show_zoomed_image_region, show_zoomed_image_region_area_outline, DataUi,

--- a/crates/viewer/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_2d.rs
@@ -1,5 +1,5 @@
 use egui::{emath::RectTransform, pos2, vec2, Align2, Color32, Pos2, Rect, Shape, Vec2};
-use macaw::IsoTransform;
+use re_math::IsoTransform;
 
 use re_entity_db::EntityPath;
 use re_log::ResultExt as _;
@@ -371,7 +371,7 @@ fn setup_target_config(
     let focal_length = 2.0 / (1.0 / focal_length.x() + 1.0 / focal_length.y()); // harmonic mean (lack of anamorphic support)
 
     // Position the camera looking straight at the principal point:
-    let view_from_world = macaw::IsoTransform::look_at_rh(
+    let view_from_world = re_math::IsoTransform::look_at_rh(
         pinhole.principal_point().extend(-focal_length),
         pinhole.principal_point().extend(0.0),
         -glam::Vec3::Y,

--- a/crates/viewer/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_3d.rs
@@ -1,11 +1,9 @@
 use egui::{emath::RectTransform, NumExt as _};
-use glam::Affine3A;
-use macaw::{BoundingBox, Quat, Vec3};
-use re_ui::ContextExt;
-use re_viewport_blueprint::ViewProperty;
+use glam::{Affine3A, Quat, Vec3};
 use web_time::Instant;
 
 use re_log_types::EntityPath;
+use re_math::BoundingBox;
 use re_renderer::{
     view_builder::{Projection, TargetConfiguration, ViewBuilder},
     LineDrawableBuilder, Size,
@@ -17,10 +15,12 @@ use re_space_view::controls::{
 use re_types::{
     blueprint::archetypes::Background, components::ViewCoordinates, view_coordinates::SignedAxis3,
 };
+use re_ui::ContextExt;
 use re_viewer_context::{
     gpu_bridge, Item, ItemSpaceContext, SpaceViewSystemExecutionError, SystemExecutionOutput,
     ViewQuery, ViewerContext,
 };
+use re_viewport_blueprint::ViewProperty;
 
 use crate::{
     scene_bounding_boxes::SceneBoundingBoxes,
@@ -520,7 +520,7 @@ impl SpatialSpaceView3D {
             let axis_length = 1.0; // The axes are also a measuring stick
             crate::visualizers::add_axis_arrows(
                 &mut line_builder,
-                macaw::Affine3A::IDENTITY,
+                glam::Affine3A::IDENTITY,
                 None,
                 axis_length,
                 re_renderer::OutlineMaskPreference::NONE,
@@ -837,7 +837,7 @@ fn show_projections_from_2d_space(
                     let origin = cam.position();
 
                     if let Some(dir) = (stop_in_world - origin).try_normalize() {
-                        let ray = macaw::Ray3::from_origin_dir(origin, dir);
+                        let ray = re_math::Ray3::from_origin_dir(origin, dir);
 
                         let thick_ray_length = (stop_in_world - origin).length();
                         add_picking_ray(
@@ -864,7 +864,7 @@ fn show_projections_from_2d_space(
                 {
                     let cam_to_pos = *pos - tracked_camera.position();
                     let distance = cam_to_pos.length();
-                    let ray = macaw::Ray3::from_origin_dir(
+                    let ray = re_math::Ray3::from_origin_dir(
                         tracked_camera.position(),
                         cam_to_pos / distance,
                     );
@@ -884,7 +884,7 @@ fn show_projections_from_2d_space(
 
 fn add_picking_ray(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
-    ray: macaw::Ray3,
+    ray: re_math::Ray3,
     scene_bbox: &BoundingBox,
     thick_ray_length: f32,
     ray_color: egui::Color32,
@@ -908,7 +908,7 @@ fn add_picking_ray(
 }
 
 fn default_eye(
-    bounding_box: &macaw::BoundingBox,
+    bounding_box: &re_math::BoundingBox,
     scene_view_coordinates: Option<ViewCoordinates>,
 ) -> ViewEye {
     // Defaults to RFU.

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -78,7 +78,7 @@ impl Arrows2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
             let origins =
                 clamped(data.origins, num_instances).chain(std::iter::repeat(&Position2D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -78,7 +78,7 @@ impl Arrows3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
             let origins =
                 clamped(data.origins, num_instances).chain(std::iter::repeat(&Position3D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -127,7 +127,7 @@ impl Boxes2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
             let centers =
                 clamped(data.centers, num_instances).chain(std::iter::repeat(&Position2D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -74,7 +74,7 @@ impl Boxes3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
             let centers =
                 clamped(data.centers, num_instances).chain(std::iter::repeat(&Position3D::ZERO));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
@@ -67,7 +67,7 @@ impl CamerasVisualizer {
             self.space_cameras.push(SpaceCamera3D {
                 ent_path: ent_path.clone(),
                 pinhole_view_coordinates,
-                world_from_camera: macaw::IsoTransform::IDENTITY,
+                world_from_camera: re_math::IsoTransform::IDENTITY,
                 pinhole: Some(pinhole.clone()),
                 picture_plane_distance: frustum_length,
             });
@@ -86,7 +86,7 @@ impl CamerasVisualizer {
             let world_from_parent = ent_path
                 .parent()
                 .and_then(|parent_path| transforms.reference_from_entity(&parent_path))
-                .unwrap_or(macaw::Affine3A::IDENTITY);
+                .unwrap_or(glam::Affine3A::IDENTITY);
 
             // Then combine it with the transform at the entity itself, if there is one.
             if let Some(transform_at_entity) = transform_at_entity {
@@ -99,7 +99,7 @@ impl CamerasVisualizer {
         // If this transform is not representable as an `IsoTransform` we can't display it yet.
         // This would happen if the camera is under another camera or under a transform with non-uniform scale.
         let Some(world_from_camera_rigid_iso) =
-            macaw::IsoTransform::from_mat4(&world_from_camera_rigid.into())
+            re_math::IsoTransform::from_mat4(&world_from_camera_rigid.into())
         else {
             return;
         };

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -76,7 +76,7 @@ impl Lines2DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
             for (i, (strip, radius, &color)) in
                 itertools::izip!(data.strips, radii, &colors).enumerate()
             {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -78,7 +78,7 @@ impl Lines3DVisualizer {
                 .outline_mask_ids(ent_context.highlight.overall)
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()));
 
-            let mut obj_space_bounding_box = macaw::BoundingBox::nothing();
+            let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
             let mut num_rendered_strips = 0usize;
             for (i, (strip, radius, &color)) in

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -118,7 +118,8 @@ impl Points2DVisualizer {
                 }
             }
 
-            let obj_space_bounding_box = macaw::BoundingBox::from_points(positions.iter().copied());
+            let obj_space_bounding_box =
+                re_math::BoundingBox::from_points(positions.iter().copied());
             self.data.add_bounding_box(
                 entity_path.hash(),
                 obj_space_bounding_box,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -123,7 +123,7 @@ impl Points3DVisualizer {
                 }
             }
 
-            let obj_space_bounding_box = macaw::BoundingBox::from_points(positions.iter().copied());
+            let obj_space_bounding_box = re_math::BoundingBox::from_points(positions.iter().copied());
             self.data.add_bounding_box(
                 entity_path.hash(),
                 obj_space_bounding_box,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -123,7 +123,8 @@ impl Points3DVisualizer {
                 }
             }
 
-            let obj_space_bounding_box = re_math::BoundingBox::from_points(positions.iter().copied());
+            let obj_space_bounding_box =
+                re_math::BoundingBox::from_points(positions.iter().copied());
             self.data.add_bounding_box(
                 entity_path.hash(),
                 obj_space_bounding_box,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -81,7 +81,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
             // Only add the center to the bounding box - the lines may be dependent on the bounding box, causing a feedback loop otherwise.
             self.0.add_bounding_box(
                 data_result.entity_path.hash(),
-                macaw::BoundingBox::ZERO,
+                re_math::BoundingBox::ZERO,
                 world_from_obj,
             );
 
@@ -123,7 +123,7 @@ const AXIS_COLOR_Z: Color32 = Color32::from_rgb(80, 80, 255);
 
 pub fn add_axis_arrows(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
-    world_from_obj: macaw::Affine3A,
+    world_from_obj: glam::Affine3A,
     ent_path: Option<&EntityPath>,
     axis_length: f32,
     outline_mask_ids: re_renderer::OutlineMaskPreference,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/spatial_view_visualizer.rs
@@ -8,7 +8,7 @@ use crate::view_kind::SpatialSpaceViewKind;
 /// Each spatial scene element is expected to fill an instance of this struct with its data.
 pub struct SpatialViewVisualizerData {
     pub ui_labels: Vec<UiLabel>,
-    pub bounding_boxes: Vec<(EntityPathHash, macaw::BoundingBox)>,
+    pub bounding_boxes: Vec<(EntityPathHash, re_math::BoundingBox)>,
     pub preferred_view_kind: Option<SpatialSpaceViewKind>,
 }
 
@@ -24,7 +24,7 @@ impl SpatialViewVisualizerData {
     pub fn add_bounding_box(
         &mut self,
         entity: EntityPathHash,
-        bbox: macaw::BoundingBox,
+        bbox: re_math::BoundingBox,
         world_from_obj: glam::Affine3A,
     ) {
         self.bounding_boxes
@@ -40,7 +40,7 @@ impl SpatialViewVisualizerData {
         re_tracing::profile_function!();
         self.add_bounding_box(
             entity,
-            macaw::BoundingBox::from_points(points),
+            re_math::BoundingBox::from_points(points),
             world_from_obj,
         );
     }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/textured_rect.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/textured_rect.rs
@@ -88,12 +88,12 @@ pub fn tensor_to_textured_rect(
 
 pub fn bounding_box_for_textured_rect(
     textured_rect: &renderer::TexturedRect,
-) -> macaw::BoundingBox {
+) -> re_math::BoundingBox {
     let left_top = textured_rect.top_left_corner_position;
     let extent_u = textured_rect.extent_u;
     let extent_v = textured_rect.extent_v;
 
-    macaw::BoundingBox::from_points(
+    re_math::BoundingBox::from_points(
         [
             left_top,
             left_top + extent_u,

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -19,14 +19,15 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_chunk_store.workspace = true
 re_chunk.workspace = true
 re_data_source.workspace = true
-re_chunk_store.workspace = true
 re_entity_db = { workspace = true, features = ["serde"] }
 re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
+re_math.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_smart_channel.workspace = true
@@ -50,7 +51,6 @@ half.workspace = true
 indexmap = { workspace = true, features = ["std", "serde"] }
 itertools.workspace = true
 linked-hash-map.workspace = true
-macaw.workspace = true
 ndarray.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -174,7 +174,7 @@ pub fn render_image(
     let target_config = re_renderer::view_builder::TargetConfiguration {
         name: debug_name.into(),
         resolution_in_pixel,
-        view_from_world: macaw::IsoTransform::from_translation(-top_left_position.extend(0.0)),
+        view_from_world: re_math::IsoTransform::from_translation(-top_left_position.extend(0.0)),
         projection_from_view: re_renderer::view_builder::Projection::Orthographic {
             camera_mode: re_renderer::view_builder::OrthographicCameraMode::TopLeftCornerAndExtendZ,
             vertical_world_size: space_from_pixel * resolution_in_pixel[1] as f32,

--- a/examples/rust/minimal_options/Cargo.toml
+++ b/examples/rust/minimal_options/Cargo.toml
@@ -14,4 +14,4 @@ rerun = { path = "../../../crates/top/rerun", features = [
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-glam = "0.22"
+glam = "0.28"

--- a/examples/rust/objectron/Cargo.toml
+++ b/examples/rust/objectron/Cargo.toml
@@ -15,7 +15,7 @@ rerun = { path = "../../../crates/top/rerun", features = [
 
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-glam = "0.22"
+glam = "0.28"
 prost = "0.12"
 
 

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -607,7 +607,7 @@ def test_lint_workspace_deps() -> None:
 
         anyhow = "1.0"
         clap = { version = "4.0", features = ["derive"] }
-        glam = "0.22"
+        glam = "0.28"
         """,
     ]
 


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6467

[macaw](https://crates.io/crates/macaw) (which I was one of the main contributors at Embark) is no longer maintained. This is holding us back from updating `glam`. So it is now forked at https://github.com/rerun-io/re_math

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6867?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6867?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6867)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.