### PR TITLE
Do instancing on superfluous leaf transforms for Boxes & Ellipsoids

### DIFF
--- a/crates/store/re_chunk/src/helpers.rs
+++ b/crates/store/re_chunk/src/helpers.rs
@@ -230,23 +230,17 @@ impl UnitChunkShared {
         self.row_ids().next()
     }
 
-    /// Returns the number of instances of the single row within.
-    ///
-    /// The maximum value amongst all components is what's returned.
+    /// Returns the number of instances of the single row within for a given component.
     #[inline]
-    pub fn num_instances(&self) -> u64 {
+    pub fn num_instances(&self, component_name: &ComponentName) -> u64 {
         debug_assert!(self.num_rows() == 1);
-        self.components
-            .values()
-            .map(|list_array| {
-                let array = list_array.value(0);
-                array.validity().map_or_else(
-                    || array.len(),
-                    |validity| validity.len() - validity.unset_bits(),
-                )
-            })
-            .max()
-            .unwrap_or(0) as u64
+        self.components.get(component_name).map_or(0, |list_array| {
+            let array = list_array.value(0);
+            array.validity().map_or_else(
+                || array.len(),
+                |validity| validity.len() - validity.unset_bits(),
+            )
+        }) as u64
     }
 }
 

--- a/crates/store/re_types/definitions/rerun/archetypes/boxes3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/boxes3d.fbs
@@ -6,6 +6,7 @@ namespace rerun.archetypes;
 ///
 /// Note that orienting and placing the box is handled via `[archetypes.LeafTransforms3D]`.
 /// Some of its component are repeated here for convenience.
+/// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 ///
 /// \example archetypes/box3d_simple !api title="Simple 3D boxes" image="https://static.rerun.io/box3d_simple/d6a3f38d2e3360fbacac52bb43e44762635be9c8/1200w.png"
 /// \example archetypes/box3d_batch title="Batch of 3D boxes" image="https://static.rerun.io/box3d_batch/6d3e453c3a0201ae42bbae9de941198513535f1d/1200w.png"

--- a/crates/store/re_types/definitions/rerun/archetypes/ellipsoids.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/ellipsoids.fbs
@@ -10,6 +10,7 @@ namespace rerun.archetypes;
 ///
 /// Note that orienting and placing the ellipsoids/spheres is handled via `[archetypes.LeafTransforms3D]`.
 /// Some of its component are repeated here for convenience.
