### PR TITLE
Fix broken querying logic with the dataframe view in time range mode

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/time_range_table.rs
+++ b/crates/viewer/re_space_view_dataframe/src/time_range_table.rs
@@ -99,13 +99,7 @@ pub(crate) fn time_range_table_ui(
             .into_iter()
             // Exploit the fact that the returned iterator (if any) is *not* bound to the lifetime
             // of the chunk (it has an internal Arc).
-            .map(move |chunk| {
-                let all_indices = Arc::clone(&chunk)
-                    .iter_indices_owned(&timeline)
-                    .filter(move |(time, _)| range_query.range.contains(*time));
-
-                (all_indices, chunk)
-            })
+            .map(move |chunk| (Arc::clone(&chunk).iter_indices_owned(&timeline), chunk))
             .flat_map(move |(indices_iter, chunk)| {
                 map_chunk_indices_to_key_value_iter(
                     indices_iter,


### PR DESCRIPTION
### What

This PR fixes the querying logic of the time range dataframe view. It was broken and gave results such as these:

![image (4)](https://github.com/user-attachments/assets/13946355-ce0d-4590-befe-aa739e2bcbfa)

<br/><br/>
(note the missing position and color data)

Now: 

<img width="772" alt="image" src="https://github.com/user-attachments/assets/a14df713-828b-4ce0-bfa1-d757722741ae">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7159?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7159?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7159)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.