### PR TITLE
Separate C++ example build from snippet compare in order to set pixi environment consistently

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -192,9 +192,15 @@ jobs:
         # --no-py-build because rerun-sdk is already built and installed
         run: pixi run -e wheel-test RUST_LOG=debug python tests/roundtrips.py --release --target ${{ needs.set-config.outputs.TARGET }} --no-py-build
 
+      - name: Build C++ examples
+        if: ${{ !inputs.FAST }}
+        # Separated out of compare_snippet_output.py run so we control the pixi environment.
+        # This used to cause issues on Windows during the setup of the pixi environment when running from inside `compare_snippet_output.py`.
+        run: pixi run -e wheel-test cpp-build-snippets
+
       - name: Run docs/snippets/compare_snippet_output.py
         if: ${{ !inputs.FAST }}
         # --release so we can inherit from some of the artifacts that maturin has just built before
         # explicit target because otherwise cargo loses the target cache… even though this is the target anyhow…
         # --no-py-build because rerun-sdk is already built and installed
-        run: pixi run -e wheel-test RUST_LOG=debug python docs/snippets/compare_snippet_output.py --release --target ${{ needs.set-config.outputs.TARGET }} --no-py-build
+        run: pixi run -e wheel-test RUST_LOG=debug python docs/snippets/compare_snippet_output.py --release --target ${{ needs.set-config.outputs.TARGET }} --no-py-build --no-cpp-build


### PR DESCRIPTION

<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

Shot in the dark to fix https://github.com/rerun-io/rerun/actions/runs/9951873366/job/27493385364
Rationale: Observed that the error happens during pixi setup script while being in the `cpp` environment nested in the `wheel-test` environment.

Testing: Works on my machine!

### Checklist
* [x] checked 