### PR TITLE
`ChunkStore`: implement new component-less indices and APIs

### DIFF
--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -39,7 +39,7 @@ impl ChunkStore {
             });
 
         let temporal_components: Option<ComponentNameSet> = self
-            .temporal_chunk_ids_per_entity
+            .temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
             .map(|temporal_chunk_ids_per_timeline| {
                 temporal_chunk_ids_per_timeline
@@ -85,7 +85,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
     ) -> Option<TimeInt> {
         let temporal_chunk_ids_per_timeline =
-            self.temporal_chunk_ids_per_entity.get(entity_path)?;
+            self.temporal_chunk_ids_per_entity_per_component.get(entity_path)?;
         let temporal_chunk_ids_per_component = temporal_chunk_ids_per_timeline.get(timeline)?;
 
         let mut time_min = TimeInt::MAX;
@@ -140,7 +140,7 @@ impl ChunkStore {
         }
 
         if let Some(temporal_chunk_ids) = self
-            .temporal_chunk_ids_per_entity
+            .temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
             .and_then(|temporal_chunk_ids_per_timeline| {
                 temporal_chunk_ids_per_timeline.get(&query.timeline())
@@ -226,7 +226,7 @@ impl ChunkStore {
             return vec![Arc::clone(static_chunk)];
         }
 
-        self.temporal_chunk_ids_per_entity
+        self.temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
             .and_then(|temporal_chunk_ids_per_timeline| {
                 temporal_chunk_ids_per_timeline.get(&query.timeline())

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -3,11 +3,12 @@ use std::{
     sync::{atomic::Ordering, Arc},
 };
 
+use itertools::Itertools;
 use re_chunk::{Chunk, LatestAtQuery, RangeQuery};
 use re_log_types::{EntityPath, TimeInt, Timeline};
 use re_types_core::{ComponentName, ComponentNameSet};
 
-use crate::ChunkStore;
+use crate::{store::ChunkIdSetPerTime, ChunkStore};
 
 // Used all over in docstrings.
 #[allow(unused_imports)]
@@ -84,8 +85,9 @@ impl ChunkStore {
         timeline: &Timeline,
         entity_path: &EntityPath,
     ) -> Option<TimeInt> {
-        let temporal_chunk_ids_per_timeline =
-            self.temporal_chunk_ids_per_entity_per_component.get(entity_path)?;
+        let temporal_chunk_ids_per_timeline = self
+            .temporal_chunk_ids_per_entity_per_component
+            .get(entity_path)?;
         let temporal_chunk_ids_per_component = temporal_chunk_ids_per_timeline.get(timeline)?;
 
         let mut time_min = TimeInt::MAX;
@@ -102,8 +104,13 @@ impl ChunkStore {
 
         (time_min != TimeInt::MAX).then_some(time_min)
     }
+}
 
-    /// Returns the most-relevant chunk(s) for the given [`LatestAtQuery`].
+// LatestAt
+impl ChunkStore {
+    /// Returns the most-relevant chunk(s) for the given [`LatestAtQuery`] and [`ComponentName`].
+    ///
+    /// The returned vector is guaranteed free of duplicates, by definition.
     ///
     /// The [`ChunkStore`] always work at the [`Chunk`] level (as opposed to the row level): it is
     /// oblivious to the data therein.
@@ -139,7 +146,7 @@ impl ChunkStore {
             return vec![Arc::clone(static_chunk)];
         }
 
-        if let Some(temporal_chunk_ids) = self
+        let chunks = self
             .temporal_chunk_ids_per_entity_per_component
             .get(entity_path)
             .and_then(|temporal_chunk_ids_per_timeline| {
@@ -149,53 +156,108 @@ impl ChunkStore {
                 temporal_chunk_ids_per_component.get(&component_name)
             })
             .and_then(|temporal_chunk_ids_per_time| {
-                let upper_bound = temporal_chunk_ids_per_time
-                    .per_start_time
-                    .range(..=query.at())
-                    .next_back()
-                    .map(|(time, _)| *time)?;
-
-                // Overlapped chunks
-                // =================
-                //
-                // To deal with potentially overlapping chunks, we keep track of the longest
-                // interval in the entire map, which gives us an upper bound on how much we
-                // would need to walk backwards in order to find all potential overlaps.
-                //
-                // This is a fairly simple solution that scales much better than interval-tree
-                // based alternatives, both in terms of complexity and performance, in the normal
-                // case where most chunks in a collection have similar lengths.
-                //
-                // The most degenerate case -- a single chunk overlaps everything else -- results
-                // in `O(n)` performance, which gets amortized by the query cache.
-                // If that turns out to be a problem in practice, we can experiment with more
-                // complex solutions then.
-                let lower_bound = upper_bound
-                    .as_i64()
-                    .saturating_sub(temporal_chunk_ids_per_time.max_interval_length as _);
-
-                Some(
-                    temporal_chunk_ids_per_time
-                        .per_start_time
-                        .range(..=query.at())
-                        .rev()
-                        .take_while(|(time, _)| time.as_i64() >= lower_bound)
-                        .flat_map(|(_time, chunk_ids)| chunk_ids.iter())
-                        .copied()
-                        .collect::<BTreeSet<_>>(),
-                )
+                self.latest_at(query, temporal_chunk_ids_per_time)
             })
-        {
-            return temporal_chunk_ids
-                .iter()
-                .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id).cloned())
-                .collect();
-        }
+            .unwrap_or_default();
 
-        Vec::new()
+        debug_assert!(chunks.iter().map(|chunk| chunk.id()).all_unique());
+
+        chunks
     }
 
-    /// Returns the most-relevant chunk(s) for the given [`RangeQuery`].
+    /// Returns the most-relevant _temporal_ chunk(s) for the given [`LatestAtQuery`].
+    ///
+    /// The returned vector is guaranteed free of duplicates, by definition.
+    ///
+    /// The [`ChunkStore`] always work at the [`Chunk`] level (as opposed to the row level): it is
+    /// oblivious to the data therein.
+    /// For that reason, and because [`Chunk`]s are allowed to temporally overlap, it is possible
+    /// that a query has more than one relevant chunk.
+    ///
+    /// The caller should filter the returned chunks further (see [`Chunk::latest_at`]) in order to
+    /// determine what exact row contains the final result.
+    ///
+    /// **This ignores static data.**
+    pub fn latest_at_relevant_chunks_for_all_components(
+        &self,
+        query: &LatestAtQuery,
+        entity_path: &EntityPath,
+    ) -> Vec<Arc<Chunk>> {
+        re_tracing::profile_function!(format!("{query:?}"));
+
+        self.query_id.fetch_add(1, Ordering::Relaxed);
+
+        let chunks = self
+            .temporal_chunk_ids_per_entity
+            .get(entity_path)
+            .and_then(|temporal_chunk_ids_per_timeline| {
+                temporal_chunk_ids_per_timeline.get(&query.timeline())
+            })
+            .and_then(|temporal_chunk_ids_per_time| {
+                self.latest_at(query, temporal_chunk_ids_per_time)
+            })
+            .unwrap_or_default();
+
+        debug_assert!(chunks.iter().map(|chunk| chunk.id()).all_unique());
+
+        chunks
+    }
+
+    fn latest_at(
+        &self,
+        query: &LatestAtQuery,
+        temporal_chunk_ids_per_time: &ChunkIdSetPerTime,
+    ) -> Option<Vec<Arc<Chunk>>> {
+        re_tracing::profile_function!();
+
+        let upper_bound = temporal_chunk_ids_per_time
+            .per_start_time
+            .range(..=query.at())
+            .next_back()
+            .map(|(time, _)| *time)?;
+
+        // Overlapped chunks
+        // =================
+        //
+        // To deal with potentially overlapping chunks, we keep track of the longest
+        // interval in the entire map, which gives us an upper bound on how much we
+        // would need to walk backwards in order to find all potential overlaps.
+        //
+        // This is a fairly simple solution that scales much better than interval-tree
+        // based alternatives, both in terms of complexity and performance, in the normal
+        // case where most chunks in a collection have similar lengths.
+        //
+        // The most degenerate case -- a single chunk overlaps everything else -- results
+        // in `O(n)` performance, which gets amortized by the query cache.
+        // If that turns out to be a problem in practice, we can experiment with more
+        // complex solutions then.
+        let lower_bound = upper_bound
+            .as_i64()
+            .saturating_sub(temporal_chunk_ids_per_time.max_interval_length as _);
+
+        let temporal_chunk_ids = temporal_chunk_ids_per_time
+            .per_start_time
+            .range(..=query.at())
+            .rev()
+            .take_while(|(time, _)| time.as_i64() >= lower_bound)
+            .flat_map(|(_time, chunk_ids)| chunk_ids.iter())
+            .copied()
+            .collect::<BTreeSet<_>>();
+
+        Some(
+            temporal_chunk_ids
+                .iter()
+                .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id).cloned())
+                .collect(),
+        )
+    }
+}
+
+// Range
+impl ChunkStore {
+    /// Returns the most-relevant chunk(s) for the given [`RangeQuery`] and [`ComponentName`].
+    ///
+    /// The returned vector is guaranteed free of duplicates, by definition.
     ///
     /// The criteria for returning a chunk is only that it may contain data that overlaps with
     /// the queried range.
@@ -226,15 +288,98 @@ impl ChunkStore {
             return vec![Arc::clone(static_chunk)];
         }
 
-        self.temporal_chunk_ids_per_entity_per_component
-            .get(entity_path)
-            .and_then(|temporal_chunk_ids_per_timeline| {
-                temporal_chunk_ids_per_timeline.get(&query.timeline())
-            })
-            .and_then(|temporal_chunk_ids_per_component| {
-                temporal_chunk_ids_per_component.get(&component_name)
-            })
+        let chunks = self
+            .range(
+                query,
+                self.temporal_chunk_ids_per_entity_per_component
+                    .get(entity_path)
+                    .and_then(|temporal_chunk_ids_per_timeline| {
+                        temporal_chunk_ids_per_timeline.get(&query.timeline())
+                    })
+                    .and_then(|temporal_chunk_ids_per_component| {
+                        temporal_chunk_ids_per_component.get(&component_name)
+                    })
+                    .into_iter(),
+            )
             .into_iter()
+            // Post-processing: `Self::range` doesn't have access to the chunk metadata, so now we
+            // need to make sure that the resulting chunks' per-component time range intersects with the
+            // time range of the query itself.
+            .filter(|chunk| {
+                chunk
+                    .timelines()
+                    .get(&query.timeline())
+                    .map_or(false, |time_chunk| {
+                        time_chunk
+                            .time_range_per_component(chunk.components())
+                            .get(&component_name)
+                            .map_or(false, |time_range| time_range.intersects(query.range()))
+                    })
+            })
+            .collect_vec();
+
+        debug_assert!(chunks.iter().map(|chunk| chunk.id()).all_unique());
+
+        chunks
+    }
+
+    /// Returns the most-relevant _temporal_ chunk(s) for the given [`RangeQuery`].
+    ///
+    /// The returned vector is guaranteed free of duplicates, by definition.
+    ///
+    /// The criteria for returning a chunk is only that it may contain data that overlaps with
+    /// the queried range.
+    ///
+    /// The caller should filter the returned chunks further (see [`Chunk::range`]) in order to
+    /// determine how exactly each row of data fit with the rest.
+    ///
+    /// **This ignores static data.**
+    pub fn range_relevant_chunks_for_all_components(
+        &self,
+        query: &RangeQuery,
+        entity_path: &EntityPath,
+    ) -> Vec<Arc<Chunk>> {
+        re_tracing::profile_function!(format!("{query:?}"));
+
+        self.query_id.fetch_add(1, Ordering::Relaxed);
+
+        let chunks = self
+            .range(
+                query,
+                self.temporal_chunk_ids_per_entity
+                    .get(entity_path)
+                    .and_then(|temporal_chunk_ids_per_timeline| {
+                        temporal_chunk_ids_per_timeline.get(&query.timeline())
+                    })
+                    .into_iter(),
+            )
+            .into_iter()
+            // Post-processing: `Self::range` doesn't have access to the chunk metadata, so now we
+            // need to make sure that the resulting chunks' global time ranges intersect with the
+            // time range of the query itself.
+            .filter(|chunk| {
+                chunk
+                    .timelines()
+                    .get(&query.timeline())
+                    .map_or(false, |time_chunk| {
+                        time_chunk.time_range().intersects(query.range())
+                    })
+            })
+            .collect_vec();
+
+        debug_assert!(chunks.iter().map(|chunk| chunk.id()).all_unique());
+
+        chunks
+    }
+
+    fn range<'a>(
+        &'a self,
+        query: &RangeQuery,
+        temporal_chunk_ids_per_times: impl Iterator<Item = &'a ChunkIdSetPerTime>,
+    ) -> Vec<Arc<Chunk>> {
+        re_tracing::profile_function!();
+
+        temporal_chunk_ids_per_times
             .map(|temporal_chunk_ids_per_time| {
                 let start_time = temporal_chunk_ids_per_time
                     .per_start_time

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -218,6 +218,10 @@ pub type ChunkIdPerComponent = BTreeMap<ComponentName, ChunkId>;
 
 pub type ChunkIdPerComponentPerEntity = BTreeMap<EntityPath, ChunkIdPerComponent>;
 
+pub type ChunkIdSetPerTimePerTimeline = BTreeMap<Timeline, ChunkIdSetPerTime>;
+
+pub type ChunkIdSetPerTimePerTimelinePerEntity = BTreeMap<EntityPath, ChunkIdSetPerTimePerTimeline>;
+
 // ---
 
 /// Incremented on each edit.
@@ -260,10 +264,20 @@ pub struct ChunkStore {
     /// duplicated [`RowId`]s.
     pub(crate) chunk_ids_per_min_row_id: BTreeMap<RowId, Vec<ChunkId>>,
 
-    /// All temporal [`ChunkId`]s for all entities on all timelines.
+    /// All temporal [`ChunkId`]s for all entities on all timelines, further indexed by [`ComponentName`].
     ///
-    /// See also [`Self::static_chunk_ids_per_entity`].
-    pub(crate) temporal_chunk_ids_per_entity: ChunkIdSetPerTimePerComponentPerTimelinePerEntity,
+    /// See also:
+    /// * [`Self::temporal_chunk_ids_per_entity`].
+    /// * [`Self::static_chunk_ids_per_entity`].
+    pub(crate) temporal_chunk_ids_per_entity_per_component:
+        ChunkIdSetPerTimePerComponentPerTimelinePerEntity,
+
+    /// All temporal [`ChunkId`]s for all entities on all timelines, without the [`ComponentName`] index.
+    ///
+    /// See also:
+    /// * [`Self::temporal_chunk_ids_per_entity_per_component`].
+    /// * [`Self::static_chunk_ids_per_entity`].
+    pub(crate) temporal_chunk_ids_per_entity: ChunkIdSetPerTimePerTimelinePerEntity,
 
     /// Accumulated size statitistics for all temporal [`Chunk`]s currently present in the store.
     ///
@@ -305,6 +319,9 @@ impl Clone for ChunkStore {
             type_registry: self.type_registry.clone(),
             chunks_per_chunk_id: self.chunks_per_chunk_id.clone(),
             chunk_ids_per_min_row_id: self.chunk_ids_per_min_row_id.clone(),
+            temporal_chunk_ids_per_entity_per_component: self
+                .temporal_chunk_ids_per_entity_per_component
+                .clone(),
             temporal_chunk_ids_per_entity: self.temporal_chunk_ids_per_entity.clone(),
             temporal_chunks_stats: self.temporal_chunks_stats,
             static_chunk_ids_per_entity: self.static_chunk_ids_per_entity.clone(),
@@ -325,6 +342,7 @@ impl std::fmt::Display for ChunkStore {
             type_registry: _,
             chunks_per_chunk_id,
             chunk_ids_per_min_row_id: chunk_id_per_min_row_id,
+            temporal_chunk_ids_per_entity_per_component: _,
             temporal_chunk_ids_per_entity: _,
             temporal_chunks_stats,
             static_chunk_ids_per_entity: _,
@@ -374,6 +392,7 @@ impl ChunkStore {
             type_registry: Default::default(),
             chunk_ids_per_min_row_id: Default::default(),
             chunks_per_chunk_id: Default::default(),
+            temporal_chunk_ids_per_entity_per_component: Default::default(),
             temporal_chunk_ids_per_entity: Default::default(),
             temporal_chunks_stats: Default::default(),
             static_chunk_ids_per_entity: Default::default(),

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -207,10 +207,29 @@ pub struct ChunkIdSetPerTime {
     /// This is used to bound the backwards linear walk when looking for overlapping chunks in
     /// latest-at queries.
     ///
-    /// See [`ChunkStore::latest_at_relevant_chunks`] implementation comments for more details.
+    /// See [`ChunkStore::latest_at`] implementation comments for more details.
     pub(crate) max_interval_length: u64,
 
+    /// [`ChunkId`]s organized by their _most specific_ start time.
+    ///
+    /// What "most specific" means depends on the context in which the [`ChunkIdSetPerTime`]
+    /// was instantiated, e.g.:
+    /// * For an `(entity, timeline, component)` index, that would be the first timestamp at which this
+    ///   [`Chunk`] contains data for this particular component on this particular timeline (see
+    ///   [`Chunk::time_range_per_component`]).
+    /// * For an `(entity, timeline)` index, that would be the first timestamp at which this [`Chunk`]
+    ///   contains data for any component on this particular timeline (see [`re_chunk::ChunkTimeline::time_range`]).
     pub(crate) per_start_time: BTreeMap<TimeInt, ChunkIdSet>,
+
+    /// [`ChunkId`]s organized by their _most specific_ end time.
+    ///
+    /// What "most specific" means depends on the context in which the [`ChunkIdSetPerTime`]
+    /// was instantiated, e.g.:
+    /// * For an `(entity, timeline, component)` index, that would be the last timestamp at which this
+    ///   [`Chunk`] contains data for this particular component on this particular timeline (see
+    ///   [`Chunk::time_range_per_component`]).
+    /// * For an `(entity, timeline)` index, that would be the last timestamp at which this [`Chunk`]
+    ///   contains data for any component on this particular timeline (see [`re_chunk::ChunkTimeline::time_range`]).
     pub(crate) per_end_time: BTreeMap<TimeInt, ChunkIdSet>,
 }
 

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -100,6 +100,14 @@ impl ChunkStoreConfig {
         chunk_max_rows_if_unsorted: 256,
     };
 
+    /// [`Self::DEFAULT`], but with compaction entirely disabled.
+    pub const COMPACTION_DISABLED: Self = Self {
+        chunk_max_bytes: 0,
+        chunk_max_rows: 0,
+        chunk_max_rows_if_unsorted: 0,
+        ..Self::DEFAULT
+    };
+
     /// Environment variable to configure [`Self::enable_changelog`].
     pub const ENV_STORE_ENABLE_CHANGELOG: &'static str = "RERUN_STORE_ENABLE_CHANGELOG";
 

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -581,108 +581,128 @@ fn range() -> anyhow::Result<()> {
 
     let entity_path = EntityPath::from("this/that");
 
+    let frame0 = TimeInt::new_temporal(0);
     let frame1 = TimeInt::new_temporal(1);
     let frame2 = TimeInt::new_temporal(2);
     let frame3 = TimeInt::new_temporal(3);
     let frame4 = TimeInt::new_temporal(4);
     let frame5 = TimeInt::new_temporal(5);
+    let frame6 = TimeInt::new_temporal(6);
 
     let row_id1 = RowId::new();
     let indices1 = MyIndex::from_iter(0..3);
     let colors1 = MyColor::from_iter(0..3);
-    let chunk1 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id1,
-            [build_frame_nr(frame1)],
-            [&indices1 as _, &colors1 as _],
-        )
-        .build()?;
+    let chunk1 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id1,
+                [build_frame_nr(frame1)],
+                [&indices1 as _, &colors1 as _],
+            )
+            .build()?,
+    );
 
     let row_id2 = RowId::new();
     let points2 = MyPoint::from_iter(0..3);
-    let chunk2 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id2,
-            [build_frame_nr(frame2)],
-            [&indices1 as _, &points2 as _],
-        )
-        .build()?;
+    let chunk2 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id2,
+                [build_frame_nr(frame2)],
+                [&indices1 as _, &points2 as _],
+            )
+            .build()?,
+    );
 
     let row_id3 = RowId::new();
     let points3 = MyPoint::from_iter(0..10);
-    let chunk3 = Chunk::builder(entity_path.clone())
-        .with_component_batches(row_id3, [build_frame_nr(frame3)], [&points3 as _])
-        .build()?;
+    let chunk3 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id3, [build_frame_nr(frame3)], [&points3 as _])
+            .build()?,
+    );
 
     let row_id4_1 = RowId::new();
     let indices4_1 = MyIndex::from_iter(20..25);
     let colors4_1 = MyColor::from_iter(0..5);
-    let chunk4_1 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id4_1,
-            [build_frame_nr(frame4)],
-            [&indices4_1 as _, &colors4_1 as _],
-        )
-        .build()?;
+    let chunk4_1 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id4_1,
+                [build_frame_nr(frame4)],
+                [&indices4_1 as _, &colors4_1 as _],
+            )
+            .build()?,
+    );
 
     let row_id4_2 = RowId::new();
     let indices4_2 = MyIndex::from_iter(25..30);
     let colors4_2 = MyColor::from_iter(0..5);
