### PR TITLE
Improve navigation between entity and data results in the selection panel

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -251,7 +251,7 @@ impl SelectionPanel {
 
                 if instance_path.is_all() {
                     ui.list_item_flat_noninteractive(
-                        PropertyContent::new("Store entity").value_fn(|ui, _| {
+                        PropertyContent::new("Entity").value_fn(|ui, _| {
                             let (query, db) = guess_query_and_db_for_selected_entity(
                                 ctx,
                                 &instance_path.entity_path,

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -250,8 +250,8 @@ impl SelectionPanel {
                 }
 
                 if instance_path.is_all() {
-                    ui.list_item_flat_noninteractive(
-                        PropertyContent::new("Entity").value_fn(|ui, _| {
+                    ui.list_item_flat_noninteractive(PropertyContent::new("Entity").value_fn(
+                        |ui, _| {
                             let (query, db) = guess_query_and_db_for_selected_entity(
                                 ctx,
                                 &instance_path.entity_path,
@@ -265,8 +265,8 @@ impl SelectionPanel {
                                 None,
                                 &instance_path.entity_path,
                             );
-                        }),
-                    );
+                        },
+                    ));
 
                     let entity_path = &instance_path.entity_path;
                     let query_result = ctx.lookup_query_result(*view_id);

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -879,7 +879,10 @@ fn list_existing_data_blueprints(
                 let response = response.on_hover_ui(|ui| {
                     item_ui::instance_hover_card_ui(ui, ctx, &query, db, instance_path);
                 });
-                item_ui::cursor_interact_with_selectable(ctx, response, item);
+
+                // We don't use item_ui::cursor_interact_with_selectable here because the forced
+                // hover background is distracting and not useful.
+                ctx.select_hovered_on_click(&response, item);
             }
         }
     }

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -250,6 +250,24 @@ impl SelectionPanel {
                 }
 
                 if instance_path.is_all() {
+                    ui.list_item_flat_noninteractive(
+                        PropertyContent::new("Store entity").value_fn(|ui, _| {
+                            let (query, db) = guess_query_and_db_for_selected_entity(
+                                ctx,
+                                &instance_path.entity_path,
+                            );
+
+                            item_ui::entity_path_button(
+                                ctx,
+                                &query,
+                                db,
+                                ui,
+                                None,
+                                &instance_path.entity_path,
+                            );
+                        }),
+                    );
+
                     let entity_path = &instance_path.entity_path;
                     let query_result = ctx.lookup_query_result(*view_id);
                     let data_result = query_result


### PR DESCRIPTION
### What

This PR does two things.

It removes the synced "forced highlighting" from the the "Shown in" items in (store) entity selection panel. Previously, when one "show in" was hovered, all would be highlighted.

![Export-1720777918663](https://github.com/user-attachments/assets/4c84e704-1cfa-4ac0-8df5-a3dbf408f9db)

It adds a "Store entity" item in the  data result selection panel. This enables navigating from data result to (store) entity. Previously, only the other way round was possible.

<img width="378" alt="image" src="https://github.com/user-attachments/assets/3946f19d-7ec8-4851-80cf-e37ca4a5e330">

<br/><br/>

**Note on the "Shown in" UI**: If you click anywhere on the item _outside_ of the "go to view" button, then we go to the data result. If you click _on_ the "go to view", you go to the view. It seems logical, but I think the UX could be improved. cc @gavrelina 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6871/?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6871/?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6871)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.