### PR TITLE
 Stress test with send_columns for Rust & C++, improve C++ TimeColumn api, fix reporting

### DIFF
--- a/rerun_cpp/src/rerun/time_column.cpp
+++ b/rerun_cpp/src/rerun/time_column.cpp
@@ -23,6 +23,33 @@ namespace rerun {
         array = std::make_shared<arrow::PrimitiveArray>(datatype, length, buffer);
     }
 
+    TimeColumn TimeColumn::from_times_nanoseconds(
+        std::string timeline_name, Collection<int64_t> times_in_nanoseconds,
+        SortingStatus sorting_status
+    ) {
+        return TimeColumn(
+            Timeline(std::move(timeline_name), TimeType::Time),
+            std::move(times_in_nanoseconds),
+            sorting_status
+        );
+    }
+
+    TimeColumn TimeColumn::from_times_seconds(
+        std::string timeline_name, Collection<double> times_in_seconds, SortingStatus sorting_status
+    ) {
+        std::vector<int64_t> times_in_nanoseconds;
+        times_in_nanoseconds.reserve(times_in_seconds.size());
+        for (auto time_in_seconds : times_in_seconds) {
+            times_in_nanoseconds.push_back(static_cast<int64_t>(time_in_seconds * 1.0e9 + 0.5));
+        }
+
+        return TimeColumn(
+            Timeline(std::move(timeline_name), TimeType::Time),
+            std::move(times_in_nanoseconds),
+            sorting_status
+        );
+    }
+
     Error to_rr_sorting_status(SortingStatus status, rr_sorting_status& out_status) {
         switch (status) {
             case SortingStatus::Unknown:

--- a/rerun_cpp/src/rerun/time_column.cpp
+++ b/rerun_cpp/src/rerun/time_column.cpp
@@ -23,7 +23,7 @@ namespace rerun {
         array = std::make_shared<arrow::PrimitiveArray>(datatype, length, buffer);
     }
 
-    TimeColumn TimeColumn::from_times_nanoseconds(
+    TimeColumn TimeColumn::from_nanoseconds(
         std::string timeline_name, Collection<int64_t> times_in_nanoseconds,
         SortingStatus sorting_status
     ) {
@@ -34,7 +34,7 @@ namespace rerun {
         );
     }
 
-    TimeColumn TimeColumn::from_times_seconds(
+    TimeColumn TimeColumn::from_seconds(
         std::string timeline_name, Collection<double> times_in_seconds, SortingStatus sorting_status
     ) {
         std::vector<int64_t> times_in_nanoseconds;

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -41,7 +41,7 @@ namespace rerun {
         SortingStatus sorting_status;
 
       public:
-        /// Creates a new time column from an array of time points.
+        /// Creates a time column from an array of time points.
         ///
         /// \param timeline The timeline this column belongs to.
         /// \param times The time values.
@@ -54,7 +54,7 @@ namespace rerun {
             SortingStatus sorting_status = SortingStatus::Unknown
         );
 
-        /// Creates a sequence time column from an array of sequence points.
+        /// Creates a time column from an array of sequence points.
         ///
         /// \param timeline_name The name of the timeline this column belongs to.
         /// \param sequence_points The sequence points.
@@ -84,7 +84,7 @@ namespace rerun {
             SortingStatus sorting_status = SortingStatus::Unknown
         );
 
-        /// Creates a sequence time column from an array of seconds.
+        /// Creates a time column from an array of seconds.
         ///
         /// \param timeline_name The name of the timeline this column belongs to.
         /// \param times_in_seconds Time values in seconds.
@@ -96,7 +96,7 @@ namespace rerun {
             SortingStatus sorting_status = SortingStatus::Unknown
         );
 
-        /// Creates a sequence time column from an array of arbitrary std::chrono durations.
+        /// Creates a time column from an array of arbitrary std::chrono durations.
         ///
         /// \param timeline_name The name of the timeline this column belongs to.
         /// \param chrono_times Time values as chrono durations.

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -79,7 +79,7 @@ namespace rerun {
         /// Make sure the sorting status is correctly specified.
         /// \param sorting_status The sorting status of the time points.
         /// Already sorted time points may perform better.
-        static TimeColumn from_times_nanoseconds(
+        static TimeColumn from_nanoseconds(
             std::string timeline_name, Collection<int64_t> times_in_nanoseconds,
             SortingStatus sorting_status = SortingStatus::Unknown
         );
@@ -91,7 +91,7 @@ namespace rerun {
         /// Make sure the sorting status is correctly specified.
         /// \param sorting_status The sorting status of the time points.
         /// Already sorted time points may perform better.
-        static TimeColumn from_times_seconds(
+        static TimeColumn from_seconds(
             std::string timeline_name, Collection<double> times_in_seconds,
             SortingStatus sorting_status = SortingStatus::Unknown
         );

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -72,7 +72,7 @@ namespace rerun {
             );
         }
 
-        /// Creates a sequence time column from an array of sequence points.
+        /// Creates a sequence time column from an array of nanoseconds.
         ///
         /// \param timeline_name The name of the timeline this column belongs to.
         /// \param times_in_nanoseconds Time values in nanoseconds.
@@ -82,13 +82,19 @@ namespace rerun {
         static TimeColumn from_times_nanoseconds(
             std::string timeline_name, Collection<int64_t> times_in_nanoseconds,
             SortingStatus sorting_status = SortingStatus::Unknown
-        ) {
-            return TimeColumn(
-                Timeline(std::move(timeline_name), TimeType::Time),
-                std::move(times_in_nanoseconds),
-                sorting_status
-            );
-        }
+        );
+
+        /// Creates a sequence time column from an array of seconds.
+        ///
+        /// \param timeline_name The name of the timeline this column belongs to.
+        /// \param times_in_seconds Time values in seconds.
+        /// Make sure the sorting status is correctly specified.
+        /// \param sorting_status The sorting status of the time points.
+        /// Already sorted time points may perform better.
+        static TimeColumn from_times_seconds(
+            std::string timeline_name, Collection<double> times_in_seconds,
+            SortingStatus sorting_status = SortingStatus::Unknown
+        );
 
         /// Creates a sequence time column from an array of arbitrary std::chrono durations.
         ///

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -72,7 +72,7 @@ namespace rerun {
             );
         }
 
-        /// Creates a sequence time column from an array of nanoseconds.
+        /// Creates a time column from an array of nanoseconds.
         ///
         /// \param timeline_name The name of the timeline this column belongs to.
         /// \param times_in_nanoseconds Time values in nanoseconds.

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
     for (auto offset : offsets) {
         std::optional<rerun::TimeColumn> time_column;
         if (temporal_batch_size.has_value()) {
-            time_column = rerun::TimeColumn::from_times_seconds(
+            time_column = rerun::TimeColumn::from_seconds(
                 "sim_time",
                 rerun::borrow(sim_times.data() + offset, *temporal_batch_size),
                 rerun::SortingStatus::Sorted

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
     const auto num_series = num_plots * num_series_per_plot;
     auto time_per_tick = 1.0 / freq;
-    auto scalars_per_tick = num_series * num_series_per_plot;
+    auto scalars_per_tick = num_series;
     if (temporal_batch_size.has_value()) {
         time_per_tick *= static_cast<double>(*temporal_batch_size);
         scalars_per_tick *= *temporal_batch_size;

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <cstdint>
 #include <iostream>
+#include <numeric>
 #include <random>
 #include <thread>
 #include <vector>

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -144,9 +144,9 @@ int main(int argc, char** argv) {
         values_per_series.push_back(values);
     }
 
-    std::vector<uint64_t> offsets;
+    std::vector<size_t> offsets;
     if (temporal_batch_size.has_value()) {
-        for (uint64_t i = 0; i < num_points_per_series; i += *temporal_batch_size) {
+        for (size_t i = 0; i < num_points_per_series; i += *temporal_batch_size) {
             offsets.push_back(i);
         }
     } else {
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
                 rerun::SortingStatus::Sorted
             );
         } else {
-            rec.set_time_seconds("sim_time", sim_times[static_cast<size_t>(offset)]);
+            rec.set_time_seconds("sim_time", sim_times[offset]);
         }
 
         // Log
@@ -180,7 +180,7 @@ int main(int argc, char** argv) {
 
             for (size_t series_idx = 0; series_idx < series_paths.size(); ++series_idx) {
                 auto path = plot_paths[plot_idx] + "/" + series_paths[series_idx];
-                auto series_values = values_per_series[global_plot_idx + series_idx];
+                const auto& series_values = values_per_series[global_plot_idx + series_idx];
                 if (temporal_batch_size.has_value()) {
                     rec.send_columns(
                         path,

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -172,7 +172,7 @@ def main() -> None:
         if args.temporal_batch_size is None:
             rr.set_time_seconds("sim_time", sim_time)
         else:
-            time_column = rr.TimeBatch("sim_time", sim_time)
+            time_column = rr.TimeSecondsColumn("sim_time", sim_time)
 
         # Log
         for plot_idx, plot_path in enumerate(plot_paths):

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -131,7 +131,7 @@ def main() -> None:
 
     num_series = len(plot_paths) * len(series_paths)
     time_per_tick = time_per_sim_step
-    scalars_per_tick = num_series * args.num_series_per_plot
+    scalars_per_tick = num_series
     if args.temporal_batch_size is not None:
         time_per_tick *= args.temporal_batch_size
         scalars_per_tick *= args.temporal_batch_size

--- a/tests/python/plot_dashboard_stress/main.py
+++ b/tests/python/plot_dashboard_stress/main.py
@@ -183,7 +183,7 @@ def main() -> None:
                 else:
                     value_index = slice(index, index + args.temporal_batch_size)
                     value_batch = rr.components.ScalarBatch(values[value_index, plot_idx, series_idx])
-                    rr.send_columnsstorage_type(
+                    rr.send_columns(
                         f"{plot_path}/{series_path}",
                         times=[time_column],
                         components=[value_batch],

--- a/tests/rust/plot_dashboard_stress/src/main.rs
+++ b/tests/rust/plot_dashboard_stress/src/main.rs
@@ -80,7 +80,7 @@ fn run(rec: &rerun::RecordingStream, args: &Args) -> anyhow::Result<()> {
 
     let num_series = args.num_plots * args.num_series_per_plot;
     let mut time_per_tick = 1.0 / args.freq;
-    let mut scalars_per_tick = num_series * args.num_series_per_plot;
+    let mut scalars_per_tick = num_series;
     if let Some(temporal_batch_size) = args.temporal_batch_size {
         time_per_tick *= temporal_batch_size as f64;
         scalars_per_tick *= temporal_batch_size;


### PR DESCRIPTION
### What

* re-opened https://github.com/rerun-io/rerun/pull/7148
    * sth strange going on with Github right now.
* Add `send_column` variant to plot stress tests for C++ and Rust.
* Small addition to C++ `TimeColumn`: `from_seconds`
* `from_times_nanoseconds` -> `from_nanoseconds`
* fix bugs in reporting on all languages


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7148?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7148?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7148)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.