-    let chunk4_2 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id4_2,
-            [build_frame_nr(frame4)],
-            [&indices4_2 as _, &colors4_2 as _],
-        )
-        .build()?;
+    let chunk4_2 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id4_2,
+                [build_frame_nr(frame4)],
+                [&indices4_2 as _, &colors4_2 as _],
+            )
+            .build()?,
+    );
 
     let row_id4_25 = RowId::new();
     let points4_25 = MyPoint::from_iter(0..5);
-    let chunk4_25 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id4_25,
-            [build_frame_nr(frame4)],
-            [&indices4_2 as _, &points4_25 as _],
-        )
-        .build()?;
+    let chunk4_25 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id4_25,
+                [build_frame_nr(frame4)],
+                [&indices4_2 as _, &points4_25 as _],
+            )
+            .build()?,
+    );
 
     let row_id4_3 = RowId::new();
     let indices4_3 = MyIndex::from_iter(30..35);
     let colors4_3 = MyColor::from_iter(0..5);
-    let chunk4_3 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id4_3,
-            [build_frame_nr(frame4)],
-            [&indices4_3 as _, &colors4_3 as _],
-        )
-        .build()?;
+    let chunk4_3 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id4_3,
+                [build_frame_nr(frame4)],
+                [&indices4_3 as _, &colors4_3 as _],
+            )
+            .build()?,
+    );
 
     let row_id4_4 = RowId::new();
     let points4_4 = MyPoint::from_iter(0..5);
