### PR TITLE
Respect 0.0 for start and end boundaries of scalar axis

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_time_series/src/space_view_class.rs
@@ -648,10 +648,10 @@ impl TypedComponentFallbackProvider<Range1D> for TimeSeriesSpaceView {
 fn make_range_sane(y_range: Range1D) -> Range1D {
     let (mut start, mut end) = (y_range.start(), y_range.end());
 
-    if !start.is_normal() {
+    if !start.is_finite() {
         start = -1.0;
     }
-    if !end.is_normal() {
+    if !end.is_finite() {
         end = 1.0;
     }
 


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

The `f64::is_normal` method rejects `0.0` that is an acceptable boundary value for a range.

This caused issues like forcing -1 as the starting boundary when entering `0.0` for start.

This should be a fix for https://github.com/rerun-io/rerun/issues/6846.

The screenshots show that we can handle `0.0` range boundaries again.

<img width="1356" alt="Screenshot 2024-07-14 at 20 23 25" src="https://github.com/user-attachments/assets/3e586b34-7bc9-4a24-8061-962603e29e33">
<img width="1356" alt="Screenshot 2024-07-14 at 20 23 17" src="https://github.com/user-attachments/assets/372f7d64-0fb4-4296-a152-f37dc798d356">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6886?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6886?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6886)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.