### PR TITLE
Refactor: Less use of `TimesPerTimeline`

### DIFF
--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -112,8 +112,6 @@ impl Chunk {
     ///
     /// This is a no-op if the underlying timeline is already sorted appropriately (happy path).
     pub fn sorted_by_timeline_if_unsorted(&self, timeline: &Timeline) -> Self {
-        re_tracing::profile_function!();
-
         let mut chunk = self.clone();
 
         let Some(time_chunk) = chunk.timelines.get(timeline) else {
@@ -123,6 +121,8 @@ impl Chunk {
         if time_chunk.is_sorted() {
             return chunk;
         }
+
+        re_tracing::profile_function!();
 
         #[cfg(not(target_arch = "wasm32"))]
         let now = std::time::Instant::now();

--- a/crates/store/re_chunk/src/slice.rs
+++ b/crates/store/re_chunk/src/slice.rs
@@ -63,6 +63,8 @@ impl Chunk {
     /// This can result in an empty [`Chunk`] being returned if the slice is completely OOB.
     #[inline]
     pub fn row_sliced(&self, index: usize, len: usize) -> Self {
+        re_tracing::profile_function!();
+
         let Self {
             id,
             entity_path,
@@ -328,6 +330,8 @@ impl Chunk {
             return self.clone();
         };
 
+        re_tracing::profile_function!();
+
         let mask = validity.iter().collect_vec();
         let is_sorted = *is_sorted || (mask.iter().filter(|&&b| b).count() < 2);
         let validity_filter = ArrowBooleanArray::from_slice(mask);
@@ -407,6 +411,8 @@ impl Chunk {
             timelines,
             components,
         } = self;
+
+        re_tracing::profile_function!();
 
         Self {
             id: *id,

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -227,7 +227,7 @@ impl EntityDb {
     }
 
     pub fn timelines(&self) -> impl ExactSizeIterator<Item = &Timeline> {
-        self.times_per_timeline().keys()
+        self.time_histogram_per_timeline.timelines()
     }
 
     pub fn times_per_timeline(&self) -> &TimesPerTimeline {
@@ -235,33 +235,17 @@ impl EntityDb {
     }
 
     pub fn has_any_data_on_timeline(&self, timeline: &Timeline) -> bool {
-        if let Some(times) = self.times_per_timeline.get(timeline) {
-            !times.is_empty()
-        } else {
-            false
-        }
+        self.time_histogram_per_timeline
+            .get(timeline)
+            .map_or(false, |hist| !hist.is_empty())
     }
 
     /// Returns the time range of data on the given timeline, ignoring any static times.
-    ///
-    /// This is O(N) in the number of times on the timeline.
     pub fn time_range_for(&self, timeline: &Timeline) -> Option<ResolvedTimeRange> {
-        let (mut start, mut end) = (None, None);
-        for time in self
-            .times_per_timeline()
-            .get(timeline)?
-            .keys()
-            .filter(|v| !v.is_static())
-            .copied()
-        {
-            if start.is_none() || Some(time) < start {
-                start = Some(time);
-            }
-            if end.is_none() || Some(time) > end {
-                end = Some(time);
-            }
-        }
-        Some(ResolvedTimeRange::new(start?, end?))
+        let hist = self.time_histogram_per_timeline.get(timeline)?;
+        let min = hist.min_key()?;
+        let max = hist.max_key()?;
+        Some(ResolvedTimeRange::new(min, max))
     }
 
     /// Histogram of all events on the timeeline, of all entities.

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -51,6 +51,8 @@ pub struct EntityDb {
     /// entities/components.
     ///
     /// Used for time control.
+    ///
+    /// TODO(#7084): Get rid of [`TimesPerTimeline`] and implement time-stepping with [`crate::TimeHistogram`] instead.
     times_per_timeline: TimesPerTimeline,
 
     /// A time histogram of all entities, for every timeline.

--- a/crates/store/re_entity_db/src/time_histogram_per_timeline.rs
+++ b/crates/store/re_entity_db/src/time_histogram_per_timeline.rs
@@ -64,6 +64,8 @@ impl TimeHistogramPerTimeline {
     }
 
     pub fn add(&mut self, times_per_timeline: &[(Timeline, &[i64])], n: u32) {
+        re_tracing::profile_function!();
+
         if times_per_timeline.is_empty() {
             self.num_static_messages = self
                 .num_static_messages
@@ -87,6 +89,8 @@ impl TimeHistogramPerTimeline {
     }
 
     pub fn remove(&mut self, times_per_timeline: &[(Timeline, &[i64])], n: u32) {
+        re_tracing::profile_function!();
+
         if times_per_timeline.is_empty() {
             self.num_static_messages = self
                 .num_static_messages
@@ -135,6 +139,8 @@ impl ChunkStoreSubscriber for TimeHistogramPerTimeline {
 
     #[allow(clippy::unimplemented)]
     fn on_events(&mut self, events: &[ChunkStoreEvent]) {
+        re_tracing::profile_function!();
+
         for event in events {
             let times = event
                 .chunk

--- a/crates/store/re_entity_db/src/times_per_timeline.rs
+++ b/crates/store/re_entity_db/src/times_per_timeline.rs
@@ -8,6 +8,8 @@ use re_log_types::{TimeInt, Timeline};
 pub type TimeCounts = BTreeMap<TimeInt, u64>;
 
 /// A [`ChunkStoreSubscriber`] that keeps track of all unique timestamps on each [`Timeline`].
+///
+/// TODO(#7084): Get rid of [`TimesPerTimeline`] and implement time-stepping with [`crate::TimeHistogram`] instead.
 pub struct TimesPerTimeline(BTreeMap<Timeline, TimeCounts>);
 
 impl std::ops::Deref for TimesPerTimeline {

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -94,7 +94,7 @@ fn annotation_info(
     query: &re_chunk_store::LatestAtQuery,
     keypoint_id: KeypointId,
 ) -> Option<AnnotationInfo> {
-    // TODO(#6358): this needs to use the index of the keypoint to look up the correct
+    // TODO(#3168): this needs to use the index of the keypoint to look up the correct
     // class_id. For now we use `latest_at_component_quiet` to avoid the warning spam.
     let (_, class_id) = ctx
         .recording()

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -15,10 +15,9 @@ pub fn blueprint_timepoint_for_writes(blueprint: &re_entity_db::EntityDb) -> Tim
     let timeline = blueprint_timeline();
 
     let max_time = blueprint
-        .times_per_timeline()
-        .get(&timeline)
-        .and_then(|times| times.last_key_value())
-        .map_or(0, |(time, _)| time.as_i64())
+        .time_histogram(&timeline)
+        .and_then(|times| times.max_key())
+        .unwrap_or(0)
         .saturating_add(1);
 
     TimePoint::from([(timeline, TimeInt::new_temporal(max_time))])


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/7084

(I thought I could go all the way, but it will take more time than I'm willing to spend right now)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7085?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7085?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7085)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.