### PR TITLE
Chunkified image visualizers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _deps
 **/.cache/
 **/rerun_cpp/docs/html
 **/rerun_cpp/docs/xml
+*.tgz
 
 # Rust compile target directory:
 **/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,6 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_math",
- "re_query",
  "re_query2",
  "re_renderer",
  "re_space_view",

--- a/crates/store/re_types/definitions/rerun/components/opacity.fbs
+++ b/crates/store/re_types/definitions/rerun/components/opacity.fbs
@@ -10,7 +10,7 @@ namespace rerun.components;
 struct Opacity (
   "attr.python.aliases": "float",
   "attr.python.array_aliases": "float, npt.ArrayLike",
-  "attr.rust.derive": "Copy, PartialEq, PartialOrd",
+  "attr.rust.derive": "Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.repr": "transparent"
 ) {
   opacity: rerun.datatypes.Float32 (order: 100);

--- a/crates/store/re_types/src/components/opacity.rs
+++ b/crates/store/re_types/src/components/opacity.rs
@@ -22,7 +22,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// The final opacity value may be a result of multiplication with alpha values as specified by other color sources.
 /// Unless otherwise specified, the default value is 1.
-#[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Opacity(pub crate::datatypes::Float32);
 
@@ -111,6 +111,6 @@ impl ::re_types_core::Loggable for Opacity {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+        crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
     }
 }

