### PR TITLE
Build all cpp binaries of test_wheels ci job in the `wheel-test-min` environment

### DIFF
--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -183,14 +183,19 @@ jobs:
         # Only check that we have the archetype roundtrip tests, but don't spend time actually running them
         run: pixi run -e wheel-test-min RUST_LOG=debug python tests/roundtrips.py --no-run
 
+      - name: Build C++ roundtrips
+        if: ${{ !inputs.FAST }}
+        # Separated out of roundtrips.py run so we control the pixi environment.
+        # This used to cause issues on Windows during the setup of the pixi environment when running from inside `roundtrips.py`.
+        run: pixi run -e wheel-test-min cpp-build-roundtrips
+
       - name: Run tests/roundtrips.py
         if: ${{ !inputs.FAST }}
-        # --release so we can inherit from some of the artifacts that maturin has just built before
         # explicit target because otherwise cargo loses the target cache… even though this is the target anyhow…
         # --no-py-build because rerun-sdk is already built and installed
-        run: pixi run -e wheel-test-min RUST_LOG=debug python tests/roundtrips.py --release --target ${{ needs.set-config.outputs.TARGET }} --no-py-build
+        run: pixi run -e wheel-test-min RUST_LOG=debug python tests/roundtrips.py --target ${{ needs.set-config.outputs.TARGET }} --no-py-build --no-cpp-build
 
-      - name: Build C++ examples
+      - name: Build C++ snippets
         if: ${{ !inputs.FAST }}
         # Separated out of compare_snippet_output.py run so we control the pixi environment.
         # This used to cause issues on Windows during the setup of the pixi environment when running from inside `compare_snippet_output.py`.
@@ -198,7 +203,6 @@ jobs:
 
       - name: Run docs/snippets/compare_snippet_output.py
         if: ${{ !inputs.FAST }}
-        # --release so we can inherit from some of the artifacts that maturin has just built before
         # explicit target because otherwise cargo loses the target cache… even though this is the target anyhow…
         # --no-py-build because rerun-sdk is already built and installed
-        run: pixi run -e wheel-test-min RUST_LOG=debug python docs/snippets/compare_snippet_output.py --release --target ${{ needs.set-config.outputs.TARGET }} --no-py-build --no-cpp-build
+        run: pixi run -e wheel-test-min RUST_LOG=debug python docs/snippets/compare_snippet_output.py --target ${{ needs.set-config.outputs.TARGET }} --no-py-build --no-cpp-build

--- a/docs/snippets/compare_snippet_output.py
+++ b/docs/snippets/compare_snippet_output.py
@@ -79,11 +79,7 @@ def main() -> None:
         help="Skip cmake configure and ahead of time build for rerun_c & rerun_cpp",
     )
     parser.add_argument("--full-dump", action="store_true", help="Dump both rrd files as tables")
-    parser.add_argument(
-        "--release",
-        action="store_true",
-        help="Run cargo invocations with --release and CMake with `-DCMAKE_BUILD_TYPE=Release` & `--config Release`",
-    )
+    parser.add_argument("--release", action="store_true", help="Run cargo invocations with --release")
     parser.add_argument("--target", type=str, default=None, help="Target used for cargo invocations")
     parser.add_argument("--target-dir", type=str, default=None, help="Target directory used for cargo invocations")
     parser.add_argument("example", nargs="*", type=str, default=None, help="Run only the specified examples")

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -203,10 +203,10 @@ def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir:
 
 def run_roundtrip_cpp(arch: str, release: bool) -> str:
     target_name = f"roundtrip_{arch}"
-    output_path = f"build/debug/tests/cpp/roundtrips/{arch}/out.rrd"
+    output_path = f"tests/cpp/roundtrips/{arch}/out.rrd"
 
     extension = ".exe" if os.name == "nt" else ""
-    cmd = [f"./build/debug/tests/cpp/roundtrips/{target_name}{extension}"]
+    cmd = [f"./build/debug/tests/cpp/roundtrips/{target_name}{extension}", output_path]
     run(cmd, env=roundtrip_env(), timeout=12000)
 
     return output_path

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -206,7 +206,7 @@ def run_roundtrip_cpp(arch: str, release: bool) -> str:
     output_path = f"build/debug/tests/cpp/roundtrips/{arch}/out.rrd"
 
     extension = ".exe" if os.name == "nt" else ""
-    cmd = [f"./build/debug/docs/roundtrips/{target_name}{extension}"]
+    cmd = [f"./build/debug/tests/cpp/roundtrips/{target_name}{extension}"]
     run(cmd, env=roundtrip_env(), timeout=12000)
 
     return output_path

--- a/tests/roundtrips.py
+++ b/tests/roundtrips.py
@@ -42,11 +42,7 @@ def main() -> None:
         help="Skip cmake configure and ahead of time build for rerun_c & rerun_cpp",
     )
     parser.add_argument("--full-dump", action="store_true", help="Dump both rrd files as tables")
-    parser.add_argument(
-        "--release",
-        action="store_true",
-        help="Run cargo invocations with --release and CMake with `-DCMAKE_BUILD_TYPE=Release` & `--config Release`",
-    )
+    parser.add_argument("--release", action="store_true", help="Run cargo invocations with --release")
     parser.add_argument("--target", type=str, default=None, help="Target used for cargo invocations")
     parser.add_argument("--target-dir", type=str, default=None, help="Target directory used for cargo invocations")
     parser.add_argument("archetype", nargs="*", type=str, default=None, help="Run only the specified archetypes")
@@ -207,12 +203,10 @@ def run_roundtrip_rust(arch: str, release: bool, target: str | None, target_dir:
 
 def run_roundtrip_cpp(arch: str, release: bool) -> str:
     target_name = f"roundtrip_{arch}"
-    output_path = f"tests/cpp/roundtrips/{arch}/out.rrd"
+    output_path = f"build/debug/tests/cpp/roundtrips/{arch}/out.rrd"
 
-    config_dir = "Release" if release else "Debug"
-
-    target_path = f"{config_dir}/{target_name}.exe" if os.name == "nt" else target_name
-    cmd = [f"{cpp_build_dir}/tests/cpp/roundtrips/{target_path}", output_path]
+    extension = ".exe" if os.name == "nt" else ""
+    cmd = [f"./build/debug/docs/roundtrips/{target_name}{extension}"]
     run(cmd, env=roundtrip_env(), timeout=12000)
 
     return output_path


### PR DESCRIPTION
### What

Similar to https://github.com/rerun-io/rerun/pull/6911
May fix Windows issues or at least make it easier to diagnose


### Checklist
* [x]  pass main ci

- [PR Build Summary](https://build.rerun.io/pr/7009)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.