-    let chunk4_4 = Chunk::builder(entity_path.clone())
-        .with_component_batches(
-            row_id4_4,
-            [build_frame_nr(frame4)],
-            [&indices4_3 as _, &points4_4 as _],
-        )
-        .build()?;
+    let chunk4_4 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(
+                row_id4_4,
+                [build_frame_nr(frame4)],
+                [&indices4_3 as _, &points4_4 as _],
+            )
+            .build()?,
+    );
 
     // injecting some static colors
     let row_id5 = RowId::new();
     let colors5 = MyColor::from_iter(0..8);
-    let chunk5 = Chunk::builder(entity_path.clone())
-        .with_component_batches(row_id5, TimePoint::default(), [&colors5 as _])
-        .build()?;
+    let chunk5 = Arc::new(
+        Chunk::builder(entity_path.clone())
+            .with_component_batches(row_id5, TimePoint::default(), [&colors5 as _])
+            .build()?,
+    );
 
-    store.insert_chunk(&Arc::new(chunk1))?;
-    store.insert_chunk(&Arc::new(chunk2))?;
-    store.insert_chunk(&Arc::new(chunk3))?;
-    store.insert_chunk(&Arc::new(chunk4_1))?;
-    store.insert_chunk(&Arc::new(chunk4_2))?;
-    store.insert_chunk(&Arc::new(chunk4_25))?;
-    store.insert_chunk(&Arc::new(chunk4_3))?;
-    store.insert_chunk(&Arc::new(chunk4_4))?;
-    store.insert_chunk(&Arc::new(chunk5))?;
+    store.insert_chunk(&chunk1)?;
+    store.insert_chunk(&chunk2)?;
+    store.insert_chunk(&chunk3)?;
+    store.insert_chunk(&chunk4_1)?;
+    store.insert_chunk(&chunk4_2)?;
+    store.insert_chunk(&chunk4_25)?;
+    store.insert_chunk(&chunk4_3)?;
+    store.insert_chunk(&chunk4_4)?;
+    store.insert_chunk(&chunk5)?;
 
     // Each entry in `rows_at_times` corresponds to a dataframe that's expected to be returned
     // by the range query.
