### PR TITLE
Require all enums to start with `Invalid = 0`

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
@@ -94,9 +94,10 @@ pub fn quote_arrow_deserializer(
             // We should never hit this unwrap or it means the enum-processing at
             // the fbs layer is totally broken.
             let enum_value = obj_field.enum_value.unwrap();
+            let quoted_enum_value = proc_macro2::Literal::u8_unsuffixed(enum_value);
 
             quote! {
-                Some(#enum_value) => Ok(Some(Self::#quoted_obj_field_type))
+                Some(#quoted_enum_value) => Ok(Some(Self::#quoted_obj_field_type))
             }
         });
 

--- a/crates/build/re_types_builder/src/objects.rs
+++ b/crates/build/re_types_builder/src/objects.rs
@@ -465,19 +465,31 @@ impl Object {
             .collect();
 
         if is_enum {
+            // We want to reserve the value of 0 in all of our enums as an Invalid type variant.
+            //
+            // The reasoning behind this is twofold:
+            // - 0 is a very common accidental value to end up with if processing an incorrectly constructed buffer.
+            // - The way the .fbs compiler works, declaring an enum as a member of a struct field either requires the
+            //   enum to have a 0 value, or every struct to specify it's contextual default for that enum. This way the
+            //   fbs schema definitions are always valid.
+            //
+            // However, we then remove this field out of our generated types. This means we don't actually have to deal with
+            // invalid arms in our enums. Instead we get a deserialization error if someone accidentally uses the invalid 0
+            // value in an arrow payload.
             assert!(
                 !fields.is_empty(),
                 "enums must have at least one variant, but {fqname} has none",
             );
 
             assert!(
-            fields[0].name == "Invalid" && fields[0].enum_value == Some(0),
-            "enums must start with 'Invalid' variant with value 0, but {fqname} starts with {} = {:?}",
-            fields[0].name,
-            fields[0].enum_value,
-        );
+                fields[0].name == "Invalid" && fields[0].enum_value == Some(0),
+                "enums must start with 'Invalid' variant with value 0, but {fqname} starts with {} = {:?}",
+                fields[0].name,
+                fields[0].enum_value,
+            );
 
-            fields.remove(0); // Remove the 'Invalid' variant.
+            // Now remove the invalid variant so that it doesn't make it into our native enum definitions.
+            fields.remove(0);
         }
 
         Self {

--- a/crates/build/re_types_builder/src/objects.rs
+++ b/crates/build/re_types_builder/src/objects.rs
@@ -448,7 +448,7 @@ impl Object {
 
         let is_enum = enm.underlying_type().base_type() != FbsBaseType::UType;
 
-        let fields: Vec<_> = enm
+        let mut fields: Vec<_> = enm
             .values()
             .iter()
             .filter(|val| {
@@ -463,6 +463,22 @@ impl Object {
                 ObjectField::from_raw_enum_value(reporter, include_dir_path, enums, objs, enm, &val)
             })
             .collect();
+
+        if is_enum {
+            assert!(
+                !fields.is_empty(),
+                "enums must have at least one variant, but {fqname} has none",
+            );
+
+            assert!(
+            fields[0].name == "Invalid" && fields[0].enum_value == Some(0),
+            "enums must start with 'Invalid' variant with value 0, but {fqname} starts with {} = {:?}",
+            fields[0].name,
+            fields[0].enum_value,
+        );
+
+            fields.remove(0); // Remove the 'Invalid' variant.
+        }
 
         Self {
             virtpath,

--- a/crates/store/re_types/definitions/rerun/blueprint/components/background_kind.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/background_kind.fbs
@@ -5,6 +5,9 @@ namespace rerun.blueprint.components;
 enum BackgroundKind: byte (
     "attr.rerun.scope": "blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// A dark gradient.
     ///
     /// In 3D views it changes depending on the direction of the view.

--- a/crates/store/re_types/definitions/rerun/blueprint/components/container_kind.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/container_kind.fbs
@@ -6,6 +6,9 @@ enum ContainerKind: byte (
     "attr.rerun.scope": "blueprint",
     "attr.rust.override_crate": "re_types_blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Put children in separate tabs
     Tabs,
 

--- a/crates/store/re_types/definitions/rerun/blueprint/components/corner_2d.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/corner_2d.fbs
@@ -5,6 +5,9 @@ enum Corner2D: byte (
     "attr.rerun.scope": "blueprint",
     "attr.rust.derive": "Copy, PartialEq, Eq"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Left top corner.
     LeftTop,
 

--- a/crates/store/re_types/definitions/rerun/blueprint/components/dataframe_view_mode.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/dataframe_view_mode.fbs
@@ -5,6 +5,9 @@ namespace rerun.blueprint.components;
 enum DataframeViewMode: byte (
     "attr.rerun.scope": "blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Display the entity values at the current time.
     ///
     /// In this mode, rows are entity instances, and columns are components. The visible time range setting is ignored.

--- a/crates/store/re_types/definitions/rerun/blueprint/components/panel_state.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/panel_state.fbs
@@ -9,6 +9,9 @@ enum PanelState: byte (
   "attr.rust.repr": "transparent",
   "attr.rust.tuple_struct"
 ) {
+      /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
   /// Completely hidden.
   Hidden,
 

--- a/crates/store/re_types/definitions/rerun/blueprint/components/sort_key.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/sort_key.fbs
@@ -5,6 +5,9 @@ namespace rerun.blueprint.components;
 enum SortKey: byte (
     "attr.rerun.scope": "blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Group by entity.
     Entity (default),
 

--- a/crates/store/re_types/definitions/rerun/blueprint/components/sort_order.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/sort_order.fbs
@@ -5,6 +5,9 @@ namespace rerun.blueprint.components;
 enum SortOrder: byte (
     "attr.rerun.scope": "blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Ascending
     Ascending (default),
 

--- a/crates/store/re_types/definitions/rerun/blueprint/components/view_fit.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/view_fit.fbs
@@ -4,6 +4,9 @@ namespace rerun.blueprint.components;
 enum ViewFit: byte (
     "attr.rerun.scope": "blueprint"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// No scaling, pixel size will match the image's width/height dimensions in pixels.
     Original,
 

--- a/crates/store/re_types/definitions/rerun/components/aggregation_policy.fbs
+++ b/crates/store/re_types/definitions/rerun/components/aggregation_policy.fbs
@@ -6,6 +6,9 @@ namespace rerun.components;
 /// i.e. a single pixel covers more than one tick worth of data. It can greatly improve performance
 /// (and readability) in such situations as it prevents overdraw.
 enum AggregationPolicy: byte {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// No aggregation.
     Off,
 

--- a/crates/store/re_types/definitions/rerun/components/channel_datatype.fbs
+++ b/crates/store/re_types/definitions/rerun/components/channel_datatype.fbs
@@ -6,6 +6,9 @@ namespace rerun.components;
 enum ChannelDatatype: byte (
     "attr.docs.unreleased"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// 8-bit unsigned integer.
     U8 (default),
 

--- a/crates/store/re_types/definitions/rerun/components/color_model.fbs
+++ b/crates/store/re_types/definitions/rerun/components/color_model.fbs
@@ -8,6 +8,9 @@ namespace rerun.components;
 enum ColorModel: byte (
     "attr.docs.unreleased"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Grayscale luminance intencity/brightness/value, sometimes called `Y`
     L (default),
 

--- a/crates/store/re_types/definitions/rerun/components/colormap.fbs
+++ b/crates/store/re_types/definitions/rerun/components/colormap.fbs
@@ -6,6 +6,9 @@ namespace rerun.components;
 /// In the future, the Rerun Viewer will allow users to define their own colormaps,
 /// but currently the Viewer is limited to the types defined here.
 enum Colormap: byte {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// A simple black to white gradient.
     ///
     /// This is a sRGB gray gradient which is perceptually uniform.

--- a/crates/store/re_types/definitions/rerun/components/fill_mode.fbs
+++ b/crates/store/re_types/definitions/rerun/components/fill_mode.fbs
@@ -4,6 +4,9 @@ namespace rerun.components;
 enum FillMode: byte(
     "attr.docs.unreleased"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Lines are drawn around the edges of the shape.
     ///
     /// The interior (2D) or surface (3D) are not drawn.

--- a/crates/store/re_types/definitions/rerun/components/magnification_filter.fbs
+++ b/crates/store/re_types/definitions/rerun/components/magnification_filter.fbs
@@ -2,6 +2,9 @@ namespace rerun.components;
 
 /// Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.
 enum MagnificationFilter: byte {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Show the nearest pixel value.
     ///
     /// This will give a blocky appearance when zooming in.

--- a/crates/store/re_types/definitions/rerun/components/marker_shape.fbs
+++ b/crates/store/re_types/definitions/rerun/components/marker_shape.fbs
@@ -4,6 +4,9 @@ namespace rerun.components;
 /// The visual appearance of a point in e.g. a 2D plot.
 enum MarkerShape: byte
  {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// `⏺`
     Circle (default),
 

--- a/crates/store/re_types/definitions/rerun/components/pixel_format.fbs
+++ b/crates/store/re_types/definitions/rerun/components/pixel_format.fbs
@@ -16,6 +16,9 @@ namespace rerun.components;
 enum PixelFormat: byte (
     "attr.docs.unreleased"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     // TODO(emilk): consider following the naming in
     // https://facebookresearch.github.io/ocean/docs/images/pixel_formats_and_plane_layout/
 

--- a/crates/store/re_types/definitions/rerun/components/transform_relation.fbs
+++ b/crates/store/re_types/definitions/rerun/components/transform_relation.fbs
@@ -4,6 +4,9 @@ namespace rerun.components;
 enum TransformRelation: byte (
     "attr.docs.unreleased"
 ) {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// The transform describes how to transform into the parent entity's space.
     ///
     /// E.g. a translation of (0, 1, 0) with this [components.TransformRelation] logged at `parent/child` means

--- a/crates/store/re_types/definitions/rerun/testing/components/enum_test.fbs
+++ b/crates/store/re_types/definitions/rerun/testing/components/enum_test.fbs
@@ -2,6 +2,9 @@ namespace rerun.testing.datatypes;
 
 /// A test of the enum type.
 enum EnumTest: byte {
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
+
     /// Great film.
     Up,
 
@@ -23,8 +26,8 @@ enum EnumTest: byte {
 
 /// A test of an enumate with specified values.
 enum ValuedEnum: byte {
-    /// Default value.
-    Default = 0 (default),
+    /// Invalid value. Won't show up in generated types.
+    Invalid = 0,
 
     /// One.
     One = 1,

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -26,15 +26,15 @@ pub enum BackgroundKind {
     ///
     /// In 3D views it changes depending on the direction of the view.
     #[default]
-    GradientDark = 0,
+    GradientDark = 1,
 
     /// A bright gradient.
     ///
     /// In 3D views it changes depending on the direction of the view.
-    GradientBright = 1,
+    GradientBright = 2,
 
     /// Simple uniform color.
-    SolidColor = 2,
+    SolidColor = 3,
 }
 
 impl ::re_types_core::reflection::Enum for BackgroundKind {
@@ -148,9 +148,9 @@ impl ::re_types_core::Loggable for BackgroundKind {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::GradientDark)),
-                Some(1u8) => Ok(Some(Self::GradientBright)),
-                Some(2u8) => Ok(Some(Self::SolidColor)),
+                Some(1) => Ok(Some(Self::GradientDark)),
+                Some(2) => Ok(Some(Self::GradientBright)),
+                Some(3) => Ok(Some(Self::SolidColor)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -23,17 +23,17 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum Corner2D {
     /// Left top corner.
-    LeftTop = 0,
+    LeftTop = 1,
 
     /// Right top corner.
-    RightTop = 1,
+    RightTop = 2,
 
     /// Left bottom corner.
-    LeftBottom = 2,
+    LeftBottom = 3,
 
     /// Right bottom corner.
     #[default]
-    RightBottom = 3,
+    RightBottom = 4,
 }
 
 impl ::re_types_core::reflection::Enum for Corner2D {
@@ -150,10 +150,10 @@ impl ::re_types_core::Loggable for Corner2D {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::LeftTop)),
-                Some(1u8) => Ok(Some(Self::RightTop)),
-                Some(2u8) => Ok(Some(Self::LeftBottom)),
-                Some(3u8) => Ok(Some(Self::RightBottom)),
+                Some(1) => Ok(Some(Self::LeftTop)),
+                Some(2) => Ok(Some(Self::RightTop)),
+                Some(3) => Ok(Some(Self::LeftBottom)),
+                Some(4) => Ok(Some(Self::RightBottom)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/dataframe_view_mode.rs
+++ b/crates/store/re_types/src/blueprint/components/dataframe_view_mode.rs
@@ -26,13 +26,13 @@ pub enum DataframeViewMode {
     ///
     /// In this mode, rows are entity instances, and columns are components. The visible time range setting is ignored.
     #[default]
-    LatestAt = 0,
+    LatestAt = 1,
 
     /// Display a temporal table of entity values.
     ///
     /// In this mode, rows are combination of entity path, timestamp, and row id, and columns are components. The
     /// timestamp shown are determined by each view entity's visible time range setting.
-    TimeRange = 1,
+    TimeRange = 2,
 }
 
 impl ::re_types_core::reflection::Enum for DataframeViewMode {
@@ -144,8 +144,8 @@ impl ::re_types_core::Loggable for DataframeViewMode {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::LatestAt)),
-                Some(1u8) => Ok(Some(Self::TimeRange)),
+                Some(1) => Ok(Some(Self::LatestAt)),
+                Some(2) => Ok(Some(Self::TimeRange)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -23,14 +23,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum PanelState {
     /// Completely hidden.
-    Hidden = 0,
+    Hidden = 1,
 
     /// Visible, but as small as possible on its shorter axis.
-    Collapsed = 1,
+    Collapsed = 2,
 
     /// Fully expanded.
     #[default]
-    Expanded = 2,
+    Expanded = 3,
 }
 
 impl ::re_types_core::reflection::Enum for PanelState {
@@ -140,9 +140,9 @@ impl ::re_types_core::Loggable for PanelState {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Hidden)),
-                Some(1u8) => Ok(Some(Self::Collapsed)),
-                Some(2u8) => Ok(Some(Self::Expanded)),
+                Some(1) => Ok(Some(Self::Hidden)),
+                Some(2) => Ok(Some(Self::Collapsed)),
+                Some(3) => Ok(Some(Self::Expanded)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/sort_key.rs
+++ b/crates/store/re_types/src/blueprint/components/sort_key.rs
@@ -24,10 +24,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum SortKey {
     /// Group by entity.
     #[default]
-    Entity = 0,
+    Entity = 1,
 
     /// Group by instance.
-    Time = 1,
+    Time = 2,
 }
 
 impl ::re_types_core::reflection::Enum for SortKey {
@@ -135,8 +135,8 @@ impl ::re_types_core::Loggable for SortKey {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Entity)),
-                Some(1u8) => Ok(Some(Self::Time)),
+                Some(1) => Ok(Some(Self::Entity)),
+                Some(2) => Ok(Some(Self::Time)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/sort_order.rs
+++ b/crates/store/re_types/src/blueprint/components/sort_order.rs
@@ -24,10 +24,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum SortOrder {
     /// Ascending
     #[default]
-    Ascending = 0,
+    Ascending = 1,
 
     /// Descending
-    Descending = 1,
+    Descending = 2,
 }
 
 impl ::re_types_core::reflection::Enum for SortOrder {
@@ -135,8 +135,8 @@ impl ::re_types_core::Loggable for SortOrder {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Ascending)),
-                Some(1u8) => Ok(Some(Self::Descending)),
+                Some(1) => Ok(Some(Self::Ascending)),
+                Some(2) => Ok(Some(Self::Descending)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -23,14 +23,14 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum ViewFit {
     /// No scaling, pixel size will match the image's width/height dimensions in pixels.
-    Original = 0,
+    Original = 1,
 
     /// Scale the image for the largest possible fit in the view's container.
-    Fill = 1,
+    Fill = 2,
 
     /// Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio.
     #[default]
-    FillKeepAspectRatio = 2,
+    FillKeepAspectRatio = 3,
 }
 
 impl ::re_types_core::reflection::Enum for ViewFit {
@@ -146,9 +146,9 @@ impl ::re_types_core::Loggable for ViewFit {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Original)),
-                Some(1u8) => Ok(Some(Self::Fill)),
-                Some(2u8) => Ok(Some(Self::FillKeepAspectRatio)),
+                Some(1) => Ok(Some(Self::Original)),
+                Some(2) => Ok(Some(Self::Fill)),
+                Some(3) => Ok(Some(Self::FillKeepAspectRatio)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -27,25 +27,25 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum AggregationPolicy {
     /// No aggregation.
-    Off = 0,
+    Off = 1,
 
     /// Average all points in the range together.
-    Average = 1,
+    Average = 2,
 
     /// Keep only the maximum values in the range.
-    Max = 2,
+    Max = 3,
 
     /// Keep only the minimum values in the range.
-    Min = 3,
+    Min = 4,
 
     /// Keep both the minimum and maximum values in the range.
     ///
     /// This will yield two aggregated points instead of one, effectively creating a vertical line.
     #[default]
-    MinMax = 4,
+    MinMax = 5,
 
     /// Find both the minimum and maximum values in the range, then use the average of those.
-    MinMaxAverage = 5,
+    MinMaxAverage = 6,
 }
 
 impl ::re_types_core::reflection::Enum for AggregationPolicy {
@@ -172,12 +172,12 @@ impl ::re_types_core::Loggable for AggregationPolicy {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Off)),
-                Some(1u8) => Ok(Some(Self::Average)),
-                Some(2u8) => Ok(Some(Self::Max)),
-                Some(3u8) => Ok(Some(Self::Min)),
-                Some(4u8) => Ok(Some(Self::MinMax)),
-                Some(5u8) => Ok(Some(Self::MinMaxAverage)),
+                Some(1) => Ok(Some(Self::Off)),
+                Some(2) => Ok(Some(Self::Average)),
+                Some(3) => Ok(Some(Self::Max)),
+                Some(4) => Ok(Some(Self::Min)),
+                Some(5) => Ok(Some(Self::MinMax)),
+                Some(6) => Ok(Some(Self::MinMaxAverage)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/channel_datatype.rs
+++ b/crates/store/re_types/src/components/channel_datatype.rs
@@ -26,37 +26,37 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum ChannelDatatype {
     /// 8-bit unsigned integer.
     #[default]
-    U8 = 0,
+    U8 = 1,
 
     /// 16-bit unsigned integer.
-    U16 = 1,
+    U16 = 2,
 
     /// 32-bit unsigned integer.
-    U32 = 2,
+    U32 = 3,
 
     /// 64-bit unsigned integer.
-    U64 = 3,
+    U64 = 4,
 
     /// 8-bit signed integer.
-    I8 = 4,
+    I8 = 5,
 
     /// 16-bit signed integer.
-    I16 = 5,
+    I16 = 6,
 
     /// 32-bit signed integer.
-    I32 = 6,
+    I32 = 7,
 
     /// 64-bit signed integer.
-    I64 = 7,
+    I64 = 8,
 
     /// 16-bit IEEE-754 floating point, also known as `half`.
-    F16 = 8,
+    F16 = 9,
 
     /// 32-bit IEEE-754 floating point, also known as `float` or `single`.
-    F32 = 9,
+    F32 = 10,
 
     /// 64-bit IEEE-754 floating point, also known as `double`.
-    F64 = 10,
+    F64 = 11,
 }
 
 impl ::re_types_core::reflection::Enum for ChannelDatatype {
@@ -194,17 +194,17 @@ impl ::re_types_core::Loggable for ChannelDatatype {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::U8)),
-                Some(1u8) => Ok(Some(Self::U16)),
-                Some(2u8) => Ok(Some(Self::U32)),
-                Some(3u8) => Ok(Some(Self::U64)),
-                Some(4u8) => Ok(Some(Self::I8)),
-                Some(5u8) => Ok(Some(Self::I16)),
-                Some(6u8) => Ok(Some(Self::I32)),
-                Some(7u8) => Ok(Some(Self::I64)),
-                Some(8u8) => Ok(Some(Self::F16)),
-                Some(9u8) => Ok(Some(Self::F32)),
-                Some(10u8) => Ok(Some(Self::F64)),
+                Some(1) => Ok(Some(Self::U8)),
+                Some(2) => Ok(Some(Self::U16)),
+                Some(3) => Ok(Some(Self::U32)),
+                Some(4) => Ok(Some(Self::U64)),
+                Some(5) => Ok(Some(Self::I8)),
+                Some(6) => Ok(Some(Self::I16)),
+                Some(7) => Ok(Some(Self::I32)),
+                Some(8) => Ok(Some(Self::I64)),
+                Some(9) => Ok(Some(Self::F16)),
+                Some(10) => Ok(Some(Self::F32)),
+                Some(11) => Ok(Some(Self::F64)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/color_model.rs
+++ b/crates/store/re_types/src/components/color_model.rs
@@ -26,15 +26,15 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum ColorModel {
     /// Grayscale luminance intencity/brightness/value, sometimes called `Y`
     #[default]
-    L = 0,
+    L = 1,
 
     /// Red, Green, Blue
     #[allow(clippy::upper_case_acronyms)]
-    RGB = 1,
+    RGB = 2,
 
     /// Red, Green, Blue, Alpha
     #[allow(clippy::upper_case_acronyms)]
-    RGBA = 2,
+    RGBA = 3,
 }
 
 impl ::re_types_core::reflection::Enum for ColorModel {
@@ -144,9 +144,9 @@ impl ::re_types_core::Loggable for ColorModel {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::L)),
-                Some(1u8) => Ok(Some(Self::RGB)),
-                Some(2u8) => Ok(Some(Self::RGBA)),
+                Some(1) => Ok(Some(Self::L)),
+                Some(2) => Ok(Some(Self::RGB)),
+                Some(3) => Ok(Some(Self::RGBA)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -29,25 +29,25 @@ pub enum Colormap {
     /// A simple black to white gradient.
     ///
     /// This is a sRGB gray gradient which is perceptually uniform.
-    Grayscale = 0,
+    Grayscale = 1,
 
     /// The Inferno colormap from Matplotlib.
     ///
     /// This is a perceptually uniform colormap.
     /// It interpolates from black to red to bright yellow.
-    Inferno = 1,
+    Inferno = 2,
 
     /// The Magma colormap from Matplotlib.
     ///
     /// This is a perceptually uniform colormap.
     /// It interpolates from black to purple to white.
-    Magma = 2,
+    Magma = 3,
 
     /// The Plasma colormap from Matplotlib.
     ///
     /// This is a perceptually uniform colormap.
     /// It interpolates from dark blue to purple to yellow.
-    Plasma = 3,
+    Plasma = 4,
 
     /// Google's Turbo colormap map.
     ///
@@ -56,20 +56,20 @@ pub enum Colormap {
     /// It is more perceptually uniform without sharp transitions and is more colorblind-friendly.
     /// Details: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>
     #[default]
-    Turbo = 4,
+    Turbo = 5,
 
     /// The Viridis colormap from Matplotlib
     ///
     /// This is a perceptually uniform colormap which is robust to color blindness.
     /// It interpolates from dark purple to green to yellow.
-    Viridis = 5,
+    Viridis = 6,
 
     /// Rasmusgo's Cyan to Yellow colormap
     ///
     /// This is a perceptually uniform colormap which is robust to color blindness.
     /// It is especially suited for visualizing signed values.
     /// It interpolates from cyan to blue to dark gray to brass to yellow.
-    CyanToYellow = 6,
+    CyanToYellow = 7,
 }
 
 impl ::re_types_core::reflection::Enum for Colormap {
@@ -209,13 +209,13 @@ impl ::re_types_core::Loggable for Colormap {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Grayscale)),
-                Some(1u8) => Ok(Some(Self::Inferno)),
-                Some(2u8) => Ok(Some(Self::Magma)),
-                Some(3u8) => Ok(Some(Self::Plasma)),
-                Some(4u8) => Ok(Some(Self::Turbo)),
-                Some(5u8) => Ok(Some(Self::Viridis)),
-                Some(6u8) => Ok(Some(Self::CyanToYellow)),
+                Some(1) => Ok(Some(Self::Grayscale)),
+                Some(2) => Ok(Some(Self::Inferno)),
+                Some(3) => Ok(Some(Self::Magma)),
+                Some(4) => Ok(Some(Self::Plasma)),
+                Some(5) => Ok(Some(Self::Turbo)),
+                Some(6) => Ok(Some(Self::Viridis)),
+                Some(7) => Ok(Some(Self::CyanToYellow)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -26,12 +26,12 @@ pub enum FillMode {
     ///
     /// The interior (2D) or surface (3D) are not drawn.
     #[default]
-    Wireframe = 0,
+    Wireframe = 1,
 
     /// The interior (2D) or surface (3D) is filled with a single color.
     ///
     /// Lines are not drawn.
-    Solid = 1,
+    Solid = 2,
 }
 
 impl ::re_types_core::reflection::Enum for FillMode {
@@ -143,8 +143,8 @@ impl ::re_types_core::Loggable for FillMode {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Wireframe)),
-                Some(1u8) => Ok(Some(Self::Solid)),
+                Some(1) => Ok(Some(Self::Wireframe)),
+                Some(2) => Ok(Some(Self::Solid)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -27,12 +27,12 @@ pub enum MagnificationFilter {
     /// This will give a blocky appearance when zooming in.
     /// Used as default when rendering 2D images.
     #[default]
-    Nearest = 0,
+    Nearest = 1,
 
     /// Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.
     ///
     /// Used as default for mesh rendering.
-    Linear = 1,
+    Linear = 2,
 }
 
 impl ::re_types_core::reflection::Enum for MagnificationFilter {
@@ -144,8 +144,8 @@ impl ::re_types_core::Loggable for MagnificationFilter {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Nearest)),
-                Some(1u8) => Ok(Some(Self::Linear)),
+                Some(1) => Ok(Some(Self::Nearest)),
+                Some(2) => Ok(Some(Self::Linear)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -24,34 +24,34 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub enum MarkerShape {
     /// `⏺`
     #[default]
-    Circle = 0,
+    Circle = 1,
 
     /// `◆`
-    Diamond = 1,
+    Diamond = 2,
 
     /// `◼️`
-    Square = 2,
+    Square = 3,
 
     /// `x`
-    Cross = 3,
+    Cross = 4,
 
     /// `+`
-    Plus = 4,
+    Plus = 5,
 
     /// `▲`
-    Up = 5,
+    Up = 6,
 
     /// `▼`
-    Down = 6,
+    Down = 7,
 
     /// `◀`
-    Left = 7,
+    Left = 8,
 
     /// `▶`
-    Right = 8,
+    Right = 9,
 
     /// `*`
-    Asterisk = 9,
+    Asterisk = 10,
 }
 
 impl ::re_types_core::reflection::Enum for MarkerShape {
@@ -186,16 +186,16 @@ impl ::re_types_core::Loggable for MarkerShape {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Circle)),
-                Some(1u8) => Ok(Some(Self::Diamond)),
-                Some(2u8) => Ok(Some(Self::Square)),
-                Some(3u8) => Ok(Some(Self::Cross)),
-                Some(4u8) => Ok(Some(Self::Plus)),
-                Some(5u8) => Ok(Some(Self::Up)),
-                Some(6u8) => Ok(Some(Self::Down)),
-                Some(7u8) => Ok(Some(Self::Left)),
-                Some(8u8) => Ok(Some(Self::Right)),
-                Some(9u8) => Ok(Some(Self::Asterisk)),
+                Some(1) => Ok(Some(Self::Circle)),
+                Some(2) => Ok(Some(Self::Diamond)),
+                Some(3) => Ok(Some(Self::Square)),
+                Some(4) => Ok(Some(Self::Cross)),
+                Some(5) => Ok(Some(Self::Plus)),
+                Some(6) => Ok(Some(Self::Up)),
+                Some(7) => Ok(Some(Self::Down)),
+                Some(8) => Ok(Some(Self::Left)),
+                Some(9) => Ok(Some(Self::Right)),
+                Some(10) => Ok(Some(Self::Asterisk)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/pixel_format.rs
+++ b/crates/store/re_types/src/components/pixel_format.rs
@@ -38,13 +38,13 @@ pub enum PixelFormat {
     /// followed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc.
     #[default]
     #[allow(clippy::upper_case_acronyms)]
-    NV12 = 0,
+    NV12 = 1,
 
     /// YUY2 (aka YUYV or YUYV16), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.
     ///
     /// The order of the channels is Y0, U0, Y1, V0, all in the same plane.
     #[allow(clippy::upper_case_acronyms)]
-    YUY2 = 1,
+    YUY2 = 2,
 }
 
 impl ::re_types_core::reflection::Enum for PixelFormat {
@@ -156,8 +156,8 @@ impl ::re_types_core::Loggable for PixelFormat {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::NV12)),
-                Some(1u8) => Ok(Some(Self::YUY2)),
+                Some(1) => Ok(Some(Self::NV12)),
+                Some(2) => Ok(Some(Self::YUY2)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -28,14 +28,14 @@ pub enum TransformRelation {
     /// that from the point of view of `parent`, `parent/child` is translated 1 unit along `parent`'s Y axis.
     /// From perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis.
     #[default]
-    ParentFromChild = 0,
+    ParentFromChild = 1,
 
     /// The transform describes how to transform into the child entity's space.
     ///
     /// E.g. a translation of (0, 1, 0) with this [`components::TransformRelation`][crate::components::TransformRelation] logged at `parent/child` means
     /// that from the point of view of `parent`, `parent/child` is translated -1 unit along `parent`'s Y axis.
     /// From perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis.
-    ChildFromParent = 1,
+    ChildFromParent = 2,
 }
 
 impl ::re_types_core::reflection::Enum for TransformRelation {
@@ -147,8 +147,8 @@ impl ::re_types_core::Loggable for TransformRelation {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::ParentFromChild)),
-                Some(1u8) => Ok(Some(Self::ChildFromParent)),
+                Some(1) => Ok(Some(Self::ParentFromChild)),
+                Some(2) => Ok(Some(Self::ChildFromParent)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/testing/datatypes/enum_test.rs
+++ b/crates/store/re_types/src/testing/datatypes/enum_test.rs
@@ -23,23 +23,23 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum EnumTest {
     /// Great film.
-    Up = 0,
+    Up = 1,
 
     /// Feeling blue.
-    Down = 1,
+    Down = 2,
 
     /// Correct.
     #[default]
-    Right = 2,
+    Right = 3,
 
     /// It's what's remaining.
-    Left = 3,
+    Left = 4,
 
     /// It's the only way to go.
-    Forward = 4,
+    Forward = 5,
 
     /// Baby's got it.
-    Back = 5,
+    Back = 6,
 }
 
 impl ::re_types_core::reflection::Enum for EnumTest {
@@ -162,12 +162,12 @@ impl ::re_types_core::Loggable for EnumTest {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Up)),
-                Some(1u8) => Ok(Some(Self::Down)),
-                Some(2u8) => Ok(Some(Self::Right)),
-                Some(3u8) => Ok(Some(Self::Left)),
-                Some(4u8) => Ok(Some(Self::Forward)),
-                Some(5u8) => Ok(Some(Self::Back)),
+                Some(1) => Ok(Some(Self::Up)),
+                Some(2) => Ok(Some(Self::Down)),
+                Some(3) => Ok(Some(Self::Right)),
+                Some(4) => Ok(Some(Self::Left)),
+                Some(5) => Ok(Some(Self::Forward)),
+                Some(6) => Ok(Some(Self::Back)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/testing/datatypes/valued_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/valued_enum.rs
@@ -19,13 +19,9 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A test of an enumate with specified values.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ValuedEnum {
-    /// Default value.
-    #[default]
-    Default = 0,
-
     /// One.
     One = 1,
 
@@ -42,19 +38,12 @@ pub enum ValuedEnum {
 impl ::re_types_core::reflection::Enum for ValuedEnum {
     #[inline]
     fn variants() -> &'static [Self] {
-        &[
-            Self::Default,
-            Self::One,
-            Self::Two,
-            Self::Three,
-            Self::TheAnswer,
-        ]
+        &[Self::One, Self::Two, Self::Three, Self::TheAnswer]
     }
 
     #[inline]
     fn docstring_md(self) -> &'static str {
         match self {
-            Self::Default => "Default value.",
             Self::One => "One.",
             Self::Two => "Two.",
             Self::Three => "Three.",
@@ -78,7 +67,6 @@ impl ::re_types_core::SizeBytes for ValuedEnum {
 impl std::fmt::Display for ValuedEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Default => write!(f, "Default"),
             Self::One => write!(f, "One"),
             Self::Two => write!(f, "Two"),
             Self::Three => write!(f, "Three"),
@@ -156,11 +144,10 @@ impl ::re_types_core::Loggable for ValuedEnum {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Default)),
-                Some(1u8) => Ok(Some(Self::One)),
-                Some(2u8) => Ok(Some(Self::Two)),
-                Some(3u8) => Ok(Some(Self::Three)),
-                Some(42u8) => Ok(Some(Self::TheAnswer)),
+                Some(1) => Ok(Some(Self::One)),
+                Some(2) => Ok(Some(Self::Two)),
+                Some(3) => Ok(Some(Self::Three)),
+                Some(42) => Ok(Some(Self::TheAnswer)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
@@ -23,17 +23,17 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(u8)]
 pub enum ContainerKind {
     /// Put children in separate tabs
-    Tabs = 0,
+    Tabs = 1,
 
     /// Order the children left to right
-    Horizontal = 1,
+    Horizontal = 2,
 
     /// Order the children top to bottom
-    Vertical = 2,
+    Vertical = 3,
 
     /// Organize children in a grid layout
     #[default]
-    Grid = 3,
+    Grid = 4,
 }
 
 impl ::re_types_core::reflection::Enum for ContainerKind {
@@ -145,10 +145,10 @@ impl ::re_types_core::Loggable for ContainerKind {
             .into_iter()
             .map(|opt| opt.copied())
             .map(|typ| match typ {
-                Some(0u8) => Ok(Some(Self::Tabs)),
-                Some(1u8) => Ok(Some(Self::Horizontal)),
-                Some(2u8) => Ok(Some(Self::Vertical)),
-                Some(3u8) => Ok(Some(Self::Grid)),
+                Some(1) => Ok(Some(Self::Tabs)),
+                Some(2) => Ok(Some(Self::Horizontal)),
+                Some(3) => Ok(Some(Self::Vertical)),
+                Some(4) => Ok(Some(Self::Grid)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/rerun_cpp/src/rerun/blueprint/components/background_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/background_kind.hpp
@@ -26,15 +26,15 @@ namespace rerun::blueprint::components {
         /// A dark gradient.
         ///
         /// In 3D views it changes depending on the direction of the view.
-        GradientDark = 0,
+        GradientDark = 1,
 
         /// A bright gradient.
         ///
         /// In 3D views it changes depending on the direction of the view.
-        GradientBright = 1,
+        GradientBright = 2,
 
         /// Simple uniform color.
-        SolidColor = 2,
+        SolidColor = 3,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/container_kind.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/container_kind.hpp
@@ -24,16 +24,16 @@ namespace rerun::blueprint::components {
     enum class ContainerKind : uint8_t {
 
         /// Put children in separate tabs
-        Tabs = 0,
+        Tabs = 1,
 
         /// Order the children left to right
-        Horizontal = 1,
+        Horizontal = 2,
 
         /// Order the children top to bottom
-        Vertical = 2,
+        Vertical = 3,
 
         /// Organize children in a grid layout
-        Grid = 3,
+        Grid = 4,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/corner2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/corner2d.hpp
@@ -24,16 +24,16 @@ namespace rerun::blueprint::components {
     enum class Corner2D : uint8_t {
 
         /// Left top corner.
-        LeftTop = 0,
+        LeftTop = 1,
 
         /// Right top corner.
-        RightTop = 1,
+        RightTop = 2,
 
         /// Left bottom corner.
-        LeftBottom = 2,
+        LeftBottom = 3,
 
         /// Right bottom corner.
-        RightBottom = 3,
+        RightBottom = 4,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/dataframe_view_mode.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/dataframe_view_mode.hpp
@@ -26,13 +26,13 @@ namespace rerun::blueprint::components {
         /// Display the entity values at the current time.
         ///
         /// In this mode, rows are entity instances, and columns are components. The visible time range setting is ignored.
-        LatestAt = 0,
+        LatestAt = 1,
 
         /// Display a temporal table of entity values.
         ///
         /// In this mode, rows are combination of entity path, timestamp, and row id, and columns are components. The
         /// timestamp shown are determined by each view entity's visible time range setting.
-        TimeRange = 1,
+        TimeRange = 2,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/panel_state.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/panel_state.hpp
@@ -24,13 +24,13 @@ namespace rerun::blueprint::components {
     enum class PanelState : uint8_t {
 
         /// Completely hidden.
-        Hidden = 0,
+        Hidden = 1,
 
         /// Visible, but as small as possible on its shorter axis.
-        Collapsed = 1,
+        Collapsed = 2,
 
         /// Fully expanded.
-        Expanded = 2,
+        Expanded = 3,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/sort_key.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/sort_key.hpp
@@ -24,10 +24,10 @@ namespace rerun::blueprint::components {
     enum class SortKey : uint8_t {
 
         /// Group by entity.
-        Entity = 0,
+        Entity = 1,
 
         /// Group by instance.
-        Time = 1,
+        Time = 2,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/sort_order.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/sort_order.hpp
@@ -24,10 +24,10 @@ namespace rerun::blueprint::components {
     enum class SortOrder : uint8_t {
 
         /// Ascending
-        Ascending = 0,
+        Ascending = 1,
 
         /// Descending
-        Descending = 1,
+        Descending = 2,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/blueprint/components/view_fit.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/view_fit.hpp
@@ -24,13 +24,13 @@ namespace rerun::blueprint::components {
     enum class ViewFit : uint8_t {
 
         /// No scaling, pixel size will match the image's width/height dimensions in pixels.
-        Original = 0,
+        Original = 1,
 
         /// Scale the image for the largest possible fit in the view's container.
-        Fill = 1,
+        Fill = 2,
 
         /// Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio.
-        FillKeepAspectRatio = 2,
+        FillKeepAspectRatio = 3,
     };
 } // namespace rerun::blueprint::components
 

--- a/rerun_cpp/src/rerun/components/aggregation_policy.hpp
+++ b/rerun_cpp/src/rerun/components/aggregation_policy.hpp
@@ -28,24 +28,24 @@ namespace rerun::components {
     enum class AggregationPolicy : uint8_t {
 
         /// No aggregation.
-        Off = 0,
+        Off = 1,
 
         /// Average all points in the range together.
-        Average = 1,
+        Average = 2,
 
         /// Keep only the maximum values in the range.
-        Max = 2,
+        Max = 3,
 
         /// Keep only the minimum values in the range.
-        Min = 3,
+        Min = 4,
 
         /// Keep both the minimum and maximum values in the range.
         ///
         /// This will yield two aggregated points instead of one, effectively creating a vertical line.
-        MinMax = 4,
+        MinMax = 5,
 
         /// Find both the minimum and maximum values in the range, then use the average of those.
-        MinMaxAverage = 5,
+        MinMaxAverage = 6,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/channel_datatype.hpp
+++ b/rerun_cpp/src/rerun/components/channel_datatype.hpp
@@ -26,37 +26,37 @@ namespace rerun::components {
     enum class ChannelDatatype : uint8_t {
 
         /// 8-bit unsigned integer.
-        U8 = 0,
+        U8 = 1,
 
         /// 16-bit unsigned integer.
-        U16 = 1,
+        U16 = 2,
 
         /// 32-bit unsigned integer.
-        U32 = 2,
+        U32 = 3,
 
         /// 64-bit unsigned integer.
-        U64 = 3,
+        U64 = 4,
 
         /// 8-bit signed integer.
-        I8 = 4,
+        I8 = 5,
 
         /// 16-bit signed integer.
-        I16 = 5,
+        I16 = 6,
 
         /// 32-bit signed integer.
-        I32 = 6,
+        I32 = 7,
 
         /// 64-bit signed integer.
-        I64 = 7,
+        I64 = 8,
 
         /// 16-bit IEEE-754 floating point, also known as `half`.
-        F16 = 8,
+        F16 = 9,
 
         /// 32-bit IEEE-754 floating point, also known as `float` or `single`.
-        F32 = 9,
+        F32 = 10,
 
         /// 64-bit IEEE-754 floating point, also known as `double`.
-        F64 = 10,
+        F64 = 11,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/color_model.hpp
+++ b/rerun_cpp/src/rerun/components/color_model.hpp
@@ -26,13 +26,13 @@ namespace rerun::components {
     enum class ColorModel : uint8_t {
 
         /// Grayscale luminance intencity/brightness/value, sometimes called `Y`
-        L = 0,
+        L = 1,
 
         /// Red, Green, Blue
-        RGB = 1,
+        RGB = 2,
 
         /// Red, Green, Blue, Alpha
-        RGBA = 2,
+        RGBA = 3,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/colormap.hpp
+++ b/rerun_cpp/src/rerun/components/colormap.hpp
@@ -30,25 +30,25 @@ namespace rerun::components {
         /// A simple black to white gradient.
         ///
         /// This is a sRGB gray gradient which is perceptually uniform.
-        Grayscale = 0,
+        Grayscale = 1,
 
         /// The Inferno colormap from Matplotlib.
         ///
         /// This is a perceptually uniform colormap.
         /// It interpolates from black to red to bright yellow.
-        Inferno = 1,
+        Inferno = 2,
 
         /// The Magma colormap from Matplotlib.
         ///
         /// This is a perceptually uniform colormap.
         /// It interpolates from black to purple to white.
-        Magma = 2,
+        Magma = 3,
 
         /// The Plasma colormap from Matplotlib.
         ///
         /// This is a perceptually uniform colormap.
         /// It interpolates from dark blue to purple to yellow.
-        Plasma = 3,
+        Plasma = 4,
 
         /// Google's Turbo colormap map.
         ///
@@ -56,20 +56,20 @@ namespace rerun::components {
         /// more traditional rainbow colormaps like Jet.
         /// It is more perceptually uniform without sharp transitions and is more colorblind-friendly.
         /// Details: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>
-        Turbo = 4,
+        Turbo = 5,
 
         /// The Viridis colormap from Matplotlib
         ///
         /// This is a perceptually uniform colormap which is robust to color blindness.
         /// It interpolates from dark purple to green to yellow.
-        Viridis = 5,
+        Viridis = 6,
 
         /// Rasmusgo's Cyan to Yellow colormap
         ///
         /// This is a perceptually uniform colormap which is robust to color blindness.
         /// It is especially suited for visualizing signed values.
         /// It interpolates from cyan to blue to dark gray to brass to yellow.
-        CyanToYellow = 6,
+        CyanToYellow = 7,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/fill_mode.hpp
+++ b/rerun_cpp/src/rerun/components/fill_mode.hpp
@@ -26,12 +26,12 @@ namespace rerun::components {
         /// Lines are drawn around the edges of the shape.
         ///
         /// The interior (2D) or surface (3D) are not drawn.
-        Wireframe = 0,
+        Wireframe = 1,
 
         /// The interior (2D) or surface (3D) is filled with a single color.
         ///
         /// Lines are not drawn.
-        Solid = 1,
+        Solid = 2,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/magnification_filter.hpp
+++ b/rerun_cpp/src/rerun/components/magnification_filter.hpp
@@ -27,12 +27,12 @@ namespace rerun::components {
         ///
         /// This will give a blocky appearance when zooming in.
         /// Used as default when rendering 2D images.
-        Nearest = 0,
+        Nearest = 1,
 
         /// Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.
         ///
         /// Used as default for mesh rendering.
-        Linear = 1,
+        Linear = 2,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/marker_shape.hpp
+++ b/rerun_cpp/src/rerun/components/marker_shape.hpp
@@ -24,34 +24,34 @@ namespace rerun::components {
     enum class MarkerShape : uint8_t {
 
         /// `⏺`
-        Circle = 0,
+        Circle = 1,
 
         /// `◆`
-        Diamond = 1,
+        Diamond = 2,
 
         /// `◼\u{fe0f}`
-        Square = 2,
+        Square = 3,
 
         /// `x`
-        Cross = 3,
+        Cross = 4,
 
         /// `+`
-        Plus = 4,
+        Plus = 5,
 
         /// `▲`
-        Up = 5,
+        Up = 6,
 
         /// `▼`
-        Down = 6,
+        Down = 7,
 
         /// `◀`
-        Left = 7,
+        Left = 8,
 
         /// `▶`
-        Right = 8,
+        Right = 9,
 
         /// `*`
-        Asterisk = 9,
+        Asterisk = 10,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/pixel_format.hpp
+++ b/rerun_cpp/src/rerun/components/pixel_format.hpp
@@ -37,12 +37,12 @@ namespace rerun::components {
         ///
         /// First comes entire image in Y in one plane,
         /// followed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc.
-        NV12 = 0,
+        NV12 = 1,
 
         /// YUY2 (aka YUYV or YUYV16), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.
         ///
         /// The order of the channels is Y0, U0, Y1, V0, all in the same plane.
-        YUY2 = 1,
+        YUY2 = 2,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/src/rerun/components/transform_relation.hpp
+++ b/rerun_cpp/src/rerun/components/transform_relation.hpp
@@ -28,14 +28,14 @@ namespace rerun::components {
         /// E.g. a translation of (0, 1, 0) with this `components::TransformRelation` logged at `parent/child` means
         /// that from the point of view of `parent`, `parent/child` is translated 1 unit along `parent`'s Y axis.
         /// From perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis.
-        ParentFromChild = 0,
+        ParentFromChild = 1,
 
         /// The transform describes how to transform into the child entity's space.
         ///
         /// E.g. a translation of (0, 1, 0) with this `components::TransformRelation` logged at `parent/child` means
         /// that from the point of view of `parent`, `parent/child` is translated -1 unit along `parent`'s Y axis.
         /// From perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis.
-        ChildFromParent = 1,
+        ChildFromParent = 2,
     };
 } // namespace rerun::components
 

--- a/rerun_cpp/tests/generated/datatypes/enum_test.hpp
+++ b/rerun_cpp/tests/generated/datatypes/enum_test.hpp
@@ -23,22 +23,22 @@ namespace rerun::datatypes {
     enum class EnumTest : uint8_t {
 
         /// Great film.
-        Up = 0,
+        Up = 1,
 
         /// Feeling blue.
-        Down = 1,
+        Down = 2,
 
         /// Correct.
-        Right = 2,
+        Right = 3,
 
         /// It's what's remaining.
-        Left = 3,
+        Left = 4,
 
         /// It's the only way to go.
-        Forward = 4,
+        Forward = 5,
 
         /// Baby's got it.
-        Back = 5,
+        Back = 6,
     };
 } // namespace rerun::datatypes
 

--- a/rerun_cpp/tests/generated/datatypes/valued_enum.hpp
+++ b/rerun_cpp/tests/generated/datatypes/valued_enum.hpp
@@ -22,9 +22,6 @@ namespace rerun::datatypes {
     /// **Datatype**: A test of an enumate with specified values.
     enum class ValuedEnum : uint8_t {
 
-        /// Default value.
-        Default = 0,
-
         /// One.
         One = 1,
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -30,21 +30,21 @@ from enum import Enum
 class BackgroundKind(Enum):
     """**Component**: The type of the background in a view."""
 
-    GradientDark = 0
+    GradientDark = 1
     """
     A dark gradient.
 
     In 3D views it changes depending on the direction of the view.
     """
 
-    GradientBright = 1
+    GradientBright = 2
     """
     A bright gradient.
 
     In 3D views it changes depending on the direction of the view.
     """
 
-    SolidColor = 2
+    SolidColor = 3
     """Simple uniform color."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -24,16 +24,16 @@ from enum import Enum
 class ContainerKind(Enum):
     """**Component**: The kind of a blueprint container (tabs, grid, …)."""
 
-    Tabs = 0
+    Tabs = 1
     """Put children in separate tabs"""
 
-    Horizontal = 1
+    Horizontal = 2
     """Order the children left to right"""
 
-    Vertical = 2
+    Vertical = 3
     """Order the children top to bottom"""
 
-    Grid = 3
+    Grid = 4
     """Organize children in a grid layout"""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -24,16 +24,16 @@ from enum import Enum
 class Corner2D(Enum):
     """**Component**: One of four 2D corners, typically used to align objects."""
 
-    LeftTop = 0
+    LeftTop = 1
     """Left top corner."""
 
-    RightTop = 1
+    RightTop = 2
     """Right top corner."""
 
-    LeftBottom = 2
+    LeftBottom = 3
     """Left bottom corner."""
 
-    RightBottom = 3
+    RightBottom = 4
     """Right bottom corner."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/dataframe_view_mode.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/dataframe_view_mode.py
@@ -30,14 +30,14 @@ from enum import Enum
 class DataframeViewMode(Enum):
     """**Component**: The kind of table displayed by the dataframe view."""
 
-    LatestAt = 0
+    LatestAt = 1
     """
     Display the entity values at the current time.
 
     In this mode, rows are entity instances, and columns are components. The visible time range setting is ignored.
     """
 
-    TimeRange = 1
+    TimeRange = 2
     """
     Display a temporal table of entity values.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -24,13 +24,13 @@ from enum import Enum
 class PanelState(Enum):
     """**Component**: Tri-state for panel controls."""
 
-    Hidden = 0
+    Hidden = 1
     """Completely hidden."""
 
-    Collapsed = 1
+    Collapsed = 2
     """Visible, but as small as possible on its shorter axis."""
 
-    Expanded = 2
+    Expanded = 3
     """Fully expanded."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/sort_key.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/sort_key.py
@@ -24,10 +24,10 @@ from enum import Enum
 class SortKey(Enum):
     """**Component**: Primary element by which to group by in a temporal data table."""
 
-    Entity = 0
+    Entity = 1
     """Group by entity."""
 
-    Time = 1
+    Time = 2
     """Group by instance."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/sort_order.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/sort_order.py
@@ -24,10 +24,10 @@ from enum import Enum
 class SortOrder(Enum):
     """**Component**: Sort order for data table."""
 
-    Ascending = 0
+    Ascending = 1
     """Ascending"""
 
-    Descending = 1
+    Descending = 2
     """Descending"""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
@@ -24,13 +24,13 @@ from enum import Enum
 class ViewFit(Enum):
     """**Component**: Determines whether an image or texture should be scaled to fit the viewport."""
 
-    Original = 0
+    Original = 1
     """No scaling, pixel size will match the image's width/height dimensions in pixels."""
 
-    Fill = 1
+    Fill = 2
     """Scale the image for the largest possible fit in the view's container."""
 
-    FillKeepAspectRatio = 2
+    FillKeepAspectRatio = 3
     """Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
+++ b/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
@@ -36,26 +36,26 @@ class AggregationPolicy(Enum):
     (and readability) in such situations as it prevents overdraw.
     """
 
-    Off = 0
+    Off = 1
     """No aggregation."""
 
-    Average = 1
+    Average = 2
     """Average all points in the range together."""
 
-    Max = 2
+    Max = 3
     """Keep only the maximum values in the range."""
 
-    Min = 3
+    Min = 4
     """Keep only the minimum values in the range."""
 
-    MinMax = 4
+    MinMax = 5
     """
     Keep both the minimum and maximum values in the range.
 
     This will yield two aggregated points instead of one, effectively creating a vertical line.
     """
 
-    MinMaxAverage = 5
+    MinMaxAverage = 6
     """Find both the minimum and maximum values in the range, then use the average of those."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/components/channel_datatype.py
+++ b/rerun_py/rerun_sdk/rerun/components/channel_datatype.py
@@ -35,37 +35,37 @@ class ChannelDatatype(ChannelDatatypeExt, Enum):
     How individual color channel components are encoded.
     """
 
-    U8 = 0
+    U8 = 1
     """8-bit unsigned integer."""
 
-    U16 = 1
+    U16 = 2
     """16-bit unsigned integer."""
 
-    U32 = 2
+    U32 = 3
     """32-bit unsigned integer."""
 
-    U64 = 3
+    U64 = 4
     """64-bit unsigned integer."""
 
-    I8 = 4
+    I8 = 5
     """8-bit signed integer."""
 
-    I16 = 5
+    I16 = 6
     """16-bit signed integer."""
 
-    I32 = 6
+    I32 = 7
     """32-bit signed integer."""
 
-    I64 = 7
+    I64 = 8
     """64-bit signed integer."""
 
-    F16 = 8
+    F16 = 9
     """16-bit IEEE-754 floating point, also known as `half`."""
 
-    F32 = 9
+    F32 = 10
     """32-bit IEEE-754 floating point, also known as `float` or `single`."""
 
-    F64 = 10
+    F64 = 11
     """64-bit IEEE-754 floating point, also known as `double`."""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/components/color_model.py
+++ b/rerun_py/rerun_sdk/rerun/components/color_model.py
@@ -28,13 +28,13 @@ class ColorModel(Enum):
     This combined with [`components.ChannelDatatype`][rerun.components.ChannelDatatype] determines the pixel format of an image.
     """
 
-    L = 0
+    L = 1
     """Grayscale luminance intencity/brightness/value, sometimes called `Y`"""
 
-    RGB = 1
+    RGB = 2
     """Red, Green, Blue"""
 
-    RGBA = 2
+    RGBA = 3
     """Red, Green, Blue, Alpha"""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -30,14 +30,14 @@ class Colormap(Enum):
     but currently the Viewer is limited to the types defined here.
     """
 
-    Grayscale = 0
+    Grayscale = 1
     """
     A simple black to white gradient.
 
     This is a sRGB gray gradient which is perceptually uniform.
     """
 
-    Inferno = 1
+    Inferno = 2
     """
     The Inferno colormap from Matplotlib.
 
@@ -45,7 +45,7 @@ class Colormap(Enum):
     It interpolates from black to red to bright yellow.
     """
 
-    Magma = 2
+    Magma = 3
     """
     The Magma colormap from Matplotlib.
 
@@ -53,7 +53,7 @@ class Colormap(Enum):
     It interpolates from black to purple to white.
     """
 
-    Plasma = 3
+    Plasma = 4
     """
     The Plasma colormap from Matplotlib.
 
@@ -61,7 +61,7 @@ class Colormap(Enum):
     It interpolates from dark blue to purple to yellow.
     """
 
-    Turbo = 4
+    Turbo = 5
     """
     Google's Turbo colormap map.
 
@@ -71,7 +71,7 @@ class Colormap(Enum):
     Details: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>
     """
 
-    Viridis = 5
+    Viridis = 6
     """
     The Viridis colormap from Matplotlib
 
@@ -79,7 +79,7 @@ class Colormap(Enum):
     It interpolates from dark purple to green to yellow.
     """
 
-    CyanToYellow = 6
+    CyanToYellow = 7
     """
     Rasmusgo's Cyan to Yellow colormap
 

--- a/rerun_py/rerun_sdk/rerun/components/fill_mode.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_mode.py
@@ -24,14 +24,14 @@ from enum import Enum
 class FillMode(Enum):
     """**Component**: How a geometric shape is drawn and colored."""
 
-    Wireframe = 0
+    Wireframe = 1
     """
     Lines are drawn around the edges of the shape.
 
     The interior (2D) or surface (3D) are not drawn.
     """
 
-    Solid = 1
+    Solid = 2
     """
     The interior (2D) or surface (3D) is filled with a single color.
 

--- a/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
+++ b/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
@@ -30,7 +30,7 @@ from enum import Enum
 class MagnificationFilter(Enum):
     """**Component**: Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen."""
 
-    Nearest = 0
+    Nearest = 1
     """
     Show the nearest pixel value.
 
@@ -38,7 +38,7 @@ class MagnificationFilter(Enum):
     Used as default when rendering 2D images.
     """
 
-    Linear = 1
+    Linear = 2
     """
     Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.
 

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -24,34 +24,34 @@ from enum import Enum
 class MarkerShape(Enum):
     """**Component**: The visual appearance of a point in e.g. a 2D plot."""
 
-    Circle = 0
+    Circle = 1
     """`⏺`"""
 
-    Diamond = 1
+    Diamond = 2
     """`◆`"""
 
-    Square = 2
+    Square = 3
     """`◼️`"""
 
-    Cross = 3
+    Cross = 4
     """`x`"""
 
-    Plus = 4
+    Plus = 5
     """`+`"""
 
-    Up = 5
+    Up = 6
     """`▲`"""
 
-    Down = 6
+    Down = 7
     """`▼`"""
 
-    Left = 7
+    Left = 8
     """`◀`"""
 
-    Right = 8
+    Right = 9
     """`▶`"""
 
-    Asterisk = 9
+    Asterisk = 10
     """`*`"""
 
     @classmethod

--- a/rerun_py/rerun_sdk/rerun/components/pixel_format.py
+++ b/rerun_py/rerun_sdk/rerun/components/pixel_format.py
@@ -36,7 +36,7 @@ class PixelFormat(Enum):
     For more compressed image formats, see [`archetypes.ImageEncoded`][rerun.archetypes.ImageEncoded].
     """
 
-    NV12 = 0
+    NV12 = 1
     """
     NV12 (aka Y_UV12) is a YUV 4:2:0 chroma downsampled format with 12 bits per pixel and 8 bits per channel.
 
@@ -44,7 +44,7 @@ class PixelFormat(Enum):
     followed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc.
     """
 
-    YUY2 = 1
+    YUY2 = 2
     """
     YUY2 (aka YUYV or YUYV16), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.
 

--- a/rerun_py/rerun_sdk/rerun/components/transform_relation.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_relation.py
@@ -30,7 +30,7 @@ from enum import Enum
 class TransformRelation(Enum):
     """**Component**: Specifies relation a spatial transform describes."""
 
-    ParentFromChild = 0
+    ParentFromChild = 1
     """
     The transform describes how to transform into the parent entity's space.
 
@@ -39,7 +39,7 @@ class TransformRelation(Enum):
     From perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis.
     """
 
-    ChildFromParent = 1
+    ChildFromParent = 2
     """
     The transform describes how to transform into the child entity's space.
 

--- a/rerun_py/tests/test_types/datatypes/enum_test.py
+++ b/rerun_py/tests/test_types/datatypes/enum_test.py
@@ -22,22 +22,22 @@ from enum import Enum
 class EnumTest(Enum):
     """**Datatype**: A test of the enum type."""
 
-    Up = 0
+    Up = 1
     """Great film."""
 
-    Down = 1
+    Down = 2
     """Feeling blue."""
 
-    Right = 2
+    Right = 3
     """Correct."""
 
-    Left = 3
+    Left = 4
     """It's what's remaining."""
 
-    Forward = 4
+    Forward = 5
     """It's the only way to go."""
 
-    Back = 5
+    Back = 6
     """Baby's got it."""
 
     @classmethod

--- a/rerun_py/tests/test_types/datatypes/valued_enum.py
+++ b/rerun_py/tests/test_types/datatypes/valued_enum.py
@@ -22,9 +22,6 @@ from enum import Enum
 class ValuedEnum(Enum):
     """**Datatype**: A test of an enumate with specified values."""
 
-    Default = 0
-    """Default value."""
-
     One = 1
     """One."""
 
@@ -58,11 +55,7 @@ class ValuedEnum(Enum):
         return self.name
 
 
-ValuedEnumLike = Union[
-    ValuedEnum,
-    Literal["Default", "One", "TheAnswer", "Three", "Two", "default", "one", "theanswer", "three", "two"],
-    int,
-]
+ValuedEnumLike = Union[ValuedEnum, Literal["One", "TheAnswer", "Three", "Two", "one", "theanswer", "three", "two"], int]
 ValuedEnumArrayLike = Union[ValuedEnumLike, Sequence[ValuedEnumLike]]
 
 


### PR DESCRIPTION
### What
This currently reserves the value of 0 in all of our enums as an Invalid type variant.

The reasoning behind this is twofold:
- 0 is a very common accidental value to end up with if processing an incorrectly constructed buffer.
- the way the .fbs compiler works, declaring an enum as a member of a struct field either requires the enum to have a 0 value, or every struct to specify it's contextual default for that enum.  This way the fbs schema definitions are always valid.

We then systemtically strip this field out of our generated types, which causes the deserialize to fail with an unknown type variant during deserialization. We can add dedicated detection of this in the deserializer in the future, but this already covers our immediate need.

Also, drive-by-fix of one more suffixed u8.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7080?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7080?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7080)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.