### PR TITLE
Use full commit sha for prerelease job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -434,7 +434,7 @@ jobs:
           # It seems to otherwise use the latest commit for the tag. From the actions's docs:
           # > If the tag of the release you are creating does not yet exist, you should set both the tag and commit action inputs.
           # We just deleted the previous tag, so this is the case!
-          commit: ${{ env.SHORT_SHA }}
+          commit: ${{github.sha}}
           name: "Development Build"
           tag: "prerelease"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/rerun_cpp/arrow_cpp_install.md
+++ b/rerun_cpp/arrow_cpp_install.md
@@ -54,7 +54,7 @@ Now, any Pixi tasks added to your project will have access to the `arrow-cpp` li
 Even without tasks, you can run `pixi shell` to create a shell environment where all your project dependencies
 (including `arrow-cpp`) will be available. You can use this `pixi shell` to run you project's build commands.
 
-Check out the [Pixi docs](https://prefix.dev/docs/pixi/basic_usage) for more information on what you can do with Pixi.
+Check out the [Pixi docs](https://pixi.sh/latest/#getting-started) for more information on what you can do with Pixi.
 
 ### Pixi in action
 


### PR DESCRIPTION
### What

And update an old pixi link


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6986?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6986?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6986)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.