+/// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 ///
 /// \example archetypes/ellipsoid_batch !api title="Batch of ellipsoids"
 table Ellipsoids3D (

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -22,6 +22,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// Note that orienting and placing the box is handled via `[archetypes.LeafTransforms3D]`.
 /// Some of its component are repeated here for convenience.
+/// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 ///
 /// ## Example
 ///

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -26,6 +26,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// Note that orienting and placing the ellipsoids/spheres is handled via `[archetypes.LeafTransforms3D]`.
 /// Some of its component are repeated here for convenience.
+/// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Ellipsoids3D {
     /// For each ellipsoid, half of its size on its three axes.

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -608,10 +608,11 @@ fn query_and_resolve_leaf_transform_at_entity(
 
     let max_count = result
         .components
-        .values()
-        .map(|comp| comp.num_instances())
+        .iter()
+        .map(|(name, row)| row.num_instances(name))
         .max()
         .unwrap_or(0) as usize;
+
     if max_count == 0 {
         return Vec::new();
     }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -22,9 +22,9 @@ use crate::{
 };
 
 use super::{
-    filter_visualizable_3d_entities, process_annotation_and_keypoint_slices, process_color_slice,
-    process_labels_3d, process_radius_slice, SpatialViewVisualizerData,
-    SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
+    entity_iterator::clamped_or_nothing, filter_visualizable_3d_entities,
+    process_annotation_and_keypoint_slices, process_color_slice, process_labels_3d,
+    process_radius_slice, SpatialViewVisualizerData, SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
 };
 
 // ---
@@ -56,15 +56,22 @@ impl Ellipsoids3DVisualizer {
         let entity_path = ctx.target_entity_path;
 
         for data in data {
-            let num_instances = data.half_sizes.len();
-            if num_instances == 0 {
+            if data.half_sizes.is_empty() {
                 continue;
             }
+
+            // Draw as many boxes as we have max(instances, boxes), all components get repeated over that number.
+            // TODO(#7026): We should formalize this kind of hybrid joining better.
+            let num_instances = data
+                .half_sizes
+                .len()
+                .max(ent_context.transform_info.reference_from_instances.len());
+            let half_sizes = clamped_or_nothing(data.half_sizes, num_instances);
 
             let (annotation_infos, _) = process_annotation_and_keypoint_slices(
                 query.latest_at,
                 num_instances,
-                data.half_sizes.iter().map(|_| glam::Vec3::ZERO),
+                std::iter::repeat(glam::Vec3::ZERO).take(num_instances),
                 data.keypoint_ids,
                 data.class_ids,
                 &ent_context.annotations,
@@ -94,7 +101,7 @@ impl Ellipsoids3DVisualizer {
                 .clamped_reference_from_instances();
 
             for (instance_index, (half_size, world_from_instance, radius, &color)) in
-                itertools::izip!(data.half_sizes, world_from_instances, radii, &colors).enumerate()
+                itertools::izip!(half_sizes, world_from_instances, radii, &colors).enumerate()
             {
                 let instance = Instance::from(instance_index as u64);
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -119,7 +119,7 @@ impl Mesh3DVisualizer {
 
             if let Some(mesh) = mesh {
                 // Let's draw the mesh once for every instance transform.
-                // TODO(#7026): This a rare form of hybrid joining.
+                // TODO(#7026): We should formalize this kind of hybrid joining better.
                 for &world_from_instance in &ent_context.transform_info.reference_from_instances {
                     instances.extend(mesh.mesh_instances.iter().map(move |mesh_instance| {
                         let entity_from_mesh = mesh_instance.world_from_mesh;

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -7,6 +7,7 @@ title: "Boxes3D"
 
 Note that orienting and placing the box is handled via `[archetypes.LeafTransforms3D]`.
 Some of its component are repeated here for convenience.
+If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 
 ## Components
 

--- a/docs/content/reference/types/archetypes/ellipsoids3d.md
+++ b/docs/content/reference/types/archetypes/ellipsoids3d.md
@@ -11,6 +11,7 @@ For points whose radii are for the sake of visualization, use [`archetypes.Point
 
 Note that orienting and placing the ellipsoids/spheres is handled via `[archetypes.LeafTransforms3D]`.
 Some of its component are repeated here for convenience.
+If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 
 ## Components
 

--- a/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/boxes3d.hpp
@@ -28,6 +28,7 @@ namespace rerun::archetypes {
     ///
     /// Note that orienting and placing the box is handled via `[archetypes.LeafTransforms3D]`.
     /// Some of its component are repeated here for convenience.
+    /// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
     ///
     /// ## Example
     ///

--- a/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/ellipsoids3d.hpp
@@ -32,6 +32,7 @@ namespace rerun::archetypes {
     ///
     /// Note that orienting and placing the ellipsoids/spheres is handled via `[archetypes.LeafTransforms3D]`.
     /// Some of its component are repeated here for convenience.
+    /// If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
     struct Ellipsoids3D {
         /// For each ellipsoid, half of its size on its three axes.
         ///

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d.py
@@ -23,6 +23,7 @@ class Boxes3D(Boxes3DExt, Archetype):
 
     Note that orienting and placing the box is handled via `[archetypes.LeafTransforms3D]`.
     Some of its component are repeated here for convenience.
+    If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d.py
@@ -27,6 +27,7 @@ class Ellipsoids3D(Ellipsoids3DExt, Archetype):
 
     Note that orienting and placing the ellipsoids/spheres is handled via `[archetypes.LeafTransforms3D]`.
     Some of its component are repeated here for convenience.
+    If there's more leaf transforms than half sizes, the last half size will be repeated for the remaining transforms.
     """
 
     # __init__ can be found in ellipsoids3d_ext.py

--- a/tests/python/release_checklist/check_component_and_transform_clamping.py
+++ b/tests/python/release_checklist/check_component_and_transform_clamping.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+README = """\
+# Component & transform clamping behavior
+
+This test checks the clamping behavior of components & leaf transforms on boxes & spheres.
+
+One view shows spheres, the other boxes.
+
+For both you should see:
+* 2x red (one bigger than the other)
+* 1x green
+* 2x blue (one bigger than the other)
+* NO other boxes/spheres, in particular no magenta ones!
+"""
+
+rerun_obj_path = f"{os.path.dirname(os.path.realpath(__file__))}/../../assets/rerun.obj"
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def blueprint() -> rrb.BlueprintLike:
+    return rrb.Blueprint(
+        rrb.Horizontal(
+            rrb.TextDocumentView(origin="readme"),
+            rrb.Spatial3DView(origin="spheres"),
+            rrb.Spatial3DView(origin="boxes"),
+        )
+    )
+
+
+def log_data() -> None:
+    rr.log("/boxes/clamped_colors", rr.Boxes3D(half_sizes=[[1, 1, 1], [2, 2, 2]], colors=[[255, 0, 0]]))
+    rr.log(
+        "/boxes/ignored_colors",
+        rr.Boxes3D(half_sizes=[[1, 1, 1]], centers=[[5, 0, 0]], colors=[[0, 255, 0], [255, 0, 255]]),
+    )
+    rr.log(
+        "/boxes/more_transforms_than_sizes",
+        rr.Boxes3D(half_sizes=[[1, 1, 1]], centers=[[0, 5, 0]], colors=[[0, 0, 255]]),
+        rr.LeafTransforms3D(scales=[[1, 1, 1], [2, 2, 2]]),
+    )
+    rr.log(
+        "/boxes/no_primaries",
+        rr.Boxes3D(half_sizes=[], centers=[[5, 0, 0]], colors=[[255, 0, 255]]),
+        rr.LeafTransforms3D(scales=[[1, 1, 1], [2, 2, 2]]),
+    )
+    # Same again but with spheres.
+    rr.log("/spheres/clamped_colors", rr.Ellipsoids3D(half_sizes=[[1, 1, 1], [2, 2, 2]], colors=[[255, 0, 0]]))
+    rr.log(
+        "/spheres/ignored_colors",
+        rr.Ellipsoids3D(half_sizes=[[1, 1, 1]], centers=[[5, 0, 0]], colors=[[0, 255, 0], [255, 0, 255]]),
+    )
+    rr.log(
+        "/spheres/more_transforms_than_sizes",
+        rr.Ellipsoids3D(half_sizes=[[1, 1, 1]], centers=[[0, 5, 0]], colors=[[0, 0, 255]]),
+        rr.LeafTransforms3D(scales=[[1, 1, 1], [2, 2, 2]]),
+    )
+    rr.log(
+        "/spheres/no_primaries",
+        rr.Ellipsoids3D(half_sizes=[], centers=[[5, 0, 0]], colors=[[255, 0, 255]]),
+        rr.LeafTransforms3D(scales=[[1, 1, 1], [2, 2, 2]]),
+    )
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
+    log_readme()
+    log_data()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7058
* fixes a pretty serious bug on the way that broke leaf transform listing!

commit by commit friendly

New release checklist:
![image](https://github.com/user-attachments/assets/16e70215-6032-4155-a78f-004dbf9ca4f4)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7119?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7119?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7119)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.