### PR TITLE
Add `--blueprint` to `plot_dashboard_stress`

### DIFF
--- a/examples/python/blueprint/blueprint.py
+++ b/examples/python/blueprint/blueprint.py
@@ -7,7 +7,7 @@ import argparse
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
-from rerun.blueprint import Blueprint, BlueprintPanel, Grid, SelectionPanel, Spatial2DView, TimePanel
+import rerun.blueprint as rrb
 
 
 def main() -> None:
@@ -26,10 +26,10 @@ def main() -> None:
         #
         # If auto_space_views is True, the blueprint will automatically add one of the heuristic
         # space views, which will include the image and both rectangles.
-        blueprint = Blueprint(
-            Grid(
-                Spatial2DView(name="Rect 0", origin="/", contents=["image", "rect/0"]),
-                Spatial2DView(
+        blueprint = rrb.Blueprint(
+            rrb.Grid(
+                rrb.Spatial2DView(name="Rect 0", origin="/", contents=["image", "rect/0"]),
+                rrb.Spatial2DView(
                     name="Rect 1",
                     origin="/",
                     contents=["/**"],
@@ -37,9 +37,9 @@ def main() -> None:
                     overrides={"rect/0": [rr.components.Radius(1)]},  # Override the radius of rect/0 to be 1
                 ),
             ),
-            BlueprintPanel(state="collapsed"),
-            SelectionPanel(state="collapsed"),
-            TimePanel(state="collapsed"),
+            rrb.BlueprintPanel(state="collapsed"),
+            rrb.SelectionPanel(state="collapsed"),
+            rrb.TimePanel(state="collapsed"),
             auto_space_views=args.auto_space_views,
         )
 
@@ -49,8 +49,14 @@ def main() -> None:
     for i in range(8):
         img[(i * 16) + 4 : (i * 16) + 12, :] = (0, 0, 200)
     rr.log("image", rr.Image(img))
-    rr.log("rect/0", rr.Boxes2D(mins=[16, 16], sizes=[64, 64], labels="Rect0", colors=(255, 0, 0)))
-    rr.log("rect/1", rr.Boxes2D(mins=[48, 48], sizes=[64, 64], labels="Rect1", colors=(0, 255, 0)))
+    rr.log(
+        "rect/0",
+        rr.Boxes2D(mins=[16, 16], sizes=[64, 64], labels="Rect0", colors=(255, 0, 0)),
+    )
+    rr.log(
+        "rect/1",
+        rr.Boxes2D(mins=[48, 48], sizes=[64, 64], labels="Rect1", colors=(0, 255, 0)),
+    )
 
 
 if __name__ == "__main__":

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -24,6 +24,7 @@ import time
 
 import numpy as np
 import rerun as rr  # pip install rerun-sdk
+import rerun.blueprint as rrb
 
 parser = argparse.ArgumentParser(description="Plot dashboard stress test")
 rr.script_add_args(parser)
@@ -98,33 +99,23 @@ def main() -> None:
     series_paths = [f"series_{i}" for i in range(0, args.num_series_per_plot)]
 
     if args.blueprint:
-        from rerun.blueprint import (
-            Blueprint,
-            BlueprintPanel,
-            Grid,
-            SelectionPanel,
-            TimeRangeBoundary,
-            TimeSeriesView,
-            VisibleTimeRange,
-        )
-
         print("logging blueprint!")
         rr.send_blueprint(
-            Blueprint(
-                Grid(*[
-                    TimeSeriesView(
+            rrb.Blueprint(
+                rrb.Grid(*[
+                    rrb.TimeSeriesView(
                         name=p,
                         origin=f"/{p}",
-                        time_ranges=VisibleTimeRange(
+                        time_ranges=rrb.VisibleTimeRange(
                             "sim_time",
-                            start=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=-2.5)),
-                            end=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=2.5)),
+                            start=rrb.TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=-2.5)),
+                            end=rrb.TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=2.5)),
                         ),
                     )
                     for p in plot_paths
                 ]),
-                BlueprintPanel(state="collapsed"),
-                SelectionPanel(state="collapsed"),
+                rrb.BlueprintPanel(state="collapsed"),
+                rrb.SelectionPanel(state="collapsed"),
             )
         )
 

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -29,10 +29,35 @@ parser = argparse.ArgumentParser(description="Plot dashboard stress test")
 rr.script_add_args(parser)
 
 parser.add_argument("--num-plots", type=int, default=1, help="How many different plots?")
