### PR TITLE
Support decoding multiplexed RRD streams

### DIFF
--- a/crates/store/re_data_source/src/load_stdin.rs
+++ b/crates/store/re_data_source/src/load_stdin.rs
@@ -9,7 +9,7 @@ pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
     let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
 
     let stdin = std::io::BufReader::new(std::io::stdin());
-    let decoder = re_log_encoding::decoder::Decoder::new_multiplexed(version_policy, stdin)?;
+    let decoder = re_log_encoding::decoder::Decoder::new_concatenated(version_policy, stdin)?;
 
     rayon::spawn(move || {
         re_tracing::profile_scope!("stdin");

--- a/crates/store/re_data_source/src/load_stdin.rs
+++ b/crates/store/re_data_source/src/load_stdin.rs
@@ -8,7 +8,8 @@ use re_smart_channel::Sender;
 pub fn load_stdin(tx: Sender<LogMsg>) -> anyhow::Result<()> {
     let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
 
-    let decoder = re_log_encoding::decoder::Decoder::new(version_policy, std::io::stdin())?;
+    let stdin = std::io::BufReader::new(std::io::stdin());
+    let decoder = re_log_encoding::decoder::Decoder::new_multiplexed(version_policy, stdin)?;
 
     rayon::spawn(move || {
         re_tracing::profile_scope!("stdin");

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -161,13 +161,14 @@ pub struct Decoder<R: std::io::Read> {
 impl<R: std::io::Read> Decoder<R> {
     /// Instantiates a new decoder.
     ///
-    /// This does not support multiplexed streams.
+    /// This does not support concatenated streams (i.e. streams of bytes where multiple RRD files
+    /// -- not recordings, RRD files! -- follow each other).
     ///
-    /// If you're not familiar with multiplexed RRD streams, then this is probably the function
+    /// If you're not familiar with concatenated RRD streams, then this is probably the function
     /// that you want to be using.
     ///
     /// See also:
-    /// * [`Decoder::new_multiplexed`]
+    /// * [`Decoder::new_concatenated`]
     pub fn new(version_policy: VersionPolicy, mut read: R) -> Result<Self, DecodeError> {
         re_tracing::profile_function!();
 
@@ -186,22 +187,23 @@ impl<R: std::io::Read> Decoder<R> {
         })
     }
 
-    /// Instantiates a new multiplexed decoder.
+    /// Instantiates a new concatenated decoder.
     ///
-    /// This will gracefully handle multiplexed RRD streams, at the cost of extra performance
-    /// overhead, by looking ahead for potential `FileHeader`s in the stream.
+    /// This will gracefully handle concatenated RRD streams (i.e. streams of bytes where multiple
+    /// RRD files -- not recordings, RRD files! -- follow each other), at the cost of extra
+    /// performance overhead, by looking ahead for potential `FileHeader`s in the stream.
     ///
-    /// The [`CrateVersion`] of the final, demultiplexed stream will correspond to the most recent
+    /// The [`CrateVersion`] of the final, deconcatenated stream will correspond to the most recent
     /// version among all the versions found in the stream.
     ///
     /// This is particularly useful when working with stdio streams.
     ///
-    /// If you're not familiar with multiplexed RRD streams, then you probably want to use
+    /// If you're not familiar with concatenated RRD streams, then you probably want to use
     /// [`Decoder::new`] instead.
     ///
     /// See also:
     /// * [`Decoder::new`]
-    pub fn new_multiplexed(
+    pub fn new_concatenated(
         version_policy: VersionPolicy,
         mut read: std::io::BufReader<R>,
     ) -> Result<Self, DecodeError> {
@@ -232,7 +234,7 @@ impl<R: std::io::Read> Decoder<R> {
     ///
     /// Returns true if a valid header was found.
     ///
-    /// No-op if the decoder wasn't initialized with [`Decoder::new_multiplexed`].
+    /// No-op if the decoder wasn't initialized with [`Decoder::new_concatenated`].
     fn peek_file_header(&mut self) -> bool {
         match &mut self.read {
             Reader::Raw(_) => false,

--- a/crates/store/re_log_encoding/src/lib.rs
+++ b/crates/store/re_log_encoding/src/lib.rs
@@ -107,7 +107,7 @@ pub enum OptionsError {
 }
 
 #[cfg(any(feature = "encoder", feature = "decoder"))]
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct FileHeader {
     pub magic: [u8; 4],
     pub version: [u8; 4],

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -90,6 +90,7 @@ fn compute_uber_table(
     use re_log_types::StoreId;
 
     let rrd_file = std::fs::File::open(path_to_rrd).context("couldn't open rrd file contents")?;
+    let rrd_file = std::io::BufReader::new(rrd_file);
 
     let mut stores: std::collections::HashMap<StoreId, EntityDb> = Default::default();
     let version_policy = re_log_encoding::decoder::VersionPolicy::Error;

--- a/crates/viewer/re_viewer/src/loading.rs
+++ b/crates/viewer/re_viewer/src/loading.rs
@@ -21,6 +21,7 @@ pub fn load_blueprint_file(
         re_tracing::profile_function!();
 
         let file = std::fs::File::open(path)?;
+        let file = std::io::BufReader::new(file);
 
         // Blueprint files change often. Be strict about the version, and then ignore any errors.
         // See https://github.com/rerun-io/rerun/issues/2830


### PR DESCRIPTION
TL;DR: the following is now possible:
```
cat docs/snippets/all/archetypes/*_rust.rrd | rerun -
```

This will of course become more interesting as you build more and more complex CLI pipelines with `rerun rrd`

(Also fixed some missing buffered io while I was around.)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7091?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7091?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7091)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.