### PR TITLE
Fix `Chunk`'s counting routines checking the wrong variable

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -266,7 +266,7 @@ impl Chunk {
             return vec![(time_range.min(), self.num_events_cumulative() as u64)];
         }
 
-        let counts = if self.is_sorted() {
+        let counts = if time_chunk.is_sorted() {
             self.num_events_cumulative_per_unique_time_sorted(time_chunk)
         } else {
             self.num_events_cumulative_per_unique_time_unsorted(time_chunk)
@@ -286,7 +286,7 @@ impl Chunk {
     ) -> Vec<(TimeInt, u64)> {
         re_tracing::profile_function!();
 
-        debug_assert!(self.is_sorted());
+        debug_assert!(time_chunk.is_sorted());
 
         // NOTE: This is used on some very hot paths (time panel rendering).
         // Performance trumps readability. Optimized empirically.
@@ -335,7 +335,7 @@ impl Chunk {
     ) -> Vec<(TimeInt, u64)> {
         re_tracing::profile_function!();
 
-        debug_assert!(!self.is_sorted());
+        debug_assert!(!time_chunk.is_sorted());
 
         self.components
             .values()

--- a/crates/viewer/re_time_panel/benches/bench_density_graph.rs
+++ b/crates/viewer/re_time_panel/benches/bench_density_graph.rs
@@ -90,8 +90,8 @@ fn add_data(
         log_times.push(time);
 
         if !sorted {
-            let mut rng = rand::thread_rng();
-            use rand::seq::SliceRandom as _;
+            use rand::{seq::SliceRandom as _, SeedableRng as _};
+            let mut rng = rand::rngs::StdRng::seed_from_u64(0xbadf00d);
             log_times.shuffle(&mut rng);
         }
 


### PR DESCRIPTION
`self.is_sorted()` tells us whether the `Chunk` as a whole is globally-ordered, `time_chunk.is_sorted()` tells us whether that particular timeline is time-ordered.
I meant to check the latter.

Also seeded the benchmark while I'm in here.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6936?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6936?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6936)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.