### PR TITLE
Sanity check the size of the image buffer in C++

### DIFF
--- a/crates/store/re_types/src/archetypes/image_ext.rs
+++ b/crates/store/re_types/src/archetypes/image_ext.rs
@@ -83,16 +83,14 @@ impl Image {
     ) -> Self {
         let buffer = bytes.into();
 
-        let actual_bytes = buffer.len();
-        let bpp = pixel_format.bits_per_pixel();
-        let num_expected_bytes = (width as usize * height as usize * bpp + 7) / 8; // rounding upwards
+        let image_format = ImageFormat::from_pixel_format([width, height], pixel_format);
+
+        let num_expected_bytes = image_format.num_bytes();
         if buffer.len() != num_expected_bytes {
             re_log::warn_once!(
-                "Expected {width}x{height} {pixel_format:?} image to be {num_expected_bytes} B, but got {actual_bytes} B",
+                "Expected {width}x{height} {pixel_format:?} image to be {num_expected_bytes} B, but got {} B", buffer.len()
             );
         }
-
-        let image_format = ImageFormat::from_pixel_format([width, height], pixel_format);
 
         Self {
             buffer,
@@ -113,16 +111,6 @@ impl Image {
     ) -> Self {
         let buffer = bytes.into();
 
-        let actual_bytes = buffer.len();
-        let num_expected_bytes =
-            (width as usize * height as usize * color_model.num_channels() * datatype.bits() + 7)
-                / 8; // rounding upwards
-        if buffer.len() != num_expected_bytes {
-            re_log::warn_once!(
-                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {actual_bytes} B",
-            );
-        }
-
         let image_format = ImageFormat {
             width,
             height,
@@ -130,6 +118,13 @@ impl Image {
             channel_datatype: Some(datatype),
             color_model: Some(color_model),
         };
+
+        let num_expected_bytes = image_format.num_bytes();
+        if buffer.len() != num_expected_bytes {
+            re_log::warn_once!(
+                "Expected {width}x{height} {color_model:?} {datatype:?} image to be {num_expected_bytes} B, but got {} B", buffer.len()
+            );
+        }
 
         Self {
             buffer,

--- a/crates/store/re_types/src/datatypes/image_format_ext.rs
+++ b/crates/store/re_types/src/datatypes/image_format_ext.rs
@@ -57,16 +57,16 @@ impl ImageFormat {
         }
     }
 
-    /// Number of bits needed to represent a single pixel.
-    ///
-    /// Note that this is not necessarily divisible by 8!
+    /// Number of bytes for the whole image.
     #[inline]
-    pub fn bits_per_pixel(&self) -> usize {
+    pub fn num_bytes(&self) -> usize {
         if let Some(pixel_format) = self.pixel_format {
-            pixel_format.bits_per_pixel()
+            pixel_format.num_bytes([self.width, self.height])
         } else {
-            self.color_model.unwrap_or_default().num_channels()
-                * self.channel_datatype.unwrap_or_default().bits()
+            let bits_per_pixel = self.color_model.unwrap_or_default().num_channels()
+                * self.channel_datatype.unwrap_or_default().bits();
+            // rounding upwards:
+            (self.width as usize * self.height as usize * bits_per_pixel + 7) / 8
         }
     }
 

--- a/crates/store/re_types/src/datatypes/pixel_format_ext.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format_ext.rs
@@ -19,14 +19,13 @@ impl PixelFormat {
         }
     }
 
-    /// Number of bits needed to represent a single pixel.
-    ///
-    /// Note that this is not necessarily divisible by 8!
+    /// Number of bytes needed to represent an image of the given size.
     #[inline]
-    pub fn bits_per_pixel(&self) -> usize {
+    pub fn num_bytes(&self, [w, h]: [u32; 2]) -> usize {
+        let num_pixels = w as usize * h as usize;
         match self {
-            Self::NV12 => 12,
-            Self::YUY2 => 16,
+            Self::NV12 => 12 * num_pixels / 8,
+            Self::YUY2 => 16 * num_pixels / 8,
         }
     }
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image.hpp
@@ -146,8 +146,10 @@ namespace rerun::archetypes {
         /// @param resolution The resolution of the image as {width, height}.
         /// @param datatype How the data should be interpreted.
         DepthImage(const void* bytes, WidthHeight resolution, datatypes::ChannelDatatype datatype)
-            : buffer{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype))},
-              format{datatypes::ImageFormat{resolution, datatype}} {}
+            : DepthImage{
+                  Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype)),
+                  resolution,
+                  datatype} {}
 
         /// Constructs image from pixel data + resolution + datatype.
         ///
@@ -160,7 +162,16 @@ namespace rerun::archetypes {
         DepthImage(
             Collection<uint8_t> bytes, WidthHeight resolution, datatypes::ChannelDatatype datatype
         )
-            : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {}
+            : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "DepthnImage buffer has the wrong size. Got " + std::to_string(buffer.size()) +
+                        " bytes, expected " + std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }
+        }
 
         // END of extensions from depth_image_ext.cpp, start of generated code:
 

--- a/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/depth_image_ext.cpp
@@ -43,8 +43,7 @@ namespace rerun::archetypes {
         const void* bytes, WidthHeight resolution,
         datatypes::ChannelDatatype datatype
     )
-        : buffer{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype))},
-          format{datatypes::ImageFormat{resolution, datatype}} {}
+        : DepthImage{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype)), resolution, datatype} {}
 
     /// Constructs image from pixel data + resolution + datatype.
     ///
