### PR TITLE
Improved CLI 5: implement `rerun rrd filter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5527,6 +5527,7 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 name = "rerun"
 version = "0.18.0-alpha.1+dev"
 dependencies = [
+ "ahash",
  "anyhow",
  "clap",
  "document-features",

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -117,6 +117,7 @@ re_memory.workspace = true
 re_smart_channel.workspace = true
 re_tracing.workspace = true
 
+ahash.workspace = true
 anyhow.workspace = true
 document-features.workspace = true
 itertools.workspace = true

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -1,0 +1,168 @@
+use std::{collections::HashSet, io::IsTerminal};
+
+use anyhow::Context as _;
+
+use re_build_info::CrateVersion;
+use re_chunk::{external::crossbeam, TransportChunk};
+
+use crate::commands::read_rrd_streams_from_file_or_stdin;
+
+// ---
+
+#[derive(Debug, Clone, clap::Parser)]
+pub struct FilterCommand {
+    /// Paths to read from. Reads from standard input if none are specified.
+    path_to_input_rrds: Vec<String>,
+
+    /// Names of the timelines to be filtered out.
+    #[clap(long = "timeline")]
+    dropped_timelines: Vec<String>,
+
+    /// If set, will try to proceed even in the face of IO and/or decoding errors in the input data.
+    #[clap(long, default_value_t = false)]
+    best_effort: bool,
+}
+
+impl FilterCommand {
+    pub fn run(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !std::io::stdout().is_terminal(),
+            "you must redirect the output to a file and/or stream"
+        );
+
+        let Self {
+            path_to_input_rrds,
+            dropped_timelines,
+            best_effort,
+        } = self;
+
+        let now = std::time::Instant::now();
+        re_log::info!(srcs = ?path_to_input_rrds, ?dropped_timelines, "filter started");
+
+        let dropped_timelines: HashSet<_> = dropped_timelines.iter().collect();
+
+        // TODO(cmc): might want to make this configurable at some point.
+        let version_policy = re_log_encoding::decoder::VersionPolicy::Warn;
+        let (rx_decoder, rx_size_bytes) =
+            read_rrd_streams_from_file_or_stdin(version_policy, path_to_input_rrds);
+
+        // TODO(cmc): might want to make this configurable at some point.
+        let (tx_encoder, rx_encoder) = crossbeam::channel::bounded(100);
+
+        let encoding_handle = std::thread::Builder::new()
+            .name("rerun-rrd-filter-out".to_owned())
+            .spawn(move || -> anyhow::Result<u64> {
+                use std::io::Write as _;
+
+                let mut rrd_out = std::io::BufWriter::new(std::io::stdout().lock());
+
+                let mut encoder = {
+                    // TODO(cmc): encoding options & version should match the original.
+                    let version = CrateVersion::LOCAL;
+                    let options = re_log_encoding::EncodingOptions::COMPRESSED;
+                    re_log_encoding::encoder::Encoder::new(version, options, &mut rrd_out)
+                        .context("couldn't init encoder")?
+                };
+
+                let mut size_bytes = 0;
+                for msg in rx_encoder {
+                    size_bytes += encoder.append(&msg).context("encoding failure")?;
+                }
+
+                rrd_out.flush().context("couldn't flush output")?;
+
+                Ok(size_bytes)
+            });
+
+        for res in rx_decoder {
+            let mut is_success = true;
+
+            match res {
+                Ok(msg) => {
+                    let msg = match msg {
+                        re_log_types::LogMsg::ArrowMsg(store_id, mut msg) => {
+                            let (fields, columns): (Vec<_>, Vec<_>) =
+                                itertools::izip!(msg.schema.fields.iter(), msg.chunk.iter())
+                                    .filter(|(field, _col)| {
+                                        filter_timeline(&dropped_timelines, field)
+                                    })
+                                    .map(|(field, col)| (field.clone(), col.clone()))
+                                    .unzip();
+
+                            msg.schema.fields = fields;
+                            msg.chunk = re_log_types::external::arrow2::chunk::Chunk::new(columns);
+
+                            re_log_types::LogMsg::ArrowMsg(store_id, msg)
+                        }
+
+                        msg => msg,
+                    };
+
+                    tx_encoder.send(msg).ok();
+                }
+
+                Err(err) => {
+                    re_log::error!(err = re_error::format(err));
+                    is_success = false;
+                }
+            }
+
+            if !*best_effort && !is_success {
+                anyhow::bail!(
+                    "one or more IO and/or decoding failures in the input stream (check logs)"
+                )
+            }
+        }
+
+        std::mem::drop(tx_encoder);
+        let rrd_out_size = encoding_handle
+            .context("couldn't spawn IO thread")?
+            .join()
+            .unwrap()?;
+
+        let rrds_in_size = rx_size_bytes.recv().ok();
+        let filtered_ratio =
+            if let (Some(rrds_in_size), rrd_out_size) = (rrds_in_size, rrd_out_size) {
+                format!(
+                    "{:3.3}%",
+                    100.0 - rrd_out_size as f64 / (rrds_in_size as f64 + f64::EPSILON) * 100.0
+                )
+            } else {
+                "N/A".to_owned()
+            };
+
+        let file_size_to_string = |size: Option<u64>| {
+            size.map_or_else(
+                || "<unknown>".to_owned(),
+                |size| re_format::format_bytes(size as _),
+            )
+        };
+
+        re_log::info!(
+            dst_size_bytes = %file_size_to_string(Some(rrd_out_size)),
+            time = ?now.elapsed(),
+            filtered_ratio,
+            srcs = ?path_to_input_rrds,
+            srcs_size_bytes = %file_size_to_string(rrds_in_size),
+            "filter finished"
+        );
+
+        Ok(())
+    }
+}
+
+// ---
+
+use re_sdk::external::arrow2::datatypes::Field as ArrowField;
+
+fn filter_timeline(dropped_timelines: &HashSet<&String>, field: &ArrowField) -> bool {
+    let is_timeline = field
+        .metadata
+        .get(TransportChunk::FIELD_METADATA_KEY_KIND)
+        .map(|s| s.as_str())
+        == Some(TransportChunk::FIELD_METADATA_VALUE_KIND_TIME);
+
+    let is_dropped = dropped_timelines.contains(&field.name);
+
+    !is_timeline || !is_dropped
+}

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -214,6 +214,7 @@ fn merge_and_compact(
         .filter(|entity_db| entity_db.store_kind() == StoreKind::Recording)
         .flat_map(|entity_db| entity_db.to_messages(None /* time selection */));
 
+    // TODO(cmc): encoding options should match the original.
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let version = entity_dbs
         .values()

--- a/crates/top/rerun/src/commands/rrd/merge_compact.rs
+++ b/crates/top/rerun/src/commands/rrd/merge_compact.rs
@@ -22,8 +22,8 @@ pub struct MergeCommand {
     path_to_output_rrd: Option<String>,
 
     /// If set, will try to proceed even in the face of IO and/or decoding errors in the input data.
-    #[clap(long, default_value_t = false)]
-    best_effort: bool,
+    #[clap(long = "continue-on-error", default_value_t = false)]
+    continue_on_error: bool,
 }
 
 impl MergeCommand {
@@ -31,7 +31,7 @@ impl MergeCommand {
         let Self {
             path_to_input_rrds,
             path_to_output_rrd,
-            best_effort,
+            continue_on_error,
         } = self;
 
         if path_to_output_rrd.is_none() {
@@ -48,7 +48,7 @@ impl MergeCommand {
         let store_config = ChunkStoreConfig::ALL_DISABLED;
 
         merge_and_compact(
-            *best_effort,
+            *continue_on_error,
             &store_config,
             path_to_input_rrds,
             path_to_output_rrd.as_ref(),
@@ -88,8 +88,8 @@ pub struct CompactCommand {
     max_rows_if_unsorted: Option<u64>,
 
     /// If set, will try to proceed even in the face of IO and/or decoding errors in the input data.
-    #[clap(long, default_value_t = false)]
-    best_effort: bool,
+    #[clap(long = "continue-on-error", default_value_t = false)]
+    continue_on_error: bool,
 }
 
 impl CompactCommand {
@@ -100,7 +100,7 @@ impl CompactCommand {
             max_bytes,
             max_rows,
             max_rows_if_unsorted,
-            best_effort,
+            continue_on_error,
         } = self;
 
         if path_to_output_rrd.is_none() {
@@ -126,7 +126,7 @@ impl CompactCommand {
         }
 
         merge_and_compact(
-            *best_effort,
+            *continue_on_error,
             &store_config,
             path_to_input_rrds,
             path_to_output_rrd.as_ref(),
@@ -135,7 +135,7 @@ impl CompactCommand {
 }
 
 fn merge_and_compact(
-    best_effort: bool,
+    continue_on_error: bool,
     store_config: &ChunkStoreConfig,
     path_to_input_rrds: &[String],
     path_to_output_rrd: Option<&String>,
@@ -189,7 +189,7 @@ fn merge_and_compact(
             }
         }
 
-        if !best_effort && !is_success {
+        if !continue_on_error && !is_success {
             anyhow::bail!(
                 "one or more IO and/or decoding failures in the input stream (check logs)"
             )

--- a/crates/top/rerun/src/commands/rrd/mod.rs
+++ b/crates/top/rerun/src/commands/rrd/mod.rs
@@ -1,8 +1,10 @@
 mod compare;
+mod filter;
 mod merge_compact;
 mod print;
 
 use self::compare::CompareCommand;
+use self::filter::FilterCommand;
 use self::merge_compact::{CompactCommand, MergeCommand};
 use self::print::PrintCommand;
 
@@ -52,6 +54,15 @@ pub enum RrdCommands {
     ///
     /// Example: `rerun merge /my/recordings/*.rrd > output.rrd`
     Merge(MergeCommand),
+
+    /// Filters out data from .rrd/.rbl files/streams, and writes the result to standard output.
+    ///
+    /// Reads from standard input if no paths are specified.
+    ///
+    /// This will not affect the chunking of the data in any way.
+    ///
+    /// Example: `rerun filter --timeline log_tick /my/recordings/*.rrd > output.rrd`
+    Filter(FilterCommand),
 }
 
 impl RrdCommands {
@@ -66,6 +77,7 @@ impl RrdCommands {
             Self::Print(print_command) => print_command.run(),
             Self::Compact(compact_command) => compact_command.run(),
             Self::Merge(merge_command) => merge_command.run(),
+            Self::Filter(drop_command) => drop_command.run(),
         }
     }
 }

--- a/crates/top/rerun/src/commands/stdio.rs
+++ b/crates/top/rerun/src/commands/stdio.rs
@@ -36,7 +36,7 @@ pub fn read_rrd_streams_from_file_or_stdin(
     let (tx_size_bytes, rx_size_bytes) = crossbeam::channel::bounded(1);
 
     _ = std::thread::Builder::new()
-        .name("rerun-cli-stdin".to_owned())
+        .name("rerun-rrd-in".to_owned())
         .spawn(move || {
             let mut size_bytes = 0;
 


### PR DESCRIPTION
You can now do this:
```
cat docs/snippets/all/archetypes/*_rust.rrd | rerun rrd compact --max-rows 99999999 --max-bytes 999999999 | rerun rrd filter --timeline log_tick | rerun -
```

- Fixes #7048 
- DNM: requires https://github.com/rerun-io/rerun/pull/7094

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7095?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7095?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7095)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.