### PR TITLE
Python benchmark for transform logging over time

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -289,7 +289,7 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends_on = [
 # Dedicated alias for building the python bindings for the `py` environment.
 py-build = "pixi run -e py py-build-common"
 
-# Dedicated alias for building the python bindings in release modefor the `py` environment.
+# Dedicated alias for building the python bindings in release mode for the `py` environment.
 py-build-release = "pixi run -e py py-build-common-release"
 
 # Helper alias to run the python interpreter in the context of the python environment

--- a/pixi.toml
+++ b/pixi.toml
@@ -114,6 +114,9 @@ rerun = "cargo run --package rerun-cli --no-default-features --features native_v
 # Compile `rerun-cli` without the web-viewer.
 rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer"
 
+# Compile `rerun-cli` without the web-viewer.
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer"
+
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
@@ -270,6 +273,10 @@ js-build-all = { cmd = "yarn --cwd rerun_js workspaces run build", depends_on = 
 py-build-common = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
   "rerun-build", # We need to build rerun-cli since it is bundled in the python package.
 ] }
+py-build-common-release = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --release --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
+  "rerun-build-release", # We need to build rerun-cli since it is bundled in the python package.
+] }
+
 
 # Build the `rerun-notebook` package.
 py-build-notebook = { cmd = "pip install -e rerun_notebook", depends_on = [
@@ -282,11 +289,14 @@ py-build-notebook = { cmd = "pip install -e rerun_notebook", depends_on = [
 # Dedicated alias for building the python bindings for the `py` environment.
 py-build = "pixi run -e py py-build-common"
 
+# Dedicated alias for building the python bindings in release modefor the `py` environment.
+py-build-release = "pixi run -e py py-build-common-release"
+
 # Helper alias to run the python interpreter in the context of the python environment
 rrpy = "python"
 
 py-bench = { cmd = "python -m pytest -c rerun_py/pyproject.toml --benchmark-only", depends_on = [
-  "py-build",
+  "py-build-release",
 ] }
 
 py-plot-dashboard = { cmd = "python tests/python/plot_dashboard_stress/main.py", depends_on = [

--- a/tests/python/log_benchmark/__init__.py
+++ b/tests/python/log_benchmark/__init__.py
@@ -16,7 +16,7 @@ class Point3DInput:
     label: str = "some label"
 
     @classmethod
-    def prepare(cls, seed: int, num_points: int):
+    def prepare(cls, seed: int, num_points: int) -> None:
         rng = np.random.default_rng(seed=seed)
 
         return cls(

--- a/tests/python/log_benchmark/test_log_benchmark.py
+++ b/tests/python/log_benchmark/test_log_benchmark.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 import rerun as rr
@@ -9,7 +11,7 @@ import rerun as rr
 from . import Point3DInput
 
 
-def log_points3d_large_batch(data: Point3DInput):
+def log_points3d_large_batch(data: Point3DInput) -> None:
     # create a new, empty memory sink for the current recording
     rr.memory_recording()
 
@@ -20,13 +22,13 @@ def log_points3d_large_batch(data: Point3DInput):
 
 
 @pytest.mark.parametrize("num_points", [50_000_000])
-def test_bench_points3d_large_batch(benchmark, num_points):
+def test_bench_points3d_large_batch(benchmark: Any, num_points: int) -> None:
     rr.init("rerun_example_benchmark_points3d_large_batch")
     data = Point3DInput.prepare(42, num_points)
     benchmark(log_points3d_large_batch, data)
 
 
-def log_points3d_many_individual(data: Point3DInput):
+def log_points3d_many_individual(data: Point3DInput) -> None:
     # create a new, empty memory sink for the current recording
     rr.memory_recording()
 
@@ -38,13 +40,13 @@ def log_points3d_many_individual(data: Point3DInput):
 
 
 @pytest.mark.parametrize("num_points", [100_000])
-def test_bench_points3d_many_individual(benchmark, num_points):
+def test_bench_points3d_many_individual(benchmark: Any, num_points: int) -> None:
     rr.init("rerun_example_benchmark_points3d_many_individual")
     data = Point3DInput.prepare(1337, num_points)
     benchmark(log_points3d_many_individual, data)
 
 
-def log_image(image: np.ndarray, num_log_calls):
+def log_image(image: np.ndarray, num_log_calls: int) -> None:
     # create a new, empty memory sink for the current recording
     rr.memory_recording()
 
@@ -56,7 +58,7 @@ def log_image(image: np.ndarray, num_log_calls):
     ["image_dimension", "image_channels", "num_log_calls"],
     [pytest.param(16_384, 4, 4, id="16384^2px-4channels-4calls")],
 )
-def test_bench_image(benchmark, image_dimension, image_channels, num_log_calls):
+def test_bench_image(benchmark: Any, image_dimension: int, image_channels: int, num_log_calls: int) -> None:
     rr.init("rerun_example_benchmark_image")
 
     image = np.zeros((image_dimension, image_dimension, image_channels), dtype=np.uint8)


### PR DESCRIPTION
### What

* based on https://github.com/rerun-io/rerun/pull/7038

Adds a new log benchmark for transforms, python only for the moment (will likely add C++ and Rust as part of https://github.com/rerun-io/rerun/issues/6810).

Also, fixes the python benchmark setup to use release builds (oops!).

---

Benchmark results on my windows machine:
```
------------------------------------------------------------------------------------------------- benchmark: 3 tests -------------------------------------------------------------------------------------------------
Name (time in ms)                                    Min                 Max                Mean             StdDev              Median                IQR            Outliers       OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_bench_transforms_over_time[10000-1000]       1.0250 (1.0)        9.1189 (1.0)        1.1567 (1.0)       0.3008 (1.0)        1.1212 (1.0)       0.0974 (1.0)         14;36  864.5532 (1.0)         776           1
test_bench_transforms_over_time[10000-100]        7.9997 (7.80)      17.3248 (1.90)       8.8829 (7.68)      1.0412 (3.46)       8.6579 (7.72)      0.4209 (4.32)          3;5  112.5764 (0.13)        101           1
test_bench_transforms_over_time[10000-1]        830.6972 (810.44)   914.6887 (100.31)   860.9382 (744.33)   38.8470 (129.13)   835.1398 (744.83)   62.9516 (646.32)        1;0    1.1615 (0.00)          5           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
In short: logging 10k transforms with rotation/scale/transform on an incrementing integer timescale takes:
* 100x batches of 100:  **8.7ms**
* 10x batches of 1000: **1.1ms**
* individually: **835ms**

batch count scales pretty much linear which implies that each log call has roughly the same overhead, independent of the number of transforms logged.

(note that this benchmark logs to a memory recording)

----

* Fixes #4227
   * or rather confirmed it being fixed now
   * cc: @nubertj please do reopen that issue if you still have issues with transform logging performance on 0.18 (once out) or current [development builds](https://github.com/rerun-io/rerun/releases/tag/prerelease) (in case you get to it)

To confirm this I took [Jeremy's quick benchmark](https://github.com/rerun-io/rerun/issues/4227#issuecomment-1811617323) from the ticket and extended it a bit to include batches:
```python
import time

import numpy as np
import rerun as rr

rr.init("rerun_example_transforms", spawn=True)
rr.set_time_sequence("frame", 0)

arrow = rr.Arrows3D(origins=[0, 0, 0], vectors=[0, 1, 0])

rr.log("base/arrow", arrow)

rand_trans = np.random.rand(1000, 3)
rand_quats = np.random.rand(1000, 4)

start = time.time()
for i in range(1000):
    rr.log(
        "base/arrow",
        rr.Transform3D(
            translation=rand_trans[i],
            rotation=rr.Quaternion(xyzw=rand_quats[i]),
        ),
    )

ellapsed = time.time() - start
print(
    f"Time to log 1000 transforms: {ellapsed:.3f}s. ({1000 / ellapsed:.3f}s transforms / sec)"
)


###########################################################
# Temporal batch transform logging (fails on Rerun 0.17.0)
###########################################################

times = np.arange(1000)

start = time.time()
rr.log_temporal_batch(
    "base/arrow",
    times=[rr.TimeSequenceBatch("frame", times)],
    components=[
        rr.Transform3D.indicator(),
        rr.components.Translation3DBatch(rand_trans),
        rr.components.RotationQuatBatch(rand_quats),
    ],
)
ellapsed = time.time() - start

print(
    f"Time to log 1000 transform with time in a single call: {ellapsed:.3f}s. ({1000 / ellapsed:.3f}s transforms / sec)"
)
```

Results for this on my windows machine (Python 3.11.9, AMD 7950X3D), each median out of 3 runs with respective viewer version already open:

* 0.17: `Time to log 1000 transforms: 0.296s. (3377.211s transforms / sec)`
   * (very similar to [previously reported numbers](https://github.com/rerun-io/rerun/issues/4227#issuecomment-1811617323) on Jeremy's linux machine) 
* `main`: `Time to log 1000 transforms: 0.077s. (13070.399s transforms / sec)`
* `main`: `Time to log 1000 transform with time in a single call: 0.003s. (333383.992s transforms / sec)`

So according to this simple benchmark it's about 3.9 times more transforms per second for individual log and (not entirely comparable and probably measure accuracy bound) factor 99.

I did not check this benchmark in since it's a bit too one-off, in particular the batch log I added is too unscientific

---

Verdict overall:
* we got a lot better here but over 800ms for 10k individual transforms still feels embarrassing
* we're clearly bound on the number of individual Python operations and almost independent on the amount of data processed by each call (that's not an excuse, means we have to reduce the in-Python overhead in the long run) which means that temporal batch logging gives us at least an escape hatch that lands with some more reasonable transforms

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
