### PR TITLE
Query: configurable timeline|component eager slicing

### DIFF
--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -12,7 +12,7 @@ pub use self::cache::{CacheKey, Caches};
 pub use self::cache_stats::{CacheStats, CachesStats};
 pub use self::clamped_zip::*;
 pub use self::latest_at::LatestAtResults;
-pub use self::range::RangeResults;
+pub use self::range::{RangeQueryOptions, RangeResults};
 pub use self::range_zip::*;
 
 pub(crate) use self::latest_at::LatestAtCache;

--- a/crates/store/re_query/src/range.rs
+++ b/crates/store/re_query/src/range.rs
@@ -13,6 +13,33 @@ use crate::{CacheKey, Caches};
 
 // --- Public API ---
 
+#[derive(Debug, Clone)]
+pub struct RangeQueryOptions {
+    /// Should the results contain all extra timeline information available in the [`Chunk`]?
+    ///
+    /// While this information can be useful in some cases, it comes at a performance cost.
+    pub keep_extra_timelines: bool,
+
+    /// Should the results contain all extra component information available in the [`Chunk`]?
+    ///
+    /// While this information can be useful in some cases, it comes at a performance cost.
+    pub keep_extra_components: bool,
+}
+
+impl RangeQueryOptions {
+    pub const DEFAULT: Self = Self {
+        keep_extra_timelines: false,
+        keep_extra_components: false,
+    };
+}
+
+impl Default for RangeQueryOptions {
+    #[inline]
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 impl Caches {
     /// Queries for the given `component_names` using range semantics.
     ///
@@ -23,6 +50,23 @@ impl Caches {
         &self,
         store: &ChunkStore,
         query: &RangeQuery,
+        entity_path: &EntityPath,
+        component_names: impl IntoIterator<Item = ComponentName>,
+    ) -> RangeResults {
+        let opts = &RangeQueryOptions::DEFAULT;
+        self.range_opts(store, query, opts, entity_path, component_names)
+    }
+
+    /// Queries for the given `component_names` using range semantics.
+    ///
+    /// See [`RangeResults`] for more information about how to handle the results.
+    ///
+    /// This is a cached API -- data will be lazily cached upon access.
+    pub fn range_opts(
+        &self,
+        store: &ChunkStore,
+        query: &RangeQuery,
+        query_opts: &RangeQueryOptions,
         entity_path: &EntityPath,
         component_names: impl IntoIterator<Item = ComponentName>,
     ) -> RangeResults {
@@ -51,7 +95,7 @@ impl Caches {
 
             cache.handle_pending_invalidation();
 
-            let cached = cache.range(store, query, entity_path, component_name);
+            let cached = cache.range(store, query, query_opts, entity_path, component_name);
             if !cached.is_empty() {
                 results.add(component_name, cached);
             }
@@ -252,6 +296,7 @@ impl RangeCache {
         &mut self,
         store: &ChunkStore,
         query: &RangeQuery,
+        query_opts: &RangeQueryOptions,
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) -> Vec<Chunk> {
@@ -288,6 +333,11 @@ impl RangeCache {
         // Since these `Chunk`s have already been pre-processed adequately, running a range filter
         // on them will be quite cheap.
 
+        let RangeQueryOptions {
+            keep_extra_timelines,
+            keep_extra_components,
+        } = query_opts;
+
         raw_chunks
             .into_iter()
             .filter_map(|raw_chunk| self.chunks.get(&raw_chunk.id()))
@@ -295,7 +345,24 @@ impl RangeCache {
                 debug_assert!(cached_sorted_chunk
                     .chunk
                     .is_timeline_sorted(&query.timeline()));
-                cached_sorted_chunk.chunk.range(query, component_name)
+
+                let chunk = &cached_sorted_chunk.chunk;
+
+                // Pre-slice the data if the caller allowed us: this will make further slicing
+                // (e.g. the range query itself) much cheaper to compute.
+                use std::borrow::Cow;
+                let chunk = if !keep_extra_timelines {
+                    Cow::Owned(chunk.timeline_sliced(query.timeline()))
+                } else {
+                    Cow::Borrowed(chunk)
+                };
+                let chunk = if !keep_extra_components {
+                    Cow::Owned(chunk.component_sliced(component_name))
+                } else {
+                    chunk
+                };
+
+                chunk.range(query, component_name)
             })
             .filter(|chunk| !chunk.is_empty())
             .collect()

--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -12,7 +12,8 @@ mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
 pub use query::{
-    latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data, DataResultQuery,
+    latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data,
+    range_with_blueprint_resolved_data_opts, DataResultQuery,
 };
 pub use results_ext::{
     HybridLatestAtResults, HybridResults, HybridResultsChunkIter, RangeResultsExt,

--- a/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
@@ -4,8 +4,9 @@ use re_chunk_store::RowId;
 use re_entity_db::EntityPath;
 use re_log_types::TimeInt;
 use re_log_types::TimePoint;
+use re_query::RangeQueryOptions;
 use re_query::{clamped_zip_1x2, range_zip_1x2};
-use re_space_view::{range_with_blueprint_resolved_data, RangeResultsExt};
+use re_space_view::{range_with_blueprint_resolved_data_opts, RangeResultsExt};
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -86,10 +87,14 @@ impl TextLogSystem {
     ) {
         re_tracing::profile_function!();
 
-        let results = range_with_blueprint_resolved_data(
+        let results = range_with_blueprint_resolved_data_opts(
             ctx,
             None,
             query,
+            &RangeQueryOptions {
+                keep_extra_timelines: true,
+                keep_extra_components: false,
+            },
             data_result,
             [Text::name(), TextLogLevel::name(), Color::name()],
         );

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -1,4 +1,4 @@
-use itertools::Itertools as _;
+use itertools::Itertools;
 
 use re_space_view::range_with_blueprint_resolved_data;
 use re_types::archetypes;
@@ -235,11 +235,11 @@ impl SeriesLineSystem {
                 re_tracing::profile_scope!("fill values");
 
                 debug_assert_eq!(Scalar::arrow_datatype(), ArrowDatatype::Float64);
-                let mut i = 0;
                 all_scalar_chunks
                     .iter()
                     .flat_map(|chunk| chunk.iter_primitive::<f64>(&Scalar::name()))
-                    .for_each(|values| {
+                    .enumerate()
+                    .for_each(|(i, values)| {
                         if !values.is_empty() {
                             if values.len() > 1 {
                                 re_log::warn_once!(
@@ -251,8 +251,6 @@ impl SeriesLineSystem {
                         } else {
                             points[i].attrs.kind = PlotSeriesKind::Clear;
                         }
-
-                        i += 1;
                     });
             }
 


### PR DESCRIPTION
This adds range query options that make it possible to discard unwanted timeline and component columns as early as possible in the query pipeline.

Because the compute cost of slicing chunks grows linearly with the number of columns, this has a non-negligible impact for large range queries that slice many many chunks.

All queries use these new options by default, except for the text-log view that needs all the timeline columns it can get. 

This results in 10-15% single-threaded perf improvement for timeseries workloads.

```
taskset -c 7 target/release/rerun ~/Downloads/vrs.rrd
```
Before:
![image (6)](https://github.com/user-attachments/assets/1fafadae-3e26-4445-b8be-1e049cdc3c01)
After:
![image (7)](https://github.com/user-attachments/assets/1b1558a5-1245-4eab-89be-c14710b16933)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7112?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7112?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7112)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.