### PR TITLE
Scroll dataframe view to focused item

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/latest_at_table.rs
+++ b/crates/viewer/re_space_view_dataframe/src/latest_at_table.rs
@@ -98,7 +98,7 @@ pub(crate) fn latest_at_table_ui(
             // We want to scroll only if the focus action originated from outside the table. We
             // allow the case of `Instance::ALL` for when the entity is double-clicked in the
             // blueprint tree.
-            //TODO(#6906): we should have an explict way to track the "source" of the focus event.
+            //TODO(#6906): we should have an explicit way to track the "source" of the focus event.
             let should_scroll =
                 (space_view_id != &query.space_view_id) || instance_path.instance.is_all();
 

--- a/crates/viewer/re_space_view_dataframe/src/table_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/table_ui.rs
@@ -15,6 +15,7 @@ pub(crate) fn table_ui(
     header_ui: impl FnOnce(egui_extras::TableRow<'_, '_>),
     row_count: usize,
     row_ui: impl FnMut(TableRow<'_, '_>),
+    scroll_to_row: Option<usize>,
 ) {
     re_tracing::profile_function!();
 
@@ -28,7 +29,7 @@ pub(crate) fn table_ui(
                 ..Default::default()
             }
             .show(ui, |ui| {
-                egui_extras::TableBuilder::new(ui)
+                let mut table_builder = egui_extras::TableBuilder::new(ui)
                     .columns(
                         Column::auto_with_initial_suggestion(200.0).clip(true),
                         extra_columns + sorted_components.len(),
@@ -38,7 +39,14 @@ pub(crate) fn table_ui(
                     //TODO(ab): remove when https://github.com/emilk/egui/pull/4817 is merged/released
                     .max_scroll_height(f32::INFINITY)
                     .auto_shrink([false, false])
-                    .striped(true)
+                    .striped(true);
+
+                if let Some(scroll_to_row) = scroll_to_row {
+                    table_builder =
+                        table_builder.scroll_to_row(scroll_to_row, Some(egui::Align::TOP));
+                }
+
+                table_builder
                     .header(re_ui::DesignTokens::table_line_height(), header_ui)
                     .body(|body| {
                         body.rows(re_ui::DesignTokens::table_line_height(), row_count, row_ui);


### PR DESCRIPTION
### What

This PR scrolls the dataframe view to the focused entity/instance.

This would be further enhanced by addressing:
- https://github.com/rerun-io/rerun/issues/6906
- https://github.com/rerun-io/rerun/issues/5382

https://github.com/user-attachments/assets/ee59960e-ec61-4f1c-ba99-89a6e726e040


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6908?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6908?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6908)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.