### PR TITLE
Higher compaction thresholds by default (x4)

### DIFF
--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -100,11 +100,11 @@ impl ChunkStoreConfig {
         // become a bit too costly to concatenate beyond that.
         chunk_max_bytes: 4 * 1024 * 1024,
 
-        // Empirical testing shows that 1024 is the threshold after which we really start to get
-        // dimishing returns space-wise.
-        chunk_max_rows: 1024,
+        // Empirical testing shows that 4096 is the threshold after which we really start to get
+        // dimishing returns space and compute wise.
+        chunk_max_rows: 4096,
 
-        chunk_max_rows_if_unsorted: 256,
+        chunk_max_rows_if_unsorted: 1024,
     };
 
     /// [`Self::DEFAULT`], but with compaction entirely disabled.


### PR DESCRIPTION
[Further empirical testing](https://www.notion.so/rerunio/Rerun-0-17-vs-0-18-perf-analysis-9a173bff2648450099a15bae0bce1032) has shown `max_rows=4096` to be worth it.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7113?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7113?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7113)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.