### PR TITLE
Add example for different data per timeline on `Events and Timelines` doc page

### DIFF
--- a/docs/content/concepts/timelines.md
+++ b/docs/content/concepts/timelines.md
@@ -18,6 +18,15 @@ snippet: tutorials/timelines_example
 This will add the logged points to the timelines `log_time`, `frame_idx`, and `sensor_time`.
 You can then choose which timeline you want to organize your data along in the expanded timeline view in the bottom of the Rerun Viewer.
 
+### Reset active timeline & differing data per timeline
+
+You can clear the active timeline(s) at any point using `reset_time`.
+This can be particularly useful when you want to log different data for individual timelines as illustrated here:
+
+snippet: concepts/different_data_per_timeline
+
+On one timeline the points will appear blue, on the other they appear red.
+
 ## Events
 
 An _event_ refer to an instance of logging one or more component batches to one or more timelines. In the viewer, the Time panel provide a graphical representation of these events across time and entities.

--- a/docs/snippets/all/concepts/different_data_per_timeline.cpp
+++ b/docs/snippets/all/concepts/different_data_per_timeline.cpp
@@ -1,0 +1,24 @@
+// Log different data on different timelines.
+
+#include <rerun.hpp>
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_different_data_per_timeline");
+    rec.spawn().exit_on_failure();
+
+    rec.set_time_sequence("blue timeline", 0);
+    rec.set_time_seconds("red timeline", 0.0);
+    rec.log("points", rerun::Points2D({{0.0, 0.0}, {1.0, 1.0}}));
+
+    // Log a red color on one timeline.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_seconds("red timeline", 1.0);
+    rec.log("points", std::array{rerun::components::Color(0xFF0000FF)});
+
+    // And a blue color on the other.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_sequence("blue timeline", 1);
+    rec.log("points", std::array{rerun::components::Color(0x0000FFFF)});
+
+    // TODO(#5521): log VisualBounds2D
+}

--- a/docs/snippets/all/concepts/different_data_per_timeline.py
+++ b/docs/snippets/all/concepts/different_data_per_timeline.py
@@ -1,0 +1,24 @@
+"""Log different data on different timelines."""
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+rr.init("rerun_example_different_data_per_timeline", spawn=True)
+
+rr.set_time_sequence("blue timeline", 0)
+rr.set_time_seconds("red timeline", 0.0)
+rr.log("points", rr.Points2D([[0, 0], [1, 1]], radii=rr.Radius.ui_points(10.0)))
+
+# Log a red color on one timeline.
+rr.reset_time()  # Clears all set timeline info.
+rr.set_time_seconds("red timeline", 1.0)
+rr.log_components("points", [rr.components.Color(0xFF0000FF)])
+
+# And a blue color on the other.
+rr.reset_time()  # Clears all set timeline info.
+rr.set_time_sequence("blue timeline", 1)
+rr.log_components("points", [rr.components.Color(0x0000FFFF)])
+
+
+# Set view bounds:
+rr.send_blueprint(rrb.Spatial2DView(visual_bounds=rrb.VisualBounds2D(x_range=[-1, 2], y_range=[-1, 2])))

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -1,0 +1,24 @@
+//! Log different data on different timelines.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec =
+        rerun::RecordingStreamBuilder::new("rerun_example_different_data_per_timeline").spawn()?;
+
+    rec.set_time_sequence("blue timeline", 0);
+    rec.set_time_seconds("red timeline", 0.0);
+    rec.log("points", &rerun::Points2D::new([(0.0, 0.0), (1.0, 1.0)]))?;
+
+    // Log a red color on one timeline.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_seconds("red timeline", 1.0);
+    rec.log("points", &[rerun::components::Color::from_u32(0xFF0000FF)])?;
+
+    // And a blue color on the other.
+    rec.reset_time(); // Clears all set timeline info.
+    rec.set_time_sequence("blue timeline", 1);
+    rec.log("points", &[rerun::components::Color::from_u32(0x0000FFFF)])?;
+
+    // TODO(#5521): log VisualBounds2D
+
+    Ok(())
+}

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -11,12 +11,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log a red color on one timeline.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_seconds("red timeline", 1.0);
-    rec.log("points", &[rerun::components::Color::from_u32(0xFF0000FF)])?;
+    rec.log_component_batches(
+        "points",
+        false,
+        [&rerun::components::Color::from_u32(0xFF0000FF) as &dyn rerun::ComponentBatch],
+    )?;
 
     // And a blue color on the other.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_sequence("blue timeline", 1);
-    rec.log("points", &[rerun::components::Color::from_u32(0x0000FFFF)])?;
+    rec.log_component_batches(
+        "points",
+        false,
+        [&rerun::components::Color::from_u32(0x0000FFFF) as &dyn rerun::ComponentBatch],
+    )?;
 
     // TODO(#5521): log VisualBounds2D
 

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -5,7 +5,23 @@
 # You should only ever use this if the test isn't implemented and cannot yet be implemented
 # for one or more specific SDKs.
 [opt_out.run]
-concepts = [
+"concepts/viscomp-base" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-component-default" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-component-override" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-visualizer-override-multiple" = [
+  "cpp",  # Blueprint API doesn't exist for C++/Rust
+  "rust", # Blueprint API doesn't exist for C++/Rust
+]
+"concepts/viscomp-visualizer-override" = [
   "cpp",  # Blueprint API doesn't exist for C++/Rust
   "rust", # Blueprint API doesn't exist for C++/Rust
 ]


### PR DESCRIPTION
### What

Preview: https://landing-7a6fnura2-rerun.vercel.app/docs/concepts/timelines#reset-active-timeline--differing-data-per-timeline

After answering with this example on Discord, I noticed we haven't documented this ability anywhere. Added a three language snippet + a little bit of text to the `Events and Timelines` doc page.

Tested examples locally using `pixi run python .\docs\snippets\compare_snippet_output.py concepts/different_data_per_timeline`.

![image](https://github.com/user-attachments/assets/ea096a74-21e4-494e-969b-6b7024883c39)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6912?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6912?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6912)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.