### PR TITLE
Better ui for `Blob`s, especially those representing images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ dependencies = [
  "re_viewer_context",
  "rfd",
  "unindent",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ log-once = "0.4"
 lz4_flex = "0.11"
 memory-stats = "1.1"
 mimalloc = "=0.1.37" # TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
-mime_guess2 = "2.0"
+mime_guess2 = "2.0" # infer MIME type by file extension, and map mime to file extension
 mint = "0.5.9"
 natord = "1.0.9"
 ndarray = "0.15"

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -271,6 +271,14 @@ impl LatestAtResults {
 impl LatestAtResults {
     // --- Batch ---
 
+    /// Returns the `RowId` for the specified component.
+    #[inline]
+    pub fn component_row_id(&self, component_name: &ComponentName) -> Option<RowId> {
+        self.components
+            .get(component_name)
+            .and_then(|unit| unit.row_id())
+    }
+
     /// Returns the raw data for the specified component.
     #[inline]
     pub fn component_batch_raw(

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -46,3 +46,8 @@ image.workspace = true
 itertools.workspace = true
 rfd.workspace = true
 unindent.workspace = true
+
+
+# web
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures.workspace = true

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -37,22 +37,17 @@ impl crate::EntityDataUi for re_types::components::ClassId {
             });
 
             let id = self.0;
-            match ui_layout {
-                UiLayout::List => {
-                    if !class.keypoint_connections.is_empty()
-                        || !class.keypoint_annotations.is_empty()
-                    {
-                        response.response.on_hover_ui(|ui| {
-                            class_description_ui(ui, UiLayout::Tooltip, class, id);
-                        });
-                    }
+
+            if ui_layout.is_single_line() {
+                if !class.keypoint_connections.is_empty() || !class.keypoint_annotations.is_empty()
+                {
+                    response.response.on_hover_ui(|ui| {
+                        class_description_ui(ui, UiLayout::Tooltip, class, id);
+                    });
                 }
-                UiLayout::Tooltip
-                | UiLayout::SelectionPanelFull
-                | UiLayout::SelectionPanelLimitHeight => {
-                    ui.separator();
-                    class_description_ui(ui, ui_layout, class, id);
-                }
+            } else {
+                ui.separator();
+                class_description_ui(ui, ui_layout, class, id);
             }
         } else {
             ui_layout.label(ui, format!("{}", self.0));

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -17,6 +17,7 @@ impl crate::EntityDataUi for re_types::components::ClassId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &re_log_types::EntityPath,
+        _row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
@@ -62,6 +63,7 @@ impl crate::EntityDataUi for re_types::components::KeypointId {
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &re_log_types::EntityPath,
+        _row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/app_id.rs
+++ b/crates/viewer/re_data_ui/src/app_id.rs
@@ -26,7 +26,7 @@ impl crate::DataUi for ApplicationId {
                 ui.end_row();
             });
 
-        if ui_layout == UiLayout::List {
+        if ui_layout.is_single_line() {
             return;
         }
 

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -168,6 +168,8 @@ fn save_blob(
     title: String,
     blob: Blob,
 ) -> anyhow::Result<()> {
+    use re_viewer_context::SystemCommandSender as _;
+
     re_tracing::profile_function!();
 
     // Web

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -168,8 +168,6 @@ fn save_blob(
     title: String,
     blob: Blob,
 ) -> anyhow::Result<()> {
-    use re_viewer_context::SystemCommandSender as _;
-
     re_tracing::profile_function!();
 
     // Web
@@ -193,6 +191,7 @@ fn save_blob(
                 .save_file()
         };
         if let Some(path) = path {
+            use re_viewer_context::SystemCommandSender as _;
             ctx.command_sender
                 .send_system(re_viewer_context::SystemCommand::FileSaver(Box::new(
                     move || {

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,6 +1,10 @@
+use egui::{NumExt, Vec2};
+use re_renderer::renderer::ColormappedTexture;
 use re_types::components::MediaType;
+use re_ui::{list_item::PropertyContent, UiExt as _};
+use re_viewer_context::gpu_bridge::image_to_gpu;
 
-use crate::EntityDataUi;
+use crate::{image::show_image_preview, EntityDataUi};
 
 impl EntityDataUi for re_types::components::Blob {
     fn entity_data_ui(
@@ -11,18 +15,113 @@ impl EntityDataUi for re_types::components::Blob {
         entity_path: &re_log_types::EntityPath,
         row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
-        db: &re_entity_db::EntityDb,
+        _db: &re_entity_db::EntityDb,
     ) {
-        let size_string = format!("{} B", re_format::format_uint(self.len()));
-        let guessed_media_type = MediaType::guess_from_data(self);
+        let compact_size_string = re_format::format_bytes(self.len() as _);
 
-        ui.horizontal(|ui| {
-            ui.label(size_string);
+        // We ignore the logged `MediaType` component, because the user is looking
+        // at the blob specifically, not the entity as a whole!
+        let media_type = MediaType::guess_from_data(self);
 
-            if let Some(media_type) = guessed_media_type {
-                ui.label(media_type.to_string())
-                    .on_hover_text("Media type (MIME) based on magic header bytes");
+        let texture = blob_as_texture(ctx, query, entity_path, row_id, self, media_type.as_ref());
+
+        if ui_layout.is_single_line() {
+            ui.horizontal(|ui| {
+                ui.label(compact_size_string);
+
+                if let Some(media_type) = &media_type {
+                    ui.label(media_type.to_string())
+                        .on_hover_text("Media type (MIME) based on magic header bytes");
+                }
+
+                if let (Some(render_ctx), Some(texture)) = (ctx.render_ctx, texture) {
+                    // We want all preview images to take up the same amount of space,
+                    // no matter what the actual aspect ratio of the images are.
+                    let preview_size = Vec2::splat(ui.available_height());
+                    let debug_name = entity_path.to_string();
+                    show_mini_image_on_same_row(render_ctx, ui, preview_size, texture, &debug_name);
+                }
+            });
+        } else {
+            let all_digits_size_string = format!("{} B", re_format::format_uint(self.len()));
+            let size_string = if self.len() < 1024 {
+                all_digits_size_string
+            } else {
+                format!("{all_digits_size_string} ({compact_size_string})")
+            };
+
+            ui.list_item_flat_noninteractive(PropertyContent::new("Size").value_text(size_string));
+
+            if let Some(media_type) = &media_type {
+                ui.list_item_flat_noninteractive(
+                    PropertyContent::new("Media type").value_text(media_type.as_str()),
+                )
+                .on_hover_text("Media type (MIME) based on magic header bytes");
+            } else {
+                ui.list_item_flat_noninteractive(
+                    PropertyContent::new("Media type").value_text("?"),
+                )
+                .on_hover_text("Failed to detect media type (Mime) from magic header bytes");
             }
-        });
+
+            if let (Some(render_ctx), Some(texture)) = (ctx.render_ctx, texture) {
+                // We want all preview images to take up the same amount of space,
+                // no matter what the actual aspect ratio of the images are.
+                let preview_size =
+                    Vec2::splat(ui.available_width().at_least(240.0)).at_most(Vec2::splat(640.0));
+                let debug_name = entity_path.to_string();
+                show_image_preview(render_ctx, ui, texture.clone(), &debug_name, preview_size).ok();
+            }
+        }
     }
+}
+
+fn show_mini_image_on_same_row(
+    render_ctx: &re_renderer::RenderContext,
+    ui: &mut egui::Ui,
+    preview_size: Vec2,
+    texture: ColormappedTexture,
+    debug_name: &str,
+) {
+    ui.allocate_ui_with_layout(
+        preview_size,
+        egui::Layout::centered_and_justified(egui::Direction::TopDown),
+        |ui| {
+            ui.set_min_size(preview_size);
+
+            match show_image_preview(render_ctx, ui, texture.clone(), debug_name, preview_size) {
+                Ok(response) => response.on_hover_ui(|ui| {
+                    // Show larger image on hover.
+                    let hover_size = Vec2::splat(400.0);
+                    show_image_preview(render_ctx, ui, texture, debug_name, hover_size).ok();
+                }),
+                Err((response, err)) => response.on_hover_text(err.to_string()),
+            }
+        },
+    );
+}
+
+fn blob_as_texture(
+    ctx: &re_viewer_context::ViewerContext<'_>,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+    row_id: Option<re_chunk_store::RowId>,
+    blob: &re_types::components::Blob,
+    media_type: Option<&MediaType>,
+) -> Option<ColormappedTexture> {
+    let render_ctx = ctx.render_ctx?;
+    let debug_name = entity_path.to_string();
+
+    let image = row_id.and_then(|row_id| {
+        ctx.cache
+            .entry(|c: &mut re_viewer_context::ImageDecodeCache| {
+                c.entry(row_id, blob, media_type.as_ref().map(|mt| mt.as_str()))
+            })
+            .ok()
+    })?;
+    let image_stats = ctx
+        .cache
+        .entry(|c: &mut re_viewer_context::ImageStatsCache| c.entry(&image));
+    let annotations = crate::annotations(ctx, query, entity_path);
+    image_to_gpu(render_ctx, &debug_name, &image, &image_stats, &annotations).ok()
 }

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -9,6 +9,7 @@ impl EntityDataUi for re_types::components::Blob {
         ui: &mut egui::Ui,
         ui_layout: re_viewer_context::UiLayout,
         entity_path: &re_log_types::EntityPath,
+        row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -220,7 +220,7 @@ async fn async_save_dialog(file_name: &str, title: &str, data: Blob) -> anyhow::
     };
 
     file_handle
-        .write(&data.as_slice())
+        .write(data.as_slice())
         .await
         .context("Failed to save")
 }

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -20,8 +20,12 @@ impl EntityDataUi for Blob {
     ) {
         let compact_size_string = re_format::format_bytes(self.len() as _);
 
-        // We ignore the logged `MediaType` component, because the user is looking
-        // at the blob specifically, not the entity as a whole!
+        // We show the actual mime of the blob here instead of doing
+        // a side-lookup of the sibling `MediaType` component.
+        // This is part of "showing the data as it is".
+        // If the user clicked on the blob, is because they want to see info about the blob,
+        // not about a sibling component.
+        // This can also help a user debug if they log the contents of `.png` file with a `image/jpeg` `MediaType`.
         let media_type = MediaType::guess_from_data(self);
 
         let texture = blob_as_texture(ctx, query, entity_path, row_id, self, media_type.as_ref());

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,0 +1,27 @@
+use re_types::components::MediaType;
+
+use crate::EntityDataUi;
+
+impl EntityDataUi for re_types::components::Blob {
+    fn entity_data_ui(
+        &self,
+        ctx: &re_viewer_context::ViewerContext<'_>,
+        ui: &mut egui::Ui,
+        ui_layout: re_viewer_context::UiLayout,
+        entity_path: &re_log_types::EntityPath,
+        query: &re_chunk_store::LatestAtQuery,
+        db: &re_entity_db::EntityDb,
+    ) {
+        let size_string = format!("{} B", re_format::format_uint(self.len()));
+        let guessed_media_type = MediaType::guess_from_data(self);
+
+        ui.horizontal(|ui| {
+            ui.label(size_string);
+
+            if let Some(media_type) = guessed_media_type {
+                ui.label(media_type.to_string())
+                    .on_hover_text("Media type (MIME) based on magic header bytes");
+            }
+        });
+    }
+}

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -37,13 +37,6 @@ impl<'a> DataUi for EntityLatestAtResults<'a> {
             return;
         };
 
-        let one_line = match ui_layout {
-            UiLayout::List => true,
-            UiLayout::Tooltip
-            | UiLayout::SelectionPanelLimitHeight
-            | UiLayout::SelectionPanelFull => false,
-        };
-
         // in some cases, we don't want to display all instances
         let max_row = match ui_layout {
             UiLayout::List => 0,
@@ -52,7 +45,7 @@ impl<'a> DataUi for EntityLatestAtResults<'a> {
         };
 
         // Display data time and additional diagnostic information for static components.
-        if ui_layout != UiLayout::List {
+        if !ui_layout.is_single_line() {
             let time = self
                 .unit
                 .index(&query.timeline())
@@ -146,7 +139,7 @@ impl<'a> DataUi for EntityLatestAtResults<'a> {
                 self.unit,
                 &Instance::from(0),
             );
-        } else if one_line {
+        } else if ui_layout.is_single_line() {
             ui.label(format!("{} values", re_format::format_uint(num_instances)));
         } else {
             ui_layout

--- a/crates/viewer/re_data_ui/src/component_name.rs
+++ b/crates/viewer/re_data_ui/src/component_name.rs
@@ -13,7 +13,7 @@ impl DataUi for ComponentName {
         _query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        if ui_layout == UiLayout::List {
+        if ui_layout.is_single_line() {
             ui.label(self.full_name());
         } else {
             ui.scope(|ui| {

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -13,6 +13,7 @@ pub fn create_component_ui_registry() -> ComponentUiRegistry {
     let mut registry = ComponentUiRegistry::new(Box::new(&fallback_component_ui));
 
     add_to_registry::<re_types::components::AnnotationContext>(&mut registry);
+    add_to_registry::<re_types::components::Blob>(&mut registry);
     add_to_registry::<re_types::components::ClassId>(&mut registry);
     add_to_registry::<re_types::components::ImageFormat>(&mut registry);
     add_to_registry::<re_types::components::KeypointId>(&mut registry);

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -1,4 +1,4 @@
-use re_chunk_store::LatestAtQuery;
+use re_chunk_store::{LatestAtQuery, RowId};
 use re_entity_db::EntityDb;
 use re_log_types::{external::arrow2, EntityPath};
 use re_types::external::arrow2::array::Utf8Array;
@@ -36,7 +36,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
     registry.add_display_ui(
         C::name(),
         Box::new(
-            |ctx, ui, ui_layout, query, db, entity_path, component_raw| match C::from_arrow(
+            |ctx, ui, ui_layout, query, db, entity_path, row_id, component_raw| match C::from_arrow(
                 component_raw,
             ) {
                 Ok(components) => match components.len() {
@@ -44,7 +44,15 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
                         ui.weak("(empty)");
                     }
                     1 => {
-                        components[0].entity_data_ui(ctx, ui, ui_layout, entity_path, query, db);
+                        components[0].entity_data_ui(
+                            ctx,
+                            ui,
+                            ui_layout,
+                            entity_path,
+                            row_id,
+                            query,
+                            db,
+                        );
                     }
                     i => {
                         ui.label(format!("{} values", re_format::format_uint(i)));
@@ -59,6 +67,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn fallback_component_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
@@ -66,6 +75,7 @@ fn fallback_component_ui(
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _entity_path: &EntityPath,
+    _row_id: Option<RowId>,
     component: &dyn arrow2::array::Array,
 ) {
     arrow_ui(ui, ui_layout, component);

--- a/crates/viewer/re_data_ui/src/data_source.rs
+++ b/crates/viewer/re_data_ui/src/data_source.rs
@@ -14,7 +14,7 @@ impl crate::DataUi for re_smart_channel::SmartChannelSource {
     ) {
         ui.label(self.to_string());
 
-        if ui_layout == UiLayout::List {
+        if ui_layout.is_single_line() {
             return;
         }
 

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -16,7 +16,7 @@ impl crate::DataUi for EntityDb {
         _query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
-        if ui_layout == UiLayout::List {
+        if ui_layout.is_single_line() {
             // TODO(emilk): standardize this formatting with that in `entity_db_button_ui`
             let mut string = self.store_id().to_string();
             if let Some(data_source) = &self.data_source {

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -15,8 +15,7 @@ use re_viewer_context::{gpu_bridge, Annotations, ImageInfo, ImageStats};
 /// This does not preserve aspect ratio, but we only stretch it to a very thin size, so it is fine.
 ///
 /// Returns error if the image could not be rendered.
-#[allow(dead_code)] // TODO(#6891): use again when we can view image archetypes in the selection view
-fn show_image_preview(
+pub fn show_image_preview(
     render_ctx: &re_renderer::RenderContext,
     ui: &mut egui::Ui,
     colormapped_texture: ColormappedTexture,

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -48,7 +48,7 @@ impl DataUi for InstancePath {
             .filter(|c| c.is_indicator_component())
             .count();
 
-        if ui_layout == UiLayout::List {
+        if ui_layout.is_single_line() {
             ui_layout.label(
                 ui,
                 format!(

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -72,12 +72,14 @@ pub trait DataUi {
 /// This is given the context of the entity it is part of so it can do queries.
 pub trait EntityDataUi {
     /// If you need to lookup something in the chunk store, use the given query to do so.
+    #[allow(clippy::too_many_arguments)]
     fn entity_data_ui(
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
+        row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     );
@@ -93,6 +95,7 @@ where
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
         entity_path: &EntityPath,
+        _row_id: Option<re_chunk_store::RowId>,
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {

--- a/crates/viewer/re_data_ui/src/lib.rs
+++ b/crates/viewer/re_data_ui/src/lib.rs
@@ -8,6 +8,7 @@ use re_viewer_context::{UiLayout, ViewerContext};
 
 mod annotation_context;
 mod app_id;
+mod blob;
 mod blueprint_data;
 mod blueprint_types;
 mod component;

--- a/crates/viewer/re_data_ui/src/pinhole.rs
+++ b/crates/viewer/re_data_ui/src/pinhole.rs
@@ -13,27 +13,24 @@ impl DataUi for PinholeProjection {
         query: &re_chunk_store::LatestAtQuery,
         db: &re_entity_db::EntityDb,
     ) {
-        match ui_layout {
-            UiLayout::List => {
-                // See if this is a trivial pinhole, and can be displayed as such:
-                let fl = self.focal_length_in_pixels();
-                let pp = self.principal_point();
-                if *self == Self::from_focal_length_and_principal_point(fl, pp) {
-                    let fl = if fl.x() == fl.y() {
-                        fl.x().to_string()
-                    } else {
-                        fl.to_string()
-                    };
-
-                    ui_layout.label(ui, format!("Focal length: {fl}, principal point: {pp}"))
+        if ui_layout.is_single_line() {
+            // See if this is a trivial pinhole, and can be displayed as such:
+            let fl = self.focal_length_in_pixels();
+            let pp = self.principal_point();
+            if *self == Self::from_focal_length_and_principal_point(fl, pp) {
+                let fl = if fl.x() == fl.y() {
+                    fl.x().to_string()
                 } else {
-                    ui_layout.label(ui, "3×3 projection matrix")
-                }
-                .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
+                    fl.to_string()
+                };
+
+                ui_layout.label(ui, format!("Focal length: {fl}, principal point: {pp}"))
+            } else {
+                ui_layout.label(ui, "3×3 projection matrix")
             }
-            _ => {
-                self.0.data_ui(ctx, ui, ui_layout, query, db);
-            }
+            .on_hover_ui(|ui| self.data_ui(ctx, ui, UiLayout::Tooltip, query, db));
+        } else {
+            self.0.data_ui(ctx, ui, ui_layout, query, db);
         }
     }
 }

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -45,17 +45,14 @@ impl EntityDataUi for re_types::components::TensorData {
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         ui_layout: UiLayout,
-        entity_path: &EntityPath,
-        query: &re_chunk_store::LatestAtQuery,
+        _entity_path: &EntityPath,
+        row_id: Option<re_chunk_store::RowId>,
+        _query: &re_chunk_store::LatestAtQuery,
         _db: &re_entity_db::EntityDb,
     ) {
         re_tracing::profile_function!();
 
-        let tensor_data_row_id = ctx
-            .recording()
-            .latest_at_component::<Self>(entity_path, query)
-            .map_or(RowId::ZERO, |((_time, row_id), _tensor)| row_id);
-
+        let tensor_data_row_id = row_id.unwrap_or(RowId::ZERO);
         tensor_ui(ctx, ui, ui_layout, tensor_data_row_id, &self.0);
     }
 }

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -73,34 +73,30 @@ pub fn tensor_ui(
         .cache
         .entry(|c: &mut TensorStatsCache| c.entry(tensor_data_row_id, tensor));
 
-    match ui_layout {
-        UiLayout::List => {
-            ui.horizontal(|ui| {
-                let shape = match tensor.image_height_width_channels() {
-                    Some([h, w, c]) => vec![
-                        TensorDimension::height(h),
-                        TensorDimension::width(w),
-                        TensorDimension::depth(c),
-                    ],
-                    None => tensor.shape.clone(),
-                };
-                let text = format!(
-                    "{}, {}",
-                    tensor.dtype(),
-                    format_tensor_shape_single_line(&shape)
-                );
-                ui_layout.label(ui, text).on_hover_ui(|ui| {
-                    tensor_summary_ui(ui, tensor, &tensor_stats);
-                });
-            });
-        }
-
-        UiLayout::SelectionPanelFull | UiLayout::SelectionPanelLimitHeight | UiLayout::Tooltip => {
-            ui.vertical(|ui| {
-                ui.set_min_width(100.0);
+    if ui_layout.is_single_line() {
+        ui.horizontal(|ui| {
+            let shape = match tensor.image_height_width_channels() {
+                Some([h, w, c]) => vec![
+                    TensorDimension::height(h),
+                    TensorDimension::width(w),
+                    TensorDimension::depth(c),
+                ],
+                None => tensor.shape.clone(),
+            };
+            let text = format!(
+                "{}, {}",
+                tensor.dtype(),
+                format_tensor_shape_single_line(&shape)
+            );
+            ui_layout.label(ui, text).on_hover_ui(|ui| {
                 tensor_summary_ui(ui, tensor, &tensor_stats);
             });
-        }
+        });
+    } else {
+        ui.vertical(|ui| {
+            ui.set_min_width(100.0);
+            tensor_summary_ui(ui, tensor, &tensor_stats);
+        });
     }
 }
 

--- a/crates/viewer/re_edit_ui/src/datatype_editors/singleline_string.rs
+++ b/crates/viewer/re_edit_ui/src/datatype_editors/singleline_string.rs
@@ -6,7 +6,11 @@ use re_types::{
 };
 use re_ui::UiExt as _;
 use re_viewer_context::{
-    external::{re_chunk_store::LatestAtQuery, re_entity_db::EntityDb, re_log_types::EntityPath},
+    external::{
+        re_chunk_store::{LatestAtQuery, RowId},
+        re_entity_db::EntityDb,
+        re_log_types::EntityPath,
+    },
     MaybeMutRef, UiLayout, ViewerContext,
 };
 
@@ -67,6 +71,7 @@ fn edit_multiline_string_impl(
 }
 
 // TODO(#6661): Should be merged with edit_singleline_string.
+#[allow(clippy::too_many_arguments)]
 pub fn display_text_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
@@ -74,6 +79,7 @@ pub fn display_text_ui(
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _path: &EntityPath,
+    _row_id: Option<RowId>,
     data: &dyn arrow2::array::Array,
 ) {
     let text = match Text::from_arrow(data) {
@@ -94,6 +100,7 @@ pub fn display_text_ui(
 }
 
 // TODO(#6661): Should be merged with edit_singleline_string.
+#[allow(clippy::too_many_arguments)]
 pub fn display_name_ui(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
@@ -101,6 +108,7 @@ pub fn display_name_ui(
     _query: &LatestAtQuery,
     _db: &EntityDb,
     _path: &EntityPath,
+    _row_id: Option<RowId>,
     data: &dyn arrow2::array::Array,
 ) {
     let name = match Name::from_arrow(data) {

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -120,9 +120,12 @@ fn active_default_ui(
 
             // TODO(jleibs): We're already doing this query above as part of the filter. This is kind of silly to do it again.
             // Change the structure to avoid this.
-            let component_array = {
+            let (row_id, component_array) = {
                 let results = db.latest_at(query, &view.defaults_path, [component_name]);
-                results.component_batch_raw(&component_name)
+                (
+                    results.component_row_id(&component_name),
+                    results.component_batch_raw(&component_name),
+                )
             };
 
             if let Some(component_array) = component_array {
@@ -133,6 +136,7 @@ fn active_default_ui(
                         db,
                         &view.defaults_path,
                         component_name,
+                        row_id,
                         Some(&*component_array),
                         visualizer.as_fallback_provider(),
                     );

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -372,8 +372,8 @@ fn visualizer_components(
                             ui,
                             component_name,
                             override_path,
-                            raw_override.as_ref().map(|(_, raw_override)| raw_override),
-                            raw_default.as_ref().map(|(_, raw_override)| raw_override),
+                            &raw_override.clone().map(|(_, raw_override)| raw_override),
+                            raw_default.clone().map(|(_, raw_override)| raw_override),
                             raw_fallback.as_ref(),
                             raw_current_value.as_ref(),
                         );
@@ -426,8 +426,8 @@ fn menu_more(
     ui: &mut egui::Ui,
     component_name: re_types::ComponentName,
     override_path: &EntityPath,
-    raw_override: Option<&Box<dyn arrow2::array::Array>>,
-    raw_default: Option<&Box<dyn arrow2::array::Array>>,
+    raw_override: &Option<Box<dyn arrow2::array::Array>>,
+    raw_default: Option<Box<dyn arrow2::array::Array>>,
     raw_fallback: &dyn arrow2::array::Array,
     raw_current_value: &dyn arrow2::array::Array,
 ) {
@@ -449,7 +449,7 @@ fn menu_more(
         .clicked()
     {
         if let Some(raw_default) = raw_default {
-            ctx.save_blueprint_array(override_path, component_name, raw_default.clone());
+            ctx.save_blueprint_array(override_path, component_name, raw_default);
         }
         ui.close_menu();
     }
@@ -460,10 +460,9 @@ fn menu_more(
     }
 
     let override_differs_from_default = raw_override
-        != ctx
+        != &ctx
             .viewer_ctx
-            .raw_latest_at_in_default_blueprint(override_path, component_name)
-            .as_ref();
+            .raw_latest_at_in_default_blueprint(override_path, component_name);
     if ui
         .add_enabled(
             override_differs_from_default,

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -1,5 +1,6 @@
 use itertools::Itertools;
 
+use re_chunk::{ComponentName, RowId, UnitChunkShared};
 use re_data_ui::{sorted_component_list_for_ui, DataUi};
 use re_entity_db::EntityDb;
 use re_log_types::EntityPath;
@@ -142,6 +143,20 @@ fn visualizer_components(
     data_result: &DataResult,
     visualizer_id: ViewSystemIdentifier,
 ) {
+    // Helper for code below
+    fn non_empty_component_batch_raw(
+        unit: Option<&UnitChunkShared>,
+        component_name: &ComponentName,
+    ) -> Option<(Option<RowId>, Box<dyn re_chunk::ArrowArray>)> {
+        let unit = unit?;
+        let batch = unit.component_batch_raw(component_name)?;
+        if batch.is_empty() {
+            None
+        } else {
+            Some((unit.row_id(), batch))
+        }
+    }
+
     // List all components that the visualizer may consume.
     let Ok(visualizer) = ctx.visualizer_collection.get_by_identifier(visualizer_id) else {
         re_log::warn!(
@@ -177,22 +192,13 @@ fn visualizer_components(
         // Query all the sources for our value.
         // (technically we only need to query those that are shown, but rolling this out makes things easier).
         let result_override = query_result.overrides.get(&component_name);
-        let raw_override = result_override.and_then(|r| {
-            r.component_batch_raw(&component_name)
-                .and_then(|v| (!v.is_empty()).then_some(v))
-        });
+        let raw_override = non_empty_component_batch_raw(result_override, &component_name);
 
         let result_store = query_result.results.get(&component_name);
-        let raw_store = result_store.and_then(|r| {
-            r.component_batch_raw(&component_name)
-                .and_then(|v| (!v.is_empty()).then_some(v))
-        });
+        let raw_store = non_empty_component_batch_raw(result_store, &component_name);
 
         let result_default = query_result.defaults.get(&component_name);
-        let raw_default = result_default.and_then(|r| {
-            r.component_batch_raw(&component_name)
-                .and_then(|v| (!v.is_empty()).then_some(v))
-        });
+        let raw_default = non_empty_component_batch_raw(result_default, &component_name);
 
         let raw_fallback = match visualizer.fallback_for(&query_ctx, component_name) {
             Ok(fallback) => fallback,
@@ -204,16 +210,16 @@ fn visualizer_components(
 
         // Determine where the final value comes from.
         // Putting this into an enum makes it easier to reason about the next steps.
-        let (value_source, raw_current_value) = match (
-            raw_override.as_ref(),
-            raw_store.as_ref(),
-            raw_default.as_ref(),
-        ) {
-            (Some(override_value), _, _) => (ValueSource::Override, override_value.as_ref()),
-            (None, Some(store_value), _) => (ValueSource::Store, store_value.as_ref()),
-            (None, None, Some(default_value)) => (ValueSource::Default, default_value.as_ref()),
-            (None, None, None) => (ValueSource::FallbackOrPlaceholder, raw_fallback.as_ref()),
-        };
+        let (value_source, (current_value_row_id, raw_current_value)) =
+            match (raw_override.clone(), raw_store.clone(), raw_default.clone()) {
+                (Some(override_value), _, _) => (ValueSource::Override, override_value),
+                (None, Some(store_value), _) => (ValueSource::Store, store_value),
+                (None, None, Some(default_value)) => (ValueSource::Default, default_value),
+                (None, None, None) => (
+                    ValueSource::FallbackOrPlaceholder,
+                    (None, raw_fallback.clone()),
+                ),
+            };
 
         let override_path = data_result.individual_override_path();
 
@@ -225,7 +231,7 @@ fn visualizer_components(
                 || !ctx.viewer_ctx.component_ui_registry.try_show_edit_ui(
                     ctx.viewer_ctx,
                     ui,
-                    raw_current_value,
+                    raw_current_value.as_ref()                    ,
                     override_path,
                     component_name,
                     multiline,
@@ -265,7 +271,8 @@ fn visualizer_components(
                             ctx.recording(),
                             &data_result.entity_path,
                             component_name,
-                            raw_current_value,
+                            current_value_row_id,
+                            raw_current_value.as_ref(),
                         );
                         return;
                     }
@@ -282,13 +289,14 @@ fn visualizer_components(
 
         let add_children = |ui: &mut egui::Ui| {
             // Override (if available)
-            if let Some(raw_override) = raw_override.as_ref() {
+            if let Some((row_id, raw_override)) = raw_override.as_ref() {
                 editable_blueprint_component_list_item(
                     &query_ctx,
                     ui,
                     "Override",
                     override_path,
                     component_name,
+                    *row_id,
                     raw_override.as_ref(),
                 )
                 .on_hover_text("Override value for this specific entity in the current view");
@@ -314,13 +322,14 @@ fn visualizer_components(
                 .on_hover_text("The value that was logged to the data store");
             }
             // Default (if available)
-            if let Some(raw_default) = raw_default.as_ref() {
+            if let Some((row_id, raw_default)) = raw_default.as_ref() {
                 editable_blueprint_component_list_item(
                     &query_ctx,
                     ui,
                     "Default",
                     ctx.defaults_path,
                     component_name,
+                    *row_id,
                     raw_default.as_ref(),
                 )
                 .on_hover_text("Default value for all component of this type is the current view");
@@ -338,6 +347,7 @@ fn visualizer_components(
                             ctx.recording(),
                             &data_result.entity_path,
                             component_name,
+                            None,
                             raw_fallback.as_ref(),
                         );
                     }),
@@ -362,10 +372,10 @@ fn visualizer_components(
                             ui,
                             component_name,
                             override_path,
-                            &raw_override,
-                            &raw_default,
+                            raw_override.as_ref().map(|(_, raw_override)| raw_override),
+                            raw_default.as_ref().map(|(_, raw_override)| raw_override),
                             raw_fallback.as_ref(),
-                            raw_current_value,
+                            raw_current_value.as_ref(),
                         );
                     }),
                 add_children,
@@ -383,6 +393,7 @@ fn editable_blueprint_component_list_item(
     name: &'static str,
     blueprint_path: &EntityPath,
     component: re_types::ComponentName,
+    row_id: Option<RowId>,
     raw_override: &dyn arrow2::array::Array,
 ) -> egui::Response {
     ui.list_item_flat_noninteractive(
@@ -395,6 +406,7 @@ fn editable_blueprint_component_list_item(
                     query_ctx.viewer_ctx.blueprint_db(),
                     blueprint_path,
                     component,
+                    row_id,
                     raw_override,
                     multiline,
                 );
@@ -414,8 +426,8 @@ fn menu_more(
     ui: &mut egui::Ui,
     component_name: re_types::ComponentName,
     override_path: &EntityPath,
-    raw_override: &Option<Box<dyn arrow2::array::Array>>,
-    raw_default: &Option<Box<dyn arrow2::array::Array>>,
+    raw_override: Option<&Box<dyn arrow2::array::Array>>,
+    raw_default: Option<&Box<dyn arrow2::array::Array>>,
     raw_fallback: &dyn arrow2::array::Array,
     raw_current_value: &dyn arrow2::array::Array,
 ) {
@@ -436,7 +448,7 @@ fn menu_more(
         .on_disabled_hover_text("There's no default component active")
         .clicked()
     {
-        if let Some(raw_default) = raw_default.as_ref() {
+        if let Some(raw_default) = raw_default {
             ctx.save_blueprint_array(override_path, component_name, raw_default.clone());
         }
         ui.close_menu();
@@ -448,9 +460,10 @@ fn menu_more(
     }
 
     let override_differs_from_default = raw_override
-        != &ctx
+        != ctx
             .viewer_ctx
-            .raw_latest_at_in_default_blueprint(override_path, component_name);
+            .raw_latest_at_in_default_blueprint(override_path, component_name)
+            .as_ref();
     if ui
         .add_enabled(
             override_differs_from_default,

--- a/crates/viewer/re_space_view/src/view_property_ui.rs
+++ b/crates/viewer/re_space_view/src/view_property_ui.rs
@@ -1,4 +1,4 @@
-use re_chunk_store::external::re_chunk::ArrowArray;
+use re_chunk_store::{external::re_chunk::ArrowArray, RowId};
 use re_types_core::{
     reflection::{ArchetypeFieldReflection, ArchetypeReflection},
     Archetype, ArchetypeName, ArchetypeReflectionMarker, ComponentName,
@@ -75,6 +75,7 @@ fn view_property_ui_impl(
             name,
             field,
             &blueprint_path,
+            component_results.component_row_id(&field.component_name),
             component_array.as_deref(),
             fallback_provider,
         );
@@ -92,6 +93,7 @@ fn view_property_ui_impl(
                     name,
                     field,
                     &blueprint_path,
+                    component_results.component_row_id(&field.component_name),
                     component_array.as_deref(),
                     fallback_provider,
                 );
@@ -120,6 +122,7 @@ fn view_property_component_ui(
     archetype_name: ArchetypeName,
     field: &ArchetypeFieldReflection,
     blueprint_path: &re_log_types::EntityPath,
+    row_id: Option<RowId>,
     component_array: Option<&dyn ArrowArray>,
     fallback_provider: &dyn ComponentFallbackProvider,
 ) {
@@ -128,6 +131,7 @@ fn view_property_component_ui(
         root_item_display_name,
         blueprint_path,
         component_name,
+        row_id,
         component_array,
         fallback_provider,
     );
@@ -154,6 +158,7 @@ fn view_property_component_ui(
                         ctx.viewer_ctx.blueprint_db(),
                         blueprint_path,
                         component_name,
+                        row_id,
                         component_array,
                         fallback_provider,
                     );
@@ -226,6 +231,7 @@ fn singleline_list_item_content<'a>(
     display_name: &str,
     blueprint_path: &'a re_log_types::EntityPath,
     component_name: ComponentName,
+    row_id: Option<RowId>,
     component_array: Option<&'a dyn ArrowArray>,
     fallback_provider: &'a dyn ComponentFallbackProvider,
 ) -> list_item::PropertyContent<'a> {
@@ -246,6 +252,7 @@ fn singleline_list_item_content<'a>(
                 ctx.viewer_ctx.blueprint_db(),
                 blueprint_path,
                 component_name,
+                row_id,
                 component_array,
                 fallback_provider,
             );

--- a/crates/viewer/re_space_view_dataframe/src/latest_at_table.rs
+++ b/crates/viewer/re_space_view_dataframe/src/latest_at_table.rs
@@ -170,7 +170,7 @@ pub(crate) fn latest_at_table_ui(
 
                 // TODO(#4466): it would be nice to display the time and row id somewhere, since we
                 //              have them.
-                if let Some(((_time, _row_id), array)) = result {
+                if let Some(((_time, row_id), array)) = result {
                     let instance_index = instance_path.instance.get() as usize;
 
                     let (data, clamped) = if instance_index >= array.len() {
@@ -188,6 +188,7 @@ pub(crate) fn latest_at_table_ui(
                             ctx.recording(),
                             &instance_path.entity_path,
                             *component_name,
+                            Some(row_id),
                             &*data,
                         );
                     });

--- a/crates/viewer/re_space_view_dataframe/src/time_range_table.rs
+++ b/crates/viewer/re_space_view_dataframe/src/time_range_table.rs
@@ -279,6 +279,7 @@ pub(crate) fn time_range_table_ui(
                         ctx.recording(),
                         entity_path,
                         *component_name,
+                        Some(*row_id),
                         &*content,
                     );
                 } else {

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -545,6 +545,12 @@ impl App {
             SystemCommand::SetFocus(item) => {
                 self.state.focused_item = Some(item);
             }
+
+            SystemCommand::FileSaver(file_saver) => {
+                if let Err(err) = self.background_tasks.spawn_file_saver(file_saver) {
+                    re_log::error!("Failed to save file: {err}");
+                }
+            }
         }
     }
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -546,6 +546,7 @@ impl App {
                 self.state.focused_item = Some(item);
             }
 
+            #[cfg(not(target_arch = "wasm32"))]
             SystemCommand::FileSaver(file_saver) => {
                 if let Err(err) = self.background_tasks.spawn_file_saver(file_saver) {
                     re_log::error!("Failed to save file: {err}");

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -70,6 +70,10 @@ pub enum SystemCommand {
     ///
     /// Just like selection highlighting, the exact behavior of focusing is up to the receiving views.
     SetFocus(crate::Item),
+
+    /// Add a task, run on a background thread, that saves something to disk.
+    #[cfg(not(target_arch = "wasm32"))]
+    FileSaver(Box<dyn FnOnce() -> anyhow::Result<std::path::PathBuf> + Send + 'static>),
 }
 
 /// Interface for sending [`SystemCommand`] messages.

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use re_chunk::{ArrowArray, UnitChunkShared};
+use re_chunk::{ArrowArray, RowId, UnitChunkShared};
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::{EntityDb, EntityPath};
 use re_log::ResultExt;
@@ -406,6 +406,7 @@ impl ComponentUiRegistry {
             db,
             entity_path,
             component_name,
+            unit.row_id(),
             component_raw.as_ref(),
         );
     }
@@ -421,6 +422,7 @@ impl ComponentUiRegistry {
         db: &EntityDb,
         entity_path: &EntityPath,
         component_name: ComponentName,
+        row_id: Option<RowId>,
         component_raw: &dyn arrow2::array::Array,
     ) {
         re_tracing::profile_function!(component_name.full_name());
@@ -464,6 +466,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
+        row_id: Option<RowId>,
         component_array: Option<&dyn ArrowArray>,
         fallback_provider: &dyn ComponentFallbackProvider,
     ) {
@@ -474,6 +477,7 @@ impl ComponentUiRegistry {
             origin_db,
             blueprint_write_path,
             component_name,
+            row_id,
             component_array,
             fallback_provider,
             multiline,
@@ -493,6 +497,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
+        row_id: Option<RowId>,
         component_query_result: Option<&dyn ArrowArray>,
         fallback_provider: &dyn ComponentFallbackProvider,
     ) {
@@ -503,6 +508,7 @@ impl ComponentUiRegistry {
             origin_db,
             blueprint_write_path,
             component_name,
+            row_id,
             component_query_result,
             fallback_provider,
             multiline,
@@ -517,6 +523,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
+        row_id: Option<RowId>,
         component_array: Option<&dyn ArrowArray>,
         fallback_provider: &dyn ComponentFallbackProvider,
         multiline: bool,
@@ -548,6 +555,7 @@ impl ComponentUiRegistry {
             origin_db,
             blueprint_write_path,
             component_name,
+            row_id,
             component_raw.as_ref(),
             multiline,
         );
@@ -561,6 +569,7 @@ impl ComponentUiRegistry {
         origin_db: &EntityDb,
         blueprint_write_path: &EntityPath,
         component_name: ComponentName,
+        row_id: Option<RowId>,
         component_raw: &dyn arrow2::array::Array,
         multiline: bool,
     ) {
@@ -581,6 +590,7 @@ impl ComponentUiRegistry {
                 origin_db,
                 ctx.target_entity_path,
                 component_name,
+                row_id,
                 component_raw,
             );
         }

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -45,6 +45,15 @@ pub enum UiLayout {
 }
 
 impl UiLayout {
+    /// Should the UI fit on one line?
+    #[inline]
+    pub fn is_single_line(&self) -> bool {
+        match self {
+            Self::List => true,
+            Self::Tooltip | Self::SelectionPanelLimitHeight | Self::SelectionPanelFull => false,
+        }
+    }
+
     /// Do we have a lot of vertical space?
     #[inline]
     pub fn is_selection_panel(self) -> bool {

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -176,6 +176,7 @@ type ComponentUiCallback = Box<
             &LatestAtQuery,
             &EntityDb,
             &EntityPath,
+            Option<RowId>,
             &dyn arrow2::array::Array,
         ) + Send
         + Sync,
@@ -434,7 +435,16 @@ impl ComponentUiRegistry {
 
         // Prefer the versatile UI callback if there is one.
         if let Some(ui_callback) = self.component_uis.get(&component_name) {
-            (*ui_callback)(ctx, ui, ui_layout, query, db, entity_path, component_raw);
+            (*ui_callback)(
+                ctx,
+                ui,
+                ui_layout,
+                query,
+                db,
+                entity_path,
+                row_id,
+                component_raw,
+            );
             return;
         }
 
@@ -450,7 +460,16 @@ impl ComponentUiRegistry {
             return;
         }
 
-        (*self.fallback_ui)(ctx, ui, ui_layout, query, db, entity_path, component_raw);
+        (*self.fallback_ui)(
+            ctx,
+            ui,
+            ui_layout,
+            query,
+            db,
+            entity_path,
+            row_id,
+            component_raw,
+        );
     }
 
     /// Show a multi-line editor for this instance of this component.

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -56,7 +56,7 @@ impl TestContext {
             let blueprint_query = LatestAtQuery::latest(self.active_timeline);
             let (command_sender, _) = command_channel();
             let component_ui_registry = ComponentUiRegistry::new(Box::new(
-                |_ctx, _ui, _ui_layout, _query, _db, _entity_path, _component| {},
+                |_ctx, _ui, _ui_layout, _query, _db, _entity_path, _row_id, _component| {},
             ));
 
             let store_context = StoreContext {


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/6891

The UI for a `Blob` now shows the size and guessed MIME  type of it.

There is a button to save it to disk (or download, on web).
The file extension is guessed from the guessed MIME type.

If it is an image, it will be shown.

### Single-row
![image](https://github.com/user-attachments/assets/31cf43fe-93ee-4e37-a555-cde2e5e87c01)

### Tooltip
![image](https://github.com/user-attachments/assets/483df57d-b5a6-4f5d-945b-8c365dff6f0a)

### Selection panel
![image](https://github.com/user-attachments/assets/546ec4ed-d6ae-4ae1-be55-2a3daeed9516)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7128?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7128?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7128)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.