### PR TITLE
Fix crash on shutdown when using global recording stream variables in C++

### DIFF
--- a/rerun_cpp/tests/recording_stream.cpp
+++ b/rerun_cpp/tests/recording_stream.cpp
@@ -653,3 +653,12 @@ SCENARIO("Deprecated log_timeless still works", TEST_TAG) {
 
     RR_POP_WARNINGS // For `RR_DISABLE_DEPRECATION_WARNING`.
 }
+
+SCENARIO("Global RecordingStream doesn't cause crashes", TEST_TAG) {
+    // This caused a crash on Mac & Linux due to issues with cleanup order of global variables
+    // in Rust vs C++.
+    // See:
+    // * https://github.com/rerun-io/rerun/issues/5697
+    // * https://github.com/rerun-io/rerun/issues/5260
+    static rerun::RecordingStream global_stream("global");
+}


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/5260
   * recently duplicated as https://github.com/rerun-io/rerun/issues/5697)

Was able to repro this on Mac but not on Windows. Fix is a bit wonky but worked reliably for me. Details see code comments!

### Checklist
* confirm this fixes things on Linux -> adjourned to when we have a new dev release
* [x] confirm this doesn't cause new issues on Windows
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7063?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7063?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7063)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.