@@ -58,7 +57,15 @@ namespace rerun::archetypes {
         Collection<uint8_t> bytes, WidthHeight resolution,
         datatypes::ChannelDatatype datatype
     )
-        : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {}
+        : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "DepthnImage buffer has the wrong size. Got " + std::to_string(buffer.size()) +
+                        " bytes, expected " + std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }}
 
     // </CODEGEN_COPY_TO_HEADER>
 

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -102,7 +102,16 @@ namespace rerun::archetypes {
         /// The length of the data should be `W * H * image_format.bytes_per_pixel`.
         /// @param format_ How the data should be interpreted.
         Image(Collection<uint8_t> bytes, components::ImageFormat format_)
-            : buffer(std::move(bytes)), format(format_) {}
+            : buffer(std::move(bytes)), format(format_) {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "Image buffer had the wrong size. Got " + std::to_string(buffer.size()) +
+                        " bytes, expected " + std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }
+        }
 
         /// Construct an image from resolution, pixel format and bytes.
         ///

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -106,7 +106,7 @@ namespace rerun::archetypes {
             if (buffer.size() != format.image_format.num_bytes()) {
                 Error(
                     ErrorCode::InvalidTensorDimension,
-                    "Image buffer had the wrong size. Got " + std::to_string(buffer.size()) +
+                    "Image buffer has the wrong size. Got " + std::to_string(buffer.size()) +
                         " bytes, expected " + std::to_string(format.image_format.num_bytes())
                 )
                     .handle();

--- a/rerun_cpp/src/rerun/archetypes/image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image_ext.cpp
@@ -25,7 +25,7 @@ namespace rerun::archetypes {
             if (buffer.size() != format.image_format.num_bytes()) {
                 Error(
                     ErrorCode::InvalidTensorDimension,
-                    "Image buffer had the wrong size. Got " + std::to_string(buffer.size()) +
+                    "Image buffer has the wrong size. Got " + std::to_string(buffer.size()) +
                         " bytes, expected " + std::to_string(format.image_format.num_bytes())
                 )
                     .handle();

--- a/rerun_cpp/src/rerun/archetypes/image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/image_ext.cpp
@@ -21,7 +21,16 @@ namespace rerun::archetypes {
     Image(
         Collection<uint8_t> bytes, components::ImageFormat format_
     )
-        : buffer(std::move(bytes)), format(format_) {}
+        : buffer(std::move(bytes)), format(format_) {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "Image buffer had the wrong size. Got " + std::to_string(buffer.size()) +
+                        " bytes, expected " + std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }
+        }
 
     /// Construct an image from resolution, pixel format and bytes.
     ///

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image.hpp
@@ -128,8 +128,10 @@ namespace rerun::archetypes {
         SegmentationImage(
             const void* bytes, WidthHeight resolution, datatypes::ChannelDatatype datatype
         )
-            : buffer{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype))},
-              format{datatypes::ImageFormat{resolution, datatype}} {}
+            : SegmentationImage{
+                  Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype)),
+                  resolution,
+                  datatype} {}
 
         /// Constructs image from pixel data + resolution + datatype.
         ///
@@ -142,7 +144,17 @@ namespace rerun::archetypes {
         SegmentationImage(
             Collection<uint8_t> bytes, WidthHeight resolution, datatypes::ChannelDatatype datatype
         )
-            : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {}
+            : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "SegmentationImage buffer has the wrong size. Got " +
+                        std::to_string(buffer.size()) + " bytes, expected " +
+                        std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }
+        }
 
         // END of extensions from segmentation_image_ext.cpp, start of generated code:
 

