### PR TITLE
Improved CLI 3: stdin streaming support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,6 +5543,7 @@ dependencies = [
  "re_crash_handler",
  "re_data_source",
  "re_entity_db",
+ "re_error",
  "re_format",
  "re_log",
  "re_log_encoding",

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -109,6 +109,7 @@ re_build_info.workspace = true
 re_chunk.workspace = true
 re_crash_handler.workspace = true
 re_entity_db.workspace = true
+re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true

--- a/crates/top/rerun/src/commands/mod.rs
+++ b/crates/top/rerun/src/commands/mod.rs
@@ -23,12 +23,14 @@ impl CallSource {
 
 mod entrypoint;
 mod rrd;
+mod stdio;
 
 #[cfg(feature = "analytics")]
 mod analytics;
 
 pub use self::entrypoint::run;
 pub use self::rrd::RrdCommands;
+pub use self::stdio::read_rrd_streams_from_file_or_stdin;
 
 #[cfg(feature = "analytics")]
 pub(crate) use self::analytics::AnalyticsCommands;

--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -19,7 +19,9 @@ pub enum RrdCommands {
     /// This ignores the `log_time` timeline.
     Compare(CompareCommand),
 
-    /// Print the contents of one or more .rrd/.rbl files.
+    /// Print the contents of one or more .rrd/.rbl files/streams.
+    ///
+    /// Reads from standard input if no paths are specified.
     ///
     /// Example: `rerun rrd print /my/recordings/*.rrd`
     Print(PrintCommand),

--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -26,7 +26,9 @@ pub enum RrdCommands {
     /// Example: `rerun rrd print /my/recordings/*.rrd`
     Print(PrintCommand),
 
-    /// Compacts the contents of one or more .rrd/.rbl files and writes the result to a new file.
+    /// Compacts the contents of one or more .rrd/.rbl files/streams and writes the result to a new file.
+    ///
+    /// Reads from standard input if no paths are specified.
     ///
     /// Uses the usual environment variables to control the compaction thresholds:
     /// `RERUN_CHUNK_MAX_ROWS`,
@@ -42,7 +44,9 @@ pub enum RrdCommands {
     /// * `rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd -o output.rrd`
     Compact(CompactCommand),
 
-    /// Merges the contents of multiple .rrd/.rbl files, and writes the result to a new file.
+    /// Merges the contents of multiple .rrd/.rbl files/streams, and writes the result to a new file.
+    ///
+    /// Reads from standard input if no paths are specified.
     ///
     /// This will not affect the chunking of the data in any way.
     ///

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -1,85 +1,104 @@
-use std::path::{Path, PathBuf};
-
-use anyhow::Context as _;
+use anyhow::Context;
 use itertools::Itertools as _;
 
 use re_log_types::{LogMsg, SetStoreInfo};
 use re_sdk::log::Chunk;
 use re_types::SizeBytes as _;
 
+use crate::commands::read_rrd_streams_from_file_or_stdin;
+
 // ---
 
 #[derive(Debug, Clone, clap::Parser)]
 pub struct PrintCommand {
+    /// Paths to read from. Reads from standard input if none are specified.
     path_to_input_rrds: Vec<String>,
 
-    /// If specified, print out table contents.
+    /// If set, print out table contents.
     #[clap(long, short, default_value_t = false)]
     verbose: bool,
+
+    /// If set, will try to proceed even in the face of IO and/or decoding errors in the input data.
+    #[clap(long, default_value_t = true)]
+    best_effort: bool,
 }
 
 impl PrintCommand {
     pub fn run(&self) -> anyhow::Result<()> {
-        let path_to_input_rrds = self.path_to_input_rrds.iter().map(PathBuf::from);
+        let Self {
+            path_to_input_rrds,
+            verbose,
+            best_effort,
+        } = self;
 
-        for rrd_path in path_to_input_rrds {
-            self.print_rrd(&rrd_path)
-                .with_context(|| format!("path: {rrd_path:?}"))?;
+        // TODO(cmc): might want to make this configurable at some point.
+        let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
+        let rx = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        for res in rx {
+            let mut is_success = true;
+
+            match res {
+                Ok(msg) => {
+                    if let Err(err) = print_msg(*verbose, msg) {
+                        re_log::error!(err = re_error::format(err));
+                        is_success = false;
+                    }
+                }
+
+                Err(err) => {
+                    re_log::error!(err = re_error::format(err));
+                    is_success = false;
+                }
+            }
+
+            if !*best_effort && !is_success {
+                anyhow::bail!(
+                    "one or more IO and/or decoding failures in the input stream (check logs)"
+                )
+            }
         }
 
         Ok(())
     }
 }
 
-impl PrintCommand {
-    fn print_rrd(&self, rrd_path: &Path) -> anyhow::Result<()> {
-        let rrd_file = std::fs::File::open(rrd_path)?;
-        let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
-        let decoder = re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)?;
-        println!("Decoded RRD stream v{}\n---", decoder.version());
-        for msg in decoder {
-            let msg = msg.context("decode rrd message")?;
-            match msg {
-                LogMsg::SetStoreInfo(msg) => {
-                    let SetStoreInfo { row_id: _, info } = msg;
-                    println!("{info:#?}");
-                }
+fn print_msg(verbose: bool, msg: LogMsg) -> anyhow::Result<()> {
+    match msg {
+        LogMsg::SetStoreInfo(msg) => {
+            let SetStoreInfo { row_id: _, info } = msg;
+            println!("{info:#?}");
+        }
 
-                LogMsg::ArrowMsg(_row_id, arrow_msg) => {
-                    let chunk = match Chunk::from_arrow_msg(&arrow_msg) {
-                        Ok(chunk) => chunk,
-                        Err(err) => {
-                            eprintln!("discarding broken chunk: {err}");
-                            continue;
-                        }
-                    };
+        LogMsg::ArrowMsg(_row_id, arrow_msg) => {
+            let chunk = Chunk::from_arrow_msg(&arrow_msg).context("skipped corrupt chunk")?;
 
-                    if self.verbose {
-                        println!("{chunk}");
-                    } else {
-                        let column_names = chunk
-                            .component_names()
-                            .map(|name| name.short_name())
-                            .join(" ");
+            if verbose {
+                println!("{chunk}");
+            } else {
+                let column_names = chunk
+                    .component_names()
+                    .map(|name| name.short_name())
+                    .join(" ");
 
-                        println!(
-                            "Chunk with {} rows ({}) - {:?} - columns: [{column_names}]",
-                            chunk.num_rows(),
-                            re_format::format_bytes(chunk.total_size_bytes() as _),
-                            chunk.entity_path(),
-                        );
-                    }
-                }
-
-                LogMsg::BlueprintActivationCommand(re_log_types::BlueprintActivationCommand {
-                    blueprint_id,
-                    make_active,
-                    make_default,
-                }) => {
-                    println!("BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})");
-                }
+                println!(
+                    "Chunk({}) with {} rows ({}) - {:?} - columns: [{column_names}]",
+                    chunk.id(),
+                    chunk.num_rows(),
+                    re_format::format_bytes(chunk.total_size_bytes() as _),
+                    chunk.entity_path(),
+                );
             }
         }
-        Ok(())
+
+        LogMsg::BlueprintActivationCommand(re_log_types::BlueprintActivationCommand {
+            blueprint_id,
+            make_active,
+            make_default,
+        }) => {
+            println!("BlueprintActivationCommand({blueprint_id}, make_active: {make_active}, make_default: {make_default})");
+        }
     }
+
+    Ok(())
 }

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -1,0 +1,90 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use crossbeam::channel;
+use itertools::Itertools as _;
+
+use re_chunk::external::crossbeam;
+use re_log_types::LogMsg;
+
+// ---
+
+/// Asynchronously decodes potentially multiplexed RRD streams from the given `paths`, or standard
+/// input if none are specified.
+///
+/// The returned channel contains both the successfully decoded data, if any, as well as any
+/// errors faced during processing.
+///
+/// This function is best-effort: it will try to make progress even in the face of errors.
+/// It is up to the user to decide whether and when to stop.
+///
+/// This function is capable of decoding multiple independent recordings from a single stream.
+pub fn read_rrd_streams_from_file_or_stdin(
+    version_policy: re_log_encoding::decoder::VersionPolicy,
+    paths: &[String],
+) -> channel::Receiver<anyhow::Result<LogMsg>> {
+    let path_to_input_rrds = paths.iter().map(PathBuf::from).collect_vec();
+
+    // TODO(cmc): might want to make this configurable at some point.
+    let (tx, rx) = crossbeam::channel::bounded(100);
+
+    _ = std::thread::Builder::new()
+        .name("rerun-cli-stdin".to_owned())
+        .spawn(move || {
+            if path_to_input_rrds.is_empty() {
+                // stdin
+
+                let stdin = std::io::BufReader::new(std::io::stdin().lock());
+
+                let decoder =
+                    match re_log_encoding::decoder::Decoder::new_multiplexed(version_policy, stdin)
+                        .context("couldn't decode stdin stream -- skipping")
+                    {
+                        Ok(decoder) => decoder,
+                        Err(err) => {
+                            tx.send(Err(err)).ok();
+                            return;
+                        }
+                    };
+
+                for res in decoder {
+                    let res = res.context("couldn't decode message from stdin -- skipping");
+                    tx.send(res).ok();
+                }
+            } else {
+                // file(s)
+
+                for rrd_path in path_to_input_rrds {
+                    let rrd_file = match std::fs::File::open(&rrd_path)
+                        .with_context(|| format!("couldn't open {rrd_path:?} -- skipping"))
+                    {
+                        Ok(file) => file,
+                        Err(err) => {
+                            tx.send(Err(err)).ok();
+                            continue;
+                        }
+                    };
+
+                    let decoder =
+                        match re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)
+                            .with_context(|| format!("couldn't decode {rrd_path:?} -- skipping"))
+                        {
+                            Ok(decoder) => decoder,
+                            Err(err) => {
+                                tx.send(Err(err)).ok();
+                                continue;
+                            }
+                        };
+
+                    for res in decoder {
+                        let res = res.context("decode rrd message").with_context(|| {
+                            format!("couldn't decode message {rrd_path:?} -- skipping")
+                        });
+                        tx.send(res).ok();
+                    }
+                }
+            }
+        });
+
+    rx
+}

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -36,16 +36,18 @@ pub fn read_rrd_streams_from_file_or_stdin(
 
                 let stdin = std::io::BufReader::new(std::io::stdin().lock());
 
-                let decoder =
-                    match re_log_encoding::decoder::Decoder::new_multiplexed(version_policy, stdin)
-                        .context("couldn't decode stdin stream -- skipping")
-                    {
-                        Ok(decoder) => decoder,
-                        Err(err) => {
-                            tx.send(Err(err)).ok();
-                            return;
-                        }
-                    };
+                let decoder = match re_log_encoding::decoder::Decoder::new_concatenated(
+                    version_policy,
+                    stdin,
+                )
+                .context("couldn't decode stdin stream -- skipping")
+                {
+                    Ok(decoder) => decoder,
+                    Err(err) => {
+                        tx.send(Err(err)).ok();
+                        return;
+                    }
+                };
 
                 for res in decoder {
                     let res = res.context("couldn't decode message from stdin -- skipping");


### PR DESCRIPTION
You can now do this:
```
cat docs/snippets/all/archetypes/*_rust.rrd | rerun rrd print
```

and this:
```
cat docs/snippets/all/archetypes/*_rust.rrd | rrd merge -o /tmp/all_merged.rrd
```

and this
```
cat docs/snippets/all/archetypes/*_rust.rrd | rerun rrd compact --max-rows 99999999 --max-bytes 999999999 -o /tmp/all_compacted_max.rrd
```

- Part of #7048 
- DNM: requires #7091 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7092?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7092?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7092)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.