### PR TITLE
Enable solid 3D boxes for nuscenes

### DIFF
--- a/examples/python/nuscenes_dataset/README.md
+++ b/examples/python/nuscenes_dataset/README.md
@@ -105,7 +105,16 @@ rr.log(f"world/ego_vehicle/{sensor_name}", rr.Points3D(points, colors=point_colo
 
 Annotations are logged as [`Boxes3D`](https://www.rerun.io/docs/reference/types/archetypes/boxes3d), containing details such as object positions, sizes, and rotation.
 ```python
-rr.log("world/anns", rr.Boxes3D(sizes=sizes, centers=centers, rotations=rotations, class_ids=class_ids))
+rr.log(
+    "world/anns",
+    rr.Boxes3D(
+        sizes=sizes,
+        centers=centers,
+        rotations=rotations,
+        class_ids=class_ids,
+        fill_mode=rr.components.FillMode.Solid,
+    ),
+)
 ```
 
 ### Setting up the default blueprint

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -174,7 +174,10 @@ def log_radars(first_radar_tokens: list[str], nusc: nuscenes.NuScenes, max_times
             points = pointcloud.points[:3].T  # shape after transposing: (num_points, 3)
             point_distances = np.linalg.norm(points, axis=1)
             point_colors = cmap(norm(point_distances))
-            rr.log(f"world/ego_vehicle/{sensor_name}", rr.Points3D(points, colors=point_colors))
+            rr.log(
+                f"world/ego_vehicle/{sensor_name}",
+                rr.Points3D(points, colors=point_colors),
+            )
             current_camera_token = sample_data["next"]
 
 
@@ -204,7 +207,16 @@ def log_annotations(first_sample_token: str, nusc: nuscenes.NuScenes, max_timest
                 label2id[ann["category_name"]] = len(label2id)
             class_ids.append(label2id[ann["category_name"]])
 
-        rr.log("world/anns", rr.Boxes3D(sizes=sizes, centers=centers, rotations=rotations, class_ids=class_ids))
+        rr.log(
+            "world/anns",
+            rr.Boxes3D(
+                sizes=sizes,
+                centers=centers,
+                rotations=rotations,
+                class_ids=class_ids,
+                fill_mode=rr.components.FillMode.Solid,
+            ),
+        )
         current_sample_token = sample_data["next"]
 
     # skipping for now since labels take too much space in 3D view (see https://github.com/rerun-io/rerun/issues/4451)
@@ -255,7 +267,10 @@ def main() -> None:
     )
     parser.add_argument("--dataset-version", type=str, default="v1.0-mini", help="Scene id to visualize")
     parser.add_argument(
-        "--seconds", type=float, default=float("inf"), help="If specified, limits the number of seconds logged"
+        "--seconds",
+        type=float,
+        default=float("inf"),
+        help="If specified, limits the number of seconds logged",
     )
     rr.script_add_args(parser)
     args = parser.parse_args()
@@ -291,7 +306,11 @@ def main() -> None:
 
     rr.script_setup(args, "rerun_example_nuscenes", default_blueprint=blueprint)
 
-    rr.log("description", rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN), timeless=True)
+    rr.log(
+        "description",
+        rr.TextDocument(DESCRIPTION, media_type=rr.MediaType.MARKDOWN),
+        timeless=True,
+    )
 
     log_nuscenes(nusc, args.scene_name, max_time_sec=args.seconds)
 


### PR DESCRIPTION
It looks soooo much better :heart_eyes: 

![image](https://github.com/user-attachments/assets/d1b3c759-381c-47b9-9859-c3c5f11f3ea4)

Also: `pixi run format`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7021?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7021?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7021)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.