### PR TITLE
Improve entity stats when hovered

### DIFF
--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -113,7 +113,7 @@ impl ChunkStore {
 
         let total_size_bytes_before = stats_before.total().total_size_bytes as f64;
         let total_num_chunks_before = stats_before.total().num_chunks;
-        let total_num_rows_before = stats_before.total().total_num_rows;
+        let total_num_rows_before = stats_before.total().num_rows;
 
         let protected_chunk_ids = self.find_all_protected_chunk_ids(options.protect_latest);
 
@@ -155,7 +155,7 @@ impl ChunkStore {
         let stats_after = self.stats();
         let total_size_bytes_after = stats_after.total().total_size_bytes as f64;
         let total_num_chunks_after = stats_after.total().num_chunks;
-        let total_num_rows_after = stats_after.total().total_num_rows;
+        let total_num_rows_after = stats_after.total().num_rows;
 
         re_log::trace!(
             kind = "gc",

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -9,7 +9,7 @@ use re_log_types::ResolvedTimeRange;
 use re_log_types::{EntityPath, TimeInt, Timeline};
 use re_types_core::{ComponentName, ComponentNameSet};
 
-use crate::{store::ChunkIdSetPerTime, ChunkStore, ChunkStoreChunkStats};
+use crate::{store::ChunkIdSetPerTime, ChunkStore};
 
 // Used all over in docstrings.
 #[allow(unused_imports)]
@@ -656,117 +656,5 @@ impl ChunkStore {
                     .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id).cloned())
             })
             .collect()
