### PR TITLE
Implement support for `RangeQueryOptions::include_extended_bounds`

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"

--- a/crates/store/re_chunk/src/range.rs
+++ b/crates/store/re_chunk/src/range.rs
@@ -263,7 +263,7 @@ impl Chunk {
             if include_extended_bounds {
                 start_index = start_index.saturating_sub(1);
                 end_index = usize::min(
-                    self.num_rows().saturating_sub(1),
+                    self.num_rows(),
                     end_index.saturating_add(1),
                 );
             }

--- a/crates/store/re_query/src/range.rs
+++ b/crates/store/re_query/src/range.rs
@@ -275,7 +275,7 @@ impl RangeCache {
                     // TODO(#7008): avoid unnecessary sorting on the unhappy path
                     chunk: raw_chunk
                         // Densify the cached chunk according to the cache key's component, which
-                        // will speed future arrow operations on this chunk.
+                        // will speed up future arrow operations on this chunk.
                         .densified(component_name)
                         // Pre-sort the cached chunk according to the cache key's timeline.
                         .sorted_by_timeline_if_unsorted(&self.cache_key.timeline),


### PR DESCRIPTION
Introduces a new range query option `include_extended_bounds`, which allows the caller to grab one tick further at each end of the range, even for non-contiguous time values.

Pre-requisite for timeseries query clamping.

- DNM: requires https://github.com/rerun-io/rerun/pull/7131

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7132?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7132?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7132)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.