### PR TITLE
Chunkified, deserialization-free visualizers for all standard shapes

### DIFF
--- a/crates/store/re_types/definitions/rerun/components/half_size2d.fbs
+++ b/crates/store/re_types/definitions/rerun/components/half_size2d.fbs
@@ -9,7 +9,8 @@ namespace rerun.components;
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 struct HalfSize2D (
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   xy: rerun.datatypes.Vec2D (order: 100);
 }

--- a/crates/store/re_types/definitions/rerun/components/half_size3d.fbs
+++ b/crates/store/re_types/definitions/rerun/components/half_size3d.fbs
@@ -10,7 +10,8 @@ namespace rerun.components;
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 struct HalfSize3D (
-  "attr.rust.derive": "Copy, PartialEq"
+  "attr.rust.derive": "Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable",
+  "attr.rust.repr": "transparent"
 ) {
   xyz: rerun.datatypes.Vec3D (order: 100);
 }

--- a/crates/store/re_types/src/components/half_size2d.rs
+++ b/crates/store/re_types/src/components/half_size2d.rs
@@ -24,7 +24,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct HalfSize2D(pub crate::datatypes::Vec2D);
 
 impl ::re_types_core::SizeBytes for HalfSize2D {
@@ -112,6 +113,6 @@ impl ::re_types_core::Loggable for HalfSize2D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+        crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/store/re_types/src/components/half_size3d.rs
+++ b/crates/store/re_types/src/components/half_size3d.rs
@@ -24,7 +24,8 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// The box extends both in negative and positive direction along each axis.
 /// Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
-#[derive(Clone, Debug, Copy, PartialEq)]
+#[derive(Clone, Debug, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+#[repr(transparent)]
 pub struct HalfSize3D(pub crate::datatypes::Vec3D);
 
 impl ::re_types_core::SizeBytes for HalfSize3D {
@@ -112,6 +113,6 @@ impl ::re_types_core::Loggable for HalfSize3D {
     where
         Self: Sized,
     {
-        crate::datatypes::Vec3D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+        crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -1,9 +1,9 @@
 use re_log_types::Instance;
-use re_query::range_zip_1x6;
 use re_renderer::{renderer::LineStripFlags, LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::Arrows2D,
     components::{ClassId, Color, DrawOrder, KeypointId, Position2D, Radius, Text, Vector2D},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_2d, process_radius_slice, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -137,10 +137,10 @@ impl Arrows2DVisualizer {
                     ))
                 };
 
-                self.data.ui_labels.extend(process_labels_2d(
+                self.data.ui_labels.extend(process_labels_2d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     world_from_obj,
@@ -160,7 +160,7 @@ struct Arrows2DComponentData<'a> {
     origins: &'a [Position2D],
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 }
@@ -198,24 +198,24 @@ impl VisualizerSystem for Arrows2DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype::<Self, Arrows2D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Arrows2D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let vectors = match results.get_required_component_dense::<Vector2D>(resolver) {
-                    Some(vectors) => vectors?,
-                    _ => return Ok(()),
+                let Some(all_vector_chunks) = results.get_required_chunks(&Vector2D::name()) else {
+                    return Ok(());
                 };
 
-                let num_vectors = vectors
-                    .range_indexed()
-                    .map(|(_, vectors)| vectors.len())
-                    .sum::<usize>();
+                let num_vectors = all_vector_chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.iter_primitive_array::<2, f32>(&Vector2D::name()))
+                    .map(|vectors| vectors.len())
+                    .sum();
+
                 if num_vectors == 0 {
                     return Ok(());
                 }
@@ -223,32 +223,37 @@ impl VisualizerSystem for Arrows2DVisualizer {
                 line_builder.reserve_strips(num_vectors)?;
                 line_builder.reserve_vertices(num_vectors * 2)?;
 
-                let origins = results.get_or_empty_dense(resolver)?;
-                let colors = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_vectors_indexed =
+                    iter_primitive_array::<2, f32>(&all_vector_chunks, timeline, Vector2D::name());
+                let all_origins = results.iter_as(timeline, Position2D::name());
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = range_zip_1x6(
-                    vectors.range_indexed(),
-                    origins.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x6(
+                    all_vectors_indexed,
+                    all_origins.primitive_array::<2, f32>(),
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(_index, vectors, origins, colors, radii, labels, class_ids, keypoint_ids)| {
                         Arrows2DComponentData {
-                            vectors,
-                            origins: origins.unwrap_or_default(),
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            vectors: bytemuck::cast_slice(vectors),
+                            origins: origins.map_or(&[], |origins| bytemuck::cast_slice(origins)),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
-    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -137,7 +137,7 @@ impl Arrows2DVisualizer {
                     ))
                 };
 
-                self.data.ui_labels.extend(process_labels_2d_2(
+                self.data.ui_labels.extend(process_labels_2d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -1,9 +1,9 @@
 use re_log_types::Instance;
-use re_query::range_zip_1x6;
 use re_renderer::{renderer::LineStripFlags, LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::Arrows3D,
     components::{ClassId, Color, KeypointId, Position3D, Radius, Text, Vector3D},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -137,10 +137,10 @@ impl Arrows3DVisualizer {
                     ))
                 };
 
-                self.data.ui_labels.extend(process_labels_3d(
+                self.data.ui_labels.extend(process_labels_3d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     world_from_obj,
@@ -160,7 +160,7 @@ struct Arrows3DComponentData<'a> {
     origins: &'a [Position3D],
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 }
@@ -198,24 +198,24 @@ impl VisualizerSystem for Arrows3DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype::<Self, Arrows3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Arrows3D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let vectors = match results.get_required_component_dense::<Vector3D>(resolver) {
-                    Some(vectors) => vectors?,
-                    _ => return Ok(()),
+                let Some(all_vector_chunks) = results.get_required_chunks(&Vector3D::name()) else {
+                    return Ok(());
                 };
 
-                let num_vectors = vectors
-                    .range_indexed()
-                    .map(|(_, vectors)| vectors.len())
-                    .sum::<usize>();
+                let num_vectors = all_vector_chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.iter_primitive_array::<3, f32>(&Vector3D::name()))
+                    .map(|vectors| vectors.len())
+                    .sum();
+
                 if num_vectors == 0 {
                     return Ok(());
                 }
@@ -223,32 +223,37 @@ impl VisualizerSystem for Arrows3DVisualizer {
                 line_builder.reserve_strips(num_vectors)?;
                 line_builder.reserve_vertices(num_vectors * 2)?;
 
-                let origins = results.get_or_empty_dense(resolver)?;
-                let colors = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_vectors_indexed =
+                    iter_primitive_array::<3, f32>(&all_vector_chunks, timeline, Vector3D::name());
+                let all_origins = results.iter_as(timeline, Position3D::name());
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = range_zip_1x6(
-                    vectors.range_indexed(),
-                    origins.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x6(
+                    all_vectors_indexed,
+                    all_origins.primitive_array::<3, f32>(),
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(_index, vectors, origins, colors, radii, labels, class_ids, keypoint_ids)| {
                         Arrows3DComponentData {
-                            vectors,
-                            origins: origins.unwrap_or_default(),
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            vectors: bytemuck::cast_slice(vectors),
+                            origins: origins.map_or(&[], |origins| bytemuck::cast_slice(origins)),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -19,7 +19,7 @@ use crate::{
 
 use super::{
     entity_iterator::clamped_or, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -137,7 +137,7 @@ impl Arrows3DVisualizer {
                     ))
                 };
 
-                self.data.ui_labels.extend(process_labels_3d_2(
+                self.data.ui_labels.extend(process_labels_3d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -1,10 +1,10 @@
 use re_entity_db::{EntityPath, InstancePathHash};
 use re_log_types::Instance;
-use re_query::range_zip_1x6;
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::Boxes2D,
     components::{ClassId, Color, DrawOrder, HalfSize2D, KeypointId, Position2D, Radius, Text},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -21,7 +21,7 @@ use crate::{
 
 use super::{
     filter_visualizable_2d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_2d, process_radius_slice, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -51,7 +51,7 @@ impl Boxes2DVisualizer {
         entity_path: &'a EntityPath,
         half_sizes: &'a [HalfSize2D],
         centers: impl Iterator<Item = &'a Position2D> + 'a,
-        labels: &'a [Text],
+        labels: &'a [ArrowString],
         colors: &'a [egui::Color32],
         annotation_infos: &'a ResolvedAnnotationInfos,
     ) -> impl Iterator<Item = UiLabel> + 'a {
@@ -169,10 +169,10 @@ impl Boxes2DVisualizer {
                 if data.labels.len() == 1 && num_instances > 1 {
                     // If there's many boxes but only a single label, place the single label at the middle of the visualization.
                     // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    self.data.ui_labels.extend(process_labels_2d(
+                    self.data.ui_labels.extend(process_labels_2d_2(
                         entity_path,
                         std::iter::once(obj_space_bounding_box.center().truncate()),
-                        data.labels,
+                        &data.labels,
                         &colors,
                         &annotation_infos,
                         world_from_obj,
@@ -183,7 +183,7 @@ impl Boxes2DVisualizer {
                         entity_path,
                         data.half_sizes,
                         centers,
-                        data.labels,
+                        &data.labels,
                         &colors,
                         &annotation_infos,
                     ));
@@ -203,7 +203,7 @@ struct Boxes2DComponentData<'a> {
     centers: &'a [Position2D],
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 }
@@ -241,25 +241,24 @@ impl VisualizerSystem for Boxes2DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        super::entity_iterator::process_archetype::<Self, Boxes2D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Boxes2D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let half_sizes = match results.get_required_component_dense::<HalfSize2D>(resolver)
-                {
-                    Some(vectors) => vectors?,
-                    _ => return Ok(()),
+                let Some(all_half_size_chunks) = results.get_required_chunks(&HalfSize2D::name())
+                else {
+                    return Ok(());
                 };
 
-                let num_boxes = half_sizes
-                    .range_indexed()
-                    .map(|(_, vectors)| vectors.len())
-                    .sum::<usize>();
+                let num_boxes: usize = all_half_size_chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.iter_primitive_array::<2, f32>(&HalfSize2D::name()))
+                    .map(|vectors| vectors.len())
+                    .sum();
                 if num_boxes == 0 {
                     return Ok(());
                 }
@@ -268,21 +267,27 @@ impl VisualizerSystem for Boxes2DVisualizer {
                 line_builder.reserve_strips(num_boxes * 4)?;
                 line_builder.reserve_vertices(num_boxes * 4 * 2)?;
 
-                let centers = results.get_or_empty_dense(resolver)?;
-                let colors = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_half_sizes_indexed = iter_primitive_array::<2, f32>(
+                    &all_half_size_chunks,
+                    timeline,
+                    HalfSize2D::name(),
+                );
+                let all_centers = results.iter_as(timeline, Position2D::name());
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = range_zip_1x6(
-                    half_sizes.range_indexed(),
-                    centers.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x6(
+                    all_half_sizes_indexed,
+                    all_centers.primitive_array::<2, f32>(),
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(
@@ -296,13 +301,15 @@ impl VisualizerSystem for Boxes2DVisualizer {
                         keypoint_ids,
                     )| {
                         Boxes2DComponentData {
-                            half_sizes,
-                            centers: centers.unwrap_or_default(),
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            half_sizes: bytemuck::cast_slice(half_sizes),
+                            centers: centers.map_or(&[], |centers| bytemuck::cast_slice(centers)),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -21,7 +21,7 @@ use crate::{
 
 use super::{
     filter_visualizable_2d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -169,7 +169,7 @@ impl Boxes2DVisualizer {
                 if data.labels.len() == 1 && num_instances > 1 {
                     // If there's many boxes but only a single label, place the single label at the middle of the visualization.
                     // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    self.data.ui_labels.extend(process_labels_2d_2(
+                    self.data.ui_labels.extend(process_labels_2d(
                         entity_path,
                         std::iter::once(obj_space_bounding_box.center().truncate()),
                         &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
     filter_visualizable_3d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -163,7 +163,7 @@ impl Boxes3DVisualizer {
                     )
                 };
 
-                self.0.ui_labels.extend(process_labels_3d_2(
+                self.0.ui_labels.extend(process_labels_3d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools as _;
+
 use re_entity_db::InstancePathHash;
 use re_log_types::Instance;
 use re_renderer::{
@@ -6,6 +8,7 @@ use re_renderer::{
 use re_types::{
     archetypes::Boxes3D,
     components::{ClassId, Color, FillMode, HalfSize3D, KeypointId, Radius, Text},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -22,7 +25,7 @@ use crate::{
 
 use super::{
     filter_visualizable_3d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -160,10 +163,10 @@ impl Boxes3DVisualizer {
                     )
                 };
 
-                self.0.ui_labels.extend(process_labels_3d(
+                self.0.ui_labels.extend(process_labels_3d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     glam::Affine3A::IDENTITY,
@@ -184,7 +187,7 @@ struct Boxes3DComponentData<'a> {
     // Clamped to edge
     colors: &'a [Color],
     radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 
@@ -231,39 +234,57 @@ impl VisualizerSystem for Boxes3DVisualizer {
         // This code should be revisited with an eye on performance.
         let mut solid_instances: Vec<MeshInstance> = Vec::new();
 
-        super::entity_iterator::process_archetype::<Self, Boxes3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Boxes3D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let half_sizes = match results.get_required_component_dense::<HalfSize3D>(resolver)
-                {
-                    Some(vectors) => vectors?,
-                    _ => return Ok(()),
+                let Some(all_half_size_chunks) = results.get_required_chunks(&HalfSize3D::name())
+                else {
+                    return Ok(());
                 };
 
-                let num_boxes = half_sizes
-                    .range_indexed()
-                    .map(|(_, vectors)| vectors.len())
-                    .sum::<usize>();
+                let num_boxes: usize = all_half_size_chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.iter_primitive_array::<3, f32>(&HalfSize3D::name()))
+                    .map(|vectors| vectors.len())
+                    .sum();
                 if num_boxes == 0 {
                     return Ok(());
                 }
 
-                let colors = results.get_or_empty_dense(resolver)?;
-                let fill_mode = results.get_or_empty_dense(resolver)?;
-                let radii = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_half_sizes_indexed = iter_primitive_array::<3, f32>(
+                    &all_half_size_chunks,
+                    timeline,
+                    HalfSize3D::name(),
+                );
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
+
+                // Deserialized because it's a union.
+                let all_fill_mode_chunks = results.get_optional_chunks(&FillMode::name());
+                let mut all_fill_mode_iters = all_fill_mode_chunks
+                    .iter()
+                    .map(|chunk| chunk.iter_component::<FillMode>())
+                    .collect_vec();
+                let mut all_fill_modes_indexed = {
+                    let all_fill_modes =
+                        all_fill_mode_iters.iter_mut().flat_map(|it| it.into_iter());
+                    let all_fill_modes_indices = all_fill_mode_chunks.iter().flat_map(|chunk| {
+                        chunk.iter_component_indices(&timeline, &FillMode::name())
+                    });
+                    itertools::izip!(all_fill_modes_indices, all_fill_modes)
+                };
 
                 // fill mode is currently a non-repeated component
-                let fill_mode: FillMode = fill_mode
-                    .range_indexed()
+                let fill_mode: FillMode = all_fill_modes_indexed
                     .next()
                     .and_then(|(_, fill_modes)| fill_modes.first().copied())
                     .unwrap_or_default();
@@ -279,25 +300,27 @@ impl VisualizerSystem for Boxes3DVisualizer {
                     }
                 }
 
-                let data = re_query::range_zip_1x5(
-                    half_sizes.range_indexed(),
-                    colors.range_indexed(),
-                    radii.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                let data = re_query2::range_zip_1x5(
+                    all_half_sizes_indexed,
+                    all_colors.primitive::<u32>(),
+                    all_radii.primitive::<f32>(),
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(_index, half_sizes, colors, radii, labels, class_ids, keypoint_ids)| {
                         Boxes3DComponentData {
-                            half_sizes,
-                            colors: colors.unwrap_or_default(),
-                            radii: radii.unwrap_or_default(),
+                            half_sizes: bytemuck::cast_slice(half_sizes),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            radii: radii.map_or(&[], |radii| bytemuck::cast_slice(radii)),
                             // fill mode is currently a non-repeated component
                             fill_mode,
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -25,7 +25,7 @@ use crate::{
 
 use super::{
     filter_visualizable_3d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -194,7 +194,7 @@ impl Ellipsoids3DVisualizer {
                     )
                 };
 
-                self.0.ui_labels.extend(process_labels_3d_2(
+                self.0.ui_labels.extend(process_labels_3d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -1,3 +1,5 @@
+use itertools::Itertools as _;
+
 use re_entity_db::InstancePathHash;
 use re_log_types::Instance;
 use re_renderer::{
@@ -6,6 +8,7 @@ use re_renderer::{
 use re_types::{
     archetypes::Ellipsoids3D,
     components::{ClassId, Color, FillMode, HalfSize3D, KeypointId, Radius, Text},
+    ArrowString, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,
@@ -22,7 +25,7 @@ use crate::{
 
 use super::{
     filter_visualizable_3d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
+    process_labels_3d_2, process_radius_slice, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -191,10 +194,10 @@ impl Ellipsoids3DVisualizer {
                     )
                 };
 
-                self.0.ui_labels.extend(process_labels_3d(
+                self.0.ui_labels.extend(process_labels_3d_2(
                     entity_path,
                     label_positions,
-                    data.labels,
+                    &data.labels,
                     &colors,
                     &annotation_infos,
                     glam::Affine3A::IDENTITY,
@@ -215,7 +218,7 @@ struct Ellipsoids3DComponentData<'a> {
     // Clamped to edge
     colors: &'a [Color],
     line_radii: &'a [Radius],
-    labels: &'a [Text],
+    labels: Vec<ArrowString>,
     keypoint_ids: &'a [KeypointId],
     class_ids: &'a [ClassId],
 
@@ -260,25 +263,24 @@ impl VisualizerSystem for Ellipsoids3DVisualizer {
         // Collects solid (that is, triangles rather than wireframe) instances to be drawn.
         let mut solid_instances: Vec<MeshInstance> = Vec::new();
 
-        super::entity_iterator::process_archetype::<Self, Ellipsoids3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype2};
+        process_archetype2::<Self, Ellipsoids3D, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let half_sizes = match results.get_required_component_dense::<HalfSize3D>(resolver)
-                {
-                    Some(vectors) => vectors?,
-                    _ => return Ok(()),
+                let Some(all_half_size_chunks) = results.get_required_chunks(&HalfSize3D::name())
+                else {
+                    return Ok(());
                 };
 
-                let num_ellipsoids = half_sizes
-                    .range_indexed()
-                    .map(|(_, vectors)| vectors.len())
-                    .sum::<usize>();
+                let num_ellipsoids: usize = all_half_size_chunks
+                    .iter()
+                    .flat_map(|chunk| chunk.iter_primitive_array::<3, f32>(&HalfSize3D::name()))
+                    .map(|vectors| vectors.len())
+                    .sum();
                 if num_ellipsoids == 0 {
                     return Ok(());
                 }
@@ -288,21 +290,41 @@ impl VisualizerSystem for Ellipsoids3DVisualizer {
                 // line_builder.reserve_strips(num_ellipsoids * sphere_mesh.line_strips.len())?;
                 // line_builder.reserve_vertices(num_ellipsoids * sphere_mesh.vertex_count)?;
 
-                let colors = results.get_or_empty_dense(resolver)?;
-                let line_radii = results.get_or_empty_dense(resolver)?;
-                let fill_mode = results.get_or_empty_dense(resolver)?;
-                let labels = results.get_or_empty_dense(resolver)?;
-                let class_ids = results.get_or_empty_dense(resolver)?;
-                let keypoint_ids = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_half_sizes_indexed = iter_primitive_array::<3, f32>(
+                    &all_half_size_chunks,
+                    timeline,
+                    HalfSize3D::name(),
+                );
+                let all_colors = results.iter_as(timeline, Color::name());
+                let all_line_radii = results.iter_as(timeline, Radius::name());
+                let all_labels = results.iter_as(timeline, Text::name());
+                let all_class_ids = results.iter_as(timeline, ClassId::name());
+                let all_keypoint_ids = results.iter_as(timeline, KeypointId::name());
 
-                let data = re_query::range_zip_1x6(
-                    half_sizes.range_indexed(),
-                    colors.range_indexed(),
-                    line_radii.range_indexed(),
-                    fill_mode.range_indexed(),
-                    labels.range_indexed(),
-                    class_ids.range_indexed(),
-                    keypoint_ids.range_indexed(),
+                // Deserialized because it's a union.
+                let all_fill_mode_chunks = results.get_optional_chunks(&FillMode::name());
+                let mut all_fill_mode_iters = all_fill_mode_chunks
+                    .iter()
+                    .map(|chunk| chunk.iter_component::<FillMode>())
+                    .collect_vec();
+                let all_fill_modes_indexed = {
+                    let all_fill_modes =
+                        all_fill_mode_iters.iter_mut().flat_map(|it| it.into_iter());
+                    let all_fill_modes_indices = all_fill_mode_chunks.iter().flat_map(|chunk| {
+                        chunk.iter_component_indices(&timeline, &FillMode::name())
+                    });
+                    itertools::izip!(all_fill_modes_indices, all_fill_modes)
+                };
+
+                let data = re_query2::range_zip_1x6(
+                    all_half_sizes_indexed,
+                    all_colors.primitive::<u32>(),
+                    all_line_radii.primitive::<f32>(),
+                    all_fill_modes_indexed,
+                    all_labels.string(),
+                    all_class_ids.primitive::<u16>(),
+                    all_keypoint_ids.primitive::<u16>(),
                 )
                 .map(
                     |(
@@ -316,9 +338,10 @@ impl VisualizerSystem for Ellipsoids3DVisualizer {
                         keypoint_ids,
                     )| {
                         Ellipsoids3DComponentData {
-                            half_sizes,
-                            colors: colors.unwrap_or_default(),
-                            line_radii: line_radii.unwrap_or_default(),
+                            half_sizes: bytemuck::cast_slice(half_sizes),
+                            colors: colors.map_or(&[], |colors| bytemuck::cast_slice(colors)),
+                            line_radii: line_radii
+                                .map_or(&[], |line_radii| bytemuck::cast_slice(line_radii)),
                             // fill mode is currently a non-repeated component
                             fill_mode: fill_mode
                                 .unwrap_or_default()
@@ -326,8 +349,10 @@ impl VisualizerSystem for Ellipsoids3DVisualizer {
                                 .copied()
                                 .unwrap_or_default(),
                             labels: labels.unwrap_or_default(),
-                            class_ids: class_ids.unwrap_or_default(),
-                            keypoint_ids: keypoint_ids.unwrap_or_default(),
+                            class_ids: class_ids
+                                .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
+                            keypoint_ids: keypoint_ids
+                                .map_or(&[], |keypoint_ids| bytemuck::cast_slice(keypoint_ids)),
                         }
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -16,7 +16,7 @@ use crate::{contexts::SpatialSceneEntityContext, view_kind::SpatialSpaceViewKind
 
 use super::{
     filter_visualizable_2d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_radius_slice, utilities::process_labels_2d_2, SpatialViewVisualizerData,
+    process_radius_slice, utilities::process_labels_2d, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
@@ -125,7 +125,7 @@ impl Lines2DVisualizer {
                     }))
                 };
 
-                self.data.ui_labels.extend(process_labels_2d_2(
+                self.data.ui_labels.extend(process_labels_2d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -14,7 +14,7 @@ use re_viewer_context::{
 
 use crate::{
     contexts::SpatialSceneEntityContext, view_kind::SpatialSpaceViewKind,
-    visualizers::process_labels_3d_2,
+    visualizers::process_labels_3d,
 };
 
 use super::{
@@ -130,7 +130,7 @@ impl Lines3DVisualizer {
                     }))
                 };
 
-                self.data.ui_labels.extend(process_labels_3d_2(
+                self.data.ui_labels.extend(process_labels_3d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
@@ -26,9 +26,8 @@ pub use images::ImageVisualizer;
 pub use segmentation_images::SegmentationImageVisualizer;
 pub use transform3d_arrows::{add_axis_arrows, AxisLengthDetector, Transform3DArrowsVisualizer};
 pub use utilities::{
-    entity_iterator, process_labels_2d, process_labels_3d, process_labels_3d_2,
-    textured_rect_from_image, SpatialViewVisualizerData, UiLabel, UiLabelTarget,
-    MAX_NUM_LABELS_PER_ENTITY,
+    entity_iterator, process_labels_3d, process_labels_3d_2, textured_rect_from_image,
+    SpatialViewVisualizerData, UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
 };
 
 // ---

--- a/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
@@ -26,8 +26,8 @@ pub use images::ImageVisualizer;
 pub use segmentation_images::SegmentationImageVisualizer;
 pub use transform3d_arrows::{add_axis_arrows, AxisLengthDetector, Transform3DArrowsVisualizer};
 pub use utilities::{
-    entity_iterator, process_labels_3d, process_labels_3d_2, textured_rect_from_image,
-    SpatialViewVisualizerData, UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
+    entity_iterator, process_labels_3d, textured_rect_from_image, SpatialViewVisualizerData,
+    UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
 };
 
 // ---

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::{
-    filter_visualizable_2d_entities, utilities::process_labels_2d_2, SpatialViewVisualizerData,
+    filter_visualizable_2d_entities, utilities::process_labels_2d, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
 };
 
@@ -141,7 +141,7 @@ impl Points2DVisualizer {
                     )
                 };
 
-                self.data.ui_labels.extend(process_labels_2d_2(
+                self.data.ui_labels.extend(process_labels_2d(
                     entity_path,
                     label_positions,
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::{
-    filter_visualizable_3d_entities, process_labels_3d_2, SpatialViewVisualizerData,
+    filter_visualizable_3d_entities, process_labels_3d, SpatialViewVisualizerData,
     SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
 };
 
@@ -145,7 +145,7 @@ impl Points3DVisualizer {
                     positions
                 };
 
-                self.data.ui_labels.extend(process_labels_3d_2(
+                self.data.ui_labels.extend(process_labels_3d(
                     entity_path,
                     label_positions.iter().copied(),
                     &data.labels,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
@@ -39,41 +39,7 @@ pub const MAX_NUM_LABELS_PER_ENTITY: usize = 30;
 ///
 /// Does nothing if there's no positions or no labels passed.
 /// Otherwise, produces one label per position passed.
-//
-// TODO(cmc): remove
 pub fn process_labels_3d<'a>(
-    entity_path: &'a EntityPath,
-    positions: impl Iterator<Item = glam::Vec3> + 'a,
-    labels: &'a [re_types::components::Text],
-    colors: &'a [egui::Color32],
-    annotation_infos: &'a ResolvedAnnotationInfos,
-    world_from_obj: glam::Affine3A,
-) -> impl Iterator<Item = UiLabel> + 'a {
-    let labels = izip!(
-        annotation_infos.iter(),
-        labels.iter().map(Some).chain(std::iter::repeat(None))
-    )
-    .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
-
-    let colors = clamped_or(colors, &egui::Color32::WHITE);
-
-    itertools::izip!(positions, labels, colors)
-        .enumerate()
-        .filter_map(move |(i, (point, label, color))| {
-            label.map(|label| UiLabel {
-                text: label,
-                color: *color,
-                target: UiLabelTarget::Position3D(world_from_obj.transform_point3(point)),
-                labeled_instance: InstancePathHash::instance(entity_path, Instance::from(i as u64)),
-            })
-        })
-}
-
-/// Produces 3D ui labels from component data.
-///
-/// Does nothing if there's no positions or no labels passed.
-/// Otherwise, produces one label per position passed.
-pub fn process_labels_3d_2<'a>(
     entity_path: &'a EntityPath,
     positions: impl Iterator<Item = glam::Vec3> + 'a,
     labels: &'a [re_types::ArrowString],

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
@@ -105,47 +105,7 @@ pub fn process_labels_3d_2<'a>(
 ///
 /// Does nothing if there's no positions or no labels passed.
 /// Otherwise, produces one label per position passed.
-//
-// TODO(cmc): remove
 pub fn process_labels_2d<'a>(
-    entity_path: &'a EntityPath,
-    positions: impl Iterator<Item = glam::Vec2> + 'a,
-    labels: &'a [re_types::components::Text],
-    colors: &'a [egui::Color32],
-    annotation_infos: &'a ResolvedAnnotationInfos,
-    world_from_obj: glam::Affine3A,
-) -> impl Iterator<Item = UiLabel> + 'a {
-    let labels = izip!(
-        annotation_infos.iter(),
-        labels.iter().map(Some).chain(std::iter::repeat(None))
-    )
-    .map(|(annotation_info, label)| annotation_info.label(label.map(|l| l.as_str())));
-
-    let colors = clamped_or(colors, &egui::Color32::WHITE);
-
-    itertools::izip!(positions, labels, colors)
-        .enumerate()
-        .filter_map(move |(i, (point, label, color))| {
-            label.map(|label| {
-                let point = world_from_obj.transform_point3(glam::Vec3::new(point.x, point.y, 0.0));
-                UiLabel {
-                    text: label,
-                    color: *color,
-                    target: UiLabelTarget::Point2D(egui::pos2(point.x, point.y)),
-                    labeled_instance: InstancePathHash::instance(
-                        entity_path,
-                        Instance::from(i as u64),
-                    ),
-                }
-            })
-        })
-}
-
-/// Produces 2D ui labels from component data.
-///
-/// Does nothing if there's no positions or no labels passed.
-/// Otherwise, produces one label per position passed.
-pub fn process_labels_2d_2<'a>(
     entity_path: &'a EntityPath,
     positions: impl Iterator<Item = glam::Vec2> + 'a,
     labels: &'a [re_types::ArrowString],

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
@@ -4,8 +4,8 @@ mod spatial_view_visualizer;
 mod textured_rect;
 
 pub use labels::{
-    process_labels_2d, process_labels_2d_2, process_labels_3d, process_labels_3d_2, UiLabel,
-    UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
+    process_labels_2d, process_labels_3d, process_labels_3d_2, UiLabel, UiLabelTarget,
+    MAX_NUM_LABELS_PER_ENTITY,
 };
 pub use spatial_view_visualizer::SpatialViewVisualizerData;
 pub use textured_rect::textured_rect_from_image;

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
@@ -4,8 +4,7 @@ mod spatial_view_visualizer;
 mod textured_rect;
 
 pub use labels::{
-    process_labels_2d, process_labels_3d, process_labels_3d_2, UiLabel, UiLabelTarget,
-    MAX_NUM_LABELS_PER_ENTITY,
+    process_labels_2d, process_labels_3d, UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
 };
 pub use spatial_view_visualizer::SpatialViewVisualizerData;
 pub use textured_rect::textured_rect_from_image;


### PR DESCRIPTION
Chunkified, (mostly)deserialization-free visualizers for all remaining standard shapes.

Pretty straightforward now that we have all the iteration tools already in place.

- DNM: requires #7019

---

#### Ellipsoids3D
![image](https://github.com/user-attachments/assets/7ca5765e-a5b9-431b-91db-85cd98cf5f56)

#### Boxes2D
![image](https://github.com/user-attachments/assets/83fadea0-9a9d-4c49-9ef4-3eb0607713ad)

#### Boxes3D
![image](https://github.com/user-attachments/assets/28414c83-0d54-4405-80ff-598f50373a9c)

#### Arrows2D
![image](https://github.com/user-attachments/assets/2a93f9e4-561d-4912-8925-a0a4e63c37b5)

#### Arrows3D
![image](https://github.com/user-attachments/assets/63d0de57-ef94-4551-bd15-bcf3d6c31c20)


---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7011)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.