### PR TITLE
Add `Transformables` subscriber for improved `TransformContext` perf

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -436,15 +436,16 @@ fn transform_at(
     // If this entity does not contain any `Transform3D`-related data at all, there's no
     // point in running actual queries.
     let is_potentially_transformed =
-        crate::transformables::Transformables::access(entity_db.store_id(), |transformables| {
-            transformables.is_potentially_transformed(entity_path)
-        })
+        crate::transform_component_tracker::TransformComponentTracker::access(
+            entity_db.store_id(),
+            |transform_component_tracker| {
+                transform_component_tracker.is_potentially_transformed(entity_path)
+            },
+        )
         .unwrap_or(false);
     let transform3d = is_potentially_transformed
         .then(|| get_parent_from_child_transform(entity_path, entity_db, query))
         .flatten();
-
-    // let transform3d = get_parent_from_child_transform(entity_path, entity_db, query);
 
     let pinhole = pinhole.map(|(image_from_camera, camera_xyz)| {
         // Everything under a pinhole camera is a 2D projection, thus doesn't actually have a proper 3D representation.

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -433,7 +433,18 @@ fn transform_at(
         }
     }
 
-    let transform3d = get_parent_from_child_transform(entity_path, entity_db, query);
+    // If this entity does not contain any `Transform3D`-related data at all, there's no
+    // point in running actual queries.
+    let is_potentially_transformed =
+        crate::transformables::Transformables::access(entity_db.store_id(), |transformables| {
+            transformables.is_potentially_transformed(entity_path)
+        })
+        .unwrap_or(false);
+    let transform3d = is_potentially_transformed
+        .then(|| get_parent_from_child_transform(entity_path, entity_db, query))
+        .flatten();
+
+    // let transform3d = get_parent_from_child_transform(entity_path, entity_db, query);
 
     let pinhole = pinhole.map(|(image_from_camera, camera_xyz)| {
         // Everything under a pinhole camera is a 2D projection, thus doesn't actually have a proper 3D representation.

--- a/crates/viewer/re_space_view_spatial/src/lib.rs
+++ b/crates/viewer/re_space_view_spatial/src/lib.rs
@@ -18,7 +18,7 @@ mod proc_mesh;
 mod scene_bounding_boxes;
 mod space_camera_3d;
 mod spatial_topology;
-mod transformables;
+mod transform_component_tracker;
 mod ui;
 mod ui_2d;
 mod ui_3d;

--- a/crates/viewer/re_space_view_spatial/src/lib.rs
+++ b/crates/viewer/re_space_view_spatial/src/lib.rs
@@ -18,6 +18,7 @@ mod proc_mesh;
 mod scene_bounding_boxes;
 mod space_camera_3d;
 mod spatial_topology;
+mod transformables;
 mod ui;
 mod ui_2d;
 mod ui_3d;

--- a/crates/viewer/re_space_view_spatial/src/transformables.rs
+++ b/crates/viewer/re_space_view_spatial/src/transformables.rs
@@ -1,0 +1,116 @@
+use ahash::HashMap;
+use once_cell::sync::OnceCell;
+
+use nohash_hasher::IntSet;
+use re_chunk_store::{
+    ChunkStore, ChunkStoreDiffKind, ChunkStoreEvent, ChunkStoreSubscriber,
+    ChunkStoreSubscriberHandle,
+};
+use re_log_types::{EntityPath, StoreId};
+use re_types::ComponentName;
+
+// ---
+
+/// Keeps track of which entities have had any `Transform3D`-related data on any timeline at any
+/// point in time.
+///
+/// This is used to optimize queries in the `TransformContext`, so that we don't unnecessarily pay
+/// for the fixed overhead of all the query layers when we know for a fact that there won't be any
+/// data there.
+/// This is a huge performance improvement in practice, especially in recordings with many entities.
+#[derive(Default)]
+pub struct Transformables {
+    /// Which entities have had any of these components at any point in time.
+    entities: IntSet<EntityPath>,
+}
+
+impl Transformables {
+    /// Accesses the spatial topology for a given store.
+    #[inline]
+    pub fn access<T>(store_id: &StoreId, f: impl FnOnce(&Self) -> T) -> Option<T> {
+        ChunkStore::with_subscriber_once(
+            TransformablesStoreSubscriber::subscription_handle(),
+            move |susbcriber: &TransformablesStoreSubscriber| {
+                susbcriber.per_store.get(store_id).map(f)
+            },
+        )
+        .flatten()
+    }
+
+    #[inline]
+    pub fn is_potentially_transformed(&self, entity_path: &EntityPath) -> bool {
+        self.entities.contains(entity_path)
+    }
+}
+
+// ---
+
+pub struct TransformablesStoreSubscriber {
+    /// The components of interest.
+    components: IntSet<ComponentName>,
+
+    per_store: HashMap<StoreId, Transformables>,
+}
+
+impl Default for TransformablesStoreSubscriber {
+    #[inline]
+    fn default() -> Self {
+        use re_types::Archetype as _;
+        let components = re_types::archetypes::Transform3D::all_components()
+            .iter()
+            .copied()
+            .collect();
+
+        Self {
+            components,
+            per_store: Default::default(),
+        }
+    }
+}
+
+impl TransformablesStoreSubscriber {
+    /// Accesses the global store subscriber.
+    ///
+    /// Lazily registers the subscriber if it hasn't been registered yet.
+    pub fn subscription_handle() -> ChunkStoreSubscriberHandle {
+        static SUBSCRIPTION: OnceCell<ChunkStoreSubscriberHandle> = OnceCell::new();
+        *SUBSCRIPTION.get_or_init(|| ChunkStore::register_subscriber(Box::<Self>::default()))
+    }
+}
+
+impl ChunkStoreSubscriber for TransformablesStoreSubscriber {
+    #[inline]
+    fn name(&self) -> String {
+        "rerun.store_subscriber.Transformables".into()
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn on_events(&mut self, events: &[ChunkStoreEvent]) {
+        re_tracing::profile_function!();
+
+        for event in events
+            .iter()
+            // This is only additive, don't care about removals.
+            .filter(|e| e.kind == ChunkStoreDiffKind::Addition)
+        {
+            let transformables = self.per_store.entry(event.store_id.clone()).or_default();
+
+            for component_name in event.chunk.component_names() {
+                if self.components.contains(&component_name) {
+                    transformables
+                        .entities
+                        .insert(event.chunk.entity_path().clone());
+                }
+            }
+        }
+    }
+}

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -68,7 +68,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     ) -> Result<(), SpaceViewClassRegistryError> {
         // Ensure spatial topology & max image dimension is registered.
         crate::spatial_topology::SpatialTopologyStoreSubscriber::subscription_handle();
-        crate::transformables::TransformablesStoreSubscriber::subscription_handle();
+        crate::transform_component_tracker::TransformComponentTrackerStoreSubscriber::subscription_handle();
         crate::max_image_dimension_subscriber::MaxImageDimensionSubscriber::subscription_handle();
 
         register_spatial_contexts(system_registry)?;

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -68,6 +68,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
     ) -> Result<(), SpaceViewClassRegistryError> {
         // Ensure spatial topology & max image dimension is registered.
         crate::spatial_topology::SpatialTopologyStoreSubscriber::subscription_handle();
+        crate::transformables::TransformablesStoreSubscriber::subscription_handle();
         crate::max_image_dimension_subscriber::MaxImageDimensionSubscriber::subscription_handle();
 
         register_spatial_contexts(system_registry)?;

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -74,6 +74,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
     ) -> Result<(), SpaceViewClassRegistryError> {
         // Ensure spatial topology is registered.
         crate::spatial_topology::SpatialTopologyStoreSubscriber::subscription_handle();
+        crate::transformables::TransformablesStoreSubscriber::subscription_handle();
 
         register_spatial_contexts(system_registry)?;
         register_3d_spatial_visualizers(system_registry)?;

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -74,7 +74,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
     ) -> Result<(), SpaceViewClassRegistryError> {
         // Ensure spatial topology is registered.
         crate::spatial_topology::SpatialTopologyStoreSubscriber::subscription_handle();
-        crate::transformables::TransformablesStoreSubscriber::subscription_handle();
+        crate::transform_component_tracker::TransformComponentTrackerStoreSubscriber::subscription_handle();
 
         register_spatial_contexts(system_registry)?;
         register_3d_spatial_visualizers(system_registry)?;


### PR DESCRIPTION
Adds a `Transformables` subscriber that greatly improves `TransformContext`'s performance by preventing unnecessary queries (see comments in code for details).

Better name welcome.

- DNM: requires https://github.com/rerun-io/rerun/pull/6996

cc @Wumpf @jleibs 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6997?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6997?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6997)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.