### PR TITLE
re_web_viewer_server: include static files from symlink

### DIFF
--- a/crates/viewer/re_web_viewer_server/src/lib.rs
+++ b/crates/viewer/re_web_viewer_server/src/lib.rs
@@ -24,11 +24,11 @@ mod data {
     #![allow(clippy::large_include_file)]
 
     // If you add/remove/change the paths here, also update the include-list in `Cargo.toml`!
-    pub const INDEX_HTML: &[u8] = include_bytes!("../../../../web_viewer/index.html");
-    pub const FAVICON: &[u8] = include_bytes!("../../../../web_viewer/favicon.svg");
-    pub const SW_JS: &[u8] = include_bytes!("../../../../web_viewer/sw.js");
-    pub const VIEWER_JS: &[u8] = include_bytes!("../../../../web_viewer/re_viewer.js");
-    pub const VIEWER_WASM: &[u8] = include_bytes!("../../../../web_viewer/re_viewer_bg.wasm");
+    pub const INDEX_HTML: &[u8] = include_bytes!("../web_viewer/index.html");
+    pub const FAVICON: &[u8] = include_bytes!("../web_viewer/favicon.svg");
+    pub const SW_JS: &[u8] = include_bytes!("../web_viewer/sw.js");
+    pub const VIEWER_JS: &[u8] = include_bytes!("../web_viewer/re_viewer.js");
+    pub const VIEWER_WASM: &[u8] = include_bytes!("../web_viewer/re_viewer_bg.wasm");
 }
 
 /// Failure to host the web viewer.


### PR DESCRIPTION
Hopefully fixes this: https://github.com/rerun-io/rerun/actions/runs/10352579579/job/28653607322

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7154?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7154?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7154)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.