### PR TITLE
Hide the component default section for views without visualizers

### DIFF
--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -19,24 +19,21 @@ pub fn view_components_defaults_section_ui(
     ui: &mut egui::Ui,
     view: &SpaceViewBlueprint,
 ) {
-    // skip this section entirely if the view doesn't have any visualizer
-    if ctx
-        .visualizer_collection
-        .systems
-        .values()
-        .all(|visualizer_system| visualizer_system.visualizer_query_info().is_empty())
-    {
-        return;
-    }
-
     let db = ctx.viewer_ctx.blueprint_db();
     let query = ctx.viewer_ctx.blueprint_query;
 
     let active_defaults = active_defaults(ctx, view, db, query);
     let component_to_vis = component_to_vis(ctx);
 
+    // If there is nothing set by the user and nothing to be possibly added, we skip the section
+    // entirely.
+    if active_defaults.is_empty() && component_to_vis.is_empty() {
+        return;
+    }
+
     let components_to_show_in_add_menu =
         components_to_show_in_add_menu(ctx, &component_to_vis, &active_defaults);
+
     let reason_we_cannot_add_more = components_to_show_in_add_menu.as_ref().err().cloned();
 
     let mut add_button_is_open = false;

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -33,7 +33,6 @@ pub fn view_components_defaults_section_ui(
 
     let components_to_show_in_add_menu =
         components_to_show_in_add_menu(ctx, &component_to_vis, &active_defaults);
-
     let reason_we_cannot_add_more = components_to_show_in_add_menu.as_ref().err().cloned();
 
     let mut add_button_is_open = false;

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -19,6 +19,16 @@ pub fn view_components_defaults_section_ui(
     ui: &mut egui::Ui,
     view: &SpaceViewBlueprint,
 ) {
+    // skip this section entirely if the view doesn't have any visualizer
+    if ctx
+        .visualizer_collection
+        .systems
+        .values()
+        .all(|visualizer_system| visualizer_system.visualizer_query_info().is_empty())
+    {
+        return;
+    }
+
     let db = ctx.viewer_ctx.blueprint_db();
     let query = ctx.viewer_ctx.blueprint_query;
 

--- a/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
@@ -72,6 +72,10 @@ impl VisualizerQueryInfo {
             queried: SortedComponentNameSet::default(),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.indicators.is_empty() && self.required.is_empty() && self.queried.0.is_empty()
+    }
 }
 
 /// Element of a scene derived from a single archetype query.

--- a/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
@@ -72,10 +72,6 @@ impl VisualizerQueryInfo {
             queried: SortedComponentNameSet::default(),
         }
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.indicators.is_empty() && self.required.is_empty() && self.queried.0.is_empty()
-    }
 }
 
 /// Element of a scene derived from a single archetype query.


### PR DESCRIPTION
### What

Component defaults do not make much sense for the dataframe view and should be hidden. This PR hides them for all view which have no non-empty visualisers.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7099?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7099?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7099)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.