### PR TITLE
Compaction-aware store events

### DIFF
--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -240,7 +240,7 @@ impl ChunkStore {
                 None,                             /* compacted */
             );
             if let Some(elected_chunk) = &elected_chunk {
-                // NOTE: The just that we've just added has been compacted already!
+                // NOTE: The chunk that we've just added has been compacted already!
                 let srcs = std::iter::once(non_compacted_chunk.id())
                     .chain(
                         self.remove_chunk(elected_chunk.id())

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -49,6 +49,8 @@ impl ChunkStore {
 
         self.insert_id += 1;
 
+        let non_compacted_chunk = Arc::clone(chunk); // we'll need it to create the store event
+
         let (chunk, diffs) = if chunk.is_static() {
             // Static data: make sure to keep the most recent chunk available for each component column.
             re_tracing::profile_scope!("static");
@@ -97,7 +99,10 @@ impl ChunkStore {
 
             (
                 Arc::clone(chunk),
-                vec![ChunkStoreDiff::addition(Arc::clone(chunk))],
+                vec![ChunkStoreDiff::addition(
+                    non_compacted_chunk, /* added */
+                    None,                /* compacted */
+                )],
             )
         } else {
             // Temporal data: just index the chunk on every dimension of interest.
@@ -222,12 +227,34 @@ impl ChunkStore {
 
             self.temporal_chunks_stats += ChunkStoreChunkStats::from_chunk(&chunk_or_compacted);
 
-            let mut diffs = vec![ChunkStoreDiff::addition(Arc::clone(&chunk_or_compacted))];
+            let mut diff = ChunkStoreDiff::addition(
+                // NOTE: We are advertising only the non-compacted chunk as "added", i.e. only the new data.
+                //
+                // This makes sure that downstream subscribers only have to process what is new,
+                // instead of needlessly reprocessing old rows that would appear to have been
+                // removed and reinserted due to compaction.
+                //
+                // Subscribers will still be capable of tracking which chunks have been merged with which
+                // by using the compaction report that we fill below.
+                Arc::clone(&non_compacted_chunk), /* added */
+                None,                             /* compacted */
+            );
             if let Some(elected_chunk) = &elected_chunk {
-                diffs.extend(self.remove_chunk(elected_chunk.id()));
+                // NOTE: The just that we've just added has been compacted already!
+                let srcs = std::iter::once(non_compacted_chunk.id())
+                    .chain(
+                        self.remove_chunk(elected_chunk.id())
+                            .into_iter()
+                            .filter(|diff| diff.kind == crate::ChunkStoreDiffKind::Deletion)
+                            .map(|diff| diff.chunk.id()),
+                    )
+                    .collect();
+                let dst = chunk_or_compacted.id();
+
+                diff.compacted = Some((srcs, dst));
             }
 
-            (chunk_or_compacted, diffs)
+            (chunk_or_compacted, vec![diff])
         };
 
         self.chunks_per_chunk_id.insert(chunk.id(), chunk.clone());

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -385,7 +385,6 @@ impl EntityDb {
             self.times_per_timeline.on_events(&store_events);
             self.query_caches.on_events(&store_events);
             self.tree.on_store_additions(&store_events);
-            self.tree.on_store_deletions(&store_events);
 
             // We inform the stats last, since it measures e2e latency.
             self.stats.on_events(&store_events);

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -193,6 +193,7 @@ impl ChunkStoreSubscriber for Caches {
             let ChunkStoreDiff {
                 kind: _, // Don't care: both additions and deletions invalidate query results.
                 chunk,
+                compacted: _,
             } = diff;
 
             {


### PR DESCRIPTION
This makes store events aware of compaction, i.e. when a new chunk comes in and gets compacted with an older chunk, downstream subscribers will now be notified of what the new chunk looked like _pre-compaction_, and which chunk was merged with what.

This results in massive perf boost in downstream subscribers without requiring code changes (existing subscribers will effectively be working with diffs without knowing).

- DNM: built on top of #6939 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6940?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6940?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6940)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.