--- a/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
+++ b/rerun_cpp/src/rerun/archetypes/segmentation_image_ext.cpp
@@ -43,8 +43,7 @@ namespace rerun::archetypes {
         const void* bytes, WidthHeight resolution,
         datatypes::ChannelDatatype datatype
     )
-        : buffer{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype))},
-          format{datatypes::ImageFormat{resolution, datatype}} {}
+        : SegmentationImage{Collection<uint8_t>::borrow(bytes, num_bytes(resolution, datatype)), resolution, datatype} {}
 
     /// Constructs image from pixel data + resolution + datatype.
     ///
@@ -58,7 +57,16 @@ namespace rerun::archetypes {
         Collection<uint8_t> bytes, WidthHeight resolution,
         datatypes::ChannelDatatype datatype
     )
-        : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {}
+        : buffer{bytes}, format{datatypes::ImageFormat{resolution, datatype}} {
+            if (buffer.size() != format.image_format.num_bytes()) {
+                Error(
+                    ErrorCode::InvalidTensorDimension,
+                    "SegmentationImage buffer has the wrong size. Got " + std::to_string(buffer.size()) +
+                        " bytes, expected " + std::to_string(format.image_format.num_bytes())
+                )
+                    .handle();
+            }
+        }
 
     // </CODEGEN_COPY_TO_HEADER>
 