@@ -798,6 +818,80 @@ fn range() -> anyhow::Result<()> {
         MyColor::name(),
         &[(TimeInt::STATIC, row_id5)],
     );
+
+    // Component-less APIs
+    {
+        let assert_range_chunk =
+            |time_range: ResolvedTimeRange, mut expected_chunk_ids: Vec<ChunkId>| {
+                let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+
+                eprintln!("--- {time_range:?} ---");
+                let mut chunk_ids = store
+                    .range_relevant_chunks_for_all_components(
+                        &RangeQuery::new(timeline_frame_nr, time_range),
+                        &entity_path,
+                    )
+                    .into_iter()
+                    .map(|chunk| {
+                        eprintln!("{chunk}");
+                        chunk.id()
+                    })
+                    .collect_vec();
+                chunk_ids.sort();
+
+                expected_chunk_ids.sort();
+
+                similar_asserts::assert_eq!(expected_chunk_ids, chunk_ids);
+            };
+
+        // Unit ranges
+        assert_range_chunk(ResolvedTimeRange::new(frame0, frame0), vec![]);
+        assert_range_chunk(ResolvedTimeRange::new(frame1, frame1), vec![chunk1.id()]);
+        assert_range_chunk(ResolvedTimeRange::new(frame2, frame2), vec![chunk2.id()]);
+        assert_range_chunk(ResolvedTimeRange::new(frame3, frame3), vec![chunk3.id()]);
+        assert_range_chunk(
+            ResolvedTimeRange::new(frame4, frame4),
+            vec![
+                chunk4_1.id(),
+                chunk4_2.id(),
+                chunk4_25.id(),
+                chunk4_3.id(),
+                chunk4_4.id(),
+            ],
+        );
+        assert_range_chunk(ResolvedTimeRange::new(frame5, frame5), vec![]);
+        assert_range_chunk(ResolvedTimeRange::new(frame6, frame6), vec![]);
+
+        // Full range
+        assert_range_chunk(
+            ResolvedTimeRange::new(frame1, frame5),
+            vec![
+                chunk1.id(),
+                chunk2.id(),
+                chunk3.id(),
+                chunk4_1.id(),
+                chunk4_2.id(),
+                chunk4_25.id(),
+                chunk4_3.id(),
+                chunk4_4.id(),
+            ],
+        );
+
+        // Infinite range
+        assert_range_chunk(
+            ResolvedTimeRange::EVERYTHING,
+            vec![
+                chunk1.id(),
+                chunk2.id(),
+                chunk3.id(),
+                chunk4_1.id(),
+                chunk4_2.id(),
+                chunk4_25.id(),
+                chunk4_3.id(),
+                chunk4_4.id(),
+            ],
+        );
+    }
 
     Ok(())
 }

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use arrow2::array::Array as ArrowArray;
 
 use itertools::Itertools;
