### PR TITLE
Show preview of `Image/DepthImage/SegmentationImage` when selected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4447,6 +4447,7 @@ dependencies = [
  "egui_plot",
  "image",
  "itertools 0.13.0",
+ "nohash-hasher",
  "re_chunk_store",
  "re_entity_db",
  "re_error",

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -44,6 +44,7 @@ egui_plot.workspace = true
 egui.workspace = true
 image.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
 rfd.workspace = true
 unindent.workspace = true
 

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -1,4 +1,4 @@
-use egui::{Color32, Vec2};
+use egui::{Color32, NumExt as _, Vec2};
 use itertools::Itertools as _;
 
 use re_renderer::renderer::ColormappedTexture;
@@ -41,7 +41,11 @@ pub fn texture_preview_ui(
         } else {
             egui::Rangef::new(240.0, 640.0)
         };
-        let preview_size = Vec2::splat(size_range.clamp(ui.available_width()));
+        let preview_size = Vec2::splat(
+            size_range
+                .clamp(ui.available_width())
+                .at_most(16.0 * texture.texture.width().max(texture.texture.height()) as f32),
+        );
         let debug_name = entity_path.to_string();
         show_image_preview(render_ctx, ui, texture, &debug_name, preview_size).unwrap_or_else(
             |(response, err)| {

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -91,7 +91,11 @@ fn show_image_preview(
         &painter,
         texture_rect_on_screen,
         colormapped_texture,
-        egui::TextureOptions::LINEAR,
+        egui::TextureOptions {
+            magnification: egui::TextureFilter::Nearest,
+            minification: egui::TextureFilter::Linear,
+            ..Default::default()
+        },
         debug_name,
     ) {
         let color = ui.visuals().error_fg_color;

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -37,7 +37,7 @@ pub fn texture_preview_ui(
         );
     } else {
         let size_range = if ui_layout == UiLayout::Tooltip {
-            egui::Rangef::new(64.0, 256.0)
+            egui::Rangef::new(64.0, 128.0)
         } else {
             egui::Rangef::new(240.0, 640.0)
         };

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -1,5 +1,7 @@
+use re_chunk_store::UnitChunkShared;
 use re_entity_db::InstancePath;
 use re_log_types::ComponentPath;
+use re_types::ComponentName;
 use re_ui::{ContextExt as _, UiExt as _};
 use re_viewer_context::{HoverHighlight, Item, UiLayout, ViewerContext};
 
@@ -62,103 +64,146 @@ impl DataUi for InstancePath {
             return;
         }
 
-        let show_indicator_comps = match ui_layout {
-            UiLayout::Tooltip => {
-                // Skip indicator components in hover ui (unless there are no other
-                // types of components).
-                indicator_count == components.len()
-            }
-            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => true,
-            UiLayout::List => false, // unreachable
-        };
+        let components = latest_at(db, query, entity_path, &components);
 
-        let interactive = ui_layout != UiLayout::Tooltip;
-
-        re_ui::list_item::list_item_scope(ui, "component list", |ui| {
-            for component_name in components {
-                if !show_indicator_comps && component_name.is_indicator_component() {
-                    continue;
-                }
-
-                let component_path = ComponentPath::new(entity_path.clone(), component_name);
-                let is_static = db
-                    .store()
-                    .entity_has_static_component(entity_path, &component_name);
-                let icon = if is_static {
-                    &re_ui::icons::COMPONENT_STATIC
-                } else {
-                    &re_ui::icons::COMPONENT_TEMPORAL
-                };
-                let item = Item::ComponentPath(component_path);
-
-                let mut list_item = ui.list_item().interactive(interactive);
-
-                if interactive {
-                    let is_hovered = ctx.selection_state().highlight_for_ui_element(&item)
-                        == HoverHighlight::Hovered;
-                    list_item = list_item.force_hovered(is_hovered);
-                }
-
-                let response = if component_name.is_indicator_component() {
-                    list_item.show_flat(
-                        ui,
-                        re_ui::list_item::LabelContent::new(component_name.short_name())
-                            .with_icon(icon),
-                    )
-                } else {
-                    let results = db.query_caches().latest_at(
-                        db.store(),
-                        query,
-                        entity_path,
-                        [component_name],
-                    );
-                    let Some(unit) = results.components.get(&component_name) else {
-                        continue; // no need to show components that are unset at this point in time
-                    };
-
-                    let content =
-                        re_ui::list_item::PropertyContent::new(component_name.short_name())
-                            .with_icon(icon)
-                            .value_fn(|ui, _| {
-                                if instance.is_all() {
-                                    crate::EntityLatestAtResults {
-                                        entity_path: entity_path.clone(),
-                                        component_name,
-                                        unit,
-                                    }
-                                    .data_ui(
-                                        ctx,
-                                        ui,
-                                        UiLayout::List,
-                                        query,
-                                        db,
-                                    );
-                                } else {
-                                    ctx.component_ui_registry.ui(
-                                        ctx,
-                                        ui,
-                                        UiLayout::List,
-                                        query,
-                                        db,
-                                        entity_path,
-                                        component_name,
-                                        unit,
-                                        instance,
-                                    );
-                                }
-                            });
-
-                    list_item.show_flat(ui, content)
-                };
-
-                let response = response.on_hover_ui(|ui| {
-                    component_name.data_ui_recording(ctx, ui, UiLayout::Tooltip);
-                });
-
-                if interactive {
-                    ctx.select_hovered_on_click(&response, item);
-                }
-            }
-        });
+        component_list_ui(
+            ctx,
+            ui,
+            ui_layout,
+            query,
+            db,
+            entity_path,
+            instance,
+            &components,
+        );
     }
+}
+
+fn latest_at(
+    db: &re_entity_db::EntityDb,
+    query: &re_chunk_store::LatestAtQuery,
+    entity_path: &re_log_types::EntityPath,
+    components: &[ComponentName],
+) -> Vec<(ComponentName, UnitChunkShared)> {
+    let components: Vec<(ComponentName, UnitChunkShared)> = components
+        .iter()
+        .filter_map(|&component_name| {
+            let mut results =
+                db.query_caches()
+                    .latest_at(db.store(), query, entity_path, [component_name]);
+
+            // We ignore components that are unset at this point in time
+            results
+                .components
+                .remove(&component_name)
+                .map(|unit| (component_name, unit))
+        })
+        .collect();
+    components
+}
+
+#[allow(clippy::too_many_arguments)]
+fn component_list_ui(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    query: &re_chunk_store::LatestAtQuery,
+    db: &re_entity_db::EntityDb,
+    entity_path: &re_log_types::EntityPath,
+    instance: &re_log_types::Instance,
+    components: &[(ComponentName, UnitChunkShared)],
+) {
+    let indicator_count = components
+        .iter()
+        .filter(|(c, _)| c.is_indicator_component())
+        .count();
+
+    let show_indicator_comps = match ui_layout {
+        UiLayout::Tooltip => {
+            // Skip indicator components in hover ui (unless there are no other
+            // types of components).
+            indicator_count == components.len()
+        }
+        UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => true,
+        UiLayout::List => false, // unreachable
+    };
+
+    let interactive = ui_layout != UiLayout::Tooltip;
+
+    re_ui::list_item::list_item_scope(ui, "component list", |ui| {
+        for (component_name, unit) in components {
+            let component_name = *component_name;
+            if !show_indicator_comps && component_name.is_indicator_component() {
+                continue;
+            }
+
+            let component_path = ComponentPath::new(entity_path.clone(), component_name);
+            let is_static = db
+                .store()
+                .entity_has_static_component(entity_path, &component_name);
+            let icon = if is_static {
+                &re_ui::icons::COMPONENT_STATIC
+            } else {
+                &re_ui::icons::COMPONENT_TEMPORAL
+            };
+            let item = Item::ComponentPath(component_path);
+
+            let mut list_item = ui.list_item().interactive(interactive);
+
+            if interactive {
+                let is_hovered = ctx.selection_state().highlight_for_ui_element(&item)
+                    == HoverHighlight::Hovered;
+                list_item = list_item.force_hovered(is_hovered);
+            }
+
+            let response = if component_name.is_indicator_component() {
+                list_item.show_flat(
+                    ui,
+                    re_ui::list_item::LabelContent::new(component_name.short_name())
+                        .with_icon(icon),
+                )
+            } else {
+                let content = re_ui::list_item::PropertyContent::new(component_name.short_name())
+                    .with_icon(icon)
+                    .value_fn(|ui, _| {
+                        if instance.is_all() {
+                            crate::EntityLatestAtResults {
+                                entity_path: entity_path.clone(),
+                                component_name,
+                                unit,
+                            }
+                            .data_ui(
+                                ctx,
+                                ui,
+                                UiLayout::List,
+                                query,
+                                db,
+                            );
+                        } else {
+                            ctx.component_ui_registry.ui(
+                                ctx,
+                                ui,
+                                UiLayout::List,
+                                query,
+                                db,
+                                entity_path,
+                                component_name,
+                                unit,
+                                instance,
+                            );
+                        }
+                    });
+
+                list_item.show_flat(ui, content)
+            };
+
+            let response = response.on_hover_ui(|ui| {
+                component_name.data_ui_recording(ctx, ui, UiLayout::Tooltip);
+            });
+
+            if interactive {
+                ctx.select_hovered_on_click(&response, item);
+            }
+        }
+    });
 }


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/6891
* Fixes https://github.com/rerun-io/rerun/issues/5127

When you select an entity that contains an `Image`, `DepthImage` or `SegmentationImage`, a preview of it will be show.

Coming later: button to copy and save/download the image.

#### Toolip
![image](https://github.com/user-attachments/assets/e3b5bb67-3e66-462b-b908-54e707197983)


#### Selection panel
![image](https://github.com/user-attachments/assets/fc01796a-7c9d-428a-ba71-33f575fe444d)




### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7147?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7147?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7147)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.