--- a/rerun_cpp/src/rerun/components/image_buffer.hpp
+++ b/rerun_cpp/src/rerun/components/image_buffer.hpp
@@ -18,6 +18,14 @@ namespace rerun::components {
     struct ImageBuffer {
         rerun::datatypes::Blob buffer;
 
+      public: // START of extensions from image_buffer_ext.cpp:
+        /// Number of bytes
+        size_t size() const {
+            return buffer.size();
+        }
+
+        // END of extensions from image_buffer_ext.cpp, start of generated code:
+
       public:
         ImageBuffer() = default;
 

--- a/rerun_cpp/src/rerun/components/image_buffer_ext.cpp
+++ b/rerun_cpp/src/rerun/components/image_buffer_ext.cpp
@@ -1,0 +1,25 @@
+#include "image_buffer.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace components {
+
+#ifdef EDIT_EXTENSION
+        struct ImageBufferExt {
+            rerun::datatypes::Blob buffer;
+#define ImageBuffer ImageBufferExt
+
+            // <CODEGEN_COPY_TO_HEADER>
+
+            /// Number of bytes
+            size_t size() const {
+                return buffer.size();
+            }
+
+            // </CODEGEN_COPY_TO_HEADER>
+        };
+#endif
+    } // namespace components
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/blob.hpp
+++ b/rerun_cpp/src/rerun/datatypes/blob.hpp
@@ -21,6 +21,14 @@ namespace rerun::datatypes {
     struct Blob {
         rerun::Collection<uint8_t> data;
 
+      public: // START of extensions from blob_ext.cpp:
+        /// Number of bytes
+        size_t size() const {
+            return data.size();
+        }
+
+        // END of extensions from blob_ext.cpp, start of generated code:
+
       public:
         Blob() = default;
 

--- a/rerun_cpp/src/rerun/datatypes/blob_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/blob_ext.cpp
@@ -1,0 +1,25 @@
+#include "blob.hpp"
+
+// Uncomment for better auto-complete while editing the extension.
+// #define EDIT_EXTENSION
+
+namespace rerun {
+    namespace datatypes {
+
+#ifdef EDIT_EXTENSION
+        struct BlobExt {
+            rerun::Collection<uint8_t> data;
+#define Blob BlobExt
+
+            // <CODEGEN_COPY_TO_HEADER>
+
+            /// Number of bytes
+            size_t size() const {
+                return data.size();
+            }
+
+            // </CODEGEN_COPY_TO_HEADER>
+        };
+#endif
+    } // namespace datatypes
+} // namespace rerun

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -73,8 +73,8 @@ namespace rerun::datatypes {
             if (pixel_format) {
                 return pixel_format_bits_per_pixel(*pixel_format);
             } else {
-                auto cm = color_model.value_or(datatypes::ColorModel());
-                auto dt = channel_datatype.value_or(datatypes::ChannelDatatype());
+                auto cm = color_model.value_or(datatypes::ColorModel::L);
+                auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
                 return color_model_channel_count(cm) * datatype_bits(dt);
             }
         }

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -63,19 +63,13 @@ namespace rerun::datatypes {
 
         /// How many bytes will this image occupy?
         size_t num_bytes() const {
-            return width * height * this->bits_per_pixel() / 8;
-        }
-
-        /// How many bits per pixel?
-        ///
-        /// Note that this is not necessarily a factor of 8.
-        size_t bits_per_pixel() const {
             if (pixel_format) {
-                return pixel_format_bits_per_pixel(*pixel_format);
+                return pixel_format_num_bytes({width, height}, *pixel_format);
             } else {
                 auto cm = color_model.value_or(datatypes::ColorModel::L);
                 auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
-                return color_model_channel_count(cm) * datatype_bits(dt);
+                auto bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
+                return (width * height * bits_per_pixel + 7) / 8; // Rounding up
             }
         }
 

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -68,7 +68,7 @@ namespace rerun::datatypes {
             } else {
                 auto cm = color_model.value_or(datatypes::ColorModel::L);
                 auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
-                auto bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
+                let bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
                 return (width * height * bits_per_pixel + 7) / 8; // Rounding up
             }
         }

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -68,7 +68,7 @@ namespace rerun::datatypes {
             } else {
                 auto cm = color_model.value_or(datatypes::ColorModel::L);
                 auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
-                let bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
+                auto bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
                 return (width * height * bits_per_pixel + 7) / 8; // Rounding up
             }
         }

--- a/rerun_cpp/src/rerun/datatypes/image_format.hpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format.hpp
@@ -61,6 +61,24 @@ namespace rerun::datatypes {
               color_model(color_model_),
               channel_datatype(datatype_) {}
 
+        /// How many bytes will this image occupy?
+        size_t num_bytes() const {
+            return width * height * this->bits_per_pixel() / 8;
+        }
+
+        /// How many bits per pixel?
+        ///
+        /// Note that this is not necessarily a factor of 8.
+        size_t bits_per_pixel() const {
+            if (pixel_format) {
+                return pixel_format_bits_per_pixel(*pixel_format);
+            } else {
+                auto cm = color_model.value_or(datatypes::ColorModel());
+                auto dt = channel_datatype.value_or(datatypes::ChannelDatatype());
+                return color_model_channel_count(cm) * datatype_bits(dt);
+            }
+        }
+
         // END of extensions from image_format_ext.cpp, start of generated code:
 
       public:

--- a/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
@@ -43,19 +43,13 @@ namespace rerun {
 
             /// How many bytes will this image occupy?
             size_t num_bytes() const {
-                return width * height * this->bits_per_pixel() / 8;
-            }
-
-            /// How many bits per pixel?
-            ///
-            /// Note that this is not necessarily a factor of 8.
-            size_t bits_per_pixel() const {
                 if (pixel_format) {
-                    return pixel_format_bits_per_pixel(*pixel_format);
+                    return pixel_format_num_bytes({width, height}, *pixel_format);
                 } else {
                     auto cm = color_model.value_or(datatypes::ColorModel::L);
                     auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
-                    return color_model_channel_count(cm) * datatype_bits(dt);
+                    let bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
+                    return (width * height * bits_per_pixel + 7) / 8; // Rounding up
                 }
             }
 

--- a/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
@@ -53,8 +53,8 @@ namespace rerun {
                 if (pixel_format) {
                     return pixel_format_bits_per_pixel(*pixel_format);
                 } else {
-                    auto cm = color_model.value_or(datatypes::ColorModel());
-                    auto dt = channel_datatype.value_or(datatypes::ChannelDatatype());
+                    auto cm = color_model.value_or(datatypes::ColorModel::L);
+                    auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
                     return color_model_channel_count(cm) * datatype_bits(dt);
                 }
             }

--- a/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
@@ -48,7 +48,7 @@ namespace rerun {
                 } else {
                     auto cm = color_model.value_or(datatypes::ColorModel::L);
                     auto dt = channel_datatype.value_or(datatypes::ChannelDatatype::U8);
-                    let bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
+                    auto bits_per_pixel = color_model_channel_count(cm) * datatype_bits(dt);
                     return (width * height * bits_per_pixel + 7) / 8; // Rounding up
                 }
             }

--- a/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
+++ b/rerun_cpp/src/rerun/datatypes/image_format_ext.cpp
@@ -41,6 +41,24 @@ namespace rerun {
                   color_model(color_model_),
                   channel_datatype(datatype_) {}
 
+            /// How many bytes will this image occupy?
+            size_t num_bytes() const {
+                return width * height * this->bits_per_pixel() / 8;
+            }
+
+            /// How many bits per pixel?
+            ///
+            /// Note that this is not necessarily a factor of 8.
+            size_t bits_per_pixel() const {
+                if (pixel_format) {
+                    return pixel_format_bits_per_pixel(*pixel_format);
+                } else {
+                    auto cm = color_model.value_or(datatypes::ColorModel());
+                    auto dt = channel_datatype.value_or(datatypes::ChannelDatatype());
+                    return color_model_channel_count(cm) * datatype_bits(dt);
+                }
+            }
+
             // </CODEGEN_COPY_TO_HEADER>
         };
 

--- a/rerun_cpp/src/rerun/image_utils.hpp
+++ b/rerun_cpp/src/rerun/image_utils.hpp
@@ -2,6 +2,7 @@
 
 #include "datatypes/channel_datatype.hpp"
 #include "datatypes/color_model.hpp"
+#include "datatypes/pixel_format.hpp"
 #include "half.hpp"
 
 #include <cstdint>
@@ -140,6 +141,16 @@ namespace rerun {
                 return 3;
             case datatypes::ColorModel::RGBA:
                 return 4;
+        }
+        return 0;
+    }
+
+    inline size_t pixel_format_bits_per_pixel(datatypes::PixelFormat pixel_format) {
+        switch (pixel_format) {
+            case datatypes::PixelFormat::NV12:
+                return 12;
+            case datatypes::PixelFormat::YUY2:
+                return 16;
         }
         return 0;
     }

--- a/rerun_cpp/src/rerun/image_utils.hpp
+++ b/rerun_cpp/src/rerun/image_utils.hpp
@@ -57,8 +57,8 @@ namespace rerun {
     }
 
     inline size_t num_bytes(WidthHeight resolution, datatypes::ChannelDatatype datatype) {
-        return (resolution.width * resolution.height * datatype_bits(datatype) + 7) /
-               8; // rounding upwards
+        // rounding upwards:
+        return (resolution.width * resolution.height * datatype_bits(datatype) + 7) / 8;
     }
 
     template <typename TElement>
@@ -145,12 +145,15 @@ namespace rerun {
         return 0;
     }
 
-    inline size_t pixel_format_bits_per_pixel(datatypes::PixelFormat pixel_format) {
+    inline size_t pixel_format_num_bytes(
+        WidthHeight resolution, datatypes::PixelFormat pixel_format
+    ) {
+        auto num_pixels = resolution.width * resolution.height;
         switch (pixel_format) {
             case datatypes::PixelFormat::NV12:
-                return 12;
+                return 12 * num_pixels / 8;
             case datatypes::PixelFormat::YUY2:
-                return 16;
+                return 16 * num_pixels / 8;
         }
         return 0;
     }

--- a/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
+++ b/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
@@ -16,6 +16,8 @@ void run_image_tests() {
         ImageType reference_image;
         reference_image.buffer = rerun::borrow(data);
         reference_image.format = ImageFormat({10, 10}, ChannelDatatype::U8);
+        INFO("Format bits-per-pixel: " << reference_image.format.image_format.bits_per_pixel());
+        INFO("Format byte size: " << reference_image.format.image_format.num_bytes());
 
         THEN("no error occurs on image construction from a pointer") {
             auto image_from_ptr = check_logged_error([&] {

--- a/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
+++ b/rerun_cpp/tests/archetypes/segmentation_and_depth_image.cpp
@@ -16,7 +16,6 @@ void run_image_tests() {
         ImageType reference_image;
         reference_image.buffer = rerun::borrow(data);
         reference_image.format = ImageFormat({10, 10}, ChannelDatatype::U8);
-        INFO("Format bits-per-pixel: " << reference_image.format.image_format.bits_per_pixel());
         INFO("Format byte size: " << reference_image.format.image_format.num_bytes());
 
         THEN("no error occurs on image construction from a pointer") {


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/7050

Sanity check the size of the image buffer in C++

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7163?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7163?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7163)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.