-use re_chunk::{Chunk, RowId, TimePoint};
+use re_chunk::{Chunk, ChunkId, RowId, TimePoint};
 use re_chunk_store::{
     ChunkStore, ChunkStoreConfig, LatestAtQuery, RangeQuery, ResolvedTimeRange, TimeInt,
 };
@@ -71,7 +71,7 @@ fn all_components() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        ChunkStoreConfig::default(),
+        ChunkStoreConfig::COMPACTION_DISABLED,
     );
 
     let components_a = &[
@@ -130,7 +130,7 @@ fn latest_at() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        ChunkStoreConfig::default(),
+        ChunkStoreConfig::COMPACTION_DISABLED,
     );
 
     let entity_path = EntityPath::from("this/that");
@@ -140,6 +140,7 @@ fn latest_at() -> anyhow::Result<()> {
     let frame2 = TimeInt::new_temporal(2);
     let frame3 = TimeInt::new_temporal(3);
     let frame4 = TimeInt::new_temporal(4);
+    let frame5 = TimeInt::new_temporal(5);
 
     let row_id1 = RowId::new();
     let (indices1, colors1) = (MyIndex::from_iter(0..3), MyColor::from_iter(0..3));
@@ -180,11 +181,17 @@ fn latest_at() -> anyhow::Result<()> {
         .with_component_batches(row_id5, TimePoint::default(), [&colors5 as _])
         .build()?;
 
-    store.insert_chunk(&Arc::new(chunk1))?;
-    store.insert_chunk(&Arc::new(chunk2))?;
-    store.insert_chunk(&Arc::new(chunk3))?;
-    store.insert_chunk(&Arc::new(chunk4))?;
-    store.insert_chunk(&Arc::new(chunk5))?;
+    let chunk1 = Arc::new(chunk1);
+    let chunk2 = Arc::new(chunk2);
+    let chunk3 = Arc::new(chunk3);
+    let chunk4 = Arc::new(chunk4);
+    let chunk5 = Arc::new(chunk5);
+
+    store.insert_chunk(&chunk1)?;
+    store.insert_chunk(&chunk2)?;
+    store.insert_chunk(&chunk3)?;
+    store.insert_chunk(&chunk4)?;
+    store.insert_chunk(&chunk5)?;
 
     let assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, Option<RowId>)]| {
         let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
@@ -243,6 +250,35 @@ fn latest_at() -> anyhow::Result<()> {
         ],
     );
 
