### PR TITLE
When launched with a file path, the viewer will now still listen for TCP connections

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -692,10 +692,9 @@ fn run_impl(
 
         #[cfg(feature = "server")]
         {
-            // Check if there is already a viewer running
-            // and if so, send the data to it.
+            // Check if there is already a viewer running and if so, send the data to it.
             use std::net::TcpStream;
-            let connect_addr = std::net::SocketAddr::new(args.bind.parse().unwrap(), args.port);
+            let connect_addr = std::net::SocketAddr::new("127.0.0.1".parse().unwrap(), args.port);
             if TcpStream::connect_timeout(&connect_addr, std::time::Duration::from_secs(1)).is_ok()
             {
                 re_log::info!(


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
related issue #6952 
When lauched with files `rerun xxx.rrd`, the viewr doesn't listen to any port.
I am using `rerun-cli 0.17.0 [rustc 1.76.0 (07dca489a 2024-02-04), LLVM 17.0.6] x86_64-unknown-linux-gnu release-0.17.0 d65ca50, built 2024-07-08T13:47:55Z`.

Before this PR:
No log msg shows we are hosting a SDK sever over some ports.
```bash
> rerun /media/Q/eulerBackUp/Box/Box/rerun_samples.rrd
[2024-07-20T19:37:04Z INFO  re_data_loader::load_file] Loading "/media/Q/eulerBackUp/Box/
Box/rerun_samples.rrd"…
[2024-07-20T19:37:04Z INFO  winit::platform_impl::platform::x11::window] Guessed window s
cale factor: 1
[2024-07-20T19:37:04Z WARN  wgpu_hal::vulkan::instance] Unable to find extension: VK_EXT_
swapchain_colorspace
[2024-07-20T19:37:04Z INFO  egui_wgpu] There were 2 available wgpu adapters: {backend: Vu

> rerun
[2024-07-20T19:38:40Z INFO  re_sdk_comms::server] Hosting a SDK server over TCP at 0.0.0.0:9876. Connect with the Rerun logging SDK.
[2024-07-20T19:38:40Z INFO  winit::platform_impl::platform::x11::window] Guessed window scale factor: 1
[2024-07-20T19:38:40Z WARN  wgpu_hal::vulkan::instance] Unable to find extension: VK_EXT_swapchain_colorspace
```
After this PR:
```bash
> target/debug/rerun /media/Q/eulerBackUp/Box/Box/rerun_samples.
[2024-07-20T19:43:09Z INFO  re_data_loader::load_file] Loading "/media/Q/eulerBackUp/Box/
Box/rerun_samples.rrd"…
[2024-07-20T19:43:09Z INFO  re_sdk_comms::server] Hosting a SDK server over TCP at 0.0.0.
0:9876. Connect with the Rerun logging SDK.
[2024-07-20T19:43:09Z INFO  winit::platform_impl::platform::x11::window] Guessed window scale factor: 1
```
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6951?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6951?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6951)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.