### PR TITLE
Add `__version__` and `__version_info__` to rerun package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,10 @@ jobs:
           echo "current=$current"   >> "$GITHUB_OUTPUT"
           echo "final=$final"       >> "$GITHUB_OUTPUT"
 
+      - name: Update rerun_py version
+        run: |
+          pixi run python scripts/ci/update_rerun_py_version.py "${{ steps.versioning.outputs.current }}"
+
       - name: Update rerun_notebook package version
         run: |
           pixi run python scripts/ci/update_rerun_notebook_version.py "${{ steps.versioning.outputs.current }}"

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -7,6 +7,9 @@ from uuid import UUID
 
 import numpy as np
 
+__version__ = "0.18.0-alpha.1"
+__version_info__ = (0, 18, 0, "alpha.1")
+
 # =====================================
 # API RE-EXPORTS
 # Important: always us the `import _ as _` format to make it explicit to type-checkers that these are public APIs.

--- a/rerun_py/tests/unit/test_version.py
+++ b/rerun_py/tests/unit/test_version.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import rerun as rr
+import semver
+
+
+def test_version() -> None:
+    ver = semver.VersionInfo.parse(rr.__version__)
+
+    assert ver.major == rr.__version_info__[0]
+    assert ver.minor == rr.__version_info__[1]
+    assert ver.patch == rr.__version_info__[2]
+
+    if ver.prerelease:
+        assert ver.prerelease == rr.__version_info__[3]
+    else:
+        assert len(rr.__version_info__) == 3
+
+    assert rr.__version__ in rr.version()
+
+
+if __name__ == "__main__":
+    test_version()

--- a/scripts/ci/update_rerun_py_version.py
+++ b/scripts/ci/update_rerun_py_version.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+"""
+Updates the version information in rerun_sdk.
+
+This includes:
+- `rerun.__version__`
+- `rerun.__version_info__`
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import semver
+
+
+def update(line, version_line, version_info_line):
+    if line.startswith("__version__"):
+        if line != version_line:
+            return version_line
+    if line.startswith("__version_info__"):
+        if line != version_info_line:
+            return version_info_line
+    return line
+
+
+def set_rerun_py_version(init_path: Path, version: str) -> None:
+    sem_version = semver.VersionInfo.parse(version)
+
+    version_line = f'__version__ = "{version}"\n'
+    version_info_line = f'__version_info__ = ({sem_version.major}, {sem_version.minor}, {sem_version.patch}, "{sem_version.prerelease}")\n'
+
+    with init_path.open() as f:
+        lines = f.readlines()
+
+    new_lines = [update(line, version_line, version_info_line) for line in lines]
+
+    if new_lines != lines:
+        with init_path.open("w") as f:
+            f.writelines(new_lines)
+    else:
+        print(f"Version already set to {version} in {init_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update rerun_py __version__ variable.")
+    parser.add_argument("VERSION", help="Version to use")
+    args = parser.parse_args()
+
+    # check that the version is valid
+    try:
+        semver.VersionInfo.parse(args.VERSION)
+    except ValueError:
+        print(f"Invalid semver version: {args.VERSION}", file=sys.stderr, flush=True)
+        sys.exit(1)
+
+    project_path = Path(__file__).parent.parent.parent.absolute()
+
+    set_rerun_py_version(project_path / "rerun_py" / "rerun_sdk" / "rerun" / "__init__.py", args.VERSION)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/release_checklist/check_version.py
+++ b/tests/python/release_checklist/check_version.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import rerun as rr
+
+README = """\
+# Version check
+
+- Verify the version number is correct given the release.
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def log_the_versions() -> None:
+    rr.log(
+        "/version",
+        rr.TextDocument(
+            f"""```
+__version__ = {rr.__version__}
+___version_info___ = {rr.__version_info__}
+rr.version() = {rr.version()}
+```
+""",
+            media_type=rr.MediaType.MARKDOWN,
+        ),
+    )
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
+
+    log_readme()
+    log_the_versions()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7059

This is more standardized and machine-readable than the `bindings.version()` implementation.

Also update it consistently when we bump it in the release script.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7104?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7104?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7104)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.