+    // Component-less APIs
+    {
+        let assert_latest_chunk =
+            |store: &ChunkStore, frame_nr: TimeInt, mut expected_chunk_ids: Vec<ChunkId>| {
+                let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+
+                let mut chunk_ids = store
+                    .latest_at_relevant_chunks_for_all_components(
+                        &LatestAtQuery::new(timeline_frame_nr, frame_nr),
+                        &entity_path,
+                    )
+                    .into_iter()
+                    .map(|chunk| chunk.id())
+                    .collect_vec();
+                chunk_ids.sort();
+
+                expected_chunk_ids.sort();
+
+                similar_asserts::assert_eq!(expected_chunk_ids, chunk_ids);
+            };
+
+        assert_latest_chunk(&store, frame0, vec![]);
+        assert_latest_chunk(&store, frame1, vec![chunk1.id()]);
+        assert_latest_chunk(&store, frame2, vec![chunk2.id()]);
+        assert_latest_chunk(&store, frame3, vec![chunk3.id()]);
+        assert_latest_chunk(&store, frame4, vec![chunk4.id()]);
+        assert_latest_chunk(&store, frame5, vec![chunk4.id()]);
+    }
+
     Ok(())
 }
 
@@ -252,14 +288,16 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        ChunkStoreConfig::default(),
+        ChunkStoreConfig::COMPACTION_DISABLED,
     );
 
     let entity_path = EntityPath::from("this/that");
 
