### PR TITLE
Implement compress directly on top of image again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * `mesh_material: Material` has been renamed to `albedo_factor: AlbedoFactor` [#6841](https://github.com/rerun-io/rerun/pull/6841)
 * 3D transform APIs: Previously, the transform component was represented as one of several variants (an Arrow union, `enum` in Rust) depending on how the transform was expressed. Instead, there are now several components for translation/scale/rotation/matrices that can live side-by-side in the 3D transform archetype.
 * Python: `NV12/YUY2` are now logged with `Image`
-* `Image.compress` has been replaced by `ImageEncoded.compress`
 * [`ImageEncoded`](https://rerun.io/docs/reference/types/archetypes/image_encoded?speculative-link):s `format` parameter has been replaced with `media_type` (MIME)
 * [`DepthImage`](https://rerun.io/docs/reference/types/archetypes/depth_image) and [`SegmentationImage`](https://rerun.io/docs/reference/types/archetypes/segmentation_image) are no longer encoded as a tensors, and expects its shape in `[width, height]` order
 

--- a/crates/store/re_types/definitions/rerun/archetypes/image_encoded.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/image_encoded.fbs
@@ -5,7 +5,7 @@ namespace rerun.archetypes;
 ///
 /// Rerun also supports uncompressed images with the [archetypes.Image].
 ///
-/// \py To compress an image, use [`rerun.ImageEncoded.compress`][].
+/// \py To compress an image, use [`rerun.Image.compress`][].
 ///
 /// \example archetypes/image_encoded
 table ImageEncoded (

--- a/docs/content/reference/migration/migration-0-18.md
+++ b/docs/content/reference/migration/migration-0-18.md
@@ -13,13 +13,14 @@ The constructs have changed to now expect the shape in `[width, height]` order.
 
 
 ### [`Image`](https://rerun.io/docs/reference/types/archetypes/image)
-* `Image.compress` has been replaced by `ImageEncoded.compress`
-* `Image` now support chroma-downsampled images
-
-`Image(…)` now require a _color_model_ argument, e.g. "RGB" or "L"
-* Before: `rr.Image(image_rgb)`
-* Now: `rr.Image(image_rgb, "RGB")`
-
+* The `Image` data no longer uses `TensorData` internally.
+* `Image` now stores a raw buffer which is decoded with an image format including resolution and pixel format.
+  * This allows for more explicit support of chroma-downsampled formats such as NV12.
+* The `data` argument of the `Image()` constructor has been removed.
+  * The first default parameter is now `image`, which can be a `numpy.ArrayLike`, which will also be used to extract
+    the relevant metadata.
+  * Alternatively images can also be constructed using a `bytes` argument, but the resolution and pixel format must
+    be provided explicitly.
 
 ### [`ImageEncoded`](https://rerun.io/docs/reference/types/archetypes/image_encoded?speculative-link)
 `ImageEncoded` is our new archetype for logging an image file, e.g. a PNG or JPEG.

--- a/examples/python/arkit_scenes/README.md
+++ b/examples/python/arkit_scenes/README.md
@@ -36,7 +36,7 @@ To log a moving RGB-D camera, we log four key components: the camera's intrinsic
 ```python
 rr.log("world/camera_lowres", rr.Transform3D(transform=camera_from_world))
 rr.log("world/camera_lowres", rr.Pinhole(image_from_camera=intrinsic, resolution=[w, h]))
-rr.log(f"{entity_id}/rgb", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=95))
+rr.log(f"{entity_id}/rgb", rr.Image(rgb).compress(jpeg_quality=95))
 rr.log(f"{entity_id}/depth", rr.DepthImage(depth, meter=1000))
 ```
 

--- a/examples/python/arkit_scenes/arkit_scenes/__main__.py
+++ b/examples/python/arkit_scenes/arkit_scenes/__main__.py
@@ -242,7 +242,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
                 LOWRES_POSED_ENTITY_PATH,
             )
 
-            rr.log(f"{LOWRES_POSED_ENTITY_PATH}/rgb", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=95))
+            rr.log(f"{LOWRES_POSED_ENTITY_PATH}/rgb", rr.Image(rgb).compress(jpeg_quality=95))
             rr.log(f"{LOWRES_POSED_ENTITY_PATH}/depth", rr.DepthImage(depth, meter=1000))
 
         # log the high res camera
@@ -264,7 +264,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
 
             highres_rgb = cv2.cvtColor(highres_bgr, cv2.COLOR_BGR2RGB)
 
-            rr.log(f"{HIGHRES_ENTITY_PATH}/rgb", rr.ImageEncoded.compress(highres_rgb, "RGB", jpeg_quality=75))
+            rr.log(f"{HIGHRES_ENTITY_PATH}/rgb", rr.Image(highres_rgb).compress(jpeg_quality=75))
             rr.log(f"{HIGHRES_ENTITY_PATH}/depth", rr.DepthImage(highres_depth, meter=1000))
 
 

--- a/examples/python/detect_and_track_objects/README.md
+++ b/examples/python/detect_and_track_objects/README.md
@@ -41,7 +41,7 @@ The input video is logged as a sequence of [`Image`](https://www.rerun.io/docs/r
 ```python
 rr.log(
     "image",
-    rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=85)
+    rr.Image(rgb).compress(jpeg_quality=85)
 )
 ```
 
@@ -51,7 +51,7 @@ This allows us to subsequently visualize the segmentation mask on top of the vid
 ```python
 rr.log(
     "segmentation/rgb_scaled",
-    rr.ImageEncoded.compress(rgb_scaled, "RGB", jpeg_quality=85)
+    rr.Image(rgb_scaled).compress(jpeg_quality=85)
 )
 ```
 

--- a/examples/python/detect_and_track_objects/detect_and_track_objects.py
+++ b/examples/python/detect_and_track_objects/detect_and_track_objects.py
@@ -97,7 +97,7 @@ class Detector:
         _, _, scaled_height, scaled_width = inputs["pixel_values"].shape
         scaled_size = (scaled_width, scaled_height)
         rgb_scaled = cv2.resize(rgb, scaled_size)
-        rr.log("segmentation/rgb_scaled", rr.ImageEncoded.compress(rgb_scaled, "RGB", jpeg_quality=85))
+        rr.log("segmentation/rgb_scaled", rr.Image(rgb_scaled).compress(jpeg_quality=85))
 
         logging.debug("Pass image to detection network")
         outputs = self.model(**inputs)
@@ -358,7 +358,7 @@ def track_objects(video_path: str, *, max_frame_count: int | None) -> None:
             break
 
         rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-        rr.log("image", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=85))
+        rr.log("image", rr.Image(rgb).compress(jpeg_quality=85))
 
         if not trackers or frame_idx % 40 == 0:
             detections = detector.detect_objects_to_track(rgb=rgb, frame_idx=frame_idx)

--- a/examples/python/face_tracking/README.md
+++ b/examples/python/face_tracking/README.md
@@ -44,7 +44,7 @@ The input video is logged as a sequence of [`Image`](https://www.rerun.io/docs/r
 ```python
 rr.log(
     "video/image",
-    rr.ImageEncoded.compress(frame, "RGB", jpeg_quality=75)
+    rr.Image(frame).compress(jpeg_quality=75)
 )
 ```
 

--- a/examples/python/gesture_detection/README.md
+++ b/examples/python/gesture_detection/README.md
@@ -45,7 +45,7 @@ The input video is logged as a sequence of [`Image`](https://www.rerun.io/docs/r
 ```python
 rr.log(
     "Media/Video",
-    rr.ImageEncoded.compress(frame, "RGB", jpeg_quality=75)
+    rr.Image(frame).compress(jpeg_quality=75)
 )
 ```
 

--- a/examples/python/gesture_detection/gesture_detection.py
+++ b/examples/python/gesture_detection/gesture_detection.py
@@ -243,7 +243,7 @@ def run_from_video_capture(vid: int | str, max_frame_count: int | None) -> None:
             rr.set_time_sequence("frame_nr", frame_idx)
             rr.set_time_nanos("frame_time", frame_time_nano)
             detector.detect_and_log(frame, frame_time_nano)
-            rr.log("media/video", rr.ImageEncoded.compress(frame, "RGB", jpeg_quality=75))
+            rr.log("media/video", rr.Image(frame).compress(jpeg_quality=75))
 
     except KeyboardInterrupt:
         pass

--- a/examples/python/human_pose_tracking/README.md
+++ b/examples/python/human_pose_tracking/README.md
@@ -46,7 +46,7 @@ The input video is logged as a sequence of
 ```python
 rr.log(
     "video/rgb",
-    rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=75)
+    rr.Image(rgb).compress(jpeg_quality=75)
 )
 ```
 

--- a/examples/python/human_pose_tracking/human_pose_tracking.py
+++ b/examples/python/human_pose_tracking/human_pose_tracking.py
@@ -85,7 +85,7 @@ def track_pose(video_path: str, model_path: str, *, segment: bool, max_frame_cou
             h, w, _ = rgb.shape
             landmark_positions_2d = read_landmark_positions_2d(results, w, h)
 
-            rr.log("video/rgb", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=75))
+            rr.log("video/rgb", rr.Image(rgb).compress(jpeg_quality=75))
             if landmark_positions_2d is not None:
                 rr.log(
                     "video/pose/points",

--- a/examples/python/open_photogrammetry_format/open_photogrammetry_format.py
+++ b/examples/python/open_photogrammetry_format/open_photogrammetry_format.py
@@ -191,7 +191,7 @@ class OPFProject:
 
             if jpeg_quality is not None:
                 with Image.open(self.path.parent / camera.uri) as img:
-                    rr.log(entity + "/image/rgb", rr.ImageEncoded.compress(img, "RGB", jpeg_quality=jpeg_quality))
+                    rr.log(entity + "/image/rgb", rr.Image(img).compress(jpeg_quality=jpeg_quality))
             else:
                 rr.log(entity + "/image/rgb", rr.ImageEncoded(path=self.path.parent / camera.uri))
 

--- a/examples/python/rgbd/README.md
+++ b/examples/python/rgbd/README.md
@@ -40,7 +40,7 @@ rr.set_time_seconds("time", time.timestamp())
 ### Image
 The example image is logged as [`Image`](https://www.rerun.io/docs/reference/types/archetypes/image) to the `world/camera/image/rgb` entity.
 ```python
-rr.log("world/camera/image/rgb", rr.ImageEncoded.compress(img_rgb, "RGB", jpeg_quality=95))
+rr.log("world/camera/image/rgb", rr.Image(img_rgb).compress(jpeg_quality=95))
 ```
 
 ### Depth image

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -86,7 +86,7 @@ def log_nyud_data(recording_path: Path, subset_idx: int, frames: int) -> None:
             if f.filename.endswith(".ppm"):
                 buf = archive.read(f)
                 img_rgb = read_image_rgb(buf)
-                rr.log("world/camera/image/rgb", rr.ImageEncoded.compress(img_rgb, "RGB", jpeg_quality=95))
+                rr.log("world/camera/image/rgb", rr.Image(img_rgb).compress(jpeg_quality=95))
 
             elif f.filename.endswith(".pgm"):
                 buf = archive.read(f)

--- a/examples/python/structure_from_motion/README.md
+++ b/examples/python/structure_from_motion/README.md
@@ -45,7 +45,7 @@ rr.set_time_sequence("frame", frame_idx)
 The images are logged through the [`Image`](https://www.rerun.io/docs/reference/types/archetypes/image) to the `camera/image` entity.
 
 ```python
-rr.log("camera/image", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=75))
+rr.log("camera/image", rr.Image(rgb).compress(jpeg_quality=75))
 ```
 
 ### Cameras

--- a/examples/python/structure_from_motion/structure_from_motion/__main__.py
+++ b/examples/python/structure_from_motion/structure_from_motion/__main__.py
@@ -163,7 +163,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
             bgr = cv2.imread(str(image_file))
             bgr = cv2.resize(bgr, resize)
             rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-            rr.log("camera/image", rr.ImageEncoded.compress(rgb, "RGB", jpeg_quality=75))
+            rr.log("camera/image", rr.Image(rgb).compress(jpeg_quality=75))
         else:
             rr.log("camera/image", rr.ImageEncoded(path=dataset_path / "images" / image.name))
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_encoded.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_encoded.py
@@ -23,7 +23,7 @@ class ImageEncoded(ImageEncodedExt, Archetype):
 
     Rerun also supports uncompressed images with the [`archetypes.Image`][rerun.archetypes.Image].
 
-    To compress an image, use [`rerun.ImageEncoded.compress`][].
+    To compress an image, use [`rerun.Image.compress`][].
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
 
+from io import BytesIO
 from typing import TYPE_CHECKING, Any, Union
 
 import numpy as np
 import numpy.typing as npt
 
-from rerun.components.channel_datatype import ChannelDatatype, ChannelDatatypeLike
-from rerun.components.color_model import ColorModel, ColorModelLike
-from rerun.components.pixel_format import PixelFormatLike
-
-from ..components import Resolution2D
+from ..components import ChannelDatatype, ChannelDatatypeLike, Resolution2D
+from ..components.color_model import ColorModel, ColorModelLike
+from ..components.pixel_format import PixelFormat, PixelFormatLike
 from ..datatypes import Float32Like
-from ..error_utils import _send_warning_or_raise
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
 
 if TYPE_CHECKING:
     ImageLike = Union[
@@ -27,6 +26,7 @@ if TYPE_CHECKING:
         npt.NDArray[np.uint64],
         npt.NDArray[np.uint8],
     ]
+    from . import Image, ImageEncoded
 
 
 def _to_numpy(tensor: ImageLike) -> npt.NDArray[Any]:
@@ -228,3 +228,91 @@ class ImageExt:
             opacity=opacity,
             draw_order=draw_order,
         )
+
+    def compress(self: Any, jpeg_quality: int = 95) -> ImageEncoded | Image:
+        """
+        Compress the given image as a JPEG.
+
+        JPEG compression works best for photographs.
+        Only RGB and grayscale images are supported, not RGBA.
+        Note that compressing to JPEG costs a bit of CPU time,
+        both when logging and later when viewing them.
+
+        Parameters
+        ----------
+        jpeg_quality:
+            Higher quality = larger file size.
+            A quality of 95 saves a lot of space, but is still visually very similar.
+
+        """
+
+        from PIL import Image as PILImage
+
+        from ..archetypes import ImageEncoded
+
+        with catch_and_log_exceptions(context="Image compression"):
+            pixel_format = None
+            if self.pixel_format is not None:
+                pixel_format = PixelFormat(self.pixel_format.as_arrow_array().storage.type_codes[0].as_py())
+
+            # TODO(jleibs): Support conversions here
+            if pixel_format is not None:
+                raise ValueError(f"Cannot JPEG compress an image with pixel_format {pixel_format}")
+
+            color_model = None
+            if self.color_model is not None:
+                color_model = ColorModel(self.color_model.as_arrow_array().storage.type_codes[0].as_py())
+
+            if color_model not in (ColorModel.L, ColorModel.RGB):
+                # TODO(#2340): BGR support!
+                raise ValueError(
+                    f"Cannot JPEG compress an image of type {color_model}. Only L (monochrome) and RGB are supported."
+                )
+
+            datatype = None
+            if self.datatype is not None:
+                datatype = ChannelDatatype(self.datatype.as_arrow_array().storage.type_codes[0].as_py())
+
+            if datatype is None:
+                raise ValueError("Cannot JPEG compress an image without a datatype")
+
+            width = None
+            height = None
+            if self.resolution is not None:
+                resolution = self.resolution.as_arrow_array()[0].as_py()
+                width = resolution[0]
+                height = resolution[1]
+
+            if width is None or height is None:
+                raise ValueError("Cannot JPEG compress an image without a resolution")
+
+            buf = None
+            if self.data is not None:
+                buf = bytes(self.data.as_arrow_array().storage[0].as_py())
+
+            if buf is None:
+                raise ValueError("Cannot JPEG compress an image without data")
+
+            # Convert from bytes back to a numpy array
+            image: npt.NDArray[Any] = np.frombuffer(buf, dtype=datatype.to_np_dtype(), count=-1, offset=0)
+
+            if color_model == ColorModel.L:
+                image = image.reshape(height, width)
+            else:
+                image = image.reshape(height, width, 3)
+
+            if image.dtype not in ["uint8", "sint32", "float32"]:
+                # Convert to a format supported by Image.fromarray
+                image = image.astype("float32")
+
+            mode = str(color_model)
+
+            pil_image = PILImage.fromarray(image, mode=mode)
+            output = BytesIO()
+            pil_image.save(output, format="JPEG", quality=jpeg_quality)
+            jpeg_bytes = output.getvalue()
+            output.close()
+            return ImageEncoded(contents=jpeg_bytes, media_type="image/jpeg")
+
+        # On failure to compress, return a raw image
+        return self  # type: ignore[no-any-return]

--- a/rerun_py/rerun_sdk/rerun/components/channel_datatype_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/channel_datatype_ext.py
@@ -29,3 +29,21 @@ class ChannelDatatypeExt:
             np.float64: ChannelDatatype.F64,
         }
         return channel_datatype_from_np_dtype[dtype.type]
+
+    def to_np_dtype(self: Any) -> type:
+        from . import ChannelDatatype
+
+        channel_datatype_to_np_dtype = {
+            ChannelDatatype.U8: np.uint8,
+            ChannelDatatype.U16: np.uint16,
+            ChannelDatatype.U32: np.uint32,
+            ChannelDatatype.U64: np.uint64,
+            ChannelDatatype.I8: np.int8,
+            ChannelDatatype.I16: np.int16,
+            ChannelDatatype.I32: np.int32,
+            ChannelDatatype.I64: np.int64,
+            ChannelDatatype.F16: np.float16,
+            ChannelDatatype.F32: np.float32,
+            ChannelDatatype.F64: np.float64,
+        }
+        return channel_datatype_to_np_dtype[self]

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -123,3 +123,23 @@ def test_image_compress() -> None:
         assert "Cannot JPEG compress an image of type" in str(warnings[0])
 
         assert type(compressed) is rr.Image
+
+    # 16-bit Not supported
+    with pytest.warns(RerunWarning) as warnings:
+        image_data = np.asarray(rng.uniform(0, 255, (10, 20, 3)), dtype=np.uint16)
+        compressed = rr.Image(image_data).compress(jpeg_quality=80)
+
+        assert len(warnings) == 1
+        assert "Cannot JPEG compress an image of datatype" in str(warnings[0])
+
+        assert type(compressed) is rr.Image
+
+    # Floating point not supported
+    with pytest.warns(RerunWarning) as warnings:
+        image_data = np.asarray(rng.uniform(0, 255, (10, 20)), dtype=np.float32)
+        compressed = rr.Image(image_data).compress(jpeg_quality=80)
+
+        assert len(warnings) == 1
+        assert "Cannot JPEG compress an image of datatype" in str(warnings[0])
+
+        assert type(compressed) is rr.Image

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -105,31 +105,19 @@ def test_image_compress() -> None:
     # RGB Supported
     image_data = np.asarray(rng.uniform(0, 255, (10, 20, 3)), dtype=np.uint8)
 
-    compressed = rr.ImageEncoded.compress(image_data, "RGB", jpeg_quality=80)
-    assert type(compressed) is rr.ImageEncoded
-
-    compressed = rr.ImageEncoded.compress(image_data, jpeg_quality=80)
+    compressed = rr.Image(image_data).compress(jpeg_quality=80)
     assert type(compressed) is rr.ImageEncoded
 
     # Mono Supported
     image_data = np.asarray(rng.uniform(0, 255, (10, 20)), dtype=np.uint8)
 
-    compressed = rr.ImageEncoded.compress(image_data, "L", jpeg_quality=80)
+    compressed = rr.Image(image_data).compress(jpeg_quality=80)
     assert type(compressed) is rr.ImageEncoded
 
     # RGBA Not supported
     with pytest.warns(RerunWarning) as warnings:
         image_data = np.asarray(rng.uniform(0, 255, (10, 20, 4)), dtype=np.uint8)
-        compressed = rr.ImageEncoded.compress(image_data, "RGBA", jpeg_quality=80)
-
-        assert len(warnings) == 1
-        assert "Cannot JPEG compress an image of type" in str(warnings[0])
-
-        assert type(compressed) is rr.Image
-
-    with pytest.warns(RerunWarning) as warnings:
-        image_data = np.asarray(rng.uniform(0, 255, (10, 20, 4)), dtype=np.uint8)
-        compressed = rr.ImageEncoded.compress(image_data, jpeg_quality=80)
+        compressed = rr.Image(image_data, "RGBA").compress(jpeg_quality=80)
 
         assert len(warnings) == 1
         assert "Cannot JPEG compress an image of type" in str(warnings[0])


### PR DESCRIPTION
### What
- Move the .compress API back from ImageEncoded to Image.

This requires a bit of hand-crafting python pseudo-deserializers, but nothing too awful.

In the process of testing I discovered the floating point / signed int pathways never worked correctly and resulted in corrupted data.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7036?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7036?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7036)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.