### PR TITLE
Remove tiny profile scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3985,14 +3985,15 @@ dependencies = [
 
 [[package]]
 name = "puffin"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f76ad4bb049fded4e572df72cbb6381ff5d1f41f85c3a04b56e4eca287a02f"
+checksum = "fa9dae7b05c02ec1a6bc9bcf20d8bc64a7dcbf57934107902a872014899b741f"
 dependencies = [
  "anyhow",
  "bincode",
  "byteorder",
  "cfg-if",
+ "itertools 0.10.5",
  "lz4_flex",
  "once_cell",
  "parking_lot",

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -629,7 +629,7 @@ impl TimeColumn {
         timeline: Timeline,
         times: ArrowPrimitiveArray<i64>,
     ) -> Self {
-        re_tracing::profile_function!(format!("{} times", times.len()));
+        re_tracing::profile_function_if!(1000 < times.len(), format!("{} times", times.len()));
 
         let times = times.to(timeline.datatype());
         let time_slice = times.values().as_slice();

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -115,7 +115,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: &ComponentName,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.entity_has_static_component(entity_path, component_name)
             || self.entity_has_temporal_component_on_timeline(timeline, entity_path, component_name)
@@ -129,7 +129,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: &ComponentName,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.entity_has_static_component(entity_path, component_name)
             || self.entity_has_temporal_component(entity_path, component_name)
@@ -144,7 +144,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: &ComponentName,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -164,7 +164,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: &ComponentName,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -187,7 +187,7 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: &ComponentName,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -212,7 +212,7 @@ impl ChunkStore {
         timeline: &Timeline,
         entity_path: &EntityPath,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.entity_has_static_data(entity_path)
             || self.entity_has_temporal_data_on_timeline(timeline, entity_path)
@@ -224,7 +224,7 @@ impl ChunkStore {
     /// that some _data_ currently exists in the store for this entity.
     #[inline]
     pub fn entity_has_data(&self, entity_path: &EntityPath) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.entity_has_static_data(entity_path) || self.entity_has_temporal_data(entity_path)
     }
@@ -235,7 +235,7 @@ impl ChunkStore {
     /// that some _data_ currently exists in the store for this entity.
     #[inline]
     pub fn entity_has_static_data(&self, entity_path: &EntityPath) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -254,7 +254,7 @@ impl ChunkStore {
     /// that some _data_ currently exists in the store for this entity.
     #[inline]
     pub fn entity_has_temporal_data(&self, entity_path: &EntityPath) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -282,7 +282,7 @@ impl ChunkStore {
         timeline: &Timeline,
         entity_path: &EntityPath,
     ) -> bool {
-        re_tracing::profile_function!();
+        // re_tracing::profile_function!(); // This function is too fast; profiling will only add overhead
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 

--- a/crates/utils/re_tracing/src/lib.rs
+++ b/crates/utils/re_tracing/src/lib.rs
@@ -24,12 +24,32 @@ macro_rules! profile_function {
     };
 }
 
+/// Create a profile scope based on the function name, if the given confition holds true.
+///
+/// Call this at the very top of a potentially expensive function.
+#[macro_export]
+macro_rules! profile_function_if {
+    ($($arg: tt)*) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        $crate::reexports::puffin::profile_function_if!($($arg)*);
+    };
+}
+
 /// Create a profiling scope with a custom name.
 #[macro_export]
 macro_rules! profile_scope {
     ($($arg: tt)*) => {
         #[cfg(not(target_arch = "wasm32"))]
         $crate::reexports::puffin::profile_scope!($($arg)*);
+    };
+}
+
+/// Create a profiling scope with a custom name, if the given confition holds true.
+#[macro_export]
+macro_rules! profile_scope_if {
+    ($($arg: tt)*) => {
+        #[cfg(not(target_arch = "wasm32"))]
+        $crate::reexports::puffin::profile_scope_if!($($arg)*);
     };
 }
 

--- a/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -89,7 +89,11 @@ where
     /// If the buffer is not big enough, only the first `self.remaining_capacity()` elements are pushed before returning an error.
     #[inline]
     pub fn extend_from_slice(&mut self, elements: &[T]) -> Result<(), CpuWriteGpuReadError> {
-        re_tracing::profile_function!();
+        if elements.is_empty() {
+            return Ok(());
+        }
+
+        re_tracing::profile_function_if!(10_000 < elements.len());
 
         let remaining_capacity = self.remaining_capacity();
         let (result, elements) = if elements.len() > remaining_capacity {
@@ -162,7 +166,7 @@ where
             return Ok(());
         }
 
-        re_tracing::profile_function!();
+        re_tracing::profile_function_if!(10_000 < num_elements);
 
         let remaining_capacity = self.remaining_capacity();
         let (result, num_elements) = if num_elements > remaining_capacity {

--- a/crates/viewer/re_renderer/src/allocator/data_texture_source.rs
+++ b/crates/viewer/re_renderer/src/allocator/data_texture_source.rs
@@ -210,7 +210,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
             return Ok(());
         }
 
-        re_tracing::profile_function!();
+        re_tracing::profile_function_if!(10_000 < elements.len());
 
         let num_elements_available = self.reserve(elements.len())?;
         let total_elements_actually_added = num_elements_available.min(elements.len());
@@ -247,7 +247,7 @@ impl<'a, T: Pod + Send + Sync> DataTextureSource<'a, T> {
             return Ok(());
         }
 
-        re_tracing::profile_function!();
+        re_tracing::profile_function_if!(10_000 < num_elements);
 
         let num_elements_available = self.reserve(num_elements)?;
         let total_elements_actually_added = num_elements_available.min(num_elements);


### PR DESCRIPTION
### What
Reduce profiling overhead and skewed results

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7116?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7116?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7116)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.