### PR TITLE
Recommend install rerun-cli with `--locked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1107,7 +1107,7 @@ This is a small release primarily to tie up some loose ends for our C++ SDK.
 [Rerun](https://www.rerun.io/) is an easy-to-use visualization toolbox for computer vision and robotics.
 
 * Python: `pip install rerun-sdk`
-* Rust: `cargo add rerun` and `cargo install rerun-cli`
+* Rust: `cargo add rerun` and `cargo install rerun-cli --locked`
 * Online demo: <https://app.rerun.io/version/0.10.0/>
 
 Release blog post: <https://www.rerun.io/blog/cpp-sdk>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ rr.log("path/to/points", rr.Points3D(positions, colors=colors))
 
 ### Installing the Rerun Viewer binary
 To stream log data over the network or load our `.rrd` data files you also need the `rerun` binary.
-It can be installed with `pip install rerun-sdk` or with `cargo install rerun-cli`.
+It can be installed with `pip install rerun-sdk` or with `cargo install rerun-cli --locked`.
 Note that only the Python SDK comes bundled with the Viewer whereas C++ & Rust always rely on a separate install.
 
 You should now be able to run `rerun --help` in any terminal.

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -82,7 +82,7 @@ pub enum Environment {
     ///
     /// This is _most likely_ a Rerun user who is compiling a `re_` crate
     /// because they depend on it either directly or indirectly in their `Cargo.toml`,
-    /// or they running `cargo install rerun-cli` or other tool that depend on a `re_` crate.
+    /// or they running `cargo install rerun-cli --locked` or other tool that depend on a `re_` crate.
     ///
     /// In these cases we should do as little shenanigans in the `build.rs` as possible.
     UsedAsDependency,

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -475,7 +475,7 @@ impl RecordingStreamBuilder {
     /// If the `open_browser` argument is `true`, your default browser will be opened with a
     /// connected web-viewer.
     ///
-    /// If not, you can connect to this server using the `rerun` binary (`cargo install rerun-cli`).
+    /// If not, you can connect to this server using the `rerun` binary (`cargo install rerun-cli --locked`).
     ///
     /// ## Details
     /// This method will spawn two servers: one HTTPS server serving the Rerun Web Viewer `.html` and `.wasm` files,

--- a/crates/top/re_sdk/src/web_viewer.rs
+++ b/crates/top/re_sdk/src/web_viewer.rs
@@ -144,7 +144,7 @@ pub fn host_web_viewer(
 /// If the `open_browser` argument is `true`, your default browser
 /// will be opened with a connected web-viewer.
 ///
-/// If not, you can connect to this server using the `rerun` binary (`cargo install rerun-cli`).
+/// If not, you can connect to this server using the `rerun` binary (`cargo install rerun-cli --locked`).
 ///
 /// NOTE: you can not connect one `Session` to another.
 ///

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/bin/rerun.rs"
 doc = false
 
 [features]
-# The default is what the user gets when they call `cargo install rerun-cli`,
+# The default is what the user gets when they call `cargo install rerun-cli --locked`,
 # so wer have all the bells and wistles here
 default = ["native_viewer", "web_viewer"]
 

--- a/crates/top/rerun-cli/README.md
+++ b/crates/top/rerun-cli/README.md
@@ -13,7 +13,7 @@
 </h1>
 
 ## Rerun command-line tool
-You can install the binary with `cargo install rerun-cli`
+You can install the binary with `cargo install rerun-cli --locked`
 
 This can act either as a server, a viewer, or both, depending on which options you use when you start it.
 

--- a/crates/top/rerun/README.md
+++ b/crates/top/rerun/README.md
@@ -41,7 +41,7 @@ You can add the `rerun` crate to your project with `cargo add rerun`.
 To get started, see [the examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust).
 
 ## Binary
-You can install the binary with `cargo install rerun-cli`
+You can install the binary with `cargo install rerun-cli --locked`
 
 This can act either as a server, a viewer, or both, depending on which options you use when you start it.
 

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -5,7 +5,7 @@
 //! There is also a `rerun` binary.
 //! The binary is required in order to stream log data
 //! over the networks, and to open our `.rrd` data files.
-//! If you need it, install the `rerun` binary with `cargo install rerun-cli`.
+//! If you need it, install the `rerun` binary with `cargo install rerun-cli --locked`.
 //!
 //!
 //! ## Feature flags
@@ -36,7 +36,7 @@
 //! The binary can act either as a server, a viewer, or both,
 //! depending on which options you use when you start it.
 //!
-//! Install it with `cargo install rerun-cli`.
+//! Install it with `cargo install rerun-cli --locked`.
 //!
 //! Running just `rerun` will start the viewer, waiting for the logging library to connect
 //! using [`RecordingStreamBuilder::connect`] (see below).

--- a/crates/viewer/re_viewer/data/quick_start_guides/cpp_connect.md
+++ b/crates/viewer/re_viewer/data/quick_start_guides/cpp_connect.md
@@ -4,7 +4,7 @@
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
-* Via cargo: `cargo install rerun-cli`
+* Via cargo: `cargo install rerun-cli --locked`
 * Via pip: `pip install rerun-sdk`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.

--- a/crates/viewer/re_viewer/data/quick_start_guides/cpp_spawn.md
+++ b/crates/viewer/re_viewer/data/quick_start_guides/cpp_spawn.md
@@ -4,7 +4,7 @@
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
-* Via cargo: `cargo install rerun-cli`
+* Via cargo: `cargo install rerun-cli --locked`
 * Via pip: `pip install rerun-sdk`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.

--- a/docs/content/getting-started/installing-viewer.md
+++ b/docs/content/getting-started/installing-viewer.md
@@ -40,7 +40,7 @@ There are many ways to install the viewer. Please pick whatever works best for y
 -   Download `rerun-cli` for your platform from the [GitHub Release artifacts](https://github.com/rerun-io/rerun/releases/latest/).
 -   Via Cargo
     -   `cargo binstall rerun-cli` - download binaries via [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall)
-    -   `cargo install rerun-cli` - build it from source (this requires Rust 1.76+)
+    -   `cargo install rerun-cli --locked` - build it from source (this requires Rust 1.76+)
 -   Together with the Rerun [Python SDK](./quick-start/python.md):
     -   `pip3 install rerun-sdk` - download it via pip
     -   `conda install -c conda-forge rerun-sdk` - download via Conda


### PR DESCRIPTION
Otherwise 3rd party crates can break the install:
* https://github.com/rerun-io/rerun/issues/6865

I've also updated https://github.com/rerun-io/rerun/releases/tag/0.17.0

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)