### PR TITLE
Fix nightly notebook test

### DIFF
--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   run-notebook:
     name: Run notebook
-    runs-on: buildjet-8vcpu-ubuntu-2204 # This image runs occasionally out of memory, BuildJet runners have more disk available.
+    runs-on: ubuntu-latest-16-cores # Note that as of writing we need the additional storage page (14 gb of the ubunut-latest runner is not enough).
     container:
       image: rerunio/ci_docker:0.14.0 # Required to run the wheel or we get "No matching distribution found for attrs>=23.1.0" during `pip install rerun-sdk`
     steps:

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install built wheel
         run: |
           pixi run python scripts/ci/pixi_install_wheel.py --feature python-pypi --package rerun-sdk --dir wheel
-          pixi run python scripts/ci/pixi_install_wheel.py --feature python-pypi --package rerun-notebook --dir wheel
+          pixi run python scripts/ci/pixi_install_wheel.py --feature python-pypi --package rerun-notebook --dir wheel --platform-independent
 
       - name: Install Deps
         run: pixi run -e wheel-test pip install -r examples/python/notebook/requirements.txt

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   run-notebook:
     name: Run notebook
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204 # This image runs occasionally out of memory, BuildJet runners have more disk available.
     container:
       image: rerunio/ci_docker:0.14.0 # Required to run the wheel or we get "No matching distribution found for attrs>=23.1.0" during `pip install rerun-sdk`
     steps:


### PR DESCRIPTION
### What

* change to buildjet runner to avoid out of disk memory issue
* handle platform independent wheel in pixi_install_wheel.py

### Checklist
* [x] yes

- [PR Build Summary](https://build.rerun.io/pr/6964)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.