### PR TITLE
Provide view state to `SpaceViewClass::default_query_range()`

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -434,10 +434,8 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
 
             let view_ctx = view.bundle_context_with_state(ctx, view_state);
             view_components_defaults_section_ui(&view_ctx, ui, view);
-        }
 
-        if let Some(view) = blueprint.view(view_id) {
-            visible_time_range_ui_for_view(ctx, ui, view);
+            visible_time_range_ui_for_view(ctx, ui, view, view_state);
         }
     }
 }

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -14,7 +14,7 @@ use re_types::{
     Archetype, SpaceViewClassIdentifier,
 };
 use re_ui::UiExt as _;
-use re_viewer_context::{QueryRange, SpaceViewClass, ViewerContext};
+use re_viewer_context::{QueryRange, SpaceViewClass, SpaceViewState, ViewerContext};
 use re_viewport_blueprint::{entity_path_for_view_property, SpaceViewBlueprint};
 
 /// These space views support the Visible History feature.
@@ -41,6 +41,7 @@ pub fn visible_time_range_ui_for_view(
     ctx: &ViewerContext<'_>,
     ui: &mut Ui,
     view: &SpaceViewBlueprint,
+    view_state: &dyn SpaceViewState,
 ) {
     if !space_view_with_visible_history(view.class_identifier()) {
         return;
@@ -57,6 +58,7 @@ pub fn visible_time_range_ui_for_view(
         ctx.blueprint_query,
         ctx.rec_cfg.time_ctrl.read().timeline(),
         ctx.space_view_class_registry,
+        view_state,
     );
 
     let is_space_view = true;

--- a/crates/viewer/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_time_series/src/space_view_class.rs
@@ -127,7 +127,7 @@ Display time series data in a plot.
         re_viewer_context::SpaceViewClassLayoutPriority::Low
     }
 
-    fn default_query_range(&self) -> QueryRange {
+    fn default_query_range(&self, _view_state: &dyn SpaceViewState) -> QueryRange {
         QueryRange::TimeRange(TimeRange::EVERYTHING)
     }
 

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -298,6 +298,7 @@ impl AppState {
                         rec_cfg.time_ctrl.read().timeline(),
                         space_view_class_registry,
                         query_result,
+                        view_states,
                     );
                 }
             }

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -94,6 +94,7 @@ pub trait SpaceViewClass: Send + Sync {
     fn layout_priority(&self) -> SpaceViewClassLayoutPriority;
 
     /// Default query range for this space view.
+    //TODO(#6918): also provide ViewerContext and SpaceViewId, to enable reading view properties.
     fn default_query_range(&self, _state: &dyn SpaceViewState) -> QueryRange {
         QueryRange::LatestAt
     }

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -94,7 +94,7 @@ pub trait SpaceViewClass: Send + Sync {
     fn layout_priority(&self) -> SpaceViewClassLayoutPriority;
 
     /// Default query range for this space view.
-    fn default_query_range(&self) -> QueryRange {
+    fn default_query_range(&self, _state: &dyn SpaceViewState) -> QueryRange {
         QueryRange::LatestAt
     }
 

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -392,6 +392,7 @@ impl SpaceViewBlueprint {
         blueprint_query: &LatestAtQuery,
         active_timeline: &Timeline,
         space_view_class_registry: &SpaceViewClassRegistry,
+        view_state: &dyn SpaceViewState,
     ) -> QueryRange {
         // Visual time range works with regular overrides for the most part but it's a bit special:
         // * we need it for all entities unconditionally
@@ -415,7 +416,7 @@ impl SpaceViewBlueprint {
             || {
                 let space_view_class =
                     space_view_class_registry.get_class_or_log_error(self.class_identifier);
-                space_view_class.default_query_range()
+                space_view_class.default_query_range(view_state)
             },
             |time_range| QueryRange::TimeRange(time_range.clone()),
         )
@@ -797,6 +798,7 @@ mod tests {
         };
 
         let mut query_result = contents.execute_query(&store_ctx, visualizable_entities);
+        let mut view_states = ViewStates::default();
 
         test_ctx.run(|ctx, _ui| {
             resolver.update_overrides(
@@ -805,6 +807,7 @@ mod tests {
                 &test_ctx.active_timeline,
                 ctx.space_view_class_registry,
                 &mut query_result,
+                &mut view_states,
             );
         });
 

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -18,7 +18,7 @@ use re_types_core::ComponentName;
 use re_viewer_context::{
     ApplicableEntities, DataQueryResult, DataResult, DataResultHandle, DataResultNode,
     DataResultTree, IndicatedEntities, OverridePath, PerVisualizer, PropertyOverrides, QueryRange,
-    SpaceViewClassRegistry, SpaceViewId, ViewerContext, VisualizableEntities,
+    SpaceViewClassRegistry, SpaceViewId, ViewStates, ViewerContext, VisualizableEntities,
 };
 
 use crate::{SpaceViewBlueprint, ViewProperty};
@@ -524,17 +524,22 @@ impl DataQueryPropertyResolver<'_> {
         active_timeline: &Timeline,
         space_view_class_registry: &SpaceViewClassRegistry,
         query_result: &mut DataQueryResult,
+        view_states: &mut ViewStates,
     ) {
         re_tracing::profile_function!();
 
         if let Some(root) = query_result.tree.root_handle() {
             let recursive_property_overrides = Default::default();
 
+            let class = self.space_view.class(space_view_class_registry);
+            let view_state = view_states.get_mut_or_create(self.space_view.id, class);
+
             let default_query_range = self.space_view.query_range(
                 blueprint,
                 blueprint_query,
                 active_timeline,
                 space_view_class_registry,
+                view_state,
             );
 
             self.update_overrides_recursive(


### PR DESCRIPTION
### What

This PR provides the view state to `SpaceViewClass::default_query_range()`, such that the default query range may be dynamic.

**Note**: this is a rather poor solution. Ideally, we would also have `&ViewContext` and friends, such that it would be possible to e.g. read view properties. This is however not possible because `default_query_range()` is called in a context where, all the way up in `AppState`, a `ViewerContext` is not available (precisely because it's being mutated). Improving on that would require a much more significant refactor. Passing the state at least allows ugly work around such as passing a value computed from e.g. `SpaceViewClass:ui()` (yes, ugly).

- See https://github.com/rerun-io/rerun/issues/6918

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6917?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6917?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6917)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.