### PR TITLE
Fix zero length transform axis having an effect bounding box used for heuristics etc.

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -78,16 +78,21 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
                 continue;
             };
 
+            let results = data_result
+                .latest_at_with_blueprint_resolved_data::<Transform3D>(ctx, &latest_at_query);
+            let axis_length: f32 = results.get_mono_with_fallback::<AxisLength>().into();
+
+            if axis_length == 0.0 {
+                // Don't draw axis and don't add to the bounding box!
+                continue;
+            }
+
             // Only add the center to the bounding box - the lines may be dependent on the bounding box, causing a feedback loop otherwise.
             self.0.add_bounding_box(
                 data_result.entity_path.hash(),
                 re_math::BoundingBox::ZERO,
                 world_from_obj,
             );
-
-            let results = data_result
-                .latest_at_with_blueprint_resolved_data::<Transform3D>(ctx, &latest_at_query);
-            let axis_length = results.get_mono_with_fallback::<AxisLength>().into();
 
             add_axis_arrows(
                 &mut line_builder,


### PR DESCRIPTION
### What

Also skips drawing it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6967?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6967?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6967)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.