### PR TITLE
Optimize gap detector on dense timelines, like `log_tick`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,6 +5092,7 @@ dependencies = [
  "re_data_ui",
  "re_entity_db",
  "re_format",
+ "re_int_histogram",
  "re_log_types",
  "re_tracing",
  "re_types",

--- a/crates/utils/re_int_histogram/src/lib.rs
+++ b/crates/utils/re_int_histogram/src/lib.rs
@@ -115,6 +115,11 @@ impl RangeI64 {
     pub fn contains(&self, value: i64) -> bool {
         self.min <= value && value <= self.max
     }
+
+    #[inline]
+    pub fn length(&self) -> u64 {
+        (self.max - self.min + 1) as u64
+    }
 }
 
 impl std::fmt::Debug for RangeI64 {

--- a/crates/viewer/re_time_panel/Cargo.toml
+++ b/crates/viewer/re_time_panel/Cargo.toml
@@ -19,11 +19,12 @@ workspace = true
 all-features = true
 
 [dependencies]
-re_context_menu.workspace = true
 re_chunk_store.workspace = true
+re_context_menu.workspace = true
 re_data_ui.workspace = true
 re_entity_db.workspace = true
 re_format.workspace = true
+re_int_histogram.workspace = true
 re_log_types.workspace = true
 re_tracing.workspace = true
 re_types.workspace = true


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/5162

We hit a specially bad case looking for small gaps on dense timeliens, like on `log_tick`.

The new code does an early-out when the gap we're looking for becomes much smaller than the total time of the (non-gap) data.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7082?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7082?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7082)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.