### PR TITLE
Use chunk recording without injected timelines

### DIFF
--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -947,7 +947,7 @@ impl RecordingStream {
 
         let chunk = Chunk::from_auto_row_ids(id, ent_path.into(), timelines, components)?;
 
-        self.record_chunk(chunk);
+        self.log_chunk(chunk);
 
         Ok(())
     }
@@ -1441,11 +1441,12 @@ impl RecordingStream {
         }
     }
 
-    /// Records a single [`Chunk`].
+    /// Logs a single [`Chunk`].
     ///
     /// Will inject `log_tick` and `log_time` timeline columns into the chunk.
+    /// If you don't want to inject these, use [`Self::send_chunk`] instead.
     #[inline]
-    pub fn record_chunk(&self, mut chunk: Chunk) {
+    pub fn log_chunk(&self, mut chunk: Chunk) {
         let f = move |inner: &RecordingStreamInner| {
             // TODO(cmc): Repeating these values is pretty wasteful. Would be nice to have a way of
             // indicating these are fixed across the whole chunk.
@@ -1499,22 +1500,22 @@ impl RecordingStream {
         };
 
         if self.with(f).is_none() {
-            re_log::warn_once!("Recording disabled - call to record_chunk() ignored");
+            re_log::warn_once!("Recording disabled - call to log_chunk() ignored");
         }
     }
 
     /// Records a single [`Chunk`].
     ///
     /// This will _not_ inject `log_tick` and `log_time` timeline columns into the chunk,
-    /// for that use [`Self::record_chunk`].
+    /// for that use [`Self::log_chunk`].
     #[inline]
-    pub fn record_chunk_raw(&self, chunk: Chunk) {
+    pub fn send_chunk(&self, chunk: Chunk) {
         let f = move |inner: &RecordingStreamInner| {
             inner.batcher.push_chunk(chunk);
         };
 
         if self.with(f).is_none() {
-            re_log::warn_once!("Recording disabled - call to record_chunk() ignored");
+            re_log::warn_once!("Recording disabled - call to send_chunk() ignored");
         }
     }
 

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -897,6 +897,10 @@ impl RecordingStream {
     /// in a columnar form. The lengths of all of the [`ChunkTimeline`] and the [`ArrowListArray`]s
     /// must match. All data that occurs at the same index across the different time and components
     /// arrays will act as a single logical row.
+    ///
+    /// Note that this API ignores any stateful time set on the log stream via the
+    /// [`Self::set_timepoint`]/[`Self::set_time_nanos`]/etc. APIs.
+    /// Furthermore, this will _not_ inject the default timelines `log_tick` and `log_time` timeline columns.
     #[inline]
     pub fn log_temporal_batch<'a>(
         &self,
@@ -947,7 +951,7 @@ impl RecordingStream {
 
         let chunk = Chunk::from_auto_row_ids(id, ent_path.into(), timelines, components)?;
 
-        self.log_chunk(chunk);
+        self.send_chunk(chunk);
 
         Ok(())
     }

--- a/rerun_py/rerun_sdk/rerun/temporal_batch.py
+++ b/rerun_py/rerun_sdk/rerun/temporal_batch.py
@@ -98,6 +98,7 @@ def log_temporal_batch(
     equivalent to a single call to `rr.log()`.
 
     Note that this API ignores any stateful time set on the log stream via the `rerun.set_time_*` APIs.
+    Furthermore, this will _not_ inject the default timelines `log_tick` and `log_time` timeline columns.
 
     When using a regular `ComponentBatch` input, the batch data will map to single-valued component
     instance at each timepoint.
@@ -197,7 +198,7 @@ def log_temporal_batch(
 
         components_args[i.component_name()] = pa.nulls(expected_length, type=pa.null())
 
-    bindings.log_arrow_chunk(
+    bindings.send_arrow_chunk(
         entity_path,
         timelines={t.timeline_name(): t.as_arrow_array() for t in times},
         components=components_args,

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -157,9 +157,9 @@ fn rerun_bindings(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
 
     // log any
     m.add_function(wrap_pyfunction!(log_arrow_msg, m)?)?;
-    m.add_function(wrap_pyfunction!(log_arrow_chunk, m)?)?;
     m.add_function(wrap_pyfunction!(log_file_from_path, m)?)?;
     m.add_function(wrap_pyfunction!(log_file_from_contents, m)?)?;
+    m.add_function(wrap_pyfunction!(send_arrow_chunk, m)?)?;
     m.add_function(wrap_pyfunction!(send_blueprint, m)?)?;
 
     // misc
@@ -1088,7 +1088,7 @@ fn log_arrow_msg(
     Ok(())
 }
 
-/// Directly log an arrow chunk to the recording stream.
+/// Directly send an arrow chunk to the recording stream.
 ///
 /// Params
 /// ------
@@ -1105,7 +1105,7 @@ fn log_arrow_msg(
     components,
     recording=None,
 ))]
-fn log_arrow_chunk(
+fn send_arrow_chunk(
     py: Python<'_>,
     entity_path: &str,
     timelines: &PyDict,
@@ -1123,7 +1123,7 @@ fn log_arrow_chunk(
     // a deadlock.
     let chunk = crate::arrow::build_chunk_from_components(entity_path, timelines, components)?;
 
-    recording.log_chunk(chunk);
+    recording.send_chunk(chunk);
 
     py.allow_threads(flush_garbage_queue);
 

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -1123,7 +1123,7 @@ fn log_arrow_chunk(
     // a deadlock.
     let chunk = crate::arrow::build_chunk_from_components(entity_path, timelines, components)?;
 
-    recording.record_chunk(chunk);
+    recording.log_chunk(chunk);
 
     py.allow_threads(flush_garbage_queue);
 

--- a/tests/rust/test_data_density_graph/src/main.rs
+++ b/tests/rust/test_data_density_graph/src/main.rs
@@ -79,7 +79,7 @@ fn log(
     let entity_path = rerun::EntityPath::parse_strict(entity_path)?;
 
     // log points
-    rec.record_chunk_raw(
+    rec.send_chunk(
         rerun::log::Chunk::builder(entity_path.clone())
             .with_archetype(
                 rerun::log::RowId::new(),
@@ -132,7 +132,7 @@ fn log(
                 &component,
             );
         }
-        rec.record_chunk_raw(chunk.build()?);
+        rec.send_chunk(chunk.build()?);
     }
 
     Ok(())


### PR DESCRIPTION
### What

* `record_chunk` -> `log_chunk`
* `record_chunk_raw` -> `send_chunk`
* use `send_chunk` in Python & Rust methods for logging temporal batches (`log_temporal_batch` on main, renamed to `send_columns`)
* clarify timeline behavior in docs
---
* sibling PR to #7076
* part of https://github.com/rerun-io/rerun/issues/7062

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7079?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7079?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7079)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.