### PR TITLE
Fix image round trip test and add backwards compatible converter

### DIFF
--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -177,6 +177,11 @@ class TensorDataExt:
             fields=[data_type.field("shape"), data_type.field("buffer")],
         ).cast(data_type)
 
+    def numpy(self: Any, force: bool) -> npt.NDArray[Any]:
+        """Convert the TensorData back to a numpy array."""
+        dims = [d.size for d in self.shape]
+        return self.buffer.inner.reshape(dims)
+
 
 ################################################################################
 # Internal construction helpers

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -180,7 +180,7 @@ class TensorDataExt:
     def numpy(self: Any, force: bool) -> npt.NDArray[Any]:
         """Convert the TensorData back to a numpy array."""
         dims = [d.size for d in self.shape]
-        return self.buffer.inner.reshape(dims)
+        return self.buffer.inner.reshape(dims)  # type: ignore[no-any-return]
 
 
 ################################################################################

--- a/rerun_py/tests/unit/test_image.py
+++ b/rerun_py/tests/unit/test_image.py
@@ -7,6 +7,7 @@ import pytest
 import rerun as rr
 import torch
 from rerun.archetypes.image import Image
+from rerun.datatypes.tensor_data import TensorData
 from rerun.error_utils import RerunWarning
 
 rng = np.random.default_rng(12345)
@@ -39,6 +40,8 @@ IMAGE_INPUTS: list[Any] = [
         "width": 20,
         "height": 10,
     },
+    # This was allowed in 0.17
+    {"image": TensorData(array=RANDOM_IMAGE_SOURCE)},
 ]
 
 

--- a/tests/python/roundtrips/image/main.py
+++ b/tests/python/roundtrips/image/main.py
@@ -8,7 +8,6 @@ import argparse
 
 import numpy as np
 import rerun as rr
-from rerun.datatypes import TensorData
 
 
 def main() -> None:
@@ -26,8 +25,6 @@ def main() -> None:
         image[i, :, 1] = i
     image[:, :, 2] = 128
 
-    image = TensorData(array=image)
-
     rr.log("image", rr.Image(image))
 
     # h=4, w=5 mono image. Pixel = x * y * 123.4
@@ -35,8 +32,6 @@ def main() -> None:
     for i in range(4):
         for j in range(5):
             image[i, j] = i * j * 123.4
-
-    image = TensorData(array=image)
 
     rr.log("image_f16", rr.Image(image))
 


### PR DESCRIPTION
### What
The roundtrip test happened to use an uncommon interface for constructing an image by passing in a TensorData.

However, just in case users are already doing this I figured it would be nice if we didn't break their code.  We already coerce any thing that exposes the `.numpy()` method, and there's no good reason TensorData shouldn't allow itself to be converted back to a numpy array.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7037?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7037?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7037)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.