### PR TITLE
Useful `ChunkStoreConfig` constants

### DIFF
--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -115,6 +115,20 @@ impl ChunkStoreConfig {
         ..Self::DEFAULT
     };
 
+    /// [`Self::DEFAULT`], but with changelog disabled.
+    pub const CHANGELOG_DISABLED: Self = Self {
+        enable_changelog: false,
+        ..Self::DEFAULT
+    };
+
+    /// All features disabled.
+    pub const ALL_DISABLED: Self = Self {
+        enable_changelog: false,
+        chunk_max_bytes: 0,
+        chunk_max_rows: 0,
+        chunk_max_rows_if_unsorted: 0,
+    };
+
     /// Environment variable to configure [`Self::enable_changelog`].
     pub const ENV_STORE_ENABLE_CHANGELOG: &'static str = "RERUN_STORE_ENABLE_CHANGELOG";
 


### PR DESCRIPTION
I've had those in my stash for a very long time. Their transformative power deserves seeing the light of day.

- DNM: requires https://github.com/rerun-io/rerun/pull/6998

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6999?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/6999?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/6999)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.