### PR TITLE
Link checker improvements

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     with:
       CONCURRENCY: nightly
+      CHANNEL: nightly
     secrets: inherit
 
   checks-cpp:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     with:
       CONCURRENCY: pr-${{ github.event.pull_request.number }}
+      CHANNEL: pr
     secrets: inherit
 
   cpp-paths-filter:

--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -21,6 +21,7 @@ jobs:
     uses: ./.github/workflows/reusable_checks.yml
     with:
       CONCURRENCY: push-${{ github.ref_name }}-${{ inputs.CONCURRENCY }}
+      CHANNEL: main
     secrets: inherit
 
   cpp_checks:

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -9,7 +9,7 @@ on:
       WHEEL_ARTIFACT_NAME:
         required: true
         type: string
-      CHANNEL: # `nightly` or `main`
+      CHANNEL: # `nightly`/`main`/`pr`
         required: true
         type: string
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -191,7 +191,6 @@ jobs:
 
   link-checker:
     name: Check links
-    if: ${{ inputs.CHANNEL != 'pr' }}
     runs-on: ubuntu-latest
     # do not fail entire workflow (e.g. nightly) if this is the only failing check
     continue-on-error: true
@@ -203,9 +202,13 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          fail: true
+          fail: ${{ inputs.CHANNEL == 'nightly' }}
           lycheeVersion: "0.15.1"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           # Pass --verbose, so that all considered links are printed, making it easier to debug.
           args: |
             --verbose --base . "**/*.md" "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"
+
+      - name: Warn because of broken links
+        if: steps.lychee.outputs.exit_code != 0
+        run: echo "::warning title="Link checker"::Link checker detected broken links!"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -6,6 +6,9 @@ on:
       CONCURRENCY:
         required: true
         type: string
+      CHANNEL: # `nightly`/`main`/`pr`
+        required: true
+        type: string
 
 concurrency:
   group: ${{ inputs.CONCURRENCY }}-checks
@@ -188,6 +191,7 @@ jobs:
 
   link-checker:
     name: Check links
+    if: ${{ inputs.CHANNEL != 'pr' }}
     runs-on: ubuntu-latest
     # do not fail entire workflow (e.g. nightly) if this is the only failing check
     continue-on-error: true

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -210,5 +210,5 @@ jobs:
             --verbose --base . "**/*.md" "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"
 
       - name: Warn because of broken links
-        if: steps.lychee.outputs.exit_code != 0
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
         run: echo "::warning title="Link checker"::Link checker detected broken links!"

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -197,10 +197,10 @@ jobs:
       # Check https://github.com/lycheeverse/lychee on how to run locally.
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v1.9.0
+        uses: lycheeverse/lychee-action@v1.10.0
         with:
           fail: true
-          lycheeVersion: "0.14.3"
+          lycheeVersion: "0.15.1"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           # Pass --verbose, so that all considered links are printed, making it easier to debug.
           args: |

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -210,5 +210,5 @@ jobs:
             --verbose --base . "**/*.md" "**/*.rs" "**/*.toml" "**/*.hpp" "**/*.cpp" "**/CMakeLists.txt" "**/*.py" "**/*.yml"
 
       - name: Warn because of broken links
-        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        if: ${{ steps.lychee.outputs.exit_code != '0' }}
         run: echo "::warning title="Link checker"::Link checker detected broken links!"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
   <a href="https://discord.gg/Gcm8BbTaAj">                              <img alt="Rerun Discord"  src="https://img.shields.io/discord/1062300748202921994?label=Rerun%20Discord"> </a>
 </h1>
 
-# TODO: failing link test http://rerunn.io/
-
 # Build time aware visualizations of multimodal data
 
 Use the Rerun SDK (available for C++, Python and Rust) to log data like images, tensors, point clouds, and text. Logs are streamed to the Rerun Viewer for live visualization or to file for later use.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <a href="https://discord.gg/Gcm8BbTaAj">                              <img alt="Rerun Discord"  src="https://img.shields.io/discord/1062300748202921994?label=Rerun%20Discord"> </a>
 </h1>
 
+# TODO: failing link test http://rerunn.io/
+
 # Build time aware visualizations of multimodal data
 
 Use the Rerun SDK (available for C++, Python and Rust) to log data like images, tensors, point clouds, and text. Logs are streamed to the Rerun Viewer for live visualization or to file for later use.

--- a/lychee.toml
+++ b/lychee.toml
@@ -32,6 +32,9 @@ insecure = true
 # Maximum number of allowed retries before a link is declared dead.
 max_retries = 4
 
+# Wait time between attempts in seconds.
+retry_wait_time = 2
+
 # Comma-separated list of accepted status codes for valid links.
 accept = [
   "100..=103", # Informational codes.


### PR DESCRIPTION
### What

* Fixes #6787

Had a look at last 10~ link failure runs on `nightly`: They are usually genuinely broken links because some page is down, which _does_ concern us if it's a permanent state. Occasionally it finds links we actually get wrong (happened once in the nightly buidls I checked, naturally they usually don't get that far).

So I think the only thing we really can do her eto make stuff less annoying is to make linkchecking a more "manual" affair.

* Update lychee
* bump retry time
* Job doesn't go red on pull request & main at all, instead it only reports a warning on the summary page of the CI
![image](https://github.com/user-attachments/assets/edda71a6-25d2-4ea2-bb26-ecae57da4955)
    * unfortunately doesn't show up in here - we could post a comment, but this might be too noise already again 🤔 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6907?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6907?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6907)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.