### PR TITLE
Allow logging batches of quaternions from numpy arrays

### DIFF
--- a/crates/store/re_types/definitions/rerun/datatypes/quaternion.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/quaternion.fbs
@@ -8,6 +8,7 @@ namespace rerun.datatypes;
 /// datastore as provided, when used in the Viewer Quaternions will always be normalized.
 struct Quaternion (
   "attr.arrow.transparent",
+  "attr.python.array_aliases": "npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]]",
   "attr.rust.derive": "Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable",
   "attr.rust.tuple_struct",
   "attr.rust.repr": "C",

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -44,8 +44,7 @@ class Quaternion(QuaternionExt):
 
 QuaternionLike = Quaternion
 QuaternionArrayLike = Union[
-    Quaternion,
-    Sequence[QuaternionLike],
+    Quaternion, Sequence[QuaternionLike], npt.NDArray[Any], npt.ArrayLike, Sequence[Sequence[float]]
 ]
 
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion_ext.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Sequence
 
 import numpy as np
 import numpy.typing as npt
@@ -29,10 +29,14 @@ class QuaternionExt:
 
     @staticmethod
     def native_to_pa_array_override(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import Quaternion
+        # TODO(ab): get rid of this once we drop support for Python 3.8. Make sure to pin numpy>=1.25.
+        if NUMPY_VERSION < (1, 25):
+            # Older numpy doesn't seem to support `data` in the form of [Point3D(1, 2), Point3D(3, 4)]
+            # this happens for python 3.8 (1.25 supports 3.9+)
+            from . import Quaternion
 
-        if isinstance(data, Quaternion):
-            data = [data]
+            if isinstance(data, Sequence):
+                data = [np.array(p.xyzw) if isinstance(p, Quaternion) else p for p in data]  # type: ignore[assignment]
 
-        quaternions = flat_np_float32_array_from_array_like([q.xyzw for q in data], 4)
-        return pa.FixedSizeListArray.from_arrays(quaternions, type=data_type)
+        points = flat_np_float32_array_from_array_like(data, 4)
+        return pa.FixedSizeListArray.from_arrays(points, type=data_type)

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion_ext.py
@@ -38,5 +38,5 @@ class QuaternionExt:
             if isinstance(data, Sequence):
                 data = [np.array(p.xyzw) if isinstance(p, Quaternion) else p for p in data]  # type: ignore[assignment]
 
-        points = flat_np_float32_array_from_array_like(data, 4)
-        return pa.FixedSizeListArray.from_arrays(points, type=data_type)
+        quaternions = flat_np_float32_array_from_array_like(data, 4)
+        return pa.FixedSizeListArray.from_arrays(quaternions, type=data_type)

--- a/rerun_py/tests/unit/common_arrays.py
+++ b/rerun_py/tests/unit/common_arrays.py
@@ -215,7 +215,7 @@ def uvec3ds_expected(obj: Any, type_: Any | None = None) -> Any:
     return type_._optional(expected)
 
 
-quaternion_arrays: list[QuaternionArrayLike] = [
+quaternions_arrays: list[QuaternionArrayLike] = [
     [],
     Quaternion(xyzw=[1, 2, 3, 4]),
     Quaternion(xyzw=[1.0, 2.0, 3.0, 4.0]),
@@ -225,13 +225,15 @@ quaternion_arrays: list[QuaternionArrayLike] = [
         Quaternion(xyzw=np.array([1, 2, 3, 4])),
         Quaternion(xyzw=[1, 2, 3, 4]),
     ],
+    # QuaternionArrayLike: npt.NDArray[np.float32]
+    np.array([[1, 2, 3, 4], [1, 2, 3, 4]], dtype=np.float32),
 ]
 
 
-def expected_quaternions(rotations: QuaternionArrayLike, type_: Any) -> Any:
+def quaternions_expected(rotations: QuaternionArrayLike, type_: Any) -> Any:
     if rotations is None:
         return type_._optional(None)
-    elif hasattr(rotations, "__len__") and len(rotations) == 0:
+    elif hasattr(rotations, "__len__") and len(rotations) == 0:  # type: ignore[arg-type]
         return type_._optional(rotations)
     elif isinstance(rotations, Quaternion):
         return type_._optional(Quaternion(xyzw=[1, 2, 3, 4]))

--- a/rerun_py/tests/unit/test_box3d.py
+++ b/rerun_py/tests/unit/test_box3d.py
@@ -20,11 +20,11 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    expected_quaternions,
     expected_rotation_axis_angles,
     labels_arrays,
     labels_expected,
-    quaternion_arrays,
+    quaternions_arrays,
+    quaternions_expected,
     radii_arrays,
     radii_expected,
     rotation_axis_angle_arrays,
@@ -42,7 +42,7 @@ def test_boxes3d() -> None:
         half_sizes_arrays,
         centers_arrays,
         rotation_axis_angle_arrays,
-        quaternion_arrays,
+        quaternions_arrays,
         colors_arrays,
         radii_arrays,
         fill_mode_arrays,
@@ -105,7 +105,7 @@ def test_boxes3d() -> None:
         assert arch.rotation_axis_angles == expected_rotation_axis_angles(
             rotation_axis_angles, LeafRotationAxisAngleBatch
         )
-        assert arch.quaternions == expected_quaternions(quaternions, LeafRotationQuatBatch)
+        assert arch.quaternions == quaternions_expected(quaternions, LeafRotationQuatBatch)
         assert arch.colors == colors_expected(colors)
         assert arch.radii == radii_expected(radii)
         assert arch.fill_mode == rr.components.FillModeBatch._optional(fill_mode)

--- a/rerun_py/tests/unit/test_ellipsoids3d.py
+++ b/rerun_py/tests/unit/test_ellipsoids3d.py
@@ -20,11 +20,11 @@ from .common_arrays import (
     class_ids_expected,
     colors_arrays,
     colors_expected,
-    expected_quaternions,
     expected_rotation_axis_angles,
     labels_arrays,
     labels_expected,
-    quaternion_arrays,
+    quaternions_arrays,
+    quaternions_expected,
     radii_arrays,
     radii_expected,
     rotation_axis_angle_arrays,
@@ -42,7 +42,7 @@ def test_ellipsoids() -> None:
         half_sizes_arrays,
         centers_arrays,
         rotation_axis_angle_arrays,
-        quaternion_arrays,
+        quaternions_arrays,
         colors_arrays,
         radii_arrays,
         fill_mode_arrays,
@@ -105,7 +105,7 @@ def test_ellipsoids() -> None:
         assert arch.rotation_axis_angles == expected_rotation_axis_angles(
             rotation_axis_angles, LeafRotationAxisAngleBatch
         )
-        assert arch.quaternions == expected_quaternions(quaternions, LeafRotationQuatBatch)
+        assert arch.quaternions == quaternions_expected(quaternions, LeafRotationQuatBatch)
         assert arch.colors == colors_expected(colors)
         assert arch.line_radii == radii_expected(line_radii)
         assert arch.fill_mode == rr.components.FillModeBatch._optional(fill_mode)

--- a/rerun_py/tests/unit/test_quaternion.py
+++ b/rerun_py/tests/unit/test_quaternion.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from rerun.datatypes import (
+    QuaternionArrayLike,
+    QuaternionBatch,
+)
+
+from .common_arrays import (
+    quaternions_arrays,
+    quaternions_expected,
+)
+
+
+@pytest.mark.parametrize("data", quaternions_arrays)
+def test_quaternion_array_valid(data: QuaternionArrayLike) -> None:
+    assert QuaternionBatch(data) == quaternions_expected(data, QuaternionBatch)
+
+
+QUATERNION_INVALID_ARRAYS_INPUT = [
+    [1],
+    [1, 2],
+    [1, 2, 3],
+    # Single quaternions are via type checking encouraged to be constructed explicitly,
+    # but we don't enforce that.
+    # [1, 2, 3, 4],
+    [1, 2, 3, 4, 5],
+    [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    [[1], [2], [3], [4]],
+    [[1, 2, 3, 4], [4, 5]],
+    [[1, 2, 3, 4], [4, 5, 6, 7, 8]],
+    [[1, 2, 3, 4, 5], [4, 5, 6, 7]],
+]
+
+
+@pytest.mark.parametrize("data", QUATERNION_INVALID_ARRAYS_INPUT)
+def test_quaternion_array_invalid(data: QuaternionArrayLike) -> None:
+    with pytest.raises(ValueError):
+        QuaternionBatch(data)
+    with pytest.raises(ValueError):
+        QuaternionBatch(np.array(data))


### PR DESCRIPTION
### What

We generally want to encourage the explicit quaternion constructor: `Quaternion(xyzw=[1,2,3,4])` since the ordering of the elements in a quaternion isn't standardized widely enough.
However, in many situations a user may just have a raw array of quaternions which is already in the correct configuration and wants to log that.

Prior to this PR `rerun.components.RotationQuatBatch(my_np_array)` would have failed.

Therefore, this PR relaxes this restriction, making the serailization code identical to vec4, but keeping the explicit constructor & more restrictive type checking for single elements.

(This came up during testing/benchmarking of batch logging of transforms)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7038?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7038?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7038)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.