### PR TITLE
Chunkified, deserialization-free LineStrip visualizers

### DIFF
--- a/crates/viewer/re_space_view/src/results_ext2.rs
+++ b/crates/viewer/re_space_view/src/results_ext2.rs
@@ -406,6 +406,23 @@ impl<'a> HybridResultsChunkIter<'a> {
         })
     }
 
+    /// Iterate as indexed list of primitive arrays.
+    ///
+    /// See [`Chunk::iter_primitive_array_list`] for more information.
+    pub fn primitive_array_list<const N: usize, T: arrow2::types::NativeType>(
+        &'a self,
+    ) -> impl Iterator<Item = ((TimeInt, RowId), Vec<&'a [[T; N]]>)> + 'a
+    where
+        [T; N]: bytemuck::Pod,
+    {
+        self.chunks.iter().flat_map(move |chunk| {
+            itertools::izip!(
+                chunk.iter_component_indices(&self.timeline, &self.component_name),
+                chunk.iter_primitive_array_list::<N, T>(&self.component_name)
+            )
+        })
+    }
+
     /// Iterate as indexed UTF-8 strings.
     ///
     /// See [`Chunk::iter_string`] for more information.

--- a/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -146,7 +146,8 @@ impl VisualizerSystem for Asset3DVisualizer {
 
         let mut instances = Vec::new();
 
-        super::entity_iterator::process_archetype2::<Self, Asset3D, _>(
+        use super::entity_iterator::{iter_buffer, process_archetype2};
+        process_archetype2::<Self, Asset3D, _>(
             ctx,
             view_query,
             context_systems,
@@ -158,12 +159,7 @@ impl VisualizerSystem for Asset3DVisualizer {
                 };
 
                 let timeline = ctx.query.timeline();
-                let all_blobs_indexed = all_blob_chunks.iter().flat_map(|chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&timeline, &Blob::name()),
-                        chunk.iter_buffer::<u8>(&Blob::name())
-                    )
-                });
+                let all_blobs_indexed = iter_buffer::<u8>(&all_blob_chunks, timeline, Blob::name());
                 let all_media_types = results.iter_as(timeline, MediaType::name());
 
                 // TODO(#6831): we have to deserialize here because `OutOfTreeTransform3D` is

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -1,9 +1,9 @@
 use re_log_types::Instance;
-use re_query::range_zip_1x5;
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips2D,
     components::{ClassId, Color, DrawOrder, KeypointId, LineStrip2D, Radius, Text},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -16,7 +16,7 @@ use crate::{contexts::SpatialSceneEntityContext, view_kind::SpatialSpaceViewKind
 
 use super::{
     filter_visualizable_2d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_2d, process_radius_slice, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -78,10 +78,10 @@ impl Lines2DVisualizer {
 
             let mut obj_space_bounding_box = re_math::BoundingBox::NOTHING;
             for (i, (strip, radius, &color)) in
-                itertools::izip!(data.strips, radii, &colors).enumerate()
+                itertools::izip!(data.strips.iter(), radii, &colors).enumerate()
             {
                 let lines = line_batch
-                    .add_strip_2d(strip.0.iter().copied().map(Into::into))
+                    .add_strip_2d(strip.iter().copied().map(Into::into))
                     .color(color)
                     .radius(radius)
                     .picking_instance_id(PickingLayerInstanceId(i as _));
@@ -94,8 +94,8 @@ impl Lines2DVisualizer {
                     lines.outline_mask_ids(*outline_mask_ids);
                 }
 
-                for p in &strip.0 {
-                    obj_space_bounding_box.extend(glam::vec3(p.x(), p.y(), 0.0));
+                for p in *strip {
+                    obj_space_bounding_box.extend(glam::vec3(p[0], p[1], 0.0));
                 }
             }
 
@@ -116,19 +116,18 @@ impl Lines2DVisualizer {
                     // Take middle point of every strip.
                     itertools::Either::Right(data.strips.iter().map(|strip| {
                         strip
-                            .0
                             .iter()
                             .copied()
                             .map(glam::Vec2::from)
                             .sum::<glam::Vec2>()
-                            / (strip.0.len() as f32)
+                            / (strip.len() as f32)
                     }))
                 };
 
-                self.data.ui_labels.extend(process_labels_2d(
+                self.data.ui_labels.extend(process_labels_2d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     ent_context.world_from_entity,
@@ -142,12 +141,12 @@ impl Lines2DVisualizer {
 
 struct Lines2DComponentData<'a> {
     // Point of views
-    strips: &'a [LineStrip2D],
+    strips: Vec<&'a [[f32; 2]]>,
 
     // Clamped to edge
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 }
@@ -185,58 +184,71 @@ impl VisualizerSystem for Lines2DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype::<Self, LineStrips2D, _>(
+        super::entity_iterator::process_archetype2::<Self, LineStrips2D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let strips = match results.get_required_component_dense::<LineStrip2D>(resolver) {
-                    Some(strips) => strips?,
-                    _ => return Ok(()),
+                let Some(all_strip_chunks) = results.get_required_chunks(&LineStrip2D::name())
+                else {
+                    return Ok(());
                 };
 
-                let num_strips = strips
-                    .range_indexed()
-                    .map(|(_, strips)| strips.len())
-                    .sum::<usize>();
+                let num_strips = all_strip_chunks
+                    .iter()
+                    .flat_map(|chunk| {
+                        chunk.iter_primitive_array_list::<2, f32>(&LineStrip2D::name())
+                    })
+                    .map(|strips| strips.len())
+                    .sum();
                 if num_strips == 0 {
                     return Ok(());
                 }
                 line_builder.reserve_strips(num_strips)?;
 
-                let num_vertices = strips
-                    .range_indexed()
-                    .map(|(_, strips)| strips.iter().map(|strip| strip.0.len()).sum::<usize>())
+                let num_vertices = all_strip_chunks
+                    .iter()
+                    .flat_map(|chunk| {
+                        chunk.iter_primitive_array_list::<2, f32>(&LineStrip2D::name())
+                    })
+                    .map(|strips| strips.iter().map(|strip| strip.len()).sum::<usize>())
                     .sum::<usize>();
                 line_builder.reserve_vertices(num_vertices)?;
 
-                let colors = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_strips_indexed = all_strip_chunks.iter().flat_map(|chunk| {
+                    itertools::izip!(
+                        chunk.iter_component_indices(&timeline, &LineStrip2D::name()),
+                        chunk.iter_primitive_array_list::<2, f32>(&LineStrip2D::name())
+                    )
+                });
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = range_zip_1x5(
-                    strips.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x5(
+                    all_strips_indexed,
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(_index, strips, colors, radii, labels, class_ids, keypoint_ids)| {
                         Lines2DComponentData {
                             strips,
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -184,7 +184,8 @@ impl VisualizerSystem for Lines2DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype2::<Self, LineStrips2D, _>(
+        use super::entity_iterator::{iter_primitive_array_list, process_archetype2};
+        process_archetype2::<Self, LineStrips2D, _>(
             ctx,
             view_query,
             context_systems,
@@ -195,6 +196,8 @@ impl VisualizerSystem for Lines2DVisualizer {
                 else {
                     return Ok(());
                 };
+
+                let timeline = ctx.query.timeline();
 
                 let num_strips = all_strip_chunks
                     .iter()
@@ -217,13 +220,8 @@ impl VisualizerSystem for Lines2DVisualizer {
                     .sum::<usize>();
                 line_builder.reserve_vertices(num_vertices)?;
 
-                let timeline = ctx.query.timeline();
-                let all_strips_indexed = all_strip_chunks.iter().flat_map(|chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&timeline, &LineStrip2D::name()),
-                        chunk.iter_primitive_array_list::<2, f32>(&LineStrip2D::name())
-                    )
-                });
+                let all_strips_indexed =
+                    iter_primitive_array_list(&all_strip_chunks, timeline, LineStrip2D::name());
                 let all_colors = results.iter_as(timeline, Color::name());
                 let all_radii = results.iter_as(timeline, Radius::name());
                 let all_labels = results.iter_as(timeline, Text::name());

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -1,9 +1,9 @@
 use re_log_types::Instance;
-use re_query::range_zip_1x5;
 use re_renderer::PickingLayerInstanceId;
 use re_types::{
     archetypes::LineStrips3D,
     components::{ClassId, Color, KeypointId, LineStrip3D, Radius, Text},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -14,7 +14,7 @@ use re_viewer_context::{
 
 use crate::{
     contexts::SpatialSceneEntityContext, view_kind::SpatialSpaceViewKind,
-    visualizers::process_labels_3d,
+    visualizers::process_labels_3d_2,
 };
 
 use super::{
@@ -82,10 +82,10 @@ impl Lines3DVisualizer {
 
             let mut num_rendered_strips = 0usize;
             for (i, (strip, radius, &color)) in
-                itertools::izip!(data.strips, radii, &colors).enumerate()
+                itertools::izip!(data.strips.iter(), radii, &colors).enumerate()
             {
                 let lines = line_batch
-                    .add_strip(strip.0.iter().copied().map(Into::into))
+                    .add_strip(strip.iter().copied().map(Into::into))
                     .color(color)
                     .radius(radius)
                     .picking_instance_id(PickingLayerInstanceId(i as _));
@@ -98,7 +98,7 @@ impl Lines3DVisualizer {
                     lines.outline_mask_ids(*outline_mask_ids);
                 }
 
-                for p in &strip.0 {
+                for p in *strip {
                     obj_space_bounding_box.extend((*p).into());
                 }
 
@@ -121,19 +121,18 @@ impl Lines3DVisualizer {
                     // Take middle point of every strip.
                     itertools::Either::Right(data.strips.iter().map(|strip| {
                         strip
-                            .0
                             .iter()
                             .copied()
                             .map(glam::Vec3::from)
                             .sum::<glam::Vec3>()
-                            / (strip.0.len() as f32)
+                            / (strip.len() as f32)
                     }))
                 };
 
-                self.data.ui_labels.extend(process_labels_3d(
+                self.data.ui_labels.extend(process_labels_3d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     ent_context.world_from_entity,
@@ -147,12 +146,12 @@ impl Lines3DVisualizer {
 
 struct Lines3DComponentData<'a> {
     // Point of views
-    strips: &'a [LineStrip3D],
+    strips: Vec<&'a [[f32; 3]]>,
 
     // Clamped to edge
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 }
@@ -190,58 +189,71 @@ impl VisualizerSystem for Lines3DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype::<Self, LineStrips3D, _>(
+        super::entity_iterator::process_archetype2::<Self, LineStrips3D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let strips = match results.get_required_component_dense::<LineStrip3D>(resolver) {
-                    Some(strips) => strips?,
-                    _ => return Ok(()),
+                let Some(all_strip_chunks) = results.get_required_chunks(&LineStrip3D::name())
+                else {
+                    return Ok(());
                 };
 
-                let num_strips = strips
-                    .range_indexed()
-                    .map(|(_, strips)| strips.len())
-                    .sum::<usize>();
+                let num_strips = all_strip_chunks
+                    .iter()
+                    .flat_map(|chunk| {
+                        chunk.iter_primitive_array_list::<3, f32>(&LineStrip3D::name())
+                    })
+                    .map(|strips| strips.len())
+                    .sum();
                 if num_strips == 0 {
                     return Ok(());
                 }
                 line_builder.reserve_strips(num_strips)?;
 
-                let num_vertices = strips
-                    .range_indexed()
-                    .map(|(_, strips)| strips.iter().map(|strip| strip.0.len()).sum::<usize>())
+                let num_vertices = all_strip_chunks
+                    .iter()
+                    .flat_map(|chunk| {
+                        chunk.iter_primitive_array_list::<3, f32>(&LineStrip3D::name())
+                    })
+                    .map(|strips| strips.iter().map(|strip| strip.len()).sum::<usize>())
                     .sum::<usize>();
                 line_builder.reserve_vertices(num_vertices)?;
 
-                let colors = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_strips_indexed = all_strip_chunks.iter().flat_map(|chunk| {
+                    itertools::izip!(
+                        chunk.iter_component_indices(&timeline, &LineStrip3D::name()),
+                        chunk.iter_primitive_array_list::<3, f32>(&LineStrip3D::name())
+                    )
+                });
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = range_zip_1x5(
-                    strips.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x5(
+                    all_strips_indexed,
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(_index, strips, colors, radii, labels, class_ids, keypoint_ids)| {
                         Lines3DComponentData {
                             strips,
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -189,7 +189,8 @@ impl VisualizerSystem for Lines3DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype2::<Self, LineStrips3D, _>(
+        use super::entity_iterator::{iter_primitive_array_list, process_archetype2};
+        process_archetype2::<Self, LineStrips3D, _>(
             ctx,
             view_query,
             context_systems,
@@ -223,12 +224,8 @@ impl VisualizerSystem for Lines3DVisualizer {
                 line_builder.reserve_vertices(num_vertices)?;
 
                 let timeline = ctx.query.timeline();
-                let all_strips_indexed = all_strip_chunks.iter().flat_map(|chunk| {
-                    itertools::izip!(
-                        chunk.iter_component_indices(&timeline, &LineStrip3D::name()),
-                        chunk.iter_primitive_array_list::<3, f32>(&LineStrip3D::name())
-                    )
-                });
+                let all_strips_indexed =
+                    iter_primitive_array_list(&all_strip_chunks, timeline, LineStrip3D::name());
                 let all_colors = results.iter_as(timeline, Color::name());
                 let all_radii = results.iter_as(timeline, Radius::name());
                 let all_labels = results.iter_as(timeline, Text::name());

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -176,7 +176,8 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
         let mut instances = Vec::new();
 
-        super::entity_iterator::process_archetype2::<Self, Mesh3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Mesh3D, _>(
             ctx,
             view_query,
             context_systems,
@@ -190,13 +191,11 @@ impl VisualizerSystem for Mesh3DVisualizer {
                 };
 
                 let timeline = ctx.query.timeline();
-                let all_vertex_positions_indexed =
-                    all_vertex_position_chunks.iter().flat_map(|chunk| {
-                        itertools::izip!(
-                            chunk.iter_component_indices(&timeline, &Position3D::name()),
-                            chunk.iter_primitive_array::<3, f32>(&Position3D::name())
-                        )
-                    });
+                let all_vertex_positions_indexed = iter_primitive_array::<3, f32>(
+                    &all_vertex_position_chunks,
+                    timeline,
+                    Position3D::name(),
+                );
                 let all_vertex_normals = results.iter_as(timeline, Vector3D::name());
                 let all_vertex_colors = results.iter_as(timeline, Color::name());
                 let all_vertex_texcoords = results.iter_as(timeline, Texcoord2D::name());

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -378,7 +378,7 @@ where
 ///
 /// See [`Chunk::iter_primitive_array_list`] for more information.
 #[allow(unused)]
-pub fn primitive_array_list<'a, const N: usize, T: arrow2::types::NativeType>(
+pub fn iter_primitive_array_list<'a, const N: usize, T: arrow2::types::NativeType>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
@@ -399,14 +399,14 @@ where
 /// See [`Chunk::iter_string`] for more information.
 #[allow(unused)]
 pub fn iter_string<'a>(
-    chunks: impl Iterator<Item = &'a Chunk> + 'a,
-    timeline: &'a Timeline,
-    component_name: &'a ComponentName,
+    chunks: &'a std::borrow::Cow<'a, [Chunk]>,
+    timeline: Timeline,
+    component_name: ComponentName,
 ) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowString>)> + 'a {
-    chunks.into_iter().flat_map(|chunk| {
+    chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(timeline, component_name),
-            chunk.iter_string(component_name)
+            chunk.iter_component_indices(&timeline, &component_name),
+            chunk.iter_string(&component_name)
         )
     })
 }
@@ -416,14 +416,14 @@ pub fn iter_string<'a>(
 /// See [`Chunk::iter_buffer`] for more information.
 #[allow(unused)]
 pub fn iter_buffer<'a, T: arrow2::types::NativeType>(
-    chunks: impl Iterator<Item = &'a Chunk> + 'a,
-    timeline: &'a Timeline,
-    component_name: &'a ComponentName,
+    chunks: &'a std::borrow::Cow<'a, [Chunk]>,
+    timeline: Timeline,
+    component_name: ComponentName,
 ) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowBuffer<T>>)> + 'a {
-    chunks.into_iter().flat_map(|chunk| {
+    chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(timeline, component_name),
-            chunk.iter_buffer(component_name)
+            chunk.iter_component_indices(&timeline, &component_name),
+            chunk.iter_buffer(&component_name)
         )
     })
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -374,6 +374,26 @@ where
     })
 }
 
+/// Iterate `chunks` as indexed list of primitive arrays.
+///
+/// See [`Chunk::iter_primitive_array_list`] for more information.
+#[allow(unused)]
+pub fn primitive_array_list<'a, const N: usize, T: arrow2::types::NativeType>(
+    chunks: &'a std::borrow::Cow<'a, [Chunk]>,
+    timeline: Timeline,
+    component_name: ComponentName,
+) -> impl Iterator<Item = ((TimeInt, RowId), Vec<&'a [[T; N]]>)> + 'a
+where
+    [T; N]: bytemuck::Pod,
+{
+    chunks.iter().flat_map(move |chunk| {
+        itertools::izip!(
+            chunk.iter_component_indices(&timeline, &component_name),
+            chunk.iter_primitive_array_list::<N, T>(&component_name)
+        )
+    })
+}
+
 /// Iterate `chunks` as indexed UTF-8 strings.
 ///
 /// See [`Chunk::iter_string`] for more information.


### PR DESCRIPTION
Title!

This introduces a new neat zero-deser zero-copy helper for array list (which should be the last one, we've covered everything!).

- DNM: requires #7016

---

#### LineStrips2D
https://github.com/rerun-io/rerun/blob/beeb939bedc1cb2b48496c49b72f6c1d903ee934/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs#L187-L260
![image](https://github.com/user-attachments/assets/5fd607fc-39d8-4f1f-bcf4-cce404197864)


#### LineStrips3D
https://github.com/rerun-io/rerun/blob/beeb939bedc1cb2b48496c49b72f6c1d903ee934/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs#L192-L265
![image](https://github.com/user-attachments/assets/2bb24ee8-f02b-4056-a3c7-f64f47bc3fb2)



---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7011)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.