### PR TITLE
Drop, rather than clear, removed blueprint entities

### DIFF
--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -206,11 +206,6 @@ impl EntityDb {
     }
 
     #[inline]
-    pub fn store_mut(&mut self) -> &mut ChunkStore {
-        &mut self.data_store
-    }
-
-    #[inline]
     pub fn store_kind(&self) -> StoreKind {
         self.store_id().kind
     }
@@ -410,6 +405,36 @@ impl EntityDb {
         );
 
         self.on_store_deletions(&store_events);
+    }
+
+    /// Unconditionally drops all the data for a given [`EntityPath`] .
+    ///
+    /// This is _not_ recursive. Children of this entity will not be affected.
+    ///
+    /// To drop the entire subtree below an entity, see: [`Self::drop_entity_path_recursive`].
+    pub fn drop_entity_path(&mut self, entity_path: &EntityPath) {
+        re_tracing::profile_function!();
+
+        let store_events = self.data_store.drop_entity_path(entity_path);
+
+        self.on_store_deletions(&store_events);
+    }
+
+    /// Unconditionally drops all the data for a given [`EntityPath`] and all its children.
+    pub fn drop_entity_path_recursive(&mut self, entity_path: &EntityPath) {
+        re_tracing::profile_function!();
+
+        let mut to_drop = vec![entity_path.clone()];
+
+        if let Some(tree) = self.tree().subtree(entity_path) {
+            tree.visit_children_recursively(|path| {
+                to_drop.push(path.clone());
+            });
+        }
+
+        for entity_path in to_drop {
+            self.drop_entity_path(&entity_path);
+        }
     }
 
     fn on_store_deletions(&mut self, store_events: &[ChunkStoreEvent]) {

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -206,6 +206,11 @@ impl EntityDb {
     }
 
     #[inline]
+    pub fn store_mut(&mut self) -> &mut ChunkStore {
+        &mut self.data_store
+    }
+
+    #[inline]
     pub fn store_kind(&self) -> StoreKind {
         self.store_id().kind
     }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -519,20 +519,9 @@ impl App {
             }
             SystemCommand::DropEntity(blueprint_id, entity_path) => {
                 let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
-
-                // Accumulate drop candidates to avoid borrowing issues
-                let mut to_drop = vec![entity_path.clone()];
-
-                if let Some(tree) = blueprint_db.tree().subtree(&entity_path) {
-                    tree.visit_children_recursively(|path| {
-                        to_drop.push(path.clone());
-                    });
-                }
-
-                for path in to_drop {
-                    blueprint_db.store_mut().drop_entity_path(&path);
-                }
+                blueprint_db.drop_entity_path(entity_path);
             }
+
             #[cfg(debug_assertions)]
             SystemCommand::EnableInspectBlueprintTimeline(show) => {
                 self.app_options_mut().inspect_blueprint_timeline = show;

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -517,6 +517,22 @@ impl App {
                     }
                 }
             }
+            SystemCommand::DropEntity(blueprint_id, entity_path) => {
+                let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
+
+                // Accumulate drop candidates to avoid borrowing issues
+                let mut to_drop = vec![entity_path.clone()];
+
+                if let Some(tree) = blueprint_db.tree().subtree(&entity_path) {
+                    tree.visit_children_recursively(|path| {
+                        to_drop.push(path.clone());
+                    });
+                }
+
+                for path in to_drop {
+                    blueprint_db.store_mut().drop_entity_path(&path);
+                }
+            }
             #[cfg(debug_assertions)]
             SystemCommand::EnableInspectBlueprintTimeline(show) => {
                 self.app_options_mut().inspect_blueprint_timeline = show;

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -519,7 +519,7 @@ impl App {
             }
             SystemCommand::DropEntity(blueprint_id, entity_path) => {
                 let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
-                blueprint_db.drop_entity_path(entity_path);
+                blueprint_db.drop_entity_path(&entity_path);
             }
 
             #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -519,7 +519,7 @@ impl App {
             }
             SystemCommand::DropEntity(blueprint_id, entity_path) => {
                 let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
-                blueprint_db.drop_entity_path(&entity_path);
+                blueprint_db.drop_entity_path_recursive(&entity_path);
             }
 
             #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -1,3 +1,4 @@
+use re_chunk::EntityPath;
 use re_chunk_store::external::re_chunk::Chunk;
 use re_data_source::DataSource;
 use re_log_types::StoreId;
@@ -46,6 +47,15 @@ pub enum SystemCommand {
     /// but is tracked manually to ensure self-consistency if the blueprint
     /// is both modified and changed in the same frame.
     UpdateBlueprint(StoreId, Vec<Chunk>),
+
+    /// Drop a specific entity from a store.
+    ///
+    /// Also drops all recursive children.
+    ///
+    /// The [`StoreId`] should generally be the currently selected blueprint
+    /// but is tracked manually to ensure self-consistency if the blueprint
+    /// is both modified and changed in the same frame.
+    DropEntity(StoreId, EntityPath),
 
     /// Show a timeline of the blueprint data.
     #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -9,7 +9,6 @@ use re_types::components::Name;
 use re_types::{blueprint::components::Visible, Archetype as _};
 use re_types_blueprint::blueprint::archetypes as blueprint_archetypes;
 use re_types_blueprint::blueprint::components::{ContainerKind, GridColumns};
-use re_types_core::archetypes::Clear;
 use re_viewer_context::{
     ContainerId, Contents, ContentsName, SpaceViewId, SystemCommand, SystemCommandSender as _,
     ViewerContext,
@@ -337,8 +336,10 @@ impl ContainerBlueprint {
     /// Clears the blueprint component for this container.
     // TODO(jleibs): Should this be a recursive clear?
     pub fn clear(&self, ctx: &ViewerContext<'_>) {
-        let clear = Clear::recursive();
-        ctx.save_blueprint_component(&self.entity_path(), &clear.is_recursive);
+        ctx.command_sender.send_system(SystemCommand::DropEntity(
+            ctx.store_context.blueprint.store_id().clone(),
+            self.entity_path(),
+        ));
     }
 
     pub fn to_tile(&self) -> egui_tiles::Tile<SpaceViewId> {

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -16,7 +16,6 @@ use re_types::{
     },
     components::Name,
 };
-use re_types_core::archetypes::Clear;
 use re_types_core::Archetype as _;
 use re_viewer_context::{
     ContentsName, PerSystemEntities, QueryRange, RecommendedSpaceView, SpaceViewClass,
@@ -310,8 +309,10 @@ impl SpaceViewBlueprint {
     }
 
     pub fn clear(&self, ctx: &ViewerContext<'_>) {
-        let clear = Clear::recursive();
-        ctx.save_blueprint_component(&self.entity_path(), &clear.is_recursive);
+        ctx.command_sender.send_system(SystemCommand::DropEntity(
+            ctx.store_context.blueprint.store_id().clone(),
+            self.entity_path(),
+        ));
     }
 
     #[inline]


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/6552

This makes it so we no longer care about fancy logic to drop cleared entities with respect to query-time-clear behavior.

Observation. It would be also be quite fast for someone to add a "Drop this entity" context menu :thinking: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7120?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7120?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7120)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.