### PR TITLE
Improved CLI 4: stdout streaming support

### DIFF
--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -156,6 +156,9 @@ pub struct Decoder<R: std::io::Read> {
     read: Reader<R>,
     uncompressed: Vec<u8>, // scratch space
     compressed: Vec<u8>,   // scratch space
+
+    /// The size in bytes of the data that has been decoded up to now.
+    size_bytes: u64,
 }
 
 impl<R: std::io::Read> Decoder<R> {
@@ -184,6 +187,7 @@ impl<R: std::io::Read> Decoder<R> {
             read: Reader::Raw(read),
             uncompressed: vec![],
             compressed: vec![],
+            size_bytes: FileHeader::SIZE as _,
         })
     }
 
@@ -221,6 +225,7 @@ impl<R: std::io::Read> Decoder<R> {
             read: Reader::Buffered(read),
             uncompressed: vec![],
             compressed: vec![],
+            size_bytes: FileHeader::SIZE as _,
         })
     }
 
@@ -228,6 +233,12 @@ impl<R: std::io::Read> Decoder<R> {
     #[inline]
     pub fn version(&self) -> CrateVersion {
         self.version
+    }
+
+    /// Returns the size in bytes of the data that has been decoded up to now.
+    #[inline]
+    pub fn size_bytes(&self) -> u64 {
+        self.size_bytes
     }
 
     /// Peeks ahead in search of additional `FileHeader`s in the stream.
@@ -277,6 +288,7 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 
             self.version = CrateVersion::max(self.version, version);
             self.compression = compression;
+            self.size_bytes += FileHeader::SIZE as u64;
         }
 
         let header = match MessageHeader::decode(&mut self.read) {
@@ -288,6 +300,7 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
                 other => return Some(Err(other)),
             },
         };
+        self.size_bytes += MessageHeader::SIZE as u64;
 
         let uncompressed_len = header.uncompressed_len as usize;
         self.uncompressed
@@ -302,7 +315,9 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
                 {
                     return Some(Err(DecodeError::Read(err)));
                 }
+                self.size_bytes += uncompressed_len as u64;
             }
+
             Compression::LZ4 => {
                 let compressed_len = header.compressed_len as usize;
                 self.compressed
@@ -322,6 +337,8 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
                 ) {
                     return Some(Err(DecodeError::Lz4(err)));
                 }
+
+                self.size_bytes += compressed_len as u64;
             }
         }
 

--- a/crates/store/re_log_encoding/src/encoder.rs
+++ b/crates/store/re_log_encoding/src/encoder.rs
@@ -81,7 +81,8 @@ impl<W: std::io::Write> Encoder<W> {
         })
     }
 