--- a/crates/viewer/re_space_view_spatial/Cargo.toml
+++ b/crates/viewer/re_space_view_spatial/Cargo.toml
@@ -27,7 +27,6 @@ re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_math = { workspace = true, features = ["serde"] }
-re_query.workspace = true
 re_query2.workspace = true
 re_renderer = { workspace = true, features = [
   "import-gltf",

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -198,8 +198,8 @@ impl VisualizerSystem for Arrows2DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Arrows2D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Arrows2D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -198,8 +198,8 @@ impl VisualizerSystem for Arrows3DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Arrows3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Arrows3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -139,8 +139,8 @@ impl VisualizerSystem for Asset3DVisualizer {
 
         let mut instances = Vec::new();
 
-        use super::entity_iterator::{iter_buffer, process_archetype2};
-        process_archetype2::<Self, Asset3D, _>(
+        use super::entity_iterator::{iter_buffer, process_archetype};
+        process_archetype::<Self, Asset3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -241,8 +241,8 @@ impl VisualizerSystem for Boxes2DVisualizer {
         let mut line_builder = LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Boxes2D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Boxes2D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -232,8 +232,8 @@ impl VisualizerSystem for Boxes3DVisualizer {
         // This code should be revisited with an eye on performance.
         let mut solid_instances: Vec<MeshInstance> = Vec::new();
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Boxes3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Boxes3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -6,8 +6,12 @@ use re_log_types::EntityPathHash;
 use re_renderer::renderer::{DepthCloud, DepthClouds};
 use re_types::{
     archetypes::DepthImage,
-    components::{self, Colormap, DepthMeter, DrawOrder, FillRatio, ViewCoordinates},
+    components::{
+        self, Blob, ChannelDatatype, Colormap, DepthMeter, DrawOrder, FillRatio, Resolution2D,
+        ViewCoordinates,
+    },
     image::ImageKind,
+    Loggable as _,
 };
 use re_viewer_context::{
     gpu_bridge::colormap_to_re_renderer, ApplicableEntities, IdentifiedViewSystem, ImageFormat,
@@ -17,8 +21,7 @@ use re_viewer_context::{
 };
 
 use crate::{
-    contexts::SpatialSceneEntityContext,
-    contexts::TwoDInThreeDTransformInfo,
+    contexts::{SpatialSceneEntityContext, TwoDInThreeDTransformInfo},
     query_pinhole_legacy,
     view_kind::SpatialSpaceViewKind,
     visualizers::{filter_visualizable_2d_entities, SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES},
@@ -238,59 +241,62 @@ impl VisualizerSystem for DepthImageVisualizer {
 
         let mut depth_clouds = Vec::new();
 
-        super::entity_iterator::process_archetype::<Self, DepthImage, _>(
+        use super::entity_iterator::{
+            iter_buffer, iter_component, iter_primitive_array, process_archetype2,
+        };
+        process_archetype2::<Self, DepthImage, _>(
             ctx,
             view_query,
             context_systems,
             |ctx, spatial_ctx, results| {
-                use re_space_view::RangeResultsExt as _;
+                use re_space_view::RangeResultsExt2 as _;
 
-                let resolver = ctx.recording().resolver();
-
-                let blobs = match results.get_required_component_dense::<components::Blob>(resolver)
-                {
-                    Some(blobs) => blobs?,
-                    _ => return Ok(()),
+                let Some(all_blob_chunks) = results.get_required_chunks(&Blob::name()) else {
+                    return Ok(());
                 };
-                let resolutions = match results
-                    .get_required_component_dense::<components::Resolution2D>(resolver)
-                {
-                    Some(resolutions) => resolutions?,
-                    _ => return Ok(()),
+                let Some(all_resolution_chunks) =
+                    results.get_required_chunks(&Resolution2D::name())
+                else {
+                    return Ok(());
                 };
-                let data_types = match results
-                    .get_required_component_dense::<components::ChannelDatatype>(resolver)
-                {
-                    Some(data_types) => data_types?,
-                    _ => return Ok(()),
+                let Some(all_datatype_chunks) =
+                    results.get_required_chunks(&ChannelDatatype::name())
+                else {
+                    return Ok(());
                 };
 
-                let colormap = results.get_or_empty_dense(resolver)?;
-                let depth_meter = results.get_or_empty_dense(resolver)?;
-                let fill_ratio = results.get_or_empty_dense(resolver)?;
+                let timeline = ctx.query.timeline();
+                let all_blobs_indexed = iter_buffer::<u8>(&all_blob_chunks, timeline, Blob::name());
+                let all_resolutions_indexed =
+                    iter_primitive_array(&all_resolution_chunks, timeline, Resolution2D::name());
+                let all_datatypes_indexed =
+                    iter_component(&all_datatype_chunks, timeline, ChannelDatatype::name());
+                let all_colormaps = results.iter_as(timeline, Colormap::name());
+                let all_depth_meters = results.iter_as(timeline, DepthMeter::name());
+                let all_fill_ratios = results.iter_as(timeline, FillRatio::name());
 
-                let mut data = re_query::range_zip_1x5(
-                    blobs.range_indexed(),
-                    resolutions.range_indexed(),
-                    data_types.range_indexed(),
-                    colormap.range_indexed(),
-                    depth_meter.range_indexed(),
-                    fill_ratio.range_indexed(),
+                let mut data = re_query2::range_zip_1x5(
+                    all_blobs_indexed,
+                    all_datatypes_indexed,
+                    all_resolutions_indexed,
+                    all_colormaps.component::<components::Colormap>(),
+                    all_depth_meters.primitive::<f32>(),
+                    all_fill_ratios.primitive::<f32>(),
                 )
                 .filter_map(
-                    |(&index, blobs, resolution, data_type, colormap, depth_meter, fill_ratio)| {
+                    |(index, blobs, data_type, resolution, colormap, depth_meter, fill_ratio)| {
                         let blob = blobs.first()?;
                         Some(DepthImageComponentData {
                             image: ImageInfo {
                                 blob_row_id: index.1,
-                                blob: blob.0.clone(),
-                                resolution: first_copied(resolution)?.0 .0,
-                                format: ImageFormat::depth(first_copied(data_type)?),
+                                blob: blob.clone().into(),
+                                resolution: first_copied(resolution)?,
+                                format: ImageFormat::depth(first_copied(data_type.as_deref())?),
                                 kind: ImageKind::Depth,
-                                colormap: first_copied(colormap),
+                                colormap: first_copied(colormap.as_deref()),
                             },
-                            depth_meter: first_copied(depth_meter),
-                            fill_ratio: first_copied(fill_ratio),
+                            depth_meter: first_copied(depth_meter).map(Into::into),
+                            fill_ratio: first_copied(fill_ratio).map(Into::into),
                         })
                     },
                 );

--- a/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -242,9 +242,9 @@ impl VisualizerSystem for DepthImageVisualizer {
         let mut depth_clouds = Vec::new();
 
         use super::entity_iterator::{
-            iter_buffer, iter_component, iter_primitive_array, process_archetype2,
+            iter_buffer, iter_component, iter_primitive_array, process_archetype,
         };
-        process_archetype2::<Self, DepthImage, _>(
+        process_archetype::<Self, DepthImage, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -261,8 +261,8 @@ impl VisualizerSystem for Ellipsoids3DVisualizer {
         // Collects solid (that is, triangles rather than wireframe) instances to be drawn.
         let mut solid_instances: Vec<MeshInstance> = Vec::new();
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Ellipsoids3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Ellipsoids3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
@@ -1,10 +1,11 @@
 use itertools::Itertools as _;
 
 use re_query::range_zip_1x2;
-use re_space_view::HybridResults;
+use re_space_view::HybridResults2;
 use re_types::{
     archetypes::ImageEncoded,
     components::{Blob, DrawOrder, MediaType, Opacity},
+    Loggable as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ImageDecodeCache, QueryContext,
@@ -20,7 +21,7 @@ use crate::{
     PickableImageRect,
 };
 
-use super::{entity_iterator::process_archetype, SpatialViewVisualizerData};
+use super::{entity_iterator::process_archetype2, SpatialViewVisualizerData};
 
 pub struct ImageEncodedVisualizer {
     pub data: SpatialViewVisualizerData,
@@ -66,11 +67,14 @@ impl VisualizerSystem for ImageEncodedVisualizer {
             return Err(SpaceViewSystemExecutionError::NoRenderContextError);
         };
 
-        process_archetype::<Self, ImageEncoded, _>(
+        process_archetype2::<Self, ImageEncoded, _>(
             ctx,
             view_query,
             context_systems,
-            |ctx, spatial_ctx, results| self.process_image_encoded(ctx, results, spatial_ctx),
+            |ctx, spatial_ctx, results| {
+                self.process_image_encoded(ctx, results, spatial_ctx);
+                Ok(())
+            },
         )?;
 
         // TODO(#702): draw order is translated to depth offset, which works fine for opaque images,
@@ -124,34 +128,39 @@ impl ImageEncodedVisualizer {
     fn process_image_encoded(
         &mut self,
         ctx: &QueryContext<'_>,
-        results: &HybridResults<'_>,
+        results: &HybridResults2<'_>,
         spatial_ctx: &SpatialSceneEntityContext<'_>,
-    ) -> Result<(), SpaceViewSystemExecutionError> {
-        use re_space_view::RangeResultsExt as _;
+    ) {
+        use super::entity_iterator::iter_buffer;
+        use re_space_view::RangeResultsExt2 as _;
 
-        let resolver = ctx.recording().resolver();
         let entity_path = ctx.target_entity_path;
 
-        let blobs = match results.get_required_component_dense::<Blob>(resolver) {
-            Some(blobs) => blobs?,
-            _ => return Ok(()),
+        let Some(all_blob_chunks) = results.get_required_chunks(&Blob::name()) else {
+            return;
         };
 
-        let media_types = results.get_or_empty_dense::<MediaType>(resolver)?;
-        let opacities = results.get_or_empty_dense::<Opacity>(resolver)?;
+        let timeline = ctx.query.timeline();
+        let all_blobs_indexed = iter_buffer::<u8>(&all_blob_chunks, timeline, Blob::name());
+        let all_media_types = results.iter_as(timeline, MediaType::name());
+        let all_opacities = results.iter_as(timeline, Opacity::name());
 
-        for (&(_time, tensor_data_row_id), blobs, media_types, opacities) in range_zip_1x2(
-            blobs.range_indexed(),
-            media_types.range_indexed(),
-            opacities.range_indexed(),
+        for ((_time, tensor_data_row_id), blobs, media_types, opacities) in range_zip_1x2(
+            all_blobs_indexed,
+            all_media_types.string(),
+            all_opacities.primitive::<f32>(),
         ) {
             let Some(blob) = blobs.first() else {
                 continue;
             };
-            let media_type = media_types.and_then(|media_types| media_types.first());
+            let media_type = media_types.and_then(|media_types| media_types.first().cloned());
 
             let image = ctx.viewer_ctx.cache.entry(|c: &mut ImageDecodeCache| {
-                c.entry(tensor_data_row_id, blob, media_type.map(|mt| mt.as_str()))
+                c.entry(
+                    tensor_data_row_id,
+                    blob,
+                    media_type.as_ref().map(|mt| mt.as_str()),
+                )
             });
 
             let image = match image {
@@ -164,8 +173,8 @@ impl ImageEncodedVisualizer {
                 }
             };
 
-            let opacity = opacities.and_then(|opacity| opacity.first());
-
+            let opacity: Option<&Opacity> =
+                opacities.and_then(|opacity| opacity.first().map(bytemuck::cast_ref));
             let opacity = opacity.copied().unwrap_or_else(|| self.fallback_for(ctx));
             let multiplicative_tint =
                 re_renderer::Rgba::from_white_alpha(opacity.0.clamp(0.0, 1.0));
@@ -187,8 +196,6 @@ impl ImageEncodedVisualizer {
                 });
             }
         }
-
-        Ok(())
     }
 }
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools as _;
 
-use re_query::range_zip_1x2;
 use re_space_view::HybridResults2;
 use re_types::{
     archetypes::ImageEncoded,
@@ -145,7 +144,7 @@ impl ImageEncodedVisualizer {
         let all_media_types = results.iter_as(timeline, MediaType::name());
         let all_opacities = results.iter_as(timeline, Opacity::name());
 
-        for ((_time, tensor_data_row_id), blobs, media_types, opacities) in range_zip_1x2(
+        for ((_time, tensor_data_row_id), blobs, media_types, opacities) in re_query2::range_zip_1x2(
             all_blobs_indexed,
             all_media_types.string(),
             all_opacities.primitive::<f32>(),

--- a/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/image_encoded.rs
@@ -21,7 +21,7 @@ use crate::{
     PickableImageRect,
 };
 
-use super::{entity_iterator::process_archetype2, SpatialViewVisualizerData};
+use super::{entity_iterator::process_archetype, SpatialViewVisualizerData};
 
 pub struct ImageEncodedVisualizer {
     pub data: SpatialViewVisualizerData,
@@ -67,7 +67,7 @@ impl VisualizerSystem for ImageEncodedVisualizer {
             return Err(SpaceViewSystemExecutionError::NoRenderContextError);
         };
 
-        process_archetype2::<Self, ImageEncoded, _>(
+        process_archetype::<Self, ImageEncoded, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
@@ -1,10 +1,13 @@
 use itertools::Itertools as _;
 
-use re_space_view::HybridResults;
+use re_space_view::HybridResults2;
 use re_types::{
     archetypes::Image,
-    components::{self, ChannelDatatype, ColorModel, DrawOrder, Opacity, PixelFormat},
+    components::{
+        Blob, ChannelDatatype, ColorModel, DrawOrder, Opacity, PixelFormat, Resolution2D,
+    },
     image::ImageKind,
+    Loggable as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ImageFormat, ImageInfo, QueryContext,
@@ -20,7 +23,7 @@ use crate::{
     PickableImageRect,
 };
 
-use super::{entity_iterator::process_archetype, SpatialViewVisualizerData};
+use super::{entity_iterator::process_archetype2, SpatialViewVisualizerData};
 
 pub struct ImageVisualizer {
     pub data: SpatialViewVisualizerData,
@@ -71,11 +74,14 @@ impl VisualizerSystem for ImageVisualizer {
             return Err(SpaceViewSystemExecutionError::NoRenderContextError);
         };
 
-        process_archetype::<Self, Image, _>(
+        process_archetype2::<Self, Image, _>(
             ctx,
             view_query,
             context_systems,
-            |ctx, spatial_ctx, results| self.process_image(ctx, results, spatial_ctx),
+            |ctx, spatial_ctx, results| {
+                self.process_image(ctx, results, spatial_ctx);
+                Ok(())
+            },
         )?;
 
         // TODO(#702): draw order is translated to depth offset, which works fine for opaque images,
@@ -129,46 +135,47 @@ impl ImageVisualizer {
     fn process_image(
         &mut self,
         ctx: &QueryContext<'_>,
-        results: &HybridResults<'_>,
+        results: &HybridResults2<'_>,
         spatial_ctx: &SpatialSceneEntityContext<'_>,
-    ) -> Result<(), SpaceViewSystemExecutionError> {
-        use re_space_view::RangeResultsExt as _;
+    ) {
+        use super::entity_iterator::{iter_buffer, iter_primitive_array};
+        use re_space_view::RangeResultsExt2 as _;
 
-        let resolver = ctx.recording().resolver();
         let entity_path = ctx.target_entity_path;
 
-        let blobs = match results.get_required_component_dense::<components::Blob>(resolver) {
-            Some(blobs) => blobs?,
-            _ => return Ok(()),
+        let Some(all_blob_chunks) = results.get_required_chunks(&Blob::name()) else {
+            return;
         };
-        let resolutions =
-            match results.get_required_component_dense::<components::Resolution2D>(resolver) {
-                Some(resolutions) => resolutions?,
-                _ => return Ok(()),
-            };
+        let Some(all_resolution_chunks) = results.get_required_chunks(&Resolution2D::name()) else {
+            return;
+        };
 
-        let pixel_formats = results.get_or_empty_dense::<PixelFormat>(resolver)?;
-        let color_models = results.get_or_empty_dense::<ColorModel>(resolver)?;
-        let datatypes = results.get_or_empty_dense::<ChannelDatatype>(resolver)?;
-        let opacity = results.get_or_empty_dense(resolver)?;
+        let timeline = ctx.query.timeline();
+        let all_blobs_indexed = iter_buffer::<u8>(&all_blob_chunks, timeline, Blob::name());
+        let all_resolutions_indexed =
+            iter_primitive_array(&all_resolution_chunks, timeline, Resolution2D::name());
+        let all_pixel_formats = results.iter_as(timeline, PixelFormat::name());
+        let all_color_models = results.iter_as(timeline, ColorModel::name());
+        let all_channel_datatypes = results.iter_as(timeline, ChannelDatatype::name());
+        let all_opacities = results.iter_as(timeline, Opacity::name());
 
-        let data = re_query::range_zip_1x5(
-            blobs.range_indexed(),
-            resolutions.range_indexed(),
-            pixel_formats.range_indexed(),
-            color_models.range_indexed(),
-            datatypes.range_indexed(),
-            opacity.range_indexed(),
+        let data = re_query2::range_zip_1x5(
+            all_blobs_indexed,
+            all_resolutions_indexed,
+            all_pixel_formats.component::<PixelFormat>(),
+            all_color_models.component::<ColorModel>(),
+            all_channel_datatypes.component::<ChannelDatatype>(),
+            all_opacities.primitive::<f32>(),
         )
         .filter_map(
-            |(&index, blobs, resolutions, pixel_formats, color_models, datatypes, opacities)| {
+            |(index, blobs, resolutions, pixel_formats, color_models, datatypes, opacities)| {
                 let blob = blobs.first()?.0.clone();
 
-                let format = if let Some(pixel_format) = first_copied(pixel_formats) {
+                let format = if let Some(pixel_format) = first_copied(pixel_formats.as_deref()) {
                     ImageFormat::PixelFormat(pixel_format)
                 } else {
-                    let color_model = first_copied(color_models)?;
-                    let datatype = first_copied(datatypes)?;
+                    let color_model = first_copied(color_models.as_deref())?;
+                    let datatype = first_copied(datatypes.as_deref())?;
                     ImageFormat::ColorModel {
                         color_model,
                         datatype,
@@ -178,13 +185,13 @@ impl ImageVisualizer {
                 Some(ImageComponentData {
                     image: ImageInfo {
                         blob_row_id: index.1,
-                        blob,
-                        resolution: first_copied(resolutions)?.0 .0,
+                        blob: re_types::datatypes::Blob(blob.into()),
+                        resolution: first_copied(resolutions)?,
                         format,
                         kind: ImageKind::Color,
                         colormap: None,
                     },
-                    opacity: first_copied(opacities),
+                    opacity: first_copied(opacities).map(Into::into),
                 })
             },
         );
@@ -211,8 +218,6 @@ impl ImageVisualizer {
                 });
             }
         }
-
-        Ok(())
     }
 }
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
@@ -23,7 +23,7 @@ use crate::{
     PickableImageRect,
 };
 
-use super::{entity_iterator::process_archetype2, SpatialViewVisualizerData};
+use super::{entity_iterator::process_archetype, SpatialViewVisualizerData};
 
 pub struct ImageVisualizer {
     pub data: SpatialViewVisualizerData,
@@ -74,7 +74,7 @@ impl VisualizerSystem for ImageVisualizer {
             return Err(SpaceViewSystemExecutionError::NoRenderContextError);
         };
 
-        process_archetype2::<Self, Image, _>(
+        process_archetype::<Self, Image, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -185,8 +185,8 @@ impl VisualizerSystem for Lines2DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array_list, process_archetype2};
-        process_archetype2::<Self, LineStrips2D, _>(
+        use super::entity_iterator::{iter_primitive_array_list, process_archetype};
+        process_archetype::<Self, LineStrips2D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -190,8 +190,8 @@ impl VisualizerSystem for Lines3DVisualizer {
         let mut line_builder = re_renderer::LineDrawableBuilder::new(render_ctx);
         line_builder.radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array_list, process_archetype2};
-        process_archetype2::<Self, LineStrips3D, _>(
+        use super::entity_iterator::{iter_primitive_array_list, process_archetype};
+        process_archetype::<Self, LineStrips3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -176,8 +176,8 @@ impl VisualizerSystem for Mesh3DVisualizer {
 
         let mut instances = Vec::new();
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Mesh3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Mesh3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -211,8 +211,8 @@ impl VisualizerSystem for Points2DVisualizer {
         line_builder
             .radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Points2D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Points2D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -200,8 +200,8 @@ impl VisualizerSystem for Points3DVisualizer {
         line_builder
             .radius_boost_in_ui_points_for_outlines(SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES);
 
-        use super::entity_iterator::{iter_primitive_array, process_archetype2};
-        process_archetype2::<Self, Points3D, _>(
+        use super::entity_iterator::{iter_primitive_array, process_archetype};
+        process_archetype::<Self, Points3D, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
@@ -72,9 +72,9 @@ impl VisualizerSystem for SegmentationImageVisualizer {
         };
 
         use super::entity_iterator::{
-            iter_buffer, iter_component, iter_primitive_array, process_archetype2,
+            iter_buffer, iter_component, iter_primitive_array, process_archetype,
         };
-        process_archetype2::<Self, SegmentationImage, _>(
+        process_archetype::<Self, SegmentationImage, _>(
             ctx,
             view_query,
             context_systems,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
@@ -105,7 +105,7 @@ impl VisualizerSystem for SegmentationImageVisualizer {
                     iter_component(&all_datatype_chunks, timeline, ChannelDatatype::name());
                 let all_opacities = results.iter_as(timeline, Opacity::name());
 
-                let data = re_query::range_zip_1x3(
+                let data = re_query2::range_zip_1x3(
                     all_blobs_indexed,
                     all_datatypes_indexed,
                     all_resolutions_indexed,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -1,10 +1,9 @@
 use itertools::Either;
+
 use re_chunk_store::{LatestAtQuery, RangeQuery};
 use re_log_types::{TimeInt, Timeline};
 use re_space_view::{
-    latest_at_with_blueprint_resolved_data, latest_at_with_blueprint_resolved_data2,
-    range_with_blueprint_resolved_data, range_with_blueprint_resolved_data2, HybridResults,
-    HybridResults2,
+    latest_at_with_blueprint_resolved_data2, range_with_blueprint_resolved_data2, HybridResults2,
 };
 use re_types::Archetype;
 use re_viewer_context::{
@@ -89,119 +88,9 @@ fn test_clamped_vec() {
     );
 }
 
-// --- Cached APIs ---
-
-pub fn query_archetype_with_history<'a, A: Archetype>(
-    ctx: &'a ViewContext<'a>,
-    timeline: &Timeline,
-    timeline_cursor: TimeInt,
-    query_range: &QueryRange,
-    data_result: &'a re_viewer_context::DataResult,
-) -> HybridResults<'a> {
-    match query_range {
-        QueryRange::TimeRange(time_range) => {
-            let range_query = RangeQuery::new(
-                *timeline,
-                re_log_types::ResolvedTimeRange::from_relative_time_range(
-                    time_range,
-                    timeline_cursor,
-                ),
-            );
-            let results = range_with_blueprint_resolved_data(
-                ctx,
-                None,
-                &range_query,
-                data_result,
-                A::all_components().iter().copied(),
-            );
-            (range_query, results).into()
-        }
-        QueryRange::LatestAt => {
-            let latest_query = LatestAtQuery::new(*timeline, timeline_cursor);
-            let query_shadowed_defaults = false;
-            let results = latest_at_with_blueprint_resolved_data(
-                ctx,
-                None,
-                &latest_query,
-                data_result,
-                A::all_components().iter().copied(),
-                query_shadowed_defaults,
-            );
-            (latest_query, results).into()
-        }
-    }
-}
-
-/// Iterates through all entity views for a given archetype.
-///
-/// The callback passed in gets passed along a [`SpatialSceneEntityContext`] which contains
-/// various useful information about an entity in the context of the current scene.
-pub fn process_archetype<System: IdentifiedViewSystem, A, F>(
-    ctx: &ViewContext<'_>,
-    query: &ViewQuery<'_>,
-    view_ctx: &ViewContextCollection,
-    mut fun: F,
-) -> Result<(), SpaceViewSystemExecutionError>
-where
-    A: Archetype,
-    F: FnMut(
-        &QueryContext<'_>,
-        &SpatialSceneEntityContext<'_>,
-        &HybridResults<'_>,
-    ) -> Result<(), SpaceViewSystemExecutionError>,
-{
-    let transforms = view_ctx.get::<TransformContext>()?;
-    let depth_offsets = view_ctx.get::<EntityDepthOffsets>()?;
-    let annotations = view_ctx.get::<AnnotationSceneContext>()?;
-
-    let latest_at = query.latest_at_query();
-
-    let system_identifier = System::identifier();
-
-    for data_result in query.iter_visible_data_results(ctx, system_identifier) {
-        let Some(transform_info) = transforms.transform_info_for_entity(&data_result.entity_path)
-        else {
-            continue;
-        };
-
-        let depth_offset_key = (system_identifier, data_result.entity_path.hash());
-        let entity_context = SpatialSceneEntityContext {
-            transform_info,
-            depth_offset: depth_offsets
-                .per_entity_and_visualizer
-                .get(&depth_offset_key)
-                .copied()
-                .unwrap_or_default(),
-            annotations: annotations.0.find(&data_result.entity_path),
-            highlight: query
-                .highlights
-                .entity_outline_mask(data_result.entity_path.hash()),
-            space_view_class_identifier: view_ctx.space_view_class_identifier(),
-        };
-
-        let results = query_archetype_with_history::<A>(
-            ctx,
-            &query.timeline,
-            query.latest_at,
-            data_result.query_range(),
-            data_result,
-        );
-
-        let mut query_ctx = ctx.query_context(data_result, &latest_at);
-        query_ctx.archetype_name = Some(A::name());
-
-        {
-            re_tracing::profile_scope!(format!("{}", data_result.entity_path));
-            fun(&query_ctx, &entity_context, &results)?;
-        }
-    }
-
-    Ok(())
-}
-
 // --- Chunk-based APIs ---
 
-pub fn query_archetype_with_history2<'a, A: Archetype>(
+pub fn query_archetype_with_history<'a, A: Archetype>(
     ctx: &'a ViewContext<'a>,
     timeline: &Timeline,
     timeline_cursor: TimeInt,
@@ -244,9 +133,9 @@ pub fn query_archetype_with_history2<'a, A: Archetype>(
 
 /// Iterates through all entity views for a given archetype.
 ///
-/// The callback passed in gets passed along an [`SpatialSceneEntityContext`] which contains
+/// The callback passed in gets passed along a [`SpatialSceneEntityContext`] which contains
 /// various useful information about an entity in the context of the current scene.
-pub fn process_archetype2<System: IdentifiedViewSystem, A, F>(
+pub fn process_archetype<System: IdentifiedViewSystem, A, F>(
     ctx: &ViewContext<'_>,
     query: &ViewQuery<'_>,
     view_ctx: &ViewContextCollection,
@@ -273,6 +162,7 @@ where
         else {
             continue;
         };
+
         let depth_offset_key = (system_identifier, data_result.entity_path.hash());
         let entity_context = SpatialSceneEntityContext {
             transform_info,
@@ -288,7 +178,7 @@ where
             space_view_class_identifier: view_ctx.space_view_class_identifier(),
         };
 
-        let results = query_archetype_with_history2::<A>(
+        let results = query_archetype_with_history::<A>(
             ctx,
             &query.timeline,
             query.latest_at,


### PR DESCRIPTION
Chunkified visualizers for all image types.

First signs of old APIs going away.
In particular, `re_space_view_spatial` has dropped its dependency on the old `re_query`.

- DNM: requires #7024

---

#### Image
![image](https://github.com/user-attachments/assets/548f2c9c-9843-470c-9ab6-611f7e677024)

#### ImageEncoded
![image](https://github.com/user-attachments/assets/0ae124bc-ef98-4d9c-91ac-077f62990a8c)

#### DepthImage
![image](https://github.com/user-attachments/assets/9a8b67b3-b85b-479b-b35f-0f43e2f10d58)

#### SegmentationImage
![image](https://github.com/user-attachments/assets/a32d4aff-d66e-4102-bdc8-ae77de641ab3)




---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7011?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7011)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.