### PR TITLE
Implement timeseries query clamping

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -180,7 +180,7 @@ impl SeriesLineSystem {
             time_offset,
             data_result,
             plot_mem,
-            ctx.viewer_ctx.app_options.experimental_plot_query_clamping,
+            ctx.viewer_ctx.app_options.plot_query_clamping,
         );
         {
             use re_space_view::RangeResultsExt as _;

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -11,13 +11,13 @@ use re_types::{
     Archetype as _, Loggable,
 };
 use re_viewer_context::{
-    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
-    TypedComponentFallbackProvider, ViewContext, ViewQuery, VisualizerQueryInfo, VisualizerSystem,
+    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewStateExt as _,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext, ViewQuery,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
-use crate::util::{
-    determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series,
-};
+use crate::space_view_class::TimeSeriesSpaceViewState;
+use crate::util::{determine_time_per_pixel, determine_time_range, points_to_series};
 use crate::{PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind};
 
 /// The system for rendering [`SeriesLine`] archetypes.
@@ -92,8 +92,11 @@ impl SeriesLineSystem {
     fn load_scalars(&mut self, ctx: &ViewContext<'_>, query: &ViewQuery<'_>) {
         re_tracing::profile_function!();
 
-        let (plot_bounds, time_per_pixel) =
-            determine_plot_bounds_and_time_per_pixel(ctx.viewer_ctx, query);
+        let plot_mem = egui_plot::PlotMemory::load(
+            ctx.viewer_ctx.egui_ctx,
+            crate::plot_id(query.space_view_id),
+        );
+        let time_per_pixel = determine_time_per_pixel(ctx.viewer_ctx, plot_mem.as_ref());
 
         let data_results = query.iter_visible_data_results(ctx, Self::identifier());
 
@@ -109,7 +112,7 @@ impl SeriesLineSystem {
                     self.load_series(
                         ctx,
                         query,
-                        plot_bounds,
+                        plot_mem.as_ref(),
                         time_per_pixel,
                         data_result,
                         &mut series,
@@ -126,7 +129,7 @@ impl SeriesLineSystem {
                 self.load_series(
                     ctx,
                     query,
-                    plot_bounds,
+                    plot_mem.as_ref(),
                     time_per_pixel,
                     data_result,
                     &mut series,
@@ -141,7 +144,7 @@ impl SeriesLineSystem {
         &self,
         ctx: &ViewContext<'_>,
         view_query: &ViewQuery<'_>,
-        plot_bounds: Option<egui_plot::PlotBounds>,
+        plot_mem: Option<&egui_plot::PlotMemory>,
         time_per_pixel: f64,
         data_result: &re_viewer_context::DataResult,
         all_series: &mut Vec<PlotSeries>,
@@ -168,10 +171,15 @@ impl SeriesLineSystem {
 
         let mut points;
 
+        let time_offset = ctx
+            .view_state
+            .downcast_ref::<TimeSeriesSpaceViewState>()
+            .map_or(0, |state| state.time_offset);
         let time_range = determine_time_range(
             view_query.latest_at,
+            time_offset,
             data_result,
-            plot_bounds,
+            plot_mem,
             ctx.viewer_ctx.app_options.experimental_plot_query_clamping,
         );
         {
@@ -180,7 +188,10 @@ impl SeriesLineSystem {
             re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
 
             let entity_path = &data_result.entity_path;
-            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range);
+            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
+                // We must fetch data with extended bounds, otherwise the query clamping would
+                // cut-off the data early at the edge of the view.
+                .include_extended_bounds(true);
 
             let results = range_with_blueprint_resolved_data(
                 ctx,

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -192,7 +192,7 @@ impl SeriesPointSystem {
             time_offset,
             data_result,
             plot_mem,
-            ctx.viewer_ctx.app_options.experimental_plot_query_clamping,
+            ctx.viewer_ctx.app_options.plot_query_clamping,
         );
 
         {

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -8,13 +8,15 @@ use re_types::{
     Archetype as _, Loggable as _,
 };
 use re_viewer_context::{
-    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
-    TypedComponentFallbackProvider, ViewContext, ViewQuery, VisualizerQueryInfo, VisualizerSystem,
+    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewStateExt as _,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext, ViewQuery,
+    VisualizerQueryInfo, VisualizerSystem,
 };
 
 use crate::{
-    util::{determine_plot_bounds_and_time_per_pixel, determine_time_range, points_to_series},
-    ScatterAttrs, {PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind},
+    space_view_class::TimeSeriesSpaceViewState,
+    util::{determine_time_per_pixel, determine_time_range, points_to_series},
+    PlotPoint, PlotPointAttrs, PlotSeries, PlotSeriesKind, ScatterAttrs,
 };
 
 /// The system for rendering [`SeriesPoint`] archetypes.
@@ -91,8 +93,11 @@ impl SeriesPointSystem {
     fn load_scalars(&mut self, ctx: &ViewContext<'_>, query: &ViewQuery<'_>) {
         re_tracing::profile_function!();
 
-        let (plot_bounds, time_per_pixel) =
-            determine_plot_bounds_and_time_per_pixel(ctx.viewer_ctx, query);
+        let plot_mem = egui_plot::PlotMemory::load(
+            ctx.viewer_ctx.egui_ctx,
+            crate::plot_id(query.space_view_id),
+        );
+        let time_per_pixel = determine_time_per_pixel(ctx.viewer_ctx, plot_mem.as_ref());
 
         let data_results = query.iter_visible_data_results(ctx, Self::identifier());
 
@@ -108,7 +113,7 @@ impl SeriesPointSystem {
                     self.load_series(
                         ctx,
                         query,
-                        plot_bounds,
+                        plot_mem.as_ref(),
                         time_per_pixel,
                         data_result,
                         &mut series,
@@ -125,7 +130,7 @@ impl SeriesPointSystem {
                 self.load_series(
                     ctx,
                     query,
-                    plot_bounds,
+                    plot_mem.as_ref(),
                     time_per_pixel,
                     data_result,
                     &mut series,
@@ -140,7 +145,7 @@ impl SeriesPointSystem {
         &self,
         ctx: &ViewContext<'_>,
         view_query: &ViewQuery<'_>,
-        plot_bounds: Option<egui_plot::PlotBounds>,
+        plot_mem: Option<&egui_plot::PlotMemory>,
         time_per_pixel: f64,
         data_result: &re_viewer_context::DataResult,
         all_series: &mut Vec<PlotSeries>,
@@ -178,10 +183,15 @@ impl SeriesPointSystem {
 
         let mut points;
 
+        let time_offset = ctx
+            .view_state
+            .downcast_ref::<TimeSeriesSpaceViewState>()
+            .map_or(0, |state| state.time_offset);
         let time_range = determine_time_range(
             view_query.latest_at,
+            time_offset,
             data_result,
-            plot_bounds,
+            plot_mem,
             ctx.viewer_ctx.app_options.experimental_plot_query_clamping,
         );
 
@@ -191,7 +201,10 @@ impl SeriesPointSystem {
             re_tracing::profile_scope!("primary", &data_result.entity_path.to_string());
 
             let entity_path = &data_result.entity_path;
-            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range);
+            let query = re_chunk_store::RangeQuery::new(view_query.timeline, time_range)
+                // We must fetch data with extended bounds, otherwise the query clamping would
+                // cut-off the data early at the edge of the view.
+                .include_extended_bounds(true);
 
             let results = range_with_blueprint_resolved_data(
                 ctx,

--- a/crates/viewer/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_time_series/src/space_view_class.rs
@@ -43,6 +43,12 @@ pub struct TimeSeriesSpaceViewState {
 
     /// The range of the scalar values currently on screen.
     scalar_range: Range1D,
+
+    /// We offset the time values of the plot so that unix timestamps don't run out of precision.
+    ///
+    /// Other parts of the system, such as query clamping, need to be aware of that offset in order
+    /// to work properly.
+    pub(crate) time_offset: i64,
 }
 
 impl Default for TimeSeriesSpaceViewState {
@@ -52,6 +58,7 @@ impl Default for TimeSeriesSpaceViewState {
             was_dragging_time_cursor: false,
             saved_auto_bounds: Default::default(),
             scalar_range: [0.0, 0.0].into(),
+            time_offset: 0,
         }
     }
 }
@@ -255,7 +262,6 @@ Display time series data in a plot.
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         state: &mut dyn SpaceViewState,
-
         query: &ViewQuery<'_>,
         system_output: SystemExecutionOutput,
     ) -> Result<(), SpaceViewSystemExecutionError> {
@@ -325,6 +331,7 @@ Display time series data in a plot.
         } else {
             min_time
         };
+        state.time_offset = time_offset;
 
         // use timeline_name as part of id, so that egui stores different pan/zoom for different timelines
         let plot_id_src = ("plot", &timeline_name);

--- a/crates/viewer/re_space_view_time_series/src/util.rs
+++ b/crates/viewer/re_space_view_time_series/src/util.rs
@@ -10,7 +10,7 @@ use crate::{
     PlotPoint, PlotSeries, PlotSeriesKind, ScatterAttrs,
 };
 
-/// Find the plot bounds and the per-ui-point delta from egui.
+/// Find the number of time units per physical pixel.
 pub fn determine_time_per_pixel(
     ctx: &ViewerContext<'_>,
     plot_mem: Option<&egui_plot::PlotMemory>,

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -367,10 +367,10 @@ fn experimental_feature_ui(
     }
 
     ui.re_checkbox(
-        &mut app_options.experimental_plot_query_clamping,
+        &mut app_options.plot_query_clamping,
         "Plots: query clamping",
     )
-    .on_hover_text("Toggle query clamping for the plot visualizers.");
+    .on_hover_text("Toggle query clamping for the plot visualizers. This is enabled by default and is only made toggable to facilitate potential bug hunts and performance comparisons.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewer_context/src/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/app_options.rs
@@ -21,7 +21,7 @@ pub struct AppOptions {
     pub experimental_dataframe_space_view: bool,
 
     /// Toggle query clamping for the plot visualizers.
-    pub experimental_plot_query_clamping: bool,
+    pub plot_query_clamping: bool,
 
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
@@ -52,7 +52,7 @@ impl Default for AppOptions {
 
             experimental_dataframe_space_view: false,
 
-            experimental_plot_query_clamping: false,
+            plot_query_clamping: true,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
Implement timeseries query clamping, which clamps the current range query to the bounds of the plot view if the user has interacted with the canvas.

This basically improves zoomed-in performance by order of magnitude, regardless of the underlying layout of the recording.

`main`:
![image](https://github.com/user-attachments/assets/7465d637-1dad-4957-80db-9c324d06e63a)


after:
![image](https://github.com/user-attachments/assets/5d5e1091-c0f9-4391-b0a0-4c550b8ae1ef)


- Fixes #5013
- Fixes #5425
- DNM: requires https://github.com/rerun-io/rerun/pull/7132

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7133?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7133?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7133)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.