+    let frame0 = TimeInt::new_temporal(0);
     let frame1 = TimeInt::new_temporal(1);
     let frame2 = TimeInt::new_temporal(2);
     let frame3 = TimeInt::new_temporal(3);
+    let frame4 = TimeInt::new_temporal(4);
 
     // This chunk has a time range of `(1, 3)`, but the actual data for `MyIndex` actually only
     // starts at `3`.
@@ -267,7 +305,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
     let row_id1_1 = RowId::new();
     let row_id1_2 = RowId::new();
     let row_id1_3 = RowId::new();
-    let chunk = Chunk::builder(entity_path.clone())
+    let chunk1 = Chunk::builder(entity_path.clone())
         .with_sparse_component_batches(
             row_id1_1,
             [build_frame_nr(frame1)],
@@ -293,14 +331,16 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             ],
         )
         .build()?;
-    eprintln!("chunk 1:\n{chunk}");
-    store.insert_chunk(&Arc::new(chunk))?;
+
+    let chunk1 = Arc::new(chunk1);
+    eprintln!("chunk 1:\n{chunk1}");
+    store.insert_chunk(&chunk1)?;
 
     // This chunk on the other hand has a time range of `(2, 3)`, and the data for `MyIndex`
     // actually does start at `2`.
 
     let row_id2_1 = RowId::new();
-    let chunk = Chunk::builder(entity_path.clone())
+    let chunk2 = Chunk::builder(entity_path.clone())
         .with_sparse_component_batches(
             row_id2_1,
             [build_frame_nr(frame2)],
@@ -310,8 +350,10 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             ],
         )
         .build()?;
-    eprintln!("chunk 2:\n{chunk}");
-    store.insert_chunk(&Arc::new(chunk))?;
+
+    let chunk2 = Arc::new(chunk2);
+    eprintln!("chunk 2:\n{chunk2}");
+    store.insert_chunk(&chunk2)?;
 
     // We expect the data for `MyIndex` to come from `row_id_1_3`, since it is the most recent
     // piece of data.
@@ -328,6 +370,37 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
 
     assert_eq!(row_id1_3, row_id.unwrap());
 
+    // Component-less APIs
+    {
+        let assert_latest_chunk = |frame_nr: TimeInt, mut expected_chunk_ids: Vec<ChunkId>| {
+            let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+
+            eprintln!("--- {frame_nr:?} ---");
+            let mut chunk_ids = store
+                .latest_at_relevant_chunks_for_all_components(
+                    &LatestAtQuery::new(timeline_frame_nr, frame_nr),
+                    &entity_path,
+                )
+                .into_iter()
+                .map(|chunk| {
+                    eprintln!("{chunk}");
+                    chunk.id()
+                })
+                .collect_vec();
+            chunk_ids.sort();
+
+            expected_chunk_ids.sort();
+
+            similar_asserts::assert_eq!(expected_chunk_ids, chunk_ids);
+        };
+
+        assert_latest_chunk(frame0, vec![]);
+        assert_latest_chunk(frame1, vec![chunk1.id()]);
+        assert_latest_chunk(frame2, vec![chunk1.id(), chunk2.id()]); // overlap
+        assert_latest_chunk(frame3, vec![chunk1.id(), chunk2.id()]); // overlap
+        assert_latest_chunk(frame4, vec![chunk1.id(), chunk2.id()]); // overlap
+    }
+
     Ok(())
 }
 
@@ -337,11 +410,12 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        ChunkStoreConfig::default(),
+        ChunkStoreConfig::COMPACTION_DISABLED,
     );
 
     let entity_path = EntityPath::from("this/that");
 
+    let frame0 = TimeInt::new_temporal(0);
     let frame1 = TimeInt::new_temporal(1);
     let frame2 = TimeInt::new_temporal(2);
     let frame3 = TimeInt::new_temporal(3);
@@ -349,6 +423,7 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
     let frame5 = TimeInt::new_temporal(5);
     let frame6 = TimeInt::new_temporal(6);
     let frame7 = TimeInt::new_temporal(7);
+    let frame8 = TimeInt::new_temporal(8);
 
     let points1 = MyPoint::from_iter(0..1);
     let points2 = MyPoint::from_iter(1..2);
@@ -362,7 +437,7 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
     let row_id1_3 = RowId::new();
     let row_id1_5 = RowId::new();
     let row_id1_7 = RowId::new();
-    let chunk = Chunk::builder(entity_path.clone())
+    let chunk1 = Chunk::builder(entity_path.clone())
         .with_sparse_component_batches(
             row_id1_1,
             [build_frame_nr(frame1)],
@@ -384,12 +459,14 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
             [(MyPoint::name(), Some(&points7 as _))],
         )
         .build()?;
