### PR TITLE
Fix `Utf8List` serializer in python

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
@@ -31,7 +31,7 @@ class Utf8ListExt:
             if len(data) == 0:
                 array = []
             elif isinstance(data[0], Utf8List):
-                array = [datum.value for datum in data]  # type: ignore[union-attr]
+                array = [[datum.value for datum in data]]  # type: ignore[union-attr]
             else:
                 array = [[str(datum) for datum in data]]
         else:


### PR DESCRIPTION
Title.

- Fixes https://github.com/rerun-io/rerun/issues/6947

![image](https://github.com/user-attachments/assets/0de07373-4554-40b9-bec0-095d932f38cc)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7003?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7003?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7003)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.