### PR TITLE
Include listarray in rerun_py extension type bypass

### DIFF
--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -59,7 +59,20 @@ fn array_to_rust(arrow_array: &PyAny, name: Option<&str>) -> PyResult<(Box<dyn A
         //
         // See <https://github.com/rerun-io/rerun/issues/6606>.
         let datatype = if let DataType::List(inner) = field.data_type() {
-            ListArray::<i32>::default_datatype(inner.data_type().to_logical_type().clone())
+            let Field {
+                name,
+                data_type,
+                is_nullable,
+                metadata,
+            } = &**inner;
+            DataType::List(std::sync::Arc::new(
+                Field::new(
+                    name.clone(),
+                    data_type.to_logical_type().clone(),
+                    *is_nullable,
+                )
+                .with_metadata(metadata.clone()),
+            ))
         } else {
             field.data_type().to_logical_type().clone()
         };

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use arrow2::{
     array::{Array, ListArray, PrimitiveArray},
-    datatypes::Field,
+    datatypes::{DataType, Field},
     ffi,
     offset::Offsets,
 };
@@ -58,7 +58,11 @@ fn array_to_rust(arrow_array: &PyAny, name: Option<&str>) -> PyResult<(Box<dyn A
         // certain where we're going, this is a nice, painless and easily reversible solution.
         //
         // See <https://github.com/rerun-io/rerun/issues/6606>.
-        let datatype = field.data_type().to_logical_type().clone();
+        let datatype = if let DataType::List(inner) = field.data_type() {
+            ListArray::<i32>::default_datatype(inner.data_type().to_logical_type().clone())
+        } else {
+            field.data_type().to_logical_type().clone()
+        };
 
         let array = ffi::import_array_from_c(*array, datatype)
             .map_err(|err| PyValueError::new_err(format!("Error importing Array: {err}")))?;


### PR DESCRIPTION
### What

Now that we always pass `ListArray` for `send_columns` calls from Python, we ran into an issue where the extension type was carried on when it shouldn't, causing comparision errors:
https://github.com/rerun-io/rerun/actions/runs/10366656880/job/28696922469

Note that this didn't break anything beyond this test.

### Checklist
* [x] pass main ci
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7160?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7160?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7160)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.