### PR TITLE
Introduce a "Selectable Toggle" widget and use it for the 3D view's camera kind

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/ui.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui.rs
@@ -159,7 +159,7 @@ impl SpatialSpaceViewState {
         }
 
         if let Some(eye) = &mut self.state_3d.view_eye {
-            ui.horizontal(|ui| {
+            ui.selectable_toggle(|ui| {
                 let mut mode = eye.mode();
                 ui.selectable_value(&mut mode, EyeMode::FirstPerson, "First Person");
                 ui.selectable_value(&mut mode, EyeMode::Orbital, "Orbital");

--- a/crates/viewer/re_ui/examples/re_ui_example/main.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/main.rs
@@ -210,6 +210,11 @@ impl eframe::App for ExampleApp {
             });
             ui.label(format!("Latest command: {}", self.latest_cmd));
 
+            ui.selectable_toggle(|ui| {
+                ui.selectable_value(&mut self.dummy_bool, false, "Inactive");
+                ui.selectable_value(&mut self.dummy_bool, true, "Active");
+            });
+
             // ---
 
             if ui.button("Open modal").clicked() {
@@ -270,26 +275,34 @@ impl eframe::App for ExampleApp {
                 ..Default::default()
             })
             .show_animated(egui_ctx, self.show_left_panel, |ui| {
-                egui::TopBottomPanel::top("left_panel_top_bar")
-                    .exact_height(re_ui::DesignTokens::title_bar_height())
-                    .frame(egui::Frame {
-                        inner_margin: egui::Margin::symmetric(
-                            re_ui::DesignTokens::view_padding(),
-                            0.0,
-                        ),
-                        ..Default::default()
-                    })
-                    .show_inside(ui, left_panel_top_section_ui);
+                let y_spacing = ui.spacing().item_spacing.y;
 
-                egui::ScrollArea::both()
-                    .auto_shrink([false; 2])
-                    .show(ui, |ui| {
-                        egui::Frame {
-                            inner_margin: egui::Margin::same(re_ui::DesignTokens::view_padding()),
+                list_item::list_item_scope(ui, "left_panel", |ui| {
+                    // revert change by `list_item_scope`
+                    ui.spacing_mut().item_spacing.y = y_spacing;
+                    egui::TopBottomPanel::top("left_panel_top_bar")
+                        .exact_height(re_ui::DesignTokens::title_bar_height())
+                        .frame(egui::Frame {
+                            inner_margin: egui::Margin::symmetric(
+                                re_ui::DesignTokens::view_padding(),
+                                0.0,
+                            ),
                             ..Default::default()
-                        }
-                        .show(ui, left_panel_bottom_section_ui);
-                    });
+                        })
+                        .show_inside(ui, left_panel_top_section_ui);
+
+                    egui::ScrollArea::both()
+                        .auto_shrink([false; 2])
+                        .show(ui, |ui| {
+                            egui::Frame {
+                                inner_margin: egui::Margin::same(
+                                    re_ui::DesignTokens::view_padding(),
+                                ),
+                                ..Default::default()
+                            }
+                            .show(ui, left_panel_bottom_section_ui);
+                        });
+                });
             });
 
         // RIGHT PANEL

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -986,6 +986,45 @@ pub trait UiExt {
         // should never happen
         egui::Rangef::EVERYTHING
     }
+
+    /// Style [`egui::Ui::selectable_value`]s and friends into a horizontal, toggle-like widget.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # egui::__run_test_ui(|ui| {
+    /// # use re_ui::UiExt as _;
+    /// let mut flag = false;
+    /// ui.selectable_toggle(|ui| {
+    ///     ui.selectable_value(&mut flag, false, "Inactive");
+    ///     ui.selectable_value(&mut flag, true, "Active");
+    /// });
+    /// # });
+    /// ```
+    fn selectable_toggle<R>(&mut self, content: impl FnOnce(&mut egui::Ui) -> R) -> R {
+        let ui = self.ui_mut();
+        egui::Frame {
+            inner_margin: egui::Margin::same(3.0),
+            stroke: design_tokens().bottom_bar_stroke,
+            rounding: ui.visuals().widgets.hovered.rounding + egui::Rounding::same(3.0),
+            ..Default::default()
+        }
+        .show(ui, |ui| {
+            ui.visuals_mut().widgets.hovered.expansion = 0.0;
+            ui.visuals_mut().widgets.active.expansion = 0.0;
+            ui.visuals_mut().widgets.inactive.expansion = 0.0;
+
+            ui.visuals_mut().selection.bg_fill = ui.visuals_mut().widgets.active.bg_fill;
+            ui.visuals_mut().selection.stroke = ui.visuals_mut().widgets.active.fg_stroke;
+            ui.visuals_mut().widgets.hovered.weak_bg_fill = egui::Color32::TRANSPARENT;
+
+            ui.spacing_mut().button_padding = egui::vec2(6.0, 2.0);
+            ui.spacing_mut().item_spacing.x = 3.0;
+
+            ui.horizontal(content).inner
+        })
+        .inner
+    }
 }
 
 impl UiExt for egui::Ui {

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -1003,6 +1003,11 @@ pub trait UiExt {
     /// ```
     fn selectable_toggle<R>(&mut self, content: impl FnOnce(&mut egui::Ui) -> R) -> R {
         let ui = self.ui_mut();
+
+        // ensure cursor is on an integer value, otherwise we get weird optical alignment of the text
+        //TODO(ab): fix when https://github.com/emilk/egui/issues/4928 is resolved
+        ui.add_space(-ui.cursor().min.y.fract());
+
         egui::Frame {
             inner_margin: egui::Margin::same(3.0),
             stroke: design_tokens().bottom_bar_stroke,
@@ -1014,9 +1019,16 @@ pub trait UiExt {
             ui.visuals_mut().widgets.active.expansion = 0.0;
             ui.visuals_mut().widgets.inactive.expansion = 0.0;
 
-            ui.visuals_mut().selection.bg_fill = ui.visuals_mut().widgets.active.bg_fill;
-            ui.visuals_mut().selection.stroke = ui.visuals_mut().widgets.active.fg_stroke;
+            ui.visuals_mut().selection.bg_fill = ui.visuals_mut().widgets.inactive.bg_fill;
+            ui.visuals_mut().selection.stroke = ui.visuals_mut().widgets.inactive.fg_stroke;
             ui.visuals_mut().widgets.hovered.weak_bg_fill = egui::Color32::TRANSPARENT;
+
+            ui.visuals_mut().widgets.hovered.fg_stroke.color =
+                ui.visuals().widgets.inactive.fg_stroke.color;
+            ui.visuals_mut().widgets.active.fg_stroke.color =
+                ui.visuals().widgets.inactive.fg_stroke.color;
+            ui.visuals_mut().widgets.inactive.fg_stroke.color =
+                ui.visuals().widgets.noninteractive.fg_stroke.color;
 
             ui.spacing_mut().button_padding = egui::vec2(6.0, 2.0);
             ui.spacing_mut().item_spacing.x = 3.0;


### PR DESCRIPTION
### What

This PR introduces `UiExt::selectable_toggle()`, which builds on `Ui::selectable_{label|value}` to make a horizontal, toggle-like widget:

```rust
let mut flag = false;
ui.selectable_toggle(|ui| {
    ui.selectable_value(&mut flag, false, "Inactive");
    ui.selectable_value(&mut flag, true, "Active");
});
```

Now used for the 3D view's camera kind selection:

<img width="291" alt="image" src="https://github.com/user-attachments/assets/d444557f-ecd2-4692-8d13-a3054987b93c">

Also fix a crash in `re_ui_example`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7064?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7064?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7064)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.