-    }
-}
-
-/// ## Entity stats
-impl ChunkStore {
-    /// Stats about all chunks with static data for an entity.
-    pub fn entity_stats_static(&self, entity_path: &EntityPath) -> ChunkStoreChunkStats {
-        re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
-        self.static_chunk_ids_per_entity.get(entity_path).map_or(
-            ChunkStoreChunkStats::default(),
-            |static_chunks_per_component| {
-                let chunk_ids: ahash::HashSet<re_chunk::ChunkId> =
-                    static_chunks_per_component.values().copied().collect();
-
-                chunk_ids
-                    .into_iter()
-                    .filter_map(|chunk_id| self.chunks_per_chunk_id.get(&chunk_id))
-                    .map(ChunkStoreChunkStats::from_chunk)
-                    .sum()
-            },
-        )
-    }
-
-    /// Stats about all the chunks that has data for an entity on a specific timeline.
-    ///
-    /// Does NOT include static data.
-    pub fn entity_stats_on_timeline(
-        &self,
-        entity_path: &EntityPath,
-        timeline: &Timeline,
-    ) -> ChunkStoreChunkStats {
-        re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
-        self.temporal_chunk_ids_per_entity
-            .get(entity_path)
-            .and_then(|temporal_chunk_ids_per_timeline| {
-                temporal_chunk_ids_per_timeline.get(timeline)
-            })
-            .map_or(
-                ChunkStoreChunkStats::default(),
-                |chunk_id_sets| -> ChunkStoreChunkStats {
-                    chunk_id_sets
-                        .per_start_time
-                        .values()
-                        .flat_map(|chunk_ids| chunk_ids.iter())
-                        .filter_map(|id| self.chunks_per_chunk_id.get(id))
-                        .map(ChunkStoreChunkStats::from_chunk)
-                        .sum()
-                },
-            )
-    }
-}
-
-/// ## Component path stats
-impl ChunkStore {
-    /// Returns the number of static events logged for an entity for a specific component.
-    ///
-    /// This ignores temporal events.
-    pub fn num_static_events_for_component(
-        &self,
-        entity_path: &EntityPath,
-        component_name: ComponentName,
-    ) -> u64 {
-        re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
-        self.static_chunk_ids_per_entity
-            .get(entity_path)
-            .and_then(|static_chunks_per_component| {
-                static_chunks_per_component.get(&component_name)
-            })
-            .and_then(|chunk_id| self.chunks_per_chunk_id.get(chunk_id))
-            .and_then(|chunk| chunk.num_events_for_component(component_name))
-            .unwrap_or(0)
-    }
-
-    /// Returns the number of temporal events logged for an entity for a specific component on a given timeline.
-    ///
-    /// This ignores static events.
-    pub fn num_temporal_events_for_component_on_timeline(
-        &self,
-        timeline: &Timeline,
-        entity_path: &EntityPath,
-        component_name: ComponentName,
-    ) -> u64 {
-        re_tracing::profile_function!();
-
-        self.query_id.fetch_add(1, Ordering::Relaxed);
-
-        self.temporal_chunk_ids_per_entity_per_component
-            .get(entity_path)
-            .and_then(|temporal_chunk_ids_per_timeline| {
-                temporal_chunk_ids_per_timeline.get(timeline)
-            })
-            .and_then(|temporal_chunk_ids_per_component| {
-                temporal_chunk_ids_per_component.get(&component_name)
-            })
-            .map_or(0, |chunk_id_sets| {
-                chunk_id_sets
-                    .per_start_time
-                    .values()
-                    .flat_map(|chunk_ids| chunk_ids.iter())
-                    .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id))
-                    .filter_map(|chunk| chunk.num_events_for_component(component_name))
-                    .sum()
-            })
     }
 }

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -670,12 +670,12 @@ impl ChunkStore {
         self.static_chunk_ids_per_entity.get(entity_path).map_or(
             ChunkStoreChunkStats::default(),
             |static_chunks_per_component| {
-                let chunk_ids: ahash::HashSet<&re_chunk::ChunkId> =
-                    static_chunks_per_component.values().collect();
+                let chunk_ids: ahash::HashSet<re_chunk::ChunkId> =
+                    static_chunks_per_component.values().copied().collect();
 
                 chunk_ids
                     .into_iter()
-                    .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id))
+                    .filter_map(|chunk_id| self.chunks_per_chunk_id.get(&chunk_id))
                     .map(ChunkStoreChunkStats::from_chunk)
                     .sum()
             },

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -670,8 +670,11 @@ impl ChunkStore {
         self.static_chunk_ids_per_entity.get(entity_path).map_or(
             ChunkStoreChunkStats::default(),
             |static_chunks_per_component| {
-                static_chunks_per_component
-                    .values()
+                let chunk_ids: ahash::HashSet<&re_chunk::ChunkId> =
+                    static_chunks_per_component.values().collect();
+
+                chunk_ids
+                    .into_iter()
                     .filter_map(|chunk_id| self.chunks_per_chunk_id.get(chunk_id))
                     .map(ChunkStoreChunkStats::from_chunk)
                     .sum()

--- a/crates/store/re_chunk_store/src/stats.rs
+++ b/crates/store/re_chunk_store/src/stats.rs
@@ -102,7 +102,7 @@ pub struct ChunkStoreChunkStats {
     /// Number of rows.
     ///
     /// This is usually the same as the number of log calls the user made.
-    /// Each row can contain multiple events (see [`num_events`]).
+    /// Each row can contain multiple events (see [`Self::num_events`]).
     pub num_rows: u64,
 
     /// How many _component batches_ ("cells").

--- a/crates/store/re_chunk_store/tests/stats.rs
+++ b/crates/store/re_chunk_store/tests/stats.rs
@@ -86,7 +86,7 @@ fn stats() -> anyhow::Result<()> {
         let chunk = Chunk::builder(entity_path.clone())
             .with_sparse_component_batches(
                 RowId::new(),
-                TimePoint::static_(),
+                TimePoint::default(),
                 [
                     (MyColor::name(), None),
                     (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
@@ -94,7 +94,7 @@ fn stats() -> anyhow::Result<()> {
             )
             .with_sparse_component_batches(
                 RowId::new(),
-                TimePoint::static_(),
+                TimePoint::default(),
                 [
                     (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
                     (MyPoint::name(), None),
@@ -102,7 +102,7 @@ fn stats() -> anyhow::Result<()> {
             )
             .with_sparse_component_batches(
                 RowId::new(),
-                TimePoint::static_(),
+                TimePoint::default(),
                 [
                     (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
                     (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),

--- a/crates/store/re_chunk_store/tests/stats.rs
+++ b/crates/store/re_chunk_store/tests/stats.rs
@@ -1,0 +1,139 @@
+use std::sync::Arc;
+
+use re_chunk::{Chunk, RowId, TimePoint};
+use re_chunk_store::{ChunkStore, ChunkStoreConfig, TimeInt};
+use re_log_types::{
+    build_frame_nr,
+    example_components::{MyColor, MyPoint},
+    EntityPath, Timeline,
+};
+use re_types_core::Loggable as _;
+
+#[test]
+fn stats() -> anyhow::Result<()> {
+    re_log::setup_logging();
+
+    let mut store = ChunkStore::new(
+        re_log_types::StoreId::random(re_log_types::StoreKind::Recording),
+        ChunkStoreConfig::COMPACTION_DISABLED,
+    );
+
+    let entity_path = EntityPath::from("this/that");
+
+    {
+        let chunk = Chunk::builder(entity_path.clone())
+            .with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(TimeInt::new_temporal(0))],
+                [
+                    (MyColor::name(), None),
+                    (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
+                ],
+            )
+            .with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(TimeInt::new_temporal(1))],
+                [
+                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::name(), None),
+                ],
+            )
+            .with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(TimeInt::new_temporal(2))],
+                [
+                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),
+                ],
+            )
+            .build()?;
+
+        let chunk = Arc::new(chunk);
+        eprintln!("chunk 1:\n{chunk}");
+        store.insert_chunk(&chunk)?;
+
+        assert_eq!(chunk.num_rows(), 3);
+        assert_eq!(chunk.num_components(), 2);
+        assert_eq!(chunk.num_events_cumulative(), 4);
+    }
+
+    {
+        let chunk = Chunk::builder(entity_path.clone())
+            .with_sparse_component_batches(
+                RowId::new(),
+                [build_frame_nr(TimeInt::new_temporal(3))],
+                [
+                    (MyColor::name(), None),
+                    (MyPoint::name(), Some(&MyPoint::from_iter(1..2) as _)),
+                ],
+            )
+            .build()?;
+
+        let chunk = Arc::new(chunk);
+        eprintln!("chunk 2:\n{chunk}");
+        store.insert_chunk(&chunk)?;
+
+        assert_eq!(chunk.num_rows(), 1);
+        assert_eq!(
+            chunk.num_components(),
+            1,
+            "MyColor has no data, so shouldn't count"
+        );
+        assert_eq!(chunk.num_events_cumulative(), 1);
+    }
+
+    {
+        let chunk = Chunk::builder(entity_path.clone())
+            .with_sparse_component_batches(
+                RowId::new(),
+                TimePoint::static_(),
+                [
+                    (MyColor::name(), None),
+                    (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
+                ],
+            )
+            .with_sparse_component_batches(
+                RowId::new(),
+                TimePoint::static_(),
+                [
+                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::name(), None),
+                ],
+            )
+            .with_sparse_component_batches(
+                RowId::new(),
+                TimePoint::static_(),
+                [
+                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),
+                ],
+            )
+            .build()?;
+
+        let chunk = Arc::new(chunk);
+        eprintln!("static chunk:\n{chunk}");
+        store.insert_chunk(&chunk)?;
+
+        assert_eq!(chunk.num_rows(), 3);
+        assert_eq!(chunk.num_components(), 2);
+        assert_eq!(chunk.num_events_cumulative(), 4);
+    }
+
+    println!("{store}");
+
+    {
+        let stats = store.entity_stats_static(&entity_path);
+        assert_eq!(stats.num_chunks, 1, "We only logged one static chunk");
+        assert_eq!(stats.num_rows, 3);
+        assert_eq!(stats.num_events, 4);
+    }
+    {
+        let stats =
+            store.entity_stats_on_timeline(&entity_path, &Timeline::new_sequence("frame_nr"));
+        assert_eq!(stats.num_chunks, 2, "We logged two temporal chunks");
+        assert_eq!(stats.num_rows, 4);
+        assert_eq!(stats.num_events, 5);
+    }
+
+    Ok(())
+}

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -5,8 +5,8 @@ use parking_lot::Mutex;
 
 use re_chunk::{Chunk, ChunkResult, RowId, TimeInt};
 use re_chunk_store::{
-    ChunkStore, ChunkStoreConfig, ChunkStoreEvent, ChunkStoreSubscriber, GarbageCollectionOptions,
-    GarbageCollectionTarget,
+    ChunkStore, ChunkStoreChunkStats, ChunkStoreConfig, ChunkStoreEvent, ChunkStoreSubscriber,
+    GarbageCollectionOptions, GarbageCollectionTarget,
 };
 use re_log_types::{
     ApplicationId, EntityPath, EntityPathHash, LogMsg, ResolvedTimeRange, ResolvedTimeRangeF,
@@ -538,29 +538,48 @@ impl EntityDb {
 
         Ok(new_db)
     }
+}
 
-    /// Returns the byte size of an entity and all its children on the given timeline, recursively.
+/// ## Stats
+impl EntityDb {
+    /// Returns the stats for the static store of the entity and all its children, recursively.
     ///
-    /// This includes static data.
-    pub fn approx_size_of_subtree_on_timeline(
-        &self,
-        timeline: &Timeline,
-        entity_path: &EntityPath,
-    ) -> u64 {
+    /// This excludes temporal data.
+    pub fn subtree_stats_static(&self, entity_path: &EntityPath) -> ChunkStoreChunkStats {
         re_tracing::profile_function!();
 
         let Some(subtree) = self.tree.subtree(entity_path) else {
-            return 0;
+            return Default::default();
         };
 
-        let mut size = 0;
+        let mut stats = ChunkStoreChunkStats::default();
         subtree.visit_children_recursively(|path| {
-            size += self
-                .store()
-                .approx_size_of_entity_on_timeline(timeline, path);
+            stats += self.store().entity_stats_static(path);
         });
 
-        size
+        stats
+    }
+
+    /// Returns the stats for the entity and all its children on the given timeline, recursively.
+    ///
+    /// This excludes static data.
+    pub fn subtree_stats_on_timeline(
+        &self,
+        entity_path: &EntityPath,
+        timeline: &Timeline,
+    ) -> ChunkStoreChunkStats {
+        re_tracing::profile_function!();
+
+        let Some(subtree) = self.tree.subtree(entity_path) else {
+            return Default::default();
+        };
+
+        let mut stats = ChunkStoreChunkStats::default();
+        subtree.visit_children_recursively(|path| {
+            stats += self.store().entity_stats_on_timeline(path, timeline);
+        });
+
+        stats
     }
 
     /// Returns true if an entity or any of its children have any data on the given timeline.

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -271,7 +271,7 @@ impl EntityDb {
 
     #[inline]
     pub fn num_rows(&self) -> u64 {
-        self.data_store.stats().total().total_num_rows
+        self.data_store.stats().total().num_rows
     }
 
     /// Return the current `ChunkStoreGeneration`. This can be used to determine whether the

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -423,7 +423,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
         db.gc_everything_but_the_latest_row_on_non_default_timelines();
 
         let stats = db.store().stats();
-        assert_eq!(stats.temporal_chunks.total_num_rows, 1);
+        assert_eq!(stats.temporal_chunks.num_rows, 1);
 
         let chunk = Chunk::builder(entity_path.clone())
             .with_component_batches(
@@ -443,7 +443,7 @@ fn clear_and_gc() -> anyhow::Result<()> {
 
         // No rows should remain because the table should have been purged
         let stats = db.store().stats();
-        assert_eq!(stats.temporal_chunks.total_num_rows, 0);
+        assert_eq!(stats.temporal_chunks.num_rows, 0);
 
         // EntityTree should be empty again when we end since everything was GC'd
         assert!(db.tree().is_empty(db.store()));

--- a/crates/store/re_log_types/src/time_point/mod.rs
+++ b/crates/store/re_log_types/src/time_point/mod.rs
@@ -32,14 +32,6 @@ impl From<BTreeMap<Timeline, TimeInt>> for TimePoint {
 }
 
 impl TimePoint {
-    /// A static [`TimePoint`], containing no times.
-    ///
-    /// Same as [`Self::default`], i.e. empty.
-    #[inline]
-    pub fn static_() -> Self {
-        Self::default()
-    }
-
     #[inline]
     pub fn get(&self, timeline: &Timeline) -> Option<&TimeInt> {
         self.0.get(timeline)

--- a/crates/store/re_log_types/src/time_point/mod.rs
+++ b/crates/store/re_log_types/src/time_point/mod.rs
@@ -32,6 +32,14 @@ impl From<BTreeMap<Timeline, TimeInt>> for TimePoint {
 }
 
 impl TimePoint {
+    /// A static [`TimePoint`], containing no times.
+    ///
+    /// Same as [`Self::default`], i.e. empty.
+    #[inline]
+    pub fn static_() -> Self {
+        Self::default()
+    }
+
     #[inline]
     pub fn get(&self, timeline: &Timeline) -> Option<&TimeInt> {
         self.0.get(timeline)

--- a/crates/utils/re_format/src/lib.rs
+++ b/crates/utils/re_format/src/lib.rs
@@ -474,6 +474,17 @@ fn test_format_large_number() {
 pub fn format_bytes(number_of_bytes: f64) -> String {
     if number_of_bytes < 0.0 {
         format!("{MINUS}{}", format_bytes(-number_of_bytes))
+    } else if number_of_bytes == 0.0 {
+        "0 B".to_owned()
+    } else if number_of_bytes < 1.0 {
+        format!("{number_of_bytes} B")
+    } else if number_of_bytes < 20.0 {
+        let is_integer = number_of_bytes.round() == number_of_bytes;
+        if is_integer {
+            format!("{number_of_bytes:.0} B")
+        } else {
+            format!("{number_of_bytes:.1} B")
+        }
     } else if number_of_bytes < 10.0_f64.exp2() {
         format!("{number_of_bytes:.0} B")
     } else if number_of_bytes < 20.0_f64.exp2() {
@@ -491,6 +502,11 @@ pub fn format_bytes(number_of_bytes: f64) -> String {
 #[test]
 fn test_format_bytes() {
     let test_cases = [
+        (0.0, "0 B"),
+        (0.25, "0.25 B"),
+        (1.51, "1.5 B"),
+        (11.0, "11 B"),
+        (12.5, "12.5 B"),
         (999.0, "999 B"),
         (1000.0, "1000 B"),
         (1001.0, "1001 B"),

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -610,12 +610,14 @@ impl BlueprintTree {
 
         let response = response.on_hover_ui(|ui| {
             let query = ctx.current_query();
+            let include_subtree = false;
             re_data_ui::item_ui::entity_hover_card_ui(
                 ui,
                 ctx,
                 &query,
                 ctx.recording(),
                 entity_path,
+                include_subtree,
             );
 
             if empty_origin {

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -3,6 +3,7 @@
 //! TODO(andreas): This is not a `data_ui`, can this go somewhere else, shouldn't be in `re_data_ui`.
 
 use re_entity_db::{EntityTree, InstancePath};
+use re_format::format_uint;
 use re_log_types::{ApplicationId, ComponentPath, EntityPath, TimeInt, Timeline};
 use re_ui::{icons, list_item, SyntaxHighlighting, UiExt as _};
 use re_viewer_context::{HoverHighlight, Item, SpaceViewId, UiLayout, ViewerContext};
@@ -308,6 +309,26 @@ fn entity_tree_stats_ui(
     let static_stats = db.subtree_stats_static(&tree.path);
     let timeline_stats = db.subtree_stats_on_timeline(&tree.path, timeline);
     let total_stats = static_stats + timeline_stats;
+
+    if total_stats.num_rows == 0 {
+        return;
+    } else if timeline_stats.num_rows == 0 {
+        ui.label(format!("{} static rows", format_uint(total_stats.num_rows)));
+    } else if static_stats.num_rows == 0 {
+        ui.label(format!(
+            "{} rows on timeline '{timeline}'",
+            format_uint(total_stats.num_rows),
+            timeline = timeline.name()
+        ));
+    } else {
+        ui.label(format!(
+            "{} rows ({} static, and {} on timeline '{timeline}')",
+            format_uint(total_stats.num_rows),
+            format_uint(static_stats.num_rows),
+            format_uint(timeline_stats.num_rows),
+            timeline = timeline.name()
+        ));
+    }
 
     let num_temporal_rows = timeline_stats.num_rows;
 

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -898,7 +898,15 @@ fn list_existing_data_blueprints(
 
                 let item = Item::DataResult(view_id, instance_path.clone());
                 let response = response.on_hover_ui(|ui| {
-                    item_ui::instance_hover_card_ui(ui, ctx, &query, db, instance_path);
+                    let include_subtree = false;
+                    item_ui::instance_hover_card_ui(
+                        ui,
+                        ctx,
+                        &query,
+                        db,
+                        instance_path,
+                        include_subtree,
+                    );
                 });
 
                 // We don't use item_ui::cursor_interact_with_selectable here because the forced

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -649,12 +649,14 @@ impl TimePanel {
             );
 
         let response = response.on_hover_ui(|ui| {
+            let include_subtree = true;
             re_data_ui::item_ui::entity_hover_card_ui(
                 ui,
                 ctx,
                 &time_ctrl.current_query(),
                 db,
                 &tree.path,
+                include_subtree,
             );
         });
 

--- a/crates/viewer/re_viewer/src/ui/memory_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/memory_panel.rs
@@ -230,6 +230,8 @@ impl MemoryPanel {
                 ui.label(egui::RichText::new("Stats").italics());
                 ui.label("Chunks");
                 ui.label("Rows (total)");
+                ui.label("Events (total)")
+                    .on_hover_text("Number of non-null component batches (cells)");
                 ui.label("Size (total)");
                 ui.end_row();
 
@@ -238,10 +240,12 @@ impl MemoryPanel {
                         num_chunks,
                         total_size_bytes,
                         total_num_rows,
+                        num_events,
                     } = stats;
 
                     ui.label(re_format::format_uint(num_chunks));
                     ui.label(re_format::format_uint(total_num_rows));
+                    ui.label(re_format::format_uint(num_events));
                     ui.label(re_format::format_bytes(total_size_bytes as _));
                 }
 

--- a/crates/viewer/re_viewer/src/ui/memory_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/memory_panel.rs
@@ -239,12 +239,12 @@ impl MemoryPanel {
                     let ChunkStoreChunkStats {
                         num_chunks,
                         total_size_bytes,
-                        total_num_rows,
+                        num_rows,
                         num_events,
                     } = stats;
 
                     ui.label(re_format::format_uint(num_chunks));
-                    ui.label(re_format::format_uint(total_num_rows));
+                    ui.label(re_format::format_uint(num_rows));
                     ui.label(re_format::format_uint(num_events));
                     ui.label(re_format::format_bytes(total_size_bytes as _));
                 }


### PR DESCRIPTION
### What
When hovering an entity in e.g. the timeline view or blueprint view, we used to show the amount of memory used by that entity, as well as a data rate. It now also includes also the number of log rows.

To do this I improved the stats pipeline of `re_chunk_store` and `EntityDb`.

Best reviewed commit-by-commit

![image](https://github.com/user-attachments/assets/c6d47da1-2483-41cf-8bb7-454b8c6f02e2)

![image](https://github.com/user-attachments/assets/5b5bf48f-c419-43ff-9d0d-60b9fad7b843)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7074?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7074?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7074)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.