### PR TITLE
Fix compaction election process not ignoring incompatible chunks

### DIFF
--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -25,7 +25,7 @@ impl Chunk {
 
         if !cl.concatenable(cr) {
             return Err(ChunkError::Malformed {
-                reason: "cannot concatenate incompatible Chunks:\n{cl}\n{cr}".to_owned(),
+                reason: format!("cannot concatenate incompatible Chunks:\n{cl}\n{cr}"),
             });
         }
 

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -256,6 +256,10 @@ impl ChunkStore {
                         store.chunks_per_chunk_id.get(&candidate_chunk_id).map_or(
                             false,
                             |candidate| {
+                                if !chunk.concatenable(candidate) {
+                                    return false;
+                                }
+
                                 let total_bytes =
                                     chunk.total_size_bytes() + candidate.total_size_bytes();
                                 let is_below_bytes_threshold = total_bytes <= chunk_max_bytes;


### PR DESCRIPTION
The election process was taking into account all the thresholds and stuff, but I forgot to check the glaringly obvious: whether the candidate is compatible at all.

This can happen if one writes completely incompatible data to the same entity path, e.g. because you're modifying a logged blueprint by playing with the UI at runtime, which would lead to this:
```
[2024-07-12T10:25:02Z WARN  re_viewer::app] Failed to store blueprint delta: Detected malformed Chunk: cannot concatenate incompatible Chunks:
    ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
    │ CHUNK METADATA:                                                                                                                                         │
    │ * entity_path: "/selection_panel"                                                                                                                       │
    │ * heap_size_bytes: "883"                                                                                                                                │
    │ * id: "17E0980D2B5B82021DF1759426EB606C"                                                                                                                │
    │ * is_sorted: ""                                                                                                                                         │
    ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ ┌──────────────────────────────────┬───────────────┬───────────────┬───────────────────────────────┬─────────────────────────┬────────────────────────┐ │
    │ │ RowId                            ┆ blueprint     ┆ log_tick      ┆ log_time                      ┆ PanelBlueprintIndicator ┆ PanelState             │ │
    │ │ ---                              ┆ ---           ┆ ---           ┆ ---                           ┆ ---                     ┆ ---                    │ │
    │ │ type: "TUID"                     ┆ type: "i64"   ┆ type: "i64"   ┆ type: "timestamp(ns)"         ┆ type: "list[null]"      ┆ type: "list[union[4]]" │ │
    │ │ kind: "control"                  ┆ is_sorted: "" ┆ is_sorted: "" ┆ is_sorted: ""                 ┆ kind: "data"            ┆ kind: "data"           │ │
    │ │                                  ┆ kind: "time"  ┆ kind: "time"  ┆ kind: "time"                  ┆                         ┆                        │ │
    │ ╞══════════════════════════════════╪═══════════════╪═══════════════╪═══════════════════════════════╪═════════════════════════╪════════════════════════╡ │
    │ │ 17E0980D2B5238F305BA7ED68D8C04EC ┆ 0             ┆ 17            ┆ 2024-07-09 16:23:59.984351092 ┆ [-]                     ┆ [-]                    │ │
    │ └──────────────────────────────────┴───────────────┴───────────────┴───────────────────────────────┴─────────────────────────┴────────────────────────┘ │
    └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    ┌───────────────────────────────────────────────────────────────────────────────┐
    │ CHUNK METADATA:                                                               │
    │ * entity_path: "/selection_panel"                                             │
    │ * heap_size_bytes: "354"                                                      │
    │ * id: "17E170343D9E70EE451201A9275619D7"                                      │
    │ * is_sorted: ""                                                               │
    ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
    │ ┌──────────────────────────────────┬───────────────┬────────────────────────┐ │
    │ │ RowId                            ┆ blueprint     ┆ PanelState             │ │
    │ │ ---                              ┆ ---           ┆ ---                    │ │
    │ │ type: "TUID"                     ┆ type: "i64"   ┆ type: "list[union[4]]" │ │
    │ │ kind: "control"                  ┆ is_sorted: "" ┆ kind: "data"           │ │
    │ │                                  ┆ kind: "time"  ┆                        │ │
    │ ╞══════════════════════════════════╪═══════════════╪════════════════════════╡ │
    │ │ 17E170343D9E713E451201A9275619D8 ┆ 1             ┆ [-]                    │ │
    │ └──────────────────────────────────┴───────────────┴────────────────────────┘ │
    └───────────────────────────────────────────────────────────────────────────────┘
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6872?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6872?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6872)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.