### PR TITLE
[C++] Fix resetting time destroying recording stream

### DIFF
--- a/crates/top/rerun_c/src/lib.rs
+++ b/crates/top/rerun_c/src/lib.rs
@@ -614,7 +614,7 @@ pub extern "C" fn rr_recording_stream_disable_timeline(
 #[allow(unsafe_code)]
 #[no_mangle]
 pub extern "C" fn rr_recording_stream_reset_time(stream: CRecordingStream) {
-    if let Some(stream) = RECORDING_STREAMS.lock().remove(stream) {
+    if let Some(stream) = RECORDING_STREAMS.lock().get(stream) {
         stream.reset_time();
     }
 }

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -560,6 +560,10 @@ SCENARIO("RecordingStream can set time without errors", TEST_TAG) {
     SECTION("Resetting time does not log errors") {
         check_logged_error([&] { stream.reset_time(); });
     }
+    SECTION("Can set time again after resetting time tim") {
+        check_logged_error([&] { stream.reset_time(); });
+        check_logged_error([&] { stream.set_time_seconds("duration", 1.0f); });
+    }
 
     SECTION("Disabling timeline does not log errors") {
         check_logged_error([&] { stream.disable_timeline("doesn't exist"); });

--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -560,7 +560,7 @@ SCENARIO("RecordingStream can set time without errors", TEST_TAG) {
     SECTION("Resetting time does not log errors") {
         check_logged_error([&] { stream.reset_time(); });
     }
-    SECTION("Can set time again after resetting time tim") {
+    SECTION("Can set time again after resetting the time") {
         check_logged_error([&] { stream.reset_time(); });
         check_logged_error([&] { stream.set_time_seconds("duration", 1.0f); });
     }


### PR DESCRIPTION
### What

`rerun::RecordingStream::reset_time` accidentally destroyed the recording stream, causing it to fail/assert on any subsequent use, making the `reset_time` method unusable.
+ test to catch this

From the looks of it the method never worked to begin with.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6914?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6914?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6914)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.