### PR TITLE
Refactor the time drag value widget code to make it more globally available

### DIFF
--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -23,6 +23,7 @@ mod space_view;
 mod store_context;
 pub mod store_hub;
 mod tensor;
+mod time_drag_value;
 //TODO(ab): this should be behind #[cfg(test)], but then ` cargo clippy --all-targets` fails
 pub mod test_context;
 mod time_control;
@@ -77,6 +78,7 @@ pub use store_context::StoreContext;
 pub use store_hub::StoreHub;
 pub use tensor::{ImageDecodeCache, ImageStatsCache, TensorStats, TensorStatsCache};
 pub use time_control::{Looping, PlayState, TimeControl, TimeView};
+pub use time_drag_value::TimeDragValue;
 pub use typed_entity_collections::{
     ApplicableEntities, IndicatedEntities, PerVisualizer, VisualizableEntities,
 };

--- a/crates/viewer/re_viewer_context/src/time_drag_value.rs
+++ b/crates/viewer/re_viewer_context/src/time_drag_value.rs
@@ -1,0 +1,232 @@
+use std::ops::RangeInclusive;
+
+use egui::{NumExt as _, Response};
+
+use re_entity_db::TimeHistogram;
+use re_log_types::{TimeType, TimeZone};
+use re_types_core::datatypes::TimeInt;
+
+/// Drag value widget for editing time values for both sequence and temporal timelines.
+///
+/// Compute and store various information about the time range related to how the UI should behave.
+#[derive(Debug)]
+pub struct TimeDragValue {
+    /// Allowed range ofr value.
+    pub range: RangeInclusive<i64>,
+
+    /// For ranges with large offsets (e.g. `log_time`), this is a rounded time just before the
+    /// first logged data, which can be used as offset in the UI.
+    base_time: Option<i64>,
+
+    /// For temporal timelines, this is a nice unit factor to use.
+    unit_factor: i64,
+
+    /// For temporal timelines, this is the unit symbol to display.
+    unit_symbol: &'static str,
+
+    /// This is a nice range of absolute times to use when editing an absolute time. The boundaries
+    /// are extended to the nearest rounded unit to minimize glitches.
+    abs_range: RangeInclusive<i64>,
+
+    /// This is a nice range of relative times to use when editing an absolute time. The boundaries
+    /// are extended to the nearest rounded unit to minimize glitches.
+    rel_range: RangeInclusive<i64>,
+}
+
+impl TimeDragValue {
+    pub fn from_time_histogram(times: &TimeHistogram) -> Self {
+        Self::from_time_range(
+            times.min_key().unwrap_or_default()..=times.max_key().unwrap_or_default(),
+        )
+    }
+
+    pub fn from_time_range(range: RangeInclusive<i64>) -> Self {
+        let span = range.end() - range.start();
+        let base_time = time_range_base_time(*range.start(), span);
+        let (unit_symbol, unit_factor) = unit_from_span(span);
+
+        // `abs_range` is used by the DragValue when editing an absolute time, its bound expended to
+        // the nearest unit to minimize glitches.
+        let abs_range =
+            round_down(*range.start(), unit_factor)..=round_up(*range.end(), unit_factor);
+
+        // `rel_range` is used by the DragValue when editing a relative time offset. It must have
+        // enough margins either side to accommodate for all possible values of current time.
+        let rel_range = round_down(-span, unit_factor)..=round_up(2 * span, unit_factor);
+
+        Self {
+            range,
+            base_time,
+            unit_factor,
+            unit_symbol,
+            abs_range,
+            rel_range,
+        }
+    }
+
+    /// Show a sequence drag value widget.
+    pub fn sequence_drag_value_ui(
+        &self,
+        ui: &mut egui::Ui,
+        value: &mut TimeInt,
+        absolute: bool,
+        low_bound_override: Option<TimeInt>,
+    ) -> Response {
+        let mut time_range = if absolute {
+            self.abs_range.clone()
+        } else {
+            self.rel_range.clone()
+        };
+
+        // speed must be computed before messing with time_range for consistency
+        let span = time_range.end() - time_range.start();
+        let speed = (span as f32 * 0.005).at_least(1.0);
+
+        if let Some(low_bound_override) = low_bound_override {
+            time_range = low_bound_override.0.at_least(*time_range.start())..=*time_range.end();
+        }
+
+        ui.add(
+            egui::DragValue::new(&mut value.0)
+                .range(time_range)
+                .speed(speed),
+        )
+    }
+
+    /// Show a temporal drag value widget.
+    ///
+    /// Feature rich:
+    /// - scale to the proper units
+    /// - display the base time if any
+    /// - etc.
+    ///
+    /// Returns a tuple of the [`egui::DragValue`]'s [`egui::Response`], and the base time label's
+    /// [`egui::Response`], if any.
+    pub fn temporal_drag_value_ui(
+        &self,
+        ui: &mut egui::Ui,
+        value: &mut TimeInt,
+        absolute: bool,
+        low_bound_override: Option<TimeInt>,
+        time_zone_for_timestamps: TimeZone,
+    ) -> (Response, Option<Response>) {
+        let mut time_range = if absolute {
+            self.abs_range.clone()
+        } else {
+            self.rel_range.clone()
+        };
+
+        let factor = self.unit_factor as f32;
+        let offset = if absolute {
+            self.base_time.unwrap_or(0)
+        } else {
+            0
+        };
+
+        // speed must be computed before messing with time_range for consistency
+        let speed = (time_range.end() - time_range.start()) as f32 / factor * 0.005;
+
+        if let Some(low_bound_override) = low_bound_override {
+            time_range = low_bound_override.0.at_least(*time_range.start())..=*time_range.end();
+        }
+
+        let mut time_unit = (value.0 - offset) as f32 / factor;
+
+        let time_range = (*time_range.start() - offset) as f32 / factor
+            ..=(*time_range.end() - offset) as f32 / factor;
+
+        let base_time_response = if absolute {
+            self.base_time.map(|base_time| {
+                ui.label(format!(
+                    "{} + ",
+                    TimeType::Time.format(TimeInt(base_time), time_zone_for_timestamps)
+                ))
+            })
+        } else {
+            None
+        };
+
+        let drag_value_response = ui.add(
+            egui::DragValue::new(&mut time_unit)
+                .range(time_range)
+                .speed(speed)
+                .suffix(self.unit_symbol),
+        );
+
+        *value = TimeInt((time_unit * factor).round() as i64 + offset);
+
+        (drag_value_response, base_time_response)
+    }
+}
+
+fn unit_from_span(span: i64) -> (&'static str, i64) {
+    if span / 1_000_000_000 > 0 {
+        ("s", 1_000_000_000)
+    } else if span / 1_000_000 > 0 {
+        ("ms", 1_000_000)
+    } else if span / 1_000 > 0 {
+        ("μs", 1_000)
+    } else {
+        ("ns", 1)
+    }
+}
+
+/// Value of the start time over time span ratio above which an explicit offset is handled.
+static SPAN_TO_START_TIME_OFFSET_THRESHOLD: i64 = 10;
+
+fn time_range_base_time(min_time: i64, span: i64) -> Option<i64> {
+    if min_time <= 0 {
+        return None;
+    }
+
+    if span.saturating_mul(SPAN_TO_START_TIME_OFFSET_THRESHOLD) < min_time {
+        let factor = if span / 1_000_000 > 0 {
+            1_000_000_000
+        } else if span / 1_000 > 0 {
+            1_000_000
+        } else {
+            1_000
+        };
+
+        Some(min_time - (min_time % factor))
+    } else {
+        None
+    }
+}
+
+fn round_down(value: i64, factor: i64) -> i64 {
+    value - (value.rem_euclid(factor))
+}
+
+fn round_up(value: i64, factor: i64) -> i64 {
+    let val = round_down(value, factor);
+
+    if val == value {
+        val
+    } else {
+        val + factor
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_round_down() {
+        assert_eq!(round_down(2200, 1000), 2000);
+        assert_eq!(round_down(2000, 1000), 2000);
+        assert_eq!(round_down(-2200, 1000), -3000);
+        assert_eq!(round_down(-3000, 1000), -3000);
+        assert_eq!(round_down(0, 1000), 0);
+    }
+
+    #[test]
+    fn test_round_up() {
+        assert_eq!(round_up(2200, 1000), 3000);
+        assert_eq!(round_up(2000, 1000), 2000);
+        assert_eq!(round_up(-2200, 1000), -2000);
+        assert_eq!(round_up(-3000, 1000), -3000);
+        assert_eq!(round_up(0, 1000), 0);
+    }
+}


### PR DESCRIPTION
### What

The Visible Time Range has some nice (albeit badly named) code for time drag values. I'll soon need this code for the dataframe view as well. This PR renames/refactors that code such that it is more globally available. Pure refactor, no change of functionality. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7077?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7077?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7077)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.