### PR TITLE
Implement `RangeQueryOptions` directly within `RangeQuery`

### DIFF
--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::helpers::{ChunkShared, UnitChunkShared};
 pub use self::id::{ChunkId, RowId};
 pub use self::iter::{ChunkComponentIter, ChunkComponentIterItem, ChunkIndicesIter};
 pub use self::latest_at::LatestAtQuery;
-pub use self::range::RangeQuery;
+pub use self::range::{RangeQuery, RangeQueryOptions};
 pub use self::transport::TransportChunk;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/store/re_chunk/tests/range.rs
+++ b/crates/store/re_chunk/tests/range.rs
@@ -63,7 +63,7 @@ fn temporal_sorted() -> anyhow::Result<()> {
         .build()?;
 
     {
-        let query = RangeQuery::new(
+        let query = RangeQuery::with_extras(
             Timeline::new_sequence("frame"),
             ResolvedTimeRange::EVERYTHING,
         );
@@ -118,7 +118,8 @@ fn temporal_sorted() -> anyhow::Result<()> {
     }
 
     {
-        let query = RangeQuery::new(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
+        let query =
+            RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
 
         let expected = chunk.emptied();
         query_and_compare((MyPoint::name(), &query), &chunk, &expected);
@@ -194,7 +195,7 @@ fn temporal_unsorted() -> anyhow::Result<()> {
         .build()?;
 
     {
-        let query = RangeQuery::new(Timeline::log_time(), ResolvedTimeRange::EVERYTHING);
+        let query = RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::EVERYTHING);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
@@ -246,7 +247,8 @@ fn temporal_unsorted() -> anyhow::Result<()> {
     }
 
     {
-        let query = RangeQuery::new(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
+        let query =
+            RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
 
         let expected = chunk.emptied();
         query_and_compare((MyPoint::name(), &query), &chunk, &expected);
@@ -311,11 +313,11 @@ fn static_sorted() -> anyhow::Result<()> {
         .build()?;
 
     let queries = [
-        RangeQuery::new(
+        RangeQuery::with_extras(
             Timeline::new_sequence("frame"),
             ResolvedTimeRange::EVERYTHING,
         ),
-        RangeQuery::new(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050)),
+        RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050)),
     ];
 
     for query in queries {
@@ -392,11 +394,11 @@ fn static_unsorted() -> anyhow::Result<()> {
         .build()?;
 
     let queries = [
-        RangeQuery::new(
+        RangeQuery::with_extras(
             Timeline::new_sequence("frame"),
             ResolvedTimeRange::EVERYTHING,
         ),
-        RangeQuery::new(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050)),
+        RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050)),
     ];
 
     for query in queries {

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -31,7 +31,8 @@ pub use self::subscribers::{ChunkStoreSubscriber, ChunkStoreSubscriberHandle};
 // Re-exports
 #[doc(no_inline)]
 pub use re_chunk::{
-    Chunk, ChunkId, ChunkShared, LatestAtQuery, RangeQuery, RowId, UnitChunkShared,
+    Chunk, ChunkId, ChunkShared, LatestAtQuery, RangeQuery, RangeQueryOptions, RowId,
+    UnitChunkShared,
 };
 #[doc(no_inline)]
 pub use re_log_types::{ResolvedTimeRange, TimeInt, TimeType, Timeline};

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -12,7 +12,7 @@ pub use self::cache::{CacheKey, Caches};
 pub use self::cache_stats::{CacheStats, CachesStats};
 pub use self::clamped_zip::*;
 pub use self::latest_at::LatestAtResults;
-pub use self::range::{RangeQueryOptions, RangeResults};
+pub use self::range::RangeResults;
 pub use self::range_zip::*;
 
 pub(crate) use self::latest_at::LatestAtCache;

--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -12,8 +12,7 @@ mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
 pub use query::{
-    latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data,
-    range_with_blueprint_resolved_data_opts, DataResultQuery,
+    latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data, DataResultQuery,
 };
 pub use results_ext::{
     HybridLatestAtResults, HybridResults, HybridResultsChunkIter, RangeResultsExt,

--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -2,7 +2,7 @@ use nohash_hasher::IntSet;
 
 use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
 use re_log_types::TimeInt;
-use re_query::{LatestAtResults, RangeQueryOptions};
+use re_query::LatestAtResults;
 use re_types_core::ComponentName;
 use re_viewer_context::{DataResult, ViewContext, ViewerContext};
 
@@ -23,37 +23,8 @@ use crate::results_ext::{HybridLatestAtResults, HybridRangeResults};
 /// [`crate::HybridResults`].
 pub fn range_with_blueprint_resolved_data(
     ctx: &ViewContext<'_>,
-    annotations: Option<&re_viewer_context::Annotations>,
-    range_query: &RangeQuery,
-    data_result: &re_viewer_context::DataResult,
-    component_names: impl IntoIterator<Item = ComponentName>,
-) -> HybridRangeResults {
-    range_with_blueprint_resolved_data_opts(
-        ctx,
-        annotations,
-        range_query,
-        &RangeQueryOptions::DEFAULT,
-        data_result,
-        component_names,
-    )
-}
-
-/// Queries for the given `component_names` using range semantics with blueprint support.
-///
-/// Data will be resolved, in order of priority:
-/// - Data overrides from the blueprint
-/// - Data from the recording
-/// - Default data from the blueprint
-/// - Fallback from the visualizer
-/// - Placeholder from the component.
-///
-/// Data should be accessed via the [`crate::RangeResultsExt`] trait which is implemented for
-/// [`crate::HybridResults`].
-pub fn range_with_blueprint_resolved_data_opts(
-    ctx: &ViewContext<'_>,
     _annotations: Option<&re_viewer_context::Annotations>,
     range_query: &RangeQuery,
-    range_query_opts: &RangeQueryOptions,
     data_result: &re_viewer_context::DataResult,
     component_names: impl IntoIterator<Item = ComponentName>,
 ) -> HybridRangeResults {
@@ -66,10 +37,9 @@ pub fn range_with_blueprint_resolved_data_opts(
     // No need to query for components that have overrides.
     component_set.retain(|component| !overrides.components.contains_key(component));
 
-    let results = ctx.recording().query_caches().range_opts(
+    let results = ctx.recording().query_caches().range(
         ctx.recording_store(),
         range_query,
-        range_query_opts,
         &data_result.entity_path,
         component_set.iter().copied(),
     );

--- a/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
@@ -4,9 +4,8 @@ use re_chunk_store::RowId;
 use re_entity_db::EntityPath;
 use re_log_types::TimeInt;
 use re_log_types::TimePoint;
-use re_query::RangeQueryOptions;
 use re_query::{clamped_zip_1x2, range_zip_1x2};
-use re_space_view::{range_with_blueprint_resolved_data_opts, RangeResultsExt};
+use re_space_view::{range_with_blueprint_resolved_data, RangeResultsExt};
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
@@ -54,7 +53,8 @@ impl VisualizerSystem for TextLogSystem {
         re_tracing::profile_function!();
 
         let query =
-            re_chunk_store::RangeQuery::new(view_query.timeline, ResolvedTimeRange::EVERYTHING);
+            re_chunk_store::RangeQuery::new(view_query.timeline, ResolvedTimeRange::EVERYTHING)
+                .keep_extra_timelines(true);
 
         for data_result in view_query.iter_visible_data_results(ctx, Self::identifier()) {
             self.process_entity(ctx, &query, data_result);
@@ -87,14 +87,10 @@ impl TextLogSystem {
     ) {
         re_tracing::profile_function!();
 
-        let results = range_with_blueprint_resolved_data_opts(
+        let results = range_with_blueprint_resolved_data(
             ctx,
             None,
             query,
-            &RangeQueryOptions {
-                keep_extra_timelines: true,
-                keep_extra_components: false,
-            },
             data_result,
             [Text::name(), TextLogLevel::name(), Color::name()],
         );


### PR DESCRIPTION
This is a pure refactor that puts `RangeQueryOptions` directly into `RangeQuery`, instead of only available to `re_query`.

This is not just a matter of esthetic: by having the options in the query object in self, we open the possibility of implementing optimizations that require cooperation across the entire stack (query engine, chunk store, chunk itself).

One of these optimizations is query clamping, a couple PRs ahead.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7131?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7131?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7131)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.