### PR TITLE
Remove redundant batch validation on Rust/Python's  `log_temporal_batch`

### DIFF
--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -945,27 +945,6 @@ impl RecordingStream {
         let components: BTreeMap<ComponentName, ArrowListArray<i32>> =
             components?.into_iter().collect();
 
-        let mut all_lengths = timelines
-            .values()
-            .map(|timeline| (timeline.name(), timeline.num_rows()))
-            .chain(
-                components
-                    .iter()
-                    .map(|(component, array)| (component.as_str(), array.len())),
-            );
-
-        if let Some((_, expected)) = all_lengths.next() {
-            for (name, len) in all_lengths {
-                if len != expected {
-                    return Err(RecordingStreamError::Chunk(ChunkError::Malformed {
-                        reason: format!(
-                            "Mismatched lengths: '{name}' has length {len} but expected {expected}",
-                        ),
-                    }));
-                }
-            }
-        }
-
         let chunk = Chunk::from_auto_row_ids(id, ent_path.into(), timelines, components)?;
 
         self.record_chunk(chunk);

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -188,25 +188,6 @@ pub fn build_chunk_from_components(
         .into_iter()
         .collect();
 
-    let mut all_lengths = timelines
-        .values()
-        .map(|timeline| (timeline.name(), timeline.num_rows()))
-        .chain(
-            components
-                .iter()
-                .map(|(component, array)| (component.as_str(), array.len())),
-        );
-
-    if let Some((_, expected)) = all_lengths.next() {
-        for (name, len) in all_lengths {
-            if len != expected {
-                return Err(PyRuntimeError::new_err(format!(
-                    "Mismatched lengths: '{name}' has length {len} but expected {expected}",
-                )));
-            }
-        }
-    }
-
     let chunk = Chunk::from_auto_row_ids(chunk_id, entity_path, timelines, components)
         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 


### PR DESCRIPTION
### What
this is already part of `Chunk::sanity_check` which runs as part of chunk creation

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7073?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7073?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7073)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.