### PR TITLE
Optimize data clamping in spatial view

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    entity_iterator::clamped, process_annotation_and_keypoint_slices, process_color_slice,
+    entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
     process_labels_2d, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
@@ -80,8 +80,8 @@ impl Arrows2DVisualizer {
 
             let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
-            let origins =
-                clamped(data.origins, num_instances).chain(std::iter::repeat(&Position2D::ZERO));
+            let origins = clamped_or(data.origins, &Position2D::ZERO);
+
             for (i, (vector, origin, radius, &color)) in
                 itertools::izip!(data.vectors, origins, radii, &colors).enumerate()
             {
@@ -127,9 +127,8 @@ impl Arrows2DVisualizer {
                     ))
                 } else {
                     // Take middle point of every arrow.
-                    let origins = clamped(data.origins, num_instances)
-                        .chain(std::iter::repeat(&Position2D::ZERO));
-                    itertools::Either::Right(data.vectors.iter().zip(origins).map(
+                    let origins = clamped_or(data.origins, &Position2D::ZERO);
+                    itertools::Either::Right(itertools::izip!(data.vectors, origins).map(
                         |(vector, origin)| {
                             // `0.45` rather than `0.5` to account for cap and such
                             glam::Vec2::from(origin.0) + glam::Vec2::from(vector.0) * 0.45

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::{
-    entity_iterator::clamped, process_annotation_and_keypoint_slices, process_color_slice,
+    entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
     process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
@@ -80,8 +80,8 @@ impl Arrows3DVisualizer {
 
             let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
-            let origins =
-                clamped(data.origins, num_instances).chain(std::iter::repeat(&Position3D::ZERO));
+            let origins = clamped_or(data.origins, &Position3D::ZERO);
+
             for (i, (vector, origin, radius, &color)) in
                 itertools::izip!(data.vectors, origins, radii, &colors).enumerate()
             {
@@ -126,10 +126,9 @@ impl Arrows3DVisualizer {
                     itertools::Either::Left(std::iter::once(obj_space_bounding_box.center()))
                 } else {
                     // Take middle point of every arrow.
-                    let origins = clamped(data.origins, num_instances)
-                        .chain(std::iter::repeat(&Position3D::ZERO));
+                    let origins = clamped_or(data.origins, &Position3D::ZERO);
 
-                    itertools::Either::Right(data.vectors.iter().zip(origins).map(
+                    itertools::Either::Right(itertools::izip!(data.vectors, origins).map(
                         |(vector, origin)| {
                             // `0.45` rather than `0.5` to account for cap and such
                             glam::Vec3::from(origin.0) + glam::Vec3::from(vector.0) * 0.45

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -16,13 +16,13 @@ use re_viewer_context::{
 use crate::{
     contexts::SpatialSceneEntityContext,
     view_kind::SpatialSpaceViewKind,
-    visualizers::{UiLabel, UiLabelTarget},
+    visualizers::{entity_iterator::clamped_or, UiLabel, UiLabelTarget},
 };
 
 use super::{
-    entity_iterator::clamped, filter_visualizable_2d_entities,
-    process_annotation_and_keypoint_slices, process_color_slice, process_labels_2d,
-    process_radius_slice, SpatialViewVisualizerData, SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
+    filter_visualizable_2d_entities, process_annotation_and_keypoint_slices, process_color_slice,
+    process_labels_2d, process_radius_slice, SpatialViewVisualizerData,
+    SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
 // ---
@@ -64,7 +64,8 @@ impl Boxes2DVisualizer {
             .iter()
             .zip(labels.iter().map(Some).chain(std::iter::repeat(None)))
             .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
-        let colors = clamped(colors, annotation_infos.len());
+
+        let colors = clamped_or(colors, &egui::Color32::WHITE);
 
         itertools::izip!(half_sizes, centers, labels, colors)
             .enumerate()
@@ -129,8 +130,8 @@ impl Boxes2DVisualizer {
 
             let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
-            let centers =
-                clamped(data.centers, num_instances).chain(std::iter::repeat(&Position2D::ZERO));
+            let centers = clamped_or(data.centers, &Position2D::ZERO);
+
             for (i, (half_size, center, radius, &color)) in
                 itertools::izip!(data.half_sizes, centers, radii, &colors).enumerate()
             {
@@ -176,8 +177,7 @@ impl Boxes2DVisualizer {
                         ent_context.world_from_entity,
                     ));
                 } else {
-                    let centers = clamped(data.centers, num_instances)
-                        .chain(std::iter::repeat(&Position2D::ZERO));
+                    let centers = clamped_or(data.centers, &Position2D::ZERO);
                     self.data.ui_labels.extend(Self::process_labels(
                         entity_path,
                         data.half_sizes,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -15,7 +15,7 @@ use re_viewer_context::{
 use crate::{contexts::SpatialSceneEntityContext, view_kind::SpatialSpaceViewKind};
 
 use super::{
-    entity_iterator::clamped, filter_visualizable_3d_entities,
+    entity_iterator::clamped_or, filter_visualizable_3d_entities,
     process_annotation_and_keypoint_slices, process_color_slice, process_labels_3d,
     process_radius_slice, SpatialViewVisualizerData, SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
@@ -76,10 +76,8 @@ impl Boxes3DVisualizer {
 
             let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
 
-            let centers =
-                clamped(data.centers, num_instances).chain(std::iter::repeat(&Position3D::ZERO));
-            let rotations = clamped(data.rotations, num_instances)
-                .chain(std::iter::repeat(&Rotation3D::IDENTITY));
+            let centers = clamped_or(data.centers, &Position3D::ZERO);
+            let rotations = clamped_or(data.rotations, &Rotation3D::IDENTITY);
             for (i, (half_size, &center, rotation, radius, &color)) in
                 itertools::izip!(data.half_sizes, centers, rotations, radii, &colors).enumerate()
             {
@@ -123,9 +121,7 @@ impl Boxes3DVisualizer {
                 } else {
                     // Take center point of every box.
                     itertools::Either::Right(
-                        clamped(data.centers, num_instances)
-                            .chain(std::iter::repeat(&Position3D::ZERO))
-                            .map(|&c| c.into()),
+                        clamped_or(data.centers, &Position3D::ZERO).map(|&c| c.into()),
                     )
                 };
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -23,7 +23,8 @@ use crate::{
 };
 
 use super::{
-    entity_iterator::clamped_vec, filter_visualizable_3d_entities, SpatialViewVisualizerData,
+    entity_iterator::clamped_vec_or_empty, filter_visualizable_3d_entities,
+    SpatialViewVisualizerData,
 };
 
 // ---
@@ -86,10 +87,12 @@ impl Mesh3DVisualizer {
                     media_type: None,
                 };
 
-                let vertex_normals = clamped_vec(data.vertex_normals, data.vertex_positions.len());
-                let vertex_colors = clamped_vec(data.vertex_colors, data.vertex_positions.len());
+                let vertex_normals =
+                    clamped_vec_or_empty(data.vertex_normals, data.vertex_positions.len());
+                let vertex_colors =
+                    clamped_vec_or_empty(data.vertex_colors, data.vertex_positions.len());
                 let vertex_texcoords =
-                    clamped_vec(data.vertex_texcoords, data.vertex_positions.len());
+                    clamped_vec_or_empty(data.vertex_texcoords, data.vertex_positions.len());
 
                 c.entry(
                     &entity_path.to_string(),

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools as _;
 use re_chunk_store::RowId;
 use re_log_types::{hash::Hash64, Instance, TimeInt};
 use re_query::range_zip_1x7;
@@ -23,7 +22,9 @@ use crate::{
     view_kind::SpatialSpaceViewKind,
 };
 
-use super::{entity_iterator::clamped, filter_visualizable_3d_entities, SpatialViewVisualizerData};
+use super::{
+    entity_iterator::clamped_vec, filter_visualizable_3d_entities, SpatialViewVisualizerData,
+};
 
 // ---
 
@@ -85,15 +86,10 @@ impl Mesh3DVisualizer {
                     media_type: None,
                 };
 
-                let vertex_normals = clamped(data.vertex_normals, data.vertex_positions.len())
-                    .copied()
-                    .collect_vec();
-                let vertex_colors = clamped(data.vertex_colors, data.vertex_positions.len())
-                    .copied()
-                    .collect_vec();
-                let vertex_texcoords = clamped(data.vertex_texcoords, data.vertex_positions.len())
-                    .copied()
-                    .collect_vec();
+                let vertex_normals = clamped_vec(data.vertex_normals, data.vertex_positions.len());
+                let vertex_colors = clamped_vec(data.vertex_colors, data.vertex_positions.len());
+                let vertex_texcoords =
+                    clamped_vec(data.vertex_texcoords, data.vertex_positions.len());
 
                 c.entry(
                     &entity_path.to_string(),

--- a/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
@@ -44,7 +44,7 @@ use re_viewer_context::{
     VisualizableFilterContext, VisualizerCollection,
 };
 
-use utilities::entity_iterator::clamped;
+use utilities::entity_iterator::clamped_or_nothing;
 
 use crate::view_2d::VisualizableFilterContext2D;
 use crate::view_3d::VisualizableFilterContext3D;
@@ -154,7 +154,7 @@ pub fn process_color_slice<'a>(
             // Common happy path
             vec![to_egui_color(last_color); num_instances]
         } else {
-            let colors = clamped(colors, num_instances);
+            let colors = clamped_or_nothing(colors, num_instances);
             colors.map(to_egui_color).collect()
         }
     } else {
@@ -206,7 +206,7 @@ pub fn process_radius_slice(
             let last_radius = process_radius(entity_path, *last_radius);
             vec![last_radius; num_instances]
         } else {
-            clamped(radii, num_instances)
+            clamped_or_nothing(radii, num_instances)
                 .map(|radius| process_radius(entity_path, *radius))
                 .collect()
         }
@@ -253,7 +253,7 @@ fn process_annotation_and_keypoint_slices(
         );
     };
 
-    let class_ids = clamped(class_ids, num_instances);
+    let class_ids = clamped_or_nothing(class_ids, num_instances);
 
     if keypoint_ids.is_empty() {
         let annotation_info = class_ids
@@ -268,7 +268,7 @@ fn process_annotation_and_keypoint_slices(
             Default::default(),
         )
     } else {
-        let keypoint_ids = clamped(keypoint_ids, num_instances);
+        let keypoint_ids = clamped_or_nothing(keypoint_ids, num_instances);
         let annotation_info = itertools::izip!(positions, keypoint_ids, class_ids)
             .map(|(position, keypoint_id, &class_id)| {
                 let class_description = annotations.resolved_class_description(Some(class_id));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -52,7 +52,7 @@ pub fn clamped_or_nothing<T>(values: &[T], clamped_len: usize) -> impl Iterator<
 pub fn clamped_vec_or_empty<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
     if values.len() == clamped_len {
         // Happy path
-        values.to_vec()
+        values.to_vec() // TODO(emilk): return a slice reference instead, in a `Cow` or similar
     } else if let Some(last) = values.last() {
         if values.len() == 1 {
             // Commo happy path

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -19,7 +19,7 @@ use crate::{
 
 // ---
 
-/// Clamp the latest value in `values` in order to reach a length of `clamped_len`.
+/// Clamp the last value in `values` in order to reach a length of `clamped_len`.
 ///
 /// Returns an empty iterator if values is empty.
 #[inline]
@@ -34,6 +34,42 @@ pub fn clamped<T>(values: &[T], clamped_len: usize) -> impl Iterator<Item = &T> 
             .chain(std::iter::repeat(last))
             .take(clamped_len),
     )
+}
+
+/// Clamp the last value in `values` in order to reach a length of `clamped_len`.
+///
+/// Returns an empty vctor if values is empty.
+#[inline]
+pub fn clamped_vec<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
+    if values.len() == clamped_len {
+        // Happy path
+        values.to_vec()
+    } else if let Some(last) = values.last() {
+        let mut vec = Vec::with_capacity(clamped_len);
+        if values.len() < clamped_len {
+            // Clamp
+            vec.extend(values.iter().cloned());
+            vec.extend(std::iter::repeat(last.clone()).take(clamped_len - values.len()));
+        } else {
+            // Trim
+            vec.extend(values.iter().take(clamped_len).cloned());
+        }
+        vec
+    } else {
+        // Empty input
+        Vec::new()
+    }
+}
+
+#[test]
+fn test_clamped_vec() {
+    assert_eq!(clamped_vec::<i32>(&[], 0), Vec::<i32>::default());
+    assert_eq!(clamped_vec::<i32>(&[], 3), Vec::<i32>::default());
+    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 0), Vec::<i32>::default());
+    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 1), vec![1]);
+    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 2), vec![1, 2]);
+    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 3), vec![1, 2, 3]);
+    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 5), vec![1, 2, 3, 3, 3]);
 }
 
 // --- Cached APIs ---

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -32,7 +32,7 @@ pub fn clamped_or<'a, T>(values: &'a [T], if_empty: &'a T) -> impl Iterator<Item
 ///
 /// Returns an empty iterator if values is empty.
 #[inline]
-pub fn clamped<T>(values: &[T], clamped_len: usize) -> impl Iterator<Item = &T> {
+pub fn clamped_or_nothing<T>(values: &[T], clamped_len: usize) -> impl Iterator<Item = &T> {
     let Some(last) = values.last() else {
         return Either::Left(std::iter::empty());
     };
@@ -49,7 +49,7 @@ pub fn clamped<T>(values: &[T], clamped_len: usize) -> impl Iterator<Item = &T> 
 ///
 /// Returns an empty vctor if values is empty.
 #[inline]
-pub fn clamped_vec<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
+pub fn clamped_vec_or_empty<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
     if values.len() == clamped_len {
         // Happy path
         values.to_vec()
@@ -72,13 +72,19 @@ pub fn clamped_vec<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T> {
 
 #[test]
 fn test_clamped_vec() {
-    assert_eq!(clamped_vec::<i32>(&[], 0), Vec::<i32>::default());
-    assert_eq!(clamped_vec::<i32>(&[], 3), Vec::<i32>::default());
-    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 0), Vec::<i32>::default());
-    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 1), vec![1]);
-    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 2), vec![1, 2]);
-    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 3), vec![1, 2, 3]);
-    assert_eq!(clamped_vec::<i32>(&[1, 2, 3], 5), vec![1, 2, 3, 3, 3]);
+    assert_eq!(clamped_vec_or_empty::<i32>(&[], 0), Vec::<i32>::default());
+    assert_eq!(clamped_vec_or_empty::<i32>(&[], 3), Vec::<i32>::default());
+    assert_eq!(
+        clamped_vec_or_empty::<i32>(&[1, 2, 3], 0),
+        Vec::<i32>::default()
+    );
+    assert_eq!(clamped_vec_or_empty::<i32>(&[1, 2, 3], 1), vec![1]);
+    assert_eq!(clamped_vec_or_empty::<i32>(&[1, 2, 3], 2), vec![1, 2]);
+    assert_eq!(clamped_vec_or_empty::<i32>(&[1, 2, 3], 3), vec![1, 2, 3]);
+    assert_eq!(
+        clamped_vec_or_empty::<i32>(&[1, 2, 3], 5),
+        vec![1, 2, 3, 3, 3]
+    );
 }
 
 // --- Cached APIs ---

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -19,6 +19,15 @@ use crate::{
 
 // ---
 
+/// Iterate over all the values in the slice, then repeat the last value forever.
+///
+/// If the input slice is empty, the second argument is returned forever.
+#[inline]
+pub fn clamped_or<'a, T>(values: &'a [T], if_empty: &'a T) -> impl Iterator<Item = &'a T> {
+    let repeated = values.last().unwrap_or(if_empty);
+    values.iter().chain(std::iter::repeat(repeated))
+}
+
 /// Clamp the last value in `values` in order to reach a length of `clamped_len`.
 ///
 /// Returns an empty iterator if values is empty.

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -54,16 +54,19 @@ pub fn clamped_vec_or_empty<T: Clone>(values: &[T], clamped_len: usize) -> Vec<T
         // Happy path
         values.to_vec()
     } else if let Some(last) = values.last() {
-        let mut vec = Vec::with_capacity(clamped_len);
-        if values.len() < clamped_len {
+        if values.len() == 1 {
+            // Commo happy path
+            return vec![last.clone(); clamped_len];
+        } else if values.len() < clamped_len {
             // Clamp
+            let mut vec = Vec::with_capacity(clamped_len);
             vec.extend(values.iter().cloned());
             vec.extend(std::iter::repeat(last.clone()).take(clamped_len - values.len()));
+            vec
         } else {
             // Trim
-            vec.extend(values.iter().take(clamped_len).cloned());
+            values.iter().take(clamped_len).cloned().collect()
         }
-        vec
     } else {
         // Empty input
         Vec::new()


### PR DESCRIPTION
### What
We do a lot of "clamped joins", where the last element of a component is repeated to match the number of instances.
The code for this was neither ergonomic, nor performant. Now it should be better at both.

In particular, complex iterators like `.chain(…).take(…)` are often slow and difficult for the optimizer to see through.

Read the commit messages!

This shaves off another 0.5-1 ms off of OPF, out of ~4ms for the inner `Points3D` visualizer.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6870?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6870?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6870)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.