### PR TITLE
Improved CLI 2: explicit CLI flags for compaction settings

### DIFF
--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -26,12 +26,18 @@ pub enum RrdCommands {
 
     /// Compacts the contents of one or more .rrd/.rbl files and writes the result to a new file.
     ///
-    /// Use the usual environment variables to control the compaction thresholds:
+    /// Uses the usual environment variables to control the compaction thresholds:
     /// `RERUN_CHUNK_MAX_ROWS`,
     /// `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`,
     /// `RERUN_CHUNK_MAX_BYTES`.
     ///
-    /// Example: `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun rrd compact /my/recordings/*.rrd -o output.rrd`
+    /// Unless explicit flags are passed, in which case they will override environment values.
+    ///
+    /// Examples:
+    ///
+    /// * `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun rrd compact /my/recordings/*.rrd -o output.rrd`
+    ///
+    /// * `rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd -o output.rrd`
     Compact(CompactCommand),
 
     /// Merges the contents of multiple .rrd/.rbl files, and writes the result to a new file.


### PR DESCRIPTION
Before:
```sh
$ RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun rrd compact /my/recordings/*.rrd -o output.rrd
```

After:
```sh
$ rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd -o output.rrd
```


```sh
$ rerun rrd compact --help

Compacts the contents of one or more .rrd/.rbl files and writes the result to a new file.

Uses the usual environment variables to control the compaction thresholds: `RERUN_CHUNK_MAX_ROWS`, `RERUN_CHUNK_MAX_ROWS_IF_UNSORTED`, `RERUN_CHUNK_MAX_BYTES`.

Unless explicit flags are passed, in which case they will override environment values.

Examples:

* `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun rrd compact /my/recordings/*.rrd -o output.rrd`

* `rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd -o output.rrd`

Usage: rerun rrd compact [OPTIONS] --output <dst.(rrd|rbl)> [PATH_TO_INPUT_RRDS]...

Arguments:
  [PATH_TO_INPUT_RRDS]...


Options:
  -o, --output <dst.(rrd|rbl)>


      --max-bytes <MAX_BYTES>
          What is the threshold, in bytes, after which a Chunk cannot be compacted any further?

          Overrides RERUN_CHUNK_MAX_BYTES if set.

      --max-rows <MAX_ROWS>
          What is the threshold, in rows, after which a Chunk cannot be compacted any further?

          Overrides RERUN_CHUNK_MAX_ROWS if set.

      --max-rows-if-unsorted <MAX_ROWS_IF_UNSORTED>
          What is the threshold, in rows, after which a Chunk cannot be compacted any further?

          This specifically applies to _non_ time-sorted chunks.

          Overrides RERUN_CHUNK_MAX_ROWS_IF_UNSORTED if set.

  -h, --help
          Print help (see a summary with '-h')
```

- Part of https://github.com/rerun-io/rerun/issues/7048
- DNM: requires https://github.com/rerun-io/rerun/pull/7060

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7061?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7061?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7061)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.