-parser.add_argument("--num-series-per-plot", type=int, default=1, help="How many series in each single plot?")
-parser.add_argument("--num-points-per-series", type=int, default=100000, help="How many points in each single series?")
-parser.add_argument("--freq", type=float, default=1000, help="Frequency of logging (applies to all series)")
-parser.add_argument("--temporal-batch-size", type=int, default=None, help="Number of rows to include in each log call")
+parser.add_argument(
+    "--num-series-per-plot",
+    type=int,
+    default=1,
+    help="How many series in each single plot?",
+)
+parser.add_argument(
+    "--num-points-per-series",
+    type=int,
+    default=100000,
+    help="How many points in each single series?",
+)
+parser.add_argument(
+    "--freq",
+    type=float,
+    default=1000,
+    help="Frequency of logging (applies to all series)",
+)
+parser.add_argument(
+    "--temporal-batch-size",
+    type=int,
+    default=None,
+    help="Number of rows to include in each log call",
+)
+parser.add_argument(
+    "--blueprint",
+    action="store_true",
+    help="Setup a blueprint for a 5s window",
+)
 
 order = [
     "forwards",
@@ -40,7 +65,11 @@ order = [
     "random",
 ]
 parser.add_argument(
-    "--order", type=str, default=order[0], help="What order to log the data in (applies to all series)", choices=order
+    "--order",
+    type=str,
+    default=order[0],
+    help="What order to log the data in (applies to all series)",
+    choices=order,
 )
 
 series_type = [
@@ -67,6 +96,37 @@ def main() -> None:
 
     plot_paths = [f"plot_{i}" for i in range(0, args.num_plots)]
     series_paths = [f"series_{i}" for i in range(0, args.num_series_per_plot)]
+
+    if args.blueprint:
+        from rerun.blueprint import (
+            Blueprint,
+            BlueprintPanel,
+            Grid,
+            SelectionPanel,
+            TimeRangeBoundary,
+            TimeSeriesView,
+            VisibleTimeRange,
+        )
+
+        print("logging blueprint!")
+        rr.send_blueprint(
+            Blueprint(
+                Grid(*[
+                    TimeSeriesView(
+                        name=p,
+                        origin=f"/{p}",
+                        time_ranges=VisibleTimeRange(
+                            "sim_time",
+                            start=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=-2.5)),
+                            end=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=2.5)),
+                        ),
+                    )
+                    for p in plot_paths
+                ]),
+                BlueprintPanel(state="collapsed"),
+                SelectionPanel(state="collapsed"),
+            )
+        )
 
     time_per_sim_step = 1.0 / args.freq
     stop_time = args.num_points_per_series * time_per_sim_step
@@ -110,7 +170,10 @@ def main() -> None:
         ticks = enumerate(sim_times)
     else:
         offsets = range(0, len(sim_times), args.temporal_batch_size)
-        ticks = zip(offsets, (sim_times[offset : offset + args.temporal_batch_size] for offset in offsets))
+        ticks = zip(
+            offsets,
+            (sim_times[offset : offset + args.temporal_batch_size] for offset in offsets),
+        )
 
     time_batch = None
 
@@ -129,7 +192,11 @@ def main() -> None:
                 else:
                     value_index = slice(index, index + args.temporal_batch_size)
                     value_batch = rr.components.ScalarBatch(values[value_index, plot_idx, series_idx])
-                    rr.log_temporal_batch(f"{plot_path}/{series_path}", times=[time_batch], components=[value_batch])
+                    rr.log_temporal_batch(
+                        f"{plot_path}/{series_path}",
+                        times=[time_batch],
+                        components=[value_batch],
+                    )
 
         # Progress report
 


### PR DESCRIPTION
Adds a `--blueprint` flag to `plot_dashboard_stress` that will force it to send a blueprint that sets a neat `5s` window query for all plots.

```python
Blueprint(
    Grid(*[
        TimeSeriesView(
            name=p,
            origin=f"/{p}",
            time_ranges=VisibleTimeRange(
                "sim_time",
                start=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=-2.5)),
                end=TimeRangeBoundary.cursor_relative(offset=rr.TimeInt(seconds=2.5)),
            ),
        )
        for p in plot_paths
    ]),
    BlueprintPanel(state="collapsed"),
    SelectionPanel(state="collapsed"),
)
```

- DNM: requires https://github.com/rerun-io/rerun/pull/6995


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6996?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6996?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6996)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.