### PR TITLE
Try to fix `nightly` builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5527,6 +5527,7 @@ dependencies = [
  "re_build_info",
  "re_build_tools",
  "re_chunk",
+ "re_chunk_store",
  "re_crash_handler",
  "re_data_source",
  "re_entity_db",

--- a/crates/build/re_dev_tools/src/build_examples/example.rs
+++ b/crates/build/re_dev_tools/src/build_examples/example.rs
@@ -211,7 +211,7 @@ impl Channel {
                 };
 
                 let Some(channel) = readme.channel else {
-                    eprintln!("{name:?}: skipped");
+                    eprintln!("{name:?}: skipped - missing `channel` in frontmatter");
                     continue;
                 };
 

--- a/crates/build/re_dev_tools/src/build_examples/example.rs
+++ b/crates/build/re_dev_tools/src/build_examples/example.rs
@@ -144,11 +144,10 @@ pub struct ExampleCategory {
     pub examples: Vec<String>,
 }
 
-#[derive(Default, Clone, Copy, serde::Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, serde::Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Channel {
     /// Our main examples, built on each PR
-    #[default]
     Main,
 
     /// Examples built for each release, plus all `Main` examples.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -80,6 +80,7 @@ native_viewer = ["dep:re_viewer"]
 run = [
   "clap",
   "sdk",
+  "dep:re_chunk_store",
   "dep:re_data_source",
   "dep:re_log_encoding",
   "dep:re_sdk_comms",
@@ -122,6 +123,7 @@ similar-asserts.workspace = true
 
 # Optional dependencies:
 re_analytics = { workspace = true, optional = true }
+re_chunk_store = { workspace = true, optional = true }
 re_data_source = { workspace = true, optional = true }
 re_log_encoding = { workspace = true, optional = true, features = [
   "decoder",

--- a/crates/top/rerun/src/run.rs
+++ b/crates/top/rerun/src/run.rs
@@ -616,7 +616,7 @@ fn run_compact(path_to_input_rrd: &Path, path_to_output_rrd: &Path) -> anyhow::R
         )
     };
 
-    use re_viewer::external::re_chunk_store::ChunkStoreConfig;
+    use re_chunk_store::ChunkStoreConfig;
     let mut store_config = ChunkStoreConfig::from_env().unwrap_or_default();
     // NOTE: We're doing headless processing, there's no point in running subscribers, it will just
     // (massively) slow us down.
@@ -719,7 +719,7 @@ fn run_merge(path_to_input_rrds: &[PathBuf], path_to_output_rrd: &Path) -> anyho
         )
     };
 
-    use re_viewer::external::re_chunk_store::ChunkStoreConfig;
+    use re_chunk_store::ChunkStoreConfig;
     let mut store_config = ChunkStoreConfig::from_env().unwrap_or_default();
     // NOTE: We're doing headless processing, there's no point in running subscribers, it will just
     // (massively) slow us down.

--- a/crates/viewer/re_space_view_dataframe/src/table_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/table_ui.rs
@@ -7,7 +7,7 @@ use re_types_core::ComponentName;
 
 /// Display a nicely configured table with the provided header ui, row ui, and row count.
 ///
-/// The `extra_columns` are hom many more columns there are in addition to the components.
+/// The `extra_columns` are how many more columns there are in addition to the components.
 pub(crate) fn table_ui(
     ui: &mut egui::Ui,
     sorted_components: &BTreeSet<ComponentName>,

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,5 +45,7 @@ The `manifest.toml` file describes the structure of the examples contained in th
 
 If you want to run the example on CI and include it in the in-viewer example page,
 add a `channel` entry to its README frontmatter. The available channels right now are:
-- `main` for simple/fast examples built on each PR and the `main` branch
+- `main` for simple/fast examples built on each merge to `main`
 - `nightly` for heavier examples built once per day
+
+If `channel` is missing, the example is never built on CI.

--- a/examples/python/segment_anything_model/README.md
+++ b/examples/python/segment_anything_model/README.md
@@ -3,7 +3,6 @@ title = "Segment anything model"
 tags = ["2D", "SAM", "Segmentation"]
 thumbnail = "https://static.rerun.io/segment-anything-model/36438df27a287e5eff3a673e2464af071e665fdf/480w.png"
 thumbnail_dimensions = [480, 480]
-channel = "release"
 -->
 
 Example of using Rerun to log and visualize the output of [Meta AI's Segment Anything model](https://segment-anything.com/).


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/6899

I had to disable the `segment_anything_model` example:
* https://github.com/rerun-io/rerun/issues/6901

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6900?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6900?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6900)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.