### PR TITLE
Add LeRobot example link

### DIFF
--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -58,6 +58,7 @@ examples = [
   "depth_guided_stable_diffusion",
   "vista",
   "mcc",
+  "lerobot",
   "shape_pointe",
   "llm_embedding_ner",
   "tfrecord_loader",

--- a/examples/python/lerobot/README.md
+++ b/examples/python/lerobot/README.md
@@ -1,0 +1,39 @@
+<!--[metadata]
+title = "Training a model on the LeRobot dataset"
+tags = ["2D", "HuggingFace", "Imitation learning"]
+source = "https://github.com/rerun-io/lerobot"
+thumbnail = "https://static.rerun.io/lerobot-thumbnail/0462caa44339d4e74e01eef2b9206eebb585f6f8/480w.png"
+thumbnail_dimensions = [480, 509]
+-->
+
+https://vimeo.com/983024799?autoplay=1&loop=1&autopause=0&background=1&muted=1&ratio=1920:1080
+
+## Background
+
+LeRobot is a project by huggingface that aims to provide models, datasets and tools for real-world robotics in PyTorch. This example shows how one can train a model on the [pusht-dataset](https://huggingface.co/datAsets/lerobot/pusht) and visualize it's progress using rerun.
+
+## Run the code
+
+This is an external example, check the [repository](https://github.com/rerun-io/rerun) for more information.
+
+To train the model as shown in the video, install git-lfs and clone the repository [repository](https://github.com/rerun-io/rerun) and then run the following code:
+
+```
+pip install -e '.[pusht]'
+WANDB_MODE=offline python lerobot/scripts/train.py \
+  hydra.run.dir=outputs/train/diffusion_pusht \
+  hydra.job.name=diffusion_pusht \
+  policy=diffusion \
+  env=pusht \
+  env.task=PushT-v0 \
+  dataset_repo_id=lerobot/pusht \
+  training.offline_steps=20000 \
+  training.save_freq=5000 ++training.log_freq=50 \
+  training.eval_freq=1500 \
+  eval.n_episodes=50 \
+  wandb.enable=true \
+  wandb.disable_artifact=true \
+  device=cuda
+```
+
+If you don't have CUDA installed you will have to change the last argument `device=cuda` to `device=cpu` or another device.


### PR DESCRIPTION
### What
Link to LeRobot example at https://github.com/rerun-io/lerobot

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6873?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6873?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6873)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.