### PR TITLE
Update doc for `new_recording` API

### DIFF
--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -26,7 +26,7 @@ def new_recording(
     If you only need a single global recording, [`rerun.init`][] might be simpler.
 
     Note that unless setting `spawn=True` new recording streams always begin connected to a buffered sink.
-    To send the data to a viewer or file you will likely want to call [`rerun.connect`][], [`rerun.save`][]
+    To send the data to a viewer or file you will likely want to call [`rerun.connect`][] or [`rerun.save`][]
     explicitly.
 
     !!! Warning

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -25,6 +25,10 @@ def new_recording(
 
     If you only need a single global recording, [`rerun.init`][] might be simpler.
 
+    Note that unless setting `spawn=True` new recording streams always begin connected to a buffered sink.
+    To send the data to a viewer or file you will likely want to call [`rerun.connect`][], [`rerun.save`][]
+    explicitly.
+
     !!! Warning
         If you don't specify a `recording_id`, it will default to a random value that is generated once
         at the start of the process.
@@ -84,6 +88,24 @@ def new_recording(
     -------
     RecordingStream
         A handle to the [`rerun.RecordingStream`][]. Use it to log data to Rerun.
+
+    Examples
+    --------
+    Using a recording stream object directly.
+    ```python
+    from uuid import uuid4
+    stream = rr.new_recording("my_app", recording_id=uuid4())
+    stream.connect()
+    stream.log("hello", rr.TextLog("Hello world"))
+    ```
+
+    Setting up a new global recording explicitly.
+    ```python
+    from uuid import uuid4
+    rr.new_recording("my_app", make_default=True, recording_id=uuid4())
+    rr.connect()
+    rr.log("hello", rr.TextLog("Hello world"))
+    ```
 
     """
 


### PR DESCRIPTION
### What

Clarify the usage of `new_recording`

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7107?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7107?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7107)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.