### PR TITLE
Chunkified, (almost)deserialization-free Mesh/Asset visualizers

### DIFF
--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -3,14 +3,15 @@ use std::sync::Arc;
 use arrow2::{
     array::{
         Array as ArrowArray, FixedSizeListArray as ArrowFixedSizeListArray,
-        PrimitiveArray as ArrowPrimitiveArray, Utf8Array as ArrowUtf8Array,
+        ListArray as ArrowListArray, PrimitiveArray as ArrowPrimitiveArray,
+        Utf8Array as ArrowUtf8Array,
     },
     Either,
 };
 use itertools::{izip, Itertools};
 
 use re_log_types::{TimeInt, Timeline};
-use re_types_core::{ArrowString, Component, ComponentName};
+use re_types_core::{ArrowBuffer, ArrowString, Component, ComponentName};
 
 use crate::{Chunk, ChunkTimeline, RowId};
 
@@ -126,8 +127,11 @@ impl Chunk {
     /// Returns an iterator over the raw arrays of a [`Chunk`], for a given component.
     ///
     /// See also:
+    /// * [`Self::iter_primitive`]
+    /// * [`Self::iter_primitive_array`]
+    /// * [`Self::iter_string`]
+    /// * [`Self::iter_buffer`].
     /// * [`Self::iter_component`].
-    /// * [`Self::iter_primitive`].
     #[inline]
     pub fn iter_component_arrays(
         &self,
@@ -150,6 +154,7 @@ impl Chunk {
     /// See also:
     /// * [`Self::iter_primitive_array`]
     /// * [`Self::iter_string`]
+    /// * [`Self::iter_buffer`].
     /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     #[inline]
@@ -192,6 +197,7 @@ impl Chunk {
     /// See also:
     /// * [`Self::iter_primitive`]
     /// * [`Self::iter_string`]
+    /// * [`Self::iter_buffer`].
     /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_primitive_array<const N: usize, T: arrow2::types::NativeType>(
@@ -243,7 +249,7 @@ impl Chunk {
         )
     }
 
-    /// Returns an iterator over the raw primitive strings of a [`Chunk`], for a given component.
+    /// Returns an iterator over the raw strings of a [`Chunk`], for a given component.
     ///
     /// This is a very fast path: the entire column will be downcasted at once, and then every
     /// component batch will be a slice reference into that global slice.
@@ -252,6 +258,7 @@ impl Chunk {
     /// See also:
     /// * [`Self::iter_primitive`]
     /// * [`Self::iter_primitive_array`]
+    /// * [`Self::iter_buffer`].
     /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_string(
@@ -287,6 +294,69 @@ impl Chunk {
                     let lengths = &lengths.as_slice()[idx..idx + len];
                     izip!(offsets, lengths)
                         .map(|(&idx, &len)| ArrowString(values.clone().sliced(idx as _, len)))
+                        .collect_vec()
+                }),
+        )
+    }
+
+    /// Returns an iterator over the raw buffers of a [`Chunk`], for a given component.
+    ///
+    /// This is a very fast path: the entire column will be downcasted at once, and then every
+    /// component batch will be a slice reference into that global slice.
+    /// Use this when working with simple arrow datatypes and performance matters (e.g. blobs, etc).
+    ///
+    /// See also:
+    /// * [`Self::iter_primitive`]
+    /// * [`Self::iter_primitive_array`]
+    /// * [`Self::iter_string`].
+    /// * [`Self::iter_component_arrays`].
+    /// * [`Self::iter_component`].
+    pub fn iter_buffer<T: arrow2::types::NativeType>(
+        &self,
+        component_name: &ComponentName,
+    ) -> impl Iterator<Item = Vec<ArrowBuffer<T>>> + '_ {
+        let Some(list_array) = self.components.get(component_name) else {
+            return Either::Left(std::iter::empty());
+        };
+
+        let Some(inner_list_array) = list_array
+            .values()
+            .as_any()
+            .downcast_ref::<ArrowListArray<i32>>()
+        else {
+            if cfg!(debug_assertions) {
+                panic!("downcast failed for {component_name}, data discarded");
+            } else {
+                re_log::error_once!("downcast failed for {component_name}, data discarded");
+            }
+            return Either::Left(std::iter::empty());
+        };
+
+        let Some(values) = inner_list_array
+            .values()
+            .as_any()
+            .downcast_ref::<ArrowPrimitiveArray<T>>()
+        else {
+            if cfg!(debug_assertions) {
+                panic!("downcast failed for {component_name}, data discarded");
+            } else {
+                re_log::error_once!("downcast failed for {component_name}, data discarded");
+            }
+            return Either::Left(std::iter::empty());
+        };
+
+        let values = values.values();
+        let offsets = inner_list_array.offsets();
+        let lengths = inner_list_array.offsets().lengths().collect_vec();
+
+        // NOTE: No need for validity checks here, `iter_offsets` already takes care of that.
+        Either::Right(
+            self.iter_component_offsets(component_name)
+                .map(move |(idx, len)| {
+                    let offsets = &offsets.as_slice()[idx..idx + len];
+                    let lengths = &lengths.as_slice()[idx..idx + len];
+                    izip!(offsets, lengths)
+                        .map(|(&idx, &len)| values.clone().sliced(idx as _, len).into())
                         .collect_vec()
                 }),
         )
@@ -419,8 +489,11 @@ impl Chunk {
     /// through enum types across many timestamps).
     ///
     /// See also:
-    /// * [`Self::iter_component`].
-    /// * [`Self::iter_primitive`].
+    /// * [`Self::iter_primitive`]
+    /// * [`Self::iter_primitive_array`]
+    /// * [`Self::iter_string`]
+    /// * [`Self::iter_buffer`].
+    /// * [`Self::iter_component_arrays`].
     #[inline]
     pub fn iter_component<C: Component>(
         &self,

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -356,6 +356,7 @@ impl Chunk {
                     let offsets = &offsets.as_slice()[idx..idx + len];
                     let lengths = &lengths.as_slice()[idx..idx + len];
                     izip!(offsets, lengths)
+                        // NOTE: Not an actual clone, just a refbump of the underlying buffer.
                         .map(|(&idx, &len)| values.clone().sliced(idx as _, len).into())
                         .collect_vec()
                 }),

--- a/crates/store/re_types_core/src/arrow_buffer.rs
+++ b/crates/store/re_types_core/src/arrow_buffer.rs
@@ -9,7 +9,7 @@ use arrow2::buffer::Buffer;
 /// arise from returning a `&[T]` directly, but is significantly more
 /// performant than doing the full allocation necessary to return a `Vec<T>`.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct ArrowBuffer<T>(Buffer<T>);
+pub struct ArrowBuffer<T>(pub Buffer<T>);
 
 impl<T: crate::SizeBytes> crate::SizeBytes for ArrowBuffer<T> {
     #[inline]

--- a/crates/viewer/re_space_view/src/results_ext2.rs
+++ b/crates/viewer/re_space_view/src/results_ext2.rs
@@ -419,6 +419,20 @@ impl<'a> HybridResultsChunkIter<'a> {
             )
         })
     }
+
+    /// Iterate as indexed buffers.
+    ///
+    /// See [`Chunk::iter_buffer`] for more information.
+    pub fn buffer<T: arrow2::types::NativeType>(
+        &'a self,
+    ) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types_core::ArrowBuffer<T>>)> + 'a {
+        self.chunks.iter().flat_map(|chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(&self.timeline, &self.component_name),
+                chunk.iter_buffer(&self.component_name)
+            )
+        })
+    }
 }
 
 impl<'a> HybridResults<'a> {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -175,13 +175,12 @@ impl VisualizerSystem for Asset3DVisualizer {
                     .map(|chunk| chunk.iter_component::<OutOfTreeTransform3D>())
                     .collect_vec();
                 let all_transforms_indexed = {
-                    let all_albedo_textures =
+                    let all_transforms =
                         all_transform_iters.iter_mut().flat_map(|it| it.into_iter());
-                    let all_albedo_textures_indices =
-                        all_transform_chunks.iter().flat_map(|chunk| {
-                            chunk.iter_component_indices(&timeline, &OutOfTreeTransform3D::name())
-                        });
-                    itertools::izip!(all_albedo_textures_indices, all_albedo_textures)
+                    let all_transforms_indices = all_transform_chunks.iter().flat_map(|chunk| {
+                        chunk.iter_component_indices(&timeline, &OutOfTreeTransform3D::name())
+                    });
+                    itertools::izip!(all_transforms_indices, all_transforms)
                 };
 
                 let data = re_query2::range_zip_1x2(

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -334,17 +334,18 @@ where
 
 // ---
 
+use re_chunk::{Chunk, ComponentName, RowId};
 use re_chunk_store::external::{re_chunk, re_chunk::external::arrow2};
 
 /// Iterate `chunks` as indexed primitives.
 ///
-/// See [`re_chunk::Chunk::iter_primitive`] for more information.
+/// See [`Chunk::iter_primitive`] for more information.
 #[allow(unused)]
 pub fn iter_primitive<'a, T: arrow2::types::NativeType>(
-    chunks: impl IntoIterator<Item = &'a re_chunk::Chunk> + 'a,
-    timeline: re_chunk::Timeline,
-    component_name: re_chunk::ComponentName,
-) -> impl Iterator<Item = ((TimeInt, re_chunk::RowId), &'a [T])> + 'a {
+    chunks: impl IntoIterator<Item = &'a Chunk> + 'a,
+    timeline: Timeline,
+    component_name: ComponentName,
+) -> impl Iterator<Item = ((TimeInt, RowId), &'a [T])> + 'a {
     chunks.into_iter().flat_map(move |chunk| {
         itertools::izip!(
             chunk.iter_component_indices(&timeline, &component_name),
@@ -355,13 +356,13 @@ pub fn iter_primitive<'a, T: arrow2::types::NativeType>(
 
 /// Iterate `chunks` as indexed primitive arrays.
 ///
-/// See [`re_chunk::Chunk::iter_primitive_array`] for more information.
+/// See [`Chunk::iter_primitive_array`] for more information.
 #[allow(unused)]
 pub fn iter_primitive_array<'a, const N: usize, T: arrow2::types::NativeType>(
-    chunks: &'a std::borrow::Cow<'a, [re_chunk::Chunk]>,
-    timeline: re_chunk::Timeline,
-    component_name: re_chunk::ComponentName,
-) -> impl Iterator<Item = ((TimeInt, re_chunk::RowId), &'a [[T; N]])> + 'a
+    chunks: &'a std::borrow::Cow<'a, [Chunk]>,
+    timeline: Timeline,
+    component_name: ComponentName,
+) -> impl Iterator<Item = ((TimeInt, RowId), &'a [[T; N]])> + 'a
 where
     [T; N]: bytemuck::Pod,
 {
@@ -375,17 +376,34 @@ where
 
 /// Iterate `chunks` as indexed UTF-8 strings.
 ///
-/// See [`re_chunk::Chunk::iter_string`] for more information.
+/// See [`Chunk::iter_string`] for more information.
 #[allow(unused)]
 pub fn iter_string<'a>(
-    chunks: impl Iterator<Item = &'a re_chunk::Chunk> + 'a,
-    timeline: &'a re_chunk::Timeline,
-    component_name: &'a re_chunk::ComponentName,
-) -> impl Iterator<Item = ((TimeInt, re_chunk::RowId), Vec<re_types::ArrowString>)> + 'a {
+    chunks: impl Iterator<Item = &'a Chunk> + 'a,
+    timeline: &'a Timeline,
+    component_name: &'a ComponentName,
+) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowString>)> + 'a {
     chunks.into_iter().flat_map(|chunk| {
         itertools::izip!(
             chunk.iter_component_indices(timeline, component_name),
             chunk.iter_string(component_name)
+        )
+    })
+}
+
+/// Iterate `chunks` as indexed buffers.
+///
+/// See [`Chunk::iter_buffer`] for more information.
+#[allow(unused)]
+pub fn iter_buffer<'a, T: arrow2::types::NativeType>(
+    chunks: impl Iterator<Item = &'a Chunk> + 'a,
+    timeline: &'a Timeline,
+    component_name: &'a ComponentName,
+) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowBuffer<T>>)> + 'a {
+    chunks.into_iter().flat_map(|chunk| {
+        itertools::izip!(
+            chunk.iter_component_indices(timeline, component_name),
+            chunk.iter_buffer(component_name)
         )
     })
 }


### PR DESCRIPTION
Title!

This introduces new neat zero-deser zero-copy helper for generic arrow buffers.

- DNM: requires #7011

---

#### Mesh3D
https://github.com/rerun-io/rerun/blob/c070efbee3713bf6459190aa5ace203a5a8b3678/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs#L179-L277
![image](https://github.com/user-attachments/assets/12b42364-1681-47b0-9804-db215e099aee)

#### Asset3D
https://github.com/rerun-io/rerun/blob/c070efbee3713bf6459190aa5ace203a5a8b3678/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs#L149-L206
![image](https://github.com/user-attachments/assets/801ddc93-c114-46f0-a94f-f73ca6ca51c6)


---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7011)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.