### PR TITLE
Fix nasty compaction threshold bug

### DIFF
--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -95,8 +95,15 @@ impl ChunkStoreConfig {
     /// Default configuration, applicable to most use cases, according to empirical testing.
     pub const DEFAULT: Self = Self {
         enable_changelog: true,
-        chunk_max_bytes: 8 * 1024 * 1024,
+
+        // Empirical testing shows that 4MiB is good middle-ground, big tensors and buffers can
+        // become a bit too costly to concatenate beyond that.
+        chunk_max_bytes: 4 * 1024 * 1024,
+
+        // Empirical testing shows that 1024 is the threshold after which we really start to get
+        // dimishing returns space-wise.
         chunk_max_rows: 1024,
+
         chunk_max_rows_if_unsorted: 256,
     };
 


### PR DESCRIPTION
The actual bug is this one-liner, everything else is just niceties that come on top (see commit per commit):
![image](https://github.com/user-attachments/assets/f3d8a1d0-4eab-41c3-bdc4-2f2d830469f7)

The chunk happens to be wrapped in an `Arc` at this point in time, and `Arc`s also implement `SizeBytes`... by always returning zero (considered amortized).

Also switched the default config to 4MiB per chunk instead of 8MiB, which has proven much nicer after an afternoon of empirical testing.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6939?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6939?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6939)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.