### PR TITLE
Re-enable per-series parallelism

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -96,7 +96,7 @@ impl SeriesLineSystem {
 
         let data_results = query.iter_visible_data_results(ctx, Self::identifier());
 
-        let parallel_loading = false; // TODO(emilk): enable parallel loading when it is faster, because right now it is often slower.
+        let parallel_loading = true;
         if parallel_loading {
             use rayon::prelude::*;
             re_tracing::profile_wait!("load_series");


### PR DESCRIPTION
We turned off per-series parallelism at some point because the space view lacks a good enough global understanding of what is going on across the entire viewer in order to decide whether the added parallelism will be worth it.
In practice, this always-on parallelism usually turned out to be a net loss in most real-world scenarios since it was basically DDOSing rayon's threadpool and the cache's locks.

With the new chunk-based query engine in place, there are now less locks, less overall contention, and in general fewer time spent in the cache routines, so this might be worth it now.

Let's try it for a few days and we can take a final decision before release.

PS: There's pretty much no diff:
![image](https://github.com/user-attachments/assets/3957c1bf-7b1f-4918-8a1e-42a124f05ff6)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