-    pub fn append(&mut self, message: &LogMsg) -> Result<(), EncodeError> {
+    /// Returns the size in bytes of the encoded data.
+    pub fn append(&mut self, message: &LogMsg) -> Result<u64, EncodeError> {
         re_tracing::profile_function!();
 
         self.uncompressed.clear();
@@ -96,8 +97,10 @@ impl<W: std::io::Write> Encoder<W> {
                 .encode(&mut self.write)?;
                 self.write
                     .write_all(&self.uncompressed)
-                    .map_err(EncodeError::Write)?;
+                    .map(|_| self.uncompressed.len() as _)
+                    .map_err(EncodeError::Write)
             }
+
             Compression::LZ4 => {
                 let max_len = lz4_flex::block::get_maximum_output_size(self.uncompressed.len());
                 self.compressed.resize(max_len, 0);
@@ -111,11 +114,10 @@ impl<W: std::io::Write> Encoder<W> {
                 .encode(&mut self.write)?;
                 self.write
                     .write_all(&self.compressed[..compressed_len])
-                    .map_err(EncodeError::Write)?;
+                    .map(|_| compressed_len as _)
+                    .map_err(EncodeError::Write)
             }
         }
-
-        Ok(())
     }
 
     pub fn flush_blocking(&mut self) -> std::io::Result<()> {
@@ -127,32 +129,36 @@ impl<W: std::io::Write> Encoder<W> {
     }
 }
 
+/// Returns the size in bytes of the encoded data.
 pub fn encode(
     version: CrateVersion,
     options: EncodingOptions,
     messages: impl Iterator<Item = ChunkResult<LogMsg>>,
     write: &mut impl std::io::Write,
-) -> Result<(), EncodeError> {
+) -> Result<u64, EncodeError> {
     re_tracing::profile_function!();
     let mut encoder = Encoder::new(version, options, write)?;
+    let mut size_bytes = 0;
     for message in messages {
-        encoder.append(&message?)?;
+        size_bytes += encoder.append(&message?)?;
     }
-    Ok(())
+    Ok(size_bytes)
 }
 
+/// Returns the size in bytes of the encoded data.
 pub fn encode_ref<'a>(
     version: CrateVersion,
     options: EncodingOptions,
     messages: impl Iterator<Item = ChunkResult<&'a LogMsg>>,
     write: &mut impl std::io::Write,
-) -> Result<(), EncodeError> {
+) -> Result<u64, EncodeError> {
     re_tracing::profile_function!();
     let mut encoder = Encoder::new(version, options, write)?;
+    let mut size_bytes = 0;
     for message in messages {
-        encoder.append(message?)?;
+        size_bytes += encoder.append(message?)?;
     }
-    Ok(())
+    Ok(size_bytes)
 }
 
 pub fn encode_as_bytes(

--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -26,7 +26,7 @@ pub enum RrdCommands {
     /// Example: `rerun rrd print /my/recordings/*.rrd`
     Print(PrintCommand),
 
-    /// Compacts the contents of one or more .rrd/.rbl files/streams and writes the result to a new file.
+    /// Compacts the contents of one or more .rrd/.rbl files/streams and writes the result standard output.
     ///
     /// Reads from standard input if no paths are specified.
     ///
@@ -41,16 +41,16 @@ pub enum RrdCommands {
     ///
     /// * `RERUN_CHUNK_MAX_ROWS=4096 RERUN_CHUNK_MAX_BYTES=1048576 rerun rrd compact /my/recordings/*.rrd -o output.rrd`
     ///
-    /// * `rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd -o output.rrd`
+    /// * `rerun rrd compact --max-rows 4096 --max-bytes=1048576 /my/recordings/*.rrd > output.rrd`
     Compact(CompactCommand),
 
-    /// Merges the contents of multiple .rrd/.rbl files/streams, and writes the result to a new file.
+    /// Merges the contents of multiple .rrd/.rbl files/streams, and writes the result to standard output.
     ///
     /// Reads from standard input if no paths are specified.
     ///
     /// This will not affect the chunking of the data in any way.
     ///
-    /// Example: `rerun merge /my/recordings/*.rrd -o output.rrd`
+    /// Example: `rerun merge /my/recordings/*.rrd > output.rrd`
     Merge(MergeCommand),
 }
 

--- a/crates/top/rerun/src/commands/rrd/print.rs
+++ b/crates/top/rerun/src/commands/rrd/print.rs
@@ -33,7 +33,7 @@ impl PrintCommand {
 
         // TODO(cmc): might want to make this configurable at some point.
         let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
-        let rx = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+        let (rx, _) = read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
 
         for res in rx {
             let mut is_success = true;

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -12,8 +12,11 @@ use re_log_types::LogMsg;
 /// Asynchronously decodes potentially multiplexed RRD streams from the given `paths`, or standard
 /// input if none are specified.
 ///
-/// The returned channel contains both the successfully decoded data, if any, as well as any
-/// errors faced during processing.
+/// This function returns 2 channels:
+/// * The first channel contains both the successfully decoded data, if any, as well as any
+///   errors faced during processing.
+/// * The second channel, which will fire only once, after all processing is done, indicates the
+///   total number of bytes processed.
 ///
 /// This function is best-effort: it will try to make progress even in the face of errors.
 /// It is up to the user to decide whether and when to stop.
@@ -22,21 +25,27 @@ use re_log_types::LogMsg;
 pub fn read_rrd_streams_from_file_or_stdin(
     version_policy: re_log_encoding::decoder::VersionPolicy,
     paths: &[String],
-) -> channel::Receiver<anyhow::Result<LogMsg>> {
+) -> (
+    channel::Receiver<anyhow::Result<LogMsg>>,
+    channel::Receiver<u64>,
+) {
     let path_to_input_rrds = paths.iter().map(PathBuf::from).collect_vec();
 
     // TODO(cmc): might want to make this configurable at some point.
     let (tx, rx) = crossbeam::channel::bounded(100);
+    let (tx_size_bytes, rx_size_bytes) = crossbeam::channel::bounded(1);
 
     _ = std::thread::Builder::new()
         .name("rerun-cli-stdin".to_owned())
         .spawn(move || {
+            let mut size_bytes = 0;
+
             if path_to_input_rrds.is_empty() {
                 // stdin
 
                 let stdin = std::io::BufReader::new(std::io::stdin().lock());
 
-                let decoder = match re_log_encoding::decoder::Decoder::new_concatenated(
+                let mut decoder = match re_log_encoding::decoder::Decoder::new_concatenated(
                     version_policy,
                     stdin,
                 )
@@ -49,10 +58,12 @@ pub fn read_rrd_streams_from_file_or_stdin(
                     }
                 };
 
-                for res in decoder {
+                for res in &mut decoder {
                     let res = res.context("couldn't decode message from stdin -- skipping");
                     tx.send(res).ok();
                 }
+
+                size_bytes += decoder.size_bytes();
             } else {
                 // file(s)
 
@@ -67,7 +78,7 @@ pub fn read_rrd_streams_from_file_or_stdin(
                         }
                     };
 
-                    let decoder =
+                    let mut decoder =
                         match re_log_encoding::decoder::Decoder::new(version_policy, rrd_file)
                             .with_context(|| format!("couldn't decode {rrd_path:?} -- skipping"))
                         {
@@ -78,15 +89,19 @@ pub fn read_rrd_streams_from_file_or_stdin(
                             }
                         };
 
-                    for res in decoder {
+                    for res in &mut decoder {
                         let res = res.context("decode rrd message").with_context(|| {
                             format!("couldn't decode message {rrd_path:?} -- skipping")
                         });
                         tx.send(res).ok();
                     }
+
+                    size_bytes += decoder.size_bytes();
                 }
             }
+
+            tx_size_bytes.send(size_bytes).ok();
         });
 
-    rx
+    (rx, rx_size_bytes)
 }

--- a/crates/viewer/re_viewer/src/saving.rs
+++ b/crates/viewer/re_viewer/src/saving.rs
@@ -73,5 +73,6 @@ pub fn encode_to_file(
 
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     re_log_encoding::encoder::encode(version, encoding_options, messages, &mut file)
+        .map(|_| ())
         .context("Message encode")
 }


### PR DESCRIPTION
You can now do this:
```
cat docs/snippets/all/archetypes/*_rust.rrd | rerun rrd compact --max-rows 99999999 --max-bytes 999999999 | rerun rrd print
```

Also made sure that encoders and decoders accurately report the size of the data they plow through.

- Part of #7048 
- DNM: requires https://github.com/rerun-io/rerun/pull/7093 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7094?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7094?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7094)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.