### PR TITLE
Streaming errors for encoders

### DIFF
--- a/crates/store/re_entity_db/examples/memory_usage.rs
+++ b/crates/store/re_entity_db/examples/memory_usage.rs
@@ -67,10 +67,10 @@ fn log_messages() {
     fn encode_log_msg(log_msg: &LogMsg) -> Vec<u8> {
         let mut bytes = vec![];
         let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
-        re_log_encoding::encoder::encode(
+        re_log_encoding::encoder::encode_ref(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
-            std::iter::once(log_msg),
+            std::iter::once(log_msg).map(Ok),
             &mut bytes,
         )
         .unwrap();

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -429,7 +429,7 @@ impl EntityDb {
     pub fn to_messages(
         &self,
         time_selection: Option<(Timeline, ResolvedTimeRangeF)>,
-    ) -> ChunkResult<Vec<LogMsg>> {
+    ) -> impl Iterator<Item = ChunkResult<LogMsg>> + '_ {
         re_tracing::profile_function!();
 
         let set_store_info_msg = self
@@ -446,7 +446,7 @@ impl EntityDb {
         let data_messages = self
             .store()
             .iter_chunks()
-            .filter(|chunk| {
+            .filter(move |chunk| {
                 let Some((timeline, time_range)) = time_filter else {
                     return true;
                 };
@@ -481,13 +481,10 @@ impl EntityDb {
             itertools::Either::Right(std::iter::empty())
         };
 
-        let messages: Result<Vec<_>, _> = set_store_info_msg
+        set_store_info_msg
             .into_iter()
             .chain(data_messages)
             .chain(blueprint_ready)
-            .collect();
-
-        messages
     }
 
     /// Make a clone of this [`EntityDb`], assigning it a new [`StoreId`].

--- a/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
+++ b/crates/store/re_log_encoding/benches/msg_encode_benchmark.rs
@@ -34,10 +34,10 @@ criterion_main!(benches);
 fn encode_log_msgs(messages: &[LogMsg]) -> Vec<u8> {
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let mut bytes = vec![];
-    re_log_encoding::encoder::encode(
+    re_log_encoding::encoder::encode_ref(
         re_build_info::CrateVersion::LOCAL,
         encoding_options,
-        messages.iter(),
+        messages.iter().map(Ok),
         &mut bytes,
     )
     .unwrap();

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -380,7 +380,8 @@ fn test_encode_decode() {
 
     for options in options {
         let mut file = vec![];
-        crate::encoder::encode(rrd_version, options, messages.iter(), &mut file).unwrap();
+        crate::encoder::encode_ref(rrd_version, options, messages.iter().map(Ok), &mut file)
+            .unwrap();
 
         let decoded_messages = Decoder::new(VersionPolicy::Error, &mut file.as_slice())
             .unwrap()

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -279,7 +279,7 @@ impl MemorySinkStorage {
         let mut inner = self.inner.lock();
         inner.has_been_used = true;
 
-        encode_as_bytes_local(std::mem::take(&mut inner.msgs).iter())
+        encode_as_bytes_local(std::mem::take(&mut inner.msgs).into_iter().map(Ok))
     }
 
     #[inline]

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 
 use re_chunk_store::ChunkStoreConfig;
 use re_entity_db::EntityDb;
-use re_log_types::{LogMsg, StoreId};
+use re_log_types::StoreId;
 use re_sdk::StoreKind;
 
 use crate::commands::read_rrd_streams_from_file_or_stdin;
@@ -199,21 +199,15 @@ fn merge_and_compact(
     let mut rrd_out = std::fs::File::create(&path_to_output_rrd)
         .with_context(|| format!("{path_to_output_rrd:?}"))?;
 
-    let messages_rbl: Result<Vec<Vec<LogMsg>>, _> = entity_dbs
+    let messages_rbl = entity_dbs
         .values()
         .filter(|entity_db| entity_db.store_kind() == StoreKind::Blueprint)
-        .map(|entity_db| entity_db.to_messages(None /* time selection */))
-        .collect();
-    let messages_rbl = messages_rbl?;
-    let messages_rbl = messages_rbl.iter().flatten();
+        .flat_map(|entity_db| entity_db.to_messages(None /* time selection */));
 
-    let messages_rrd: Result<Vec<Vec<LogMsg>>, _> = entity_dbs
+    let messages_rrd = entity_dbs
         .values()
         .filter(|entity_db| entity_db.store_kind() == StoreKind::Recording)
-        .map(|entity_db| entity_db.to_messages(None /* time selection */))
-        .collect();
-    let messages_rrd = messages_rrd?;
-    let messages_rrd = messages_rrd.iter().flatten();
+        .flat_map(|entity_db| entity_db.to_messages(None /* time selection */));
 
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let version = entity_dbs

--- a/crates/viewer/re_viewer/src/saving.rs
+++ b/crates/viewer/re_viewer/src/saving.rs
@@ -60,10 +60,10 @@ pub fn default_blueprint_path(app_id: &ApplicationId) -> anyhow::Result<std::pat
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn encode_to_file<'a>(
+pub fn encode_to_file(
     version: re_build_info::CrateVersion,
     path: &std::path::Path,
-    messages: impl Iterator<Item = &'a re_log_types::LogMsg>,
+    messages: impl Iterator<Item = re_chunk::ChunkResult<re_log_types::LogMsg>>,
 ) -> anyhow::Result<()> {
     re_tracing::profile_function!();
     use anyhow::Context as _;

--- a/rerun_py/src/python_bridge.rs
+++ b/rerun_py/src/python_bridge.rs
@@ -16,7 +16,7 @@ use pyo3::{
 use re_log::ResultExt;
 use re_log_types::LogMsg;
 use re_log_types::{BlueprintActivationCommand, EntityPathPart, StoreKind};
-use re_sdk::external::re_log_encoding::encoder::encode_as_bytes_local;
+use re_sdk::external::re_log_encoding::encoder::encode_ref_as_bytes_local;
 use re_sdk::sink::CallbackSink;
 use re_sdk::{
     sink::{BinaryStreamStorage, MemorySinkStorage},
@@ -781,7 +781,7 @@ fn set_callback_sink(callback: PyObject, recording: Option<&PyRecordingStream>, 
 
     let callback = move |msgs: &[LogMsg]| {
         Python::with_gil(|py| {
-            let data = encode_as_bytes_local(msgs).ok_or_log_error()?;
+            let data = encode_ref_as_bytes_local(msgs.iter().map(Ok)).ok_or_log_error()?;
             let bytes = PyBytes::new(py, &data);
             callback.as_ref(py).call1((bytes,)).ok_or_log_error()?;
             Some(())


### PR DESCRIPTION
This is a simple change to make our encoding methods take iterators of results instead of iterators of unwrapped values.

In most (all?) real-world scenarios, you will have to deal with errors as you serialize `LogMsg`s.
The previous design forced you to collect all that data in order to first check for errors, and only then start encoding. Now you can just stream as needed.
In the rare case where nothing can fail, you're just one `.map(Ok)` away anyway.

As a side-effect, `rerun rrd merge|compact` now streams their output.

- DNM: requires https://github.com/rerun-io/rerun/pull/7092
- Related to #6984

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7093?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7093?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7093)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.