### PR TITLE
Introduce `Chunk` component-level helpers and `UnitChunk`

### DIFF
--- a/crates/store/re_chunk/src/helpers.rs
+++ b/crates/store/re_chunk/src/helpers.rs
@@ -1,0 +1,360 @@
+use std::sync::Arc;
+
+use arrow2::array::Array as ArrowArray;
+
+use re_log_types::{TimeInt, Timeline};
+use re_types_core::{Component, ComponentName, SizeBytes};
+
+use crate::{Chunk, ChunkResult, RowId};
+
+// --- Helpers ---
+
+impl Chunk {
+    // --- Batch ---
+
+    /// Returns the raw data for the specified component.
+    ///
+    /// Returns an error if the row index is out of bounds.
+    #[inline]
+    pub fn component_batch_raw(
+        &self,
+        component_name: &ComponentName,
+        row_index: usize,
+    ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
+        self.components.get(component_name).map(|list_array| {
+            if list_array.len() > row_index {
+                Ok(list_array.value(row_index))
+            } else {
+                Err(crate::ChunkError::IndexOutOfBounds {
+                    kind: "row".to_owned(),
+                    len: list_array.len(),
+                    index: row_index,
+                })
+            }
+        })
+    }
+
+    /// Returns the deserialized data for the specified component.
+    ///
+    /// Returns an error if the data cannot be deserialized, or if the row index is out of bounds.
+    #[inline]
+    pub fn component_batch<C: Component>(&self, row_index: usize) -> Option<ChunkResult<Vec<C>>> {
+        let res = self.component_batch_raw(&C::name(), row_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        let data = C::from_arrow(&*array);
+        Some(data.map_err(Into::into))
+    }
+
+    // --- Instance ---
+
+    /// Returns the raw data for the specified component at the given instance index.
+    ///
+    /// Returns an error if either the row index or instance index are out of bounds.
+    #[inline]
+    pub fn component_instance_raw(
+        &self,
+        component_name: &ComponentName,
+        row_index: usize,
+        instance_index: usize,
+    ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
+        let res = self.component_batch_raw(component_name, row_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        if array.len() > instance_index {
+            Some(Ok(array.sliced(instance_index, 1)))
+        } else {
+            Some(Err(crate::ChunkError::IndexOutOfBounds {
+                kind: "instance".to_owned(),
+                len: array.len(),
+                index: instance_index,
+            }))
+        }
+    }
+
+    /// Returns the component data of the specified instance.
+    ///
+    /// Returns an error if the data cannot be deserialized, or if either the row index or instance index
+    /// are out of bounds.
+    #[inline]
+    pub fn component_instance<C: Component>(
+        &self,
+        row_index: usize,
+        instance_index: usize,
+    ) -> Option<ChunkResult<C>> {
+        let res = self.component_instance_raw(&C::name(), row_index, instance_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        match C::from_arrow(&*array) {
+            Ok(data) => data.into_iter().next().map(Ok), // NOTE: It's already sliced!
+            Err(err) => Some(Err(err.into())),
+        }
+    }
+
+    // --- Mono ---
+
+    /// Returns the raw data for the specified component, assuming a mono-batch.
+    ///
+    /// Returns an error if either the row index is out of bounds, or the underlying batch is not
+    /// of unit length.
+    #[inline]
+    pub fn component_mono_raw(
+        &self,
+        component_name: &ComponentName,
+        row_index: usize,
+    ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
+        let res = self.component_batch_raw(component_name, row_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        if array.len() == 1 {
+            Some(Ok(array.sliced(0, 1)))
+        } else {
+            Some(Err(crate::ChunkError::IndexOutOfBounds {
+                kind: "mono".to_owned(),
+                len: array.len(),
+                index: 0,
+            }))
+        }
+    }
+
+    /// Returns the deserialized data for the specified component, assuming a mono-batch.
+    ///
+    /// Returns an error if the data cannot be deserialized, or if either the row index is out of bounds,
+    /// or the underlying batch is not of unit length.
+    #[inline]
+    pub fn component_mono<C: Component>(&self, row_index: usize) -> Option<ChunkResult<C>> {
+        let res = self.component_mono_raw(&C::name(), row_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        match C::from_arrow(&*array) {
+            Ok(data) => data.into_iter().next().map(Ok), // NOTE: It's already sliced!
+            Err(err) => Some(Err(err.into())),
+        }
+    }
+}
+
+// --- Unit ---
+
+/// A simple type alias for an `Arc<Chunk>`.
+pub type ChunkShared = Arc<Chunk>;
+
+/// A [`ChunkShared`] that is guaranteed to always contain a single row's worth of data.
+#[derive(Debug, Clone)]
+pub struct UnitChunkShared(ChunkShared);
+
+impl std::ops::Deref for UnitChunkShared {
+    type Target = Chunk;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl SizeBytes for UnitChunkShared {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        Chunk::heap_size_bytes(&self.0)
+    }
+}
+
+impl Chunk {
+    /// Turns the chunk into a [`UnitChunkShared`], if possible.
+    #[inline]
+    pub fn to_unit(self: &ChunkShared) -> Option<UnitChunkShared> {
+        (self.num_rows() == 1).then(|| UnitChunkShared(Arc::clone(self)))
+    }
+
+    /// Turns the chunk into a [`UnitChunkShared`], if possible.
+    #[inline]
+    pub fn into_unit(self) -> Option<UnitChunkShared> {
+        (self.num_rows() == 1).then(|| UnitChunkShared(Arc::new(self)))
+    }
+}
+
+impl UnitChunkShared {
+    // Turns the unit chunk back into a standard [`Chunk`].
+    #[inline]
+    pub fn into_chunk(self) -> ChunkShared {
+        self.0
+    }
+}
+
+impl UnitChunkShared {
+    /// Returns the index (`(TimeInt, RowId)` pair) of the single row within, on the given timeline.
+    ///
+    /// Returns the single static index if the chunk is static.
+    #[inline]
+    pub fn index(&self, timeline: &Timeline) -> Option<(TimeInt, RowId)> {
+        debug_assert!(self.num_rows() == 1);
+        if self.is_static() {
+            self.row_ids()
+                .next()
+                .map(|row_id| (TimeInt::STATIC, row_id))
+        } else {
+            self.timelines.get(timeline).and_then(|time_chunk| {
+                time_chunk
+                    .times()
+                    .next()
+                    .and_then(|time| self.row_ids().next().map(|row_id| (time, row_id)))
+            })
+        }
+    }
+
+    /// Returns the [`RowId`] of the single row within, on the given timeline.
+    ///
+    /// Returns the single static `RowId` if the chunk is static.
+    #[inline]
+    pub fn row_id(&self) -> Option<RowId> {
+        debug_assert!(self.num_rows() == 1);
+        self.row_ids().next()
+    }
+
+    /// Returns the number of instances of the single row within.
+    ///
+    /// The maximum value amongst all components is what's returned.
+    #[inline]
+    pub fn num_instances(&self) -> u64 {
+        self.components
+            .values()
+            .map(|list_array| {
+                list_array.validity().map_or_else(
+                    || list_array.len(),
+                    |validity| validity.len() - validity.unset_bits(),
+                )
+            })
+            .max()
+            .unwrap_or(0) as u64
+    }
+}
+
+// --- Unit helpers ---
+
+impl UnitChunkShared {
+    // --- Batch ---
+
+    /// Returns the raw data for the specified component.
+    #[inline]
+    pub fn component_batch_raw(
+        &self,
+        component_name: &ComponentName,
+    ) -> Option<Box<dyn ArrowArray>> {
+        debug_assert!(self.num_rows() == 1);
+        self.components
+            .get(component_name)
+            .map(|list_array| list_array.value(0))
+    }
+
+    /// Returns the deserialized data for the specified component.
+    ///
+    /// Returns an error if the data cannot be deserialized.
+    #[inline]
+    pub fn component_batch<C: Component>(&self) -> Option<ChunkResult<Vec<C>>> {
+        let data = C::from_arrow(&*self.component_batch_raw(&C::name())?);
+        Some(data.map_err(Into::into))
+    }
+
+    // --- Instance ---
+
+    /// Returns the raw data for the specified component at the given instance index.
+    ///
+    /// Returns an error if the instance index is out of bounds.
+    #[inline]
+    pub fn component_instance_raw(
+        &self,
+        component_name: &ComponentName,
+        instance_index: usize,
+    ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
+        let array = self.component_batch_raw(component_name)?;
+        if array.len() > instance_index {
+            Some(Ok(array.sliced(instance_index, 1)))
+        } else {
+            Some(Err(crate::ChunkError::IndexOutOfBounds {
+                kind: "instance".to_owned(),
+                len: array.len(),
+                index: instance_index,
+            }))
+        }
+    }
+
+    /// Returns the deserialized data for the specified component at the given instance index.
+    ///
+    /// Returns an error if the data cannot be deserialized, or if the instance index is out of bounds.
+    #[inline]
+    pub fn component_instance<C: Component>(
+        &self,
+        instance_index: usize,
+    ) -> Option<ChunkResult<C>> {
+        let res = self.component_instance_raw(&C::name(), instance_index)?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        match C::from_arrow(&*array) {
+            Ok(data) => data.into_iter().next().map(Ok), // NOTE: It's already sliced!
+            Err(err) => Some(Err(err.into())),
+        }
+    }
+
+    // --- Mono ---
+
+    /// Returns the raw data for the specified component, assuming a mono-batch.
+    ///
+    /// Returns an error if the underlying batch is not of unit length.
+    #[inline]
+    pub fn component_mono_raw(
+        &self,
+        component_name: &ComponentName,
+    ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
+        let array = self.component_batch_raw(component_name)?;
+        if array.len() == 1 {
+            Some(Ok(array.sliced(0, 1)))
+        } else {
+            Some(Err(crate::ChunkError::IndexOutOfBounds {
+                kind: "mono".to_owned(),
+                len: array.len(),
+                index: 0,
+            }))
+        }
+    }
+
+    /// Returns the deserialized data for the specified component, assuming a mono-batch.
+    ///
+    /// Returns an error if the data cannot be deserialized, or if the underlying batch is not of unit length.
+    #[inline]
+    pub fn component_mono<C: Component>(&self) -> Option<ChunkResult<C>> {
+        let res = self.component_mono_raw(&C::name())?;
+
+        let array = match res {
+            Ok(array) => array,
+            Err(err) => return Some(Err(err)),
+        };
+
+        match C::from_arrow(&*array) {
+            Ok(data) => data.into_iter().next().map(Ok), // NOTE: It's already sliced!
+            Err(err) => Some(Err(err.into())),
+        }
+    }
+}

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -176,42 +176,6 @@ impl Chunk {
     }
 }
 
-// TODO(cmc): get rid of this
-impl Chunk {
-    /// Returns an iterator over the rows of the [`Chunk`].
-    ///
-    /// If the chunk is static, `timeline` will be ignored.
-    ///
-    /// Iterating a [`Chunk`] on a row basis is very wasteful, performance-wise.
-    /// Prefer columnar access when possible.
-    pub fn iter_rows(
-        &self,
-        timeline: &Timeline,
-        component_name: &ComponentName,
-    ) -> impl Iterator<Item = (TimeInt, RowId)> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
-            return Either::Left(std::iter::empty());
-        };
-
-        if self.is_static() {
-            let indices = izip!(std::iter::repeat(TimeInt::STATIC), self.row_ids());
-
-        let data_times = timelines
-            .get(timeline)
-            .into_iter()
-            .flat_map(|time_chunk| time_chunk.times().collect::<Vec<_>>())
-            // If there's no time data, then the associate data time must be `TimeInt::STATIC`.
-            .chain(std::iter::repeat(TimeInt::STATIC));
-
-        let arrays = components
-            .get(component_name)
-            .into_iter()
-            .flat_map(|list_array| list_array.into_iter());
-
-        itertools::izip!(data_times, row_ids, arrays)
-    }
-}
-
 // ---
 
 pub struct ChunkIndicesIter {

--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod builder;
 mod chunk;
+mod helpers;
 mod id;
 mod iter;
 mod latest_at;
@@ -21,6 +22,7 @@ mod batcher;
 
 pub use self::builder::{ChunkBuilder, ChunkTimelineBuilder};
 pub use self::chunk::{Chunk, ChunkError, ChunkResult, ChunkTimeline};
+pub use self::helpers::{ChunkShared, UnitChunkShared};
 pub use self::id::{ChunkId, RowId};
 pub use self::latest_at::LatestAtQuery;
 pub use self::range::RangeQuery;

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -30,7 +30,9 @@ pub use self::subscribers::{ChunkStoreSubscriber, ChunkStoreSubscriberHandle};
 
 // Re-exports
 #[doc(no_inline)]
-pub use re_chunk::{Chunk, ChunkId, LatestAtQuery, RangeQuery, RowId};
+pub use re_chunk::{
+    Chunk, ChunkId, ChunkShared, LatestAtQuery, RangeQuery, RowId, UnitChunkShared,
+};
 #[doc(no_inline)]
 pub use re_log_types::{ResolvedTimeRange, TimeInt, TimeType, Timeline};
 

--- a/crates/store/re_chunk_store/tests/correctness.rs
+++ b/crates/store/re_chunk_store/tests/correctness.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use itertools::Itertools as _;
 use re_chunk::{Chunk, ChunkId, RowId};
 use re_chunk_store::{ChunkStore, ChunkStoreError, LatestAtQuery};
 use re_log_types::example_components::{MyIndex, MyPoint};
@@ -22,21 +21,20 @@ fn query_latest_component<C: re_types_core::Component>(
 ) -> Option<(TimeInt, RowId, C)> {
     re_tracing::profile_function!();
 
-    let (data_time, row_id, array) = store
+    let ((data_time, row_id), unit) = store
         .latest_at_relevant_chunks(query, entity_path, C::name())
         .into_iter()
-        .flat_map(|chunk| {
+        .filter_map(|chunk| {
             chunk
                 .latest_at(query, C::name())
-                .iter_rows(&query.timeline(), &C::name())
-                .collect_vec()
+                .into_unit()
+                .and_then(|unit| unit.index(&query.timeline()).map(|index| (index, unit)))
         })
-        .max_by_key(|(data_time, row_id, _)| (*data_time, *row_id))
-        .and_then(|(data_time, row_id, array)| array.map(|array| (data_time, row_id, array)))?;
+        .max_by_key(|(index, _unit)| *index)?;
 
-    let value = C::from_arrow(&*array).ok()?.first()?.clone();
-
-    Some((data_time, row_id, value))
+    unit.component_mono()?
+        .ok()
+        .map(|values| (data_time, row_id, values))
 }
 
 // ---

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use arrow2::array::Array as ArrowArray;
-use itertools::Itertools as _;
 use rand::Rng as _;
 
 use re_chunk::{Chunk, ChunkId, ComponentName, LatestAtQuery, RowId, TimeInt, TimePoint};
@@ -27,19 +26,19 @@ fn query_latest_array(
 ) -> Option<(TimeInt, RowId, Box<dyn ArrowArray>)> {
     re_tracing::profile_function!();
 
-    let (data_time, row_id, array) = store
+    let ((data_time, row_id), unit) = store
         .latest_at_relevant_chunks(query, entity_path, component_name)
         .into_iter()
-        .flat_map(|chunk| {
+        .filter_map(|chunk| {
             chunk
                 .latest_at(query, component_name)
-                .iter_rows(&query.timeline(), &component_name)
-                .collect_vec()
+                .into_unit()
+                .and_then(|chunk| chunk.index(&query.timeline()).map(|index| (index, chunk)))
         })
-        .max_by_key(|(data_time, row_id, _)| (*data_time, *row_id))
-        .and_then(|(data_time, row_id, array)| array.map(|array| (data_time, row_id, array)))?;
+        .max_by_key(|(index, _chunk)| *index)?;
 
-    Some((data_time, row_id, array))
+    unit.component_batch_raw(&component_name)
+        .map(|array| (data_time, row_id, array))
 }
 
 // ---


### PR DESCRIPTION
This introduces all the usual crazy helpers for when you want to retrieve some very particular piece of data out of a chunk, in one (hopefully) neat, consistent package.

In particular this adds `UnitChunk`, a wrapper type for `Chunk` with is guaranteed to only ever hold one row of data, which is going to be very useful when introducing the new `Chunk`-based latest-at API later on.

- DNM: requires https://github.com/rerun-io/rerun/pull/6989

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6990?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6990?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6990)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.