-    store.insert_chunk(&Arc::new(chunk))?;
+
+    let chunk1 = Arc::new(chunk1);
+    store.insert_chunk(&chunk1)?;
 
     let row_id2_2 = RowId::new();
     let row_id2_3 = RowId::new();
     let row_id2_4 = RowId::new();
-    let chunk = Chunk::builder(entity_path.clone())
+    let chunk2 = Chunk::builder(entity_path.clone())
         .with_sparse_component_batches(
             row_id2_2,
             [build_frame_nr(frame2)],
@@ -406,12 +483,14 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
             [(MyPoint::name(), Some(&points4 as _))],
         )
         .build()?;
-    store.insert_chunk(&Arc::new(chunk))?;
+
+    let chunk2 = Arc::new(chunk2);
+    store.insert_chunk(&chunk2)?;
 
     let row_id3_2 = RowId::new();
     let row_id3_4 = RowId::new();
     let row_id3_6 = RowId::new();
-    let chunk = Chunk::builder(entity_path.clone())
+    let chunk3 = Chunk::builder(entity_path.clone())
         .with_sparse_component_batches(
             row_id3_2,
             [build_frame_nr(frame2)],
@@ -428,7 +507,9 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
             [(MyPoint::name(), Some(&points6 as _))],
         )
         .build()?;
-    store.insert_chunk(&Arc::new(chunk))?;
+
+    let chunk3 = Arc::new(chunk3);
+    store.insert_chunk(&chunk3)?;
 
     eprintln!("{store}");
 
@@ -449,6 +530,41 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
         assert_eq!(expected_row_id, row_id.unwrap());
     }
 
+    // Component-less APIs
+    {
+        let assert_latest_chunk = |frame_nr: TimeInt, mut expected_chunk_ids: Vec<ChunkId>| {
+            let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+
+            eprintln!("--- {frame_nr:?} ---");
+            let mut chunk_ids = store
+                .latest_at_relevant_chunks_for_all_components(
+                    &LatestAtQuery::new(timeline_frame_nr, frame_nr),
+                    &entity_path,
+                )
+                .into_iter()
+                .map(|chunk| {
+                    eprintln!("{chunk}");
+                    chunk.id()
+                })
+                .collect_vec();
+            chunk_ids.sort();
+
+            expected_chunk_ids.sort();
+
+            similar_asserts::assert_eq!(expected_chunk_ids, chunk_ids);
+        };
+
+        assert_latest_chunk(frame0, vec![]);
+        assert_latest_chunk(frame1, vec![chunk1.id()]);
+        assert_latest_chunk(frame2, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame3, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame4, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame5, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame6, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame7, vec![chunk1.id(), chunk2.id(), chunk3.id()]); // overlap
+        assert_latest_chunk(frame8, vec![chunk1.id(), chunk2.id(), chunk3.id()]);
+    }
+
     Ok(())
 }
 
@@ -460,7 +576,7 @@ fn range() -> anyhow::Result<()> {
 
     let mut store = ChunkStore::new(
         re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
-        ChunkStoreConfig::default(),
+        ChunkStoreConfig::COMPACTION_DISABLED,
     );
 
     let entity_path = EntityPath::from("this/that");

--- a/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
@@ -4,6 +4,6 @@ expression: "[format!(\"{NUM_SCALARS} scalars\"),\n        format!(\"{} in total
 ---
 [
     "1048576 scalars",
-    "41.9 MiB in total",
+    "42.4 MiB in total",
     "42 B per row",
 ]


### PR DESCRIPTION
Introduces new component-less indices and APIs that allow for efficiently searching for relevant chunks directly at the entity level, as opposed to the entity+component level.

cc @jprochazk 

```rust
/// Returns the most-relevant _temporal_ chunk(s) for the given [`LatestAtQuery`].
///
/// The returned vector is guaranteed free of duplicates, by definition.
///
/// The [`ChunkStore`] always work at the [`Chunk`] level (as opposed to the row level): it is
/// oblivious to the data therein.
/// For that reason, and because [`Chunk`]s are allowed to temporally overlap, it is possible
/// that a query has more than one relevant chunk.
///
/// The caller should filter the returned chunks further (see [`Chunk::latest_at`]) in order to
/// determine what exact row contains the final result.
///
/// **This ignores static data.**
pub fn latest_at_relevant_chunks_for_all_components(
    &self,
    query: &LatestAtQuery,
    entity_path: &EntityPath,
) -> Vec<Arc<Chunk>> {
    // ...
}

/// Returns the most-relevant _temporal_ chunk(s) for the given [`RangeQuery`].
///
/// The returned vector is guaranteed free of duplicates, by definition.
///
/// The criteria for returning a chunk is only that it may contain data that overlaps with
/// the queried range.
///
/// The caller should filter the returned chunks further (see [`Chunk::range`]) in order to
/// determine how exactly each row of data fit with the rest.
///
/// **This ignores static data.**
pub fn range_relevant_chunks_for_all_components(
    &self,
    query: &RangeQuery,
    entity_path: &EntityPath,
) -> Vec<Arc<Chunk>> {
    // ...
}
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6879?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6879?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6879)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.