### PR TITLE
New example for the `Ellipsoids3D` archetype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6335,6 +6335,7 @@ dependencies = [
  "itertools 0.13.0",
  "ndarray",
  "rand",
+ "rand_distr",
  "re_build_tools",
  "rerun",
  "rust-format",

--- a/crates/store/re_types/definitions/rerun/archetypes/ellipsoids3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/ellipsoids3d.fbs
@@ -12,7 +12,7 @@ namespace rerun.archetypes;
 /// Some of its component are repeated here for convenience.
 /// If there's more instance poses than half sizes, the last half size will be repeated for the remaining poses.
 ///
-/// \example archetypes/ellipsoid3d_batch !api title="Batch of ellipsoids"
+/// \example archetypes/ellipsoid3d_simple !api title="Covariance ellipsoid" image="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/1200w.png"
 table Ellipsoids3D (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/docs/content/reference/types/archetypes/ellipsoids3d.md
+++ b/docs/content/reference/types/archetypes/ellipsoids3d.md
@@ -32,7 +32,15 @@ If there's more instance poses than half sizes, the last half size will be repea
 
 ## Example
 
-### Batch of ellipsoids
+### Covariance ellipsoid
 
-snippet: archetypes/ellipsoid3d_batch
+snippet: archetypes/ellipsoid3d_simple
+
+<picture data-inline-viewer="snippets/ellipsoid3d_simple">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/1200w.png">
+  <img src="https://static.rerun.io/elliopsoid3d_simple/bd5d46e61b80ae44792b52ee07d750a7137002ea/full.png">
+</picture>
 

--- a/docs/snippets/Cargo.toml
+++ b/docs/snippets/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 [dependencies]
 ndarray.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
-rand_distr.workspace = true
+rand_distr = { workspace = true, features = ["std"] }
 rerun = { path = "../../crates/top/rerun" }
 
 [build-dependencies]

--- a/docs/snippets/Cargo.toml
+++ b/docs/snippets/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 ndarray.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
+rand_distr.workspace = true
 rerun = { path = "../../crates/top/rerun" }
 
 [build-dependencies]

--- a/docs/snippets/README.md
+++ b/docs/snippets/README.md
@@ -10,7 +10,7 @@ You can run each example individually using the following:
 
 - **C++**:
   - `pixi run -e cpp cpp-build-snippets` to compile all examples
-  - `./build/docs/snippets/all/<example_name>` to run, e.g. `./build/docs/snippets/all/point3d_random`
+  - `./build/debug/docs/snippets/all/<example_name>` to run, e.g. `./build/debug/docs/snippets/all/point3d_random`
 - **Python**: `pixi run -e py python <example_name>.py`, e.g. `pixi run -e py python point3d_random.py`.
 - **Rust**: `cargo run -p snippets -- <example_name> [args]`, e.g. `cargo run -p snippets -- point3d_random`.
 

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
@@ -26,7 +26,7 @@ int main() {
 
     rec.log(
         "points",
-        rerun::Points3D(points3d).with_radii(0.02).with_colors(rerun::Rgba32(188, 77, 185))
+        rerun::Points3D(points3d).with_radii(0.02f).with_colors(rerun::Rgba32(188, 77, 185))
     );
 
     rec.log(

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
@@ -1,0 +1,50 @@
+// Log random points and the corresponding covariance ellipsoid.
+
+#include <rerun.hpp>
+
+#include <algorithm>
+#include <random>
+#include <vector>
+
+int main() {
+    const auto rec = rerun::RecordingStream("rerun_example_ellipsoid_simple");
+    rec.spawn().exit_on_failure();
+
+    const float sigmas[3] = {5.0f, 3.0f, 1.0f};
+
+    std::default_random_engine gen;
+    std::normal_distribution<float> dist(0.0, 1.0f);
+
+    std::vector<rerun::Position3D> points3d(50000);
+    std::generate(points3d.begin(), points3d.end(), [&] {
+        return rerun::Position3D(
+            sigmas[0] * dist(gen),
+            sigmas[1] * dist(gen),
+            sigmas[2] * dist(gen)
+        );
+    });
+
+    rec.log(
+        "points",
+        rerun::Points3D(points3d).with_radii(0.02).with_colors(rerun::Rgba32(188, 77, 185))
+    );
+
+    float three = 3.0f;
+    rec.log(
+        "ellipsoid",
+        rerun::Ellipsoids3D::from_centers_and_half_sizes(
+            {
+                {0.0f, 0.0f, 0.0f},
+                {0.0f, 0.0f, 0.0f},
+            },
+            {
+                {sigmas[0], sigmas[1], sigmas[2]},
+                {3.0f * sigmas[0], 3.0f * sigmas[1], 3.0f * sigmas[2]},
+            }
+        )
+            .with_colors({
+                rerun::Rgba32(255, 255, 0),
+                rerun::Rgba32(64, 64, 0),
+            })
+    );
+}

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.cpp
@@ -29,7 +29,6 @@ int main() {
         rerun::Points3D(points3d).with_radii(0.02).with_colors(rerun::Rgba32(188, 77, 185))
     );
 
-    float three = 3.0f;
     rec.log(
         "ellipsoid",
         rerun::Ellipsoids3D::from_centers_and_half_sizes(

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.py
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.py
@@ -1,0 +1,21 @@
+"""Log random points and the corresponding covariance ellipsoid."""
+
+import numpy as np
+
+import rerun as rr
+
+rr.init("rerun_example_ellipsoid_simple", spawn=True)
+
+center = np.array([0, 0, 0])
+sigmas = np.array([5, 3, 1])
+points = np.random.randn(50_000, 3) * sigmas.reshape(1, -1)
+
+rr.log("points", rr.Points3D(points, radii=0.02, colors=[188, 77, 185]))
+rr.log(
+    "ellipsoid",
+    rr.Ellipsoids3D(
+        centers=[center, center],
+        half_sizes=[sigmas, 3 * sigmas],
+        colors=[[255, 255, 0], [64, 64, 0]],
+    ),
+)

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.py
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.py
@@ -1,7 +1,6 @@
 """Log random points and the corresponding covariance ellipsoid."""
 
 import numpy as np
-
 import rerun as rr
 
 rr.init("rerun_example_ellipsoid_simple", spawn=True)

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
@@ -1,0 +1,39 @@
+//! Log random points and the corresponding covariance ellipsoid.
+
+use rand::distributions::Distribution;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_ellipsoid_simple").spawn()?;
+
+    let sigmas: [f32; 3] = [5., 3., 1.];
+
+    let mut rng = rand::thread_rng();
+    let normal = rand_distr::Normal::new(0.0, 1.0).unwrap();
+
+    rec.log(
+        "random",
+        &rerun::Points3D::new((0..50_000).map(|_| {
+            (
+                sigmas[0] * normal.sample(&mut rng),
+                sigmas[1] * normal.sample(&mut rng),
+                sigmas[2] * normal.sample(&mut rng),
+            )
+        }))
+        .with_radii([0.02])
+        .with_colors([rerun::Color::from_rgb(188, 77, 185)]),
+    )?;
+
+    rec.log(
+        "ellipsoid",
+        &rerun::Ellipsoids3D::from_centers_and_half_sizes(
+            [(0.0, 0.0, 0.0), (0.0, 0.0, 0.0)],
+            [sigmas, [sigmas[0] * 3., sigmas[1] * 3., sigmas[2] * 3.]],
+        )
+        .with_colors([
+            rerun::Color::from_rgb(255, 255, 0),
+            rerun::Color::from_rgb(64, 64, 0),
+        ]),
+    )?;
+
+    Ok(())
+}

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sigmas: [f32; 3] = [5., 3., 1.];
 
     let mut rng = rand::thread_rng();
-    let normal = rand_distr::Normal::new(0.0, 1.0).unwrap();
+    let normal = rand_distr::Normal::new(0.0, 1.0)?;
 
     rec.log(
         "points",

--- a/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
+++ b/docs/snippets/all/archetypes/ellipsoid3d_simple.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let normal = rand_distr::Normal::new(0.0, 1.0).unwrap();
 
     rec.log(
-        "random",
+        "points",
         &rerun::Points3D::new((0..50_000).map(|_| {
             (
                 sigmas[0] * normal.sample(&mut rng),

--- a/docs/snippets/build.rs
+++ b/docs/snippets/build.rs
@@ -73,6 +73,8 @@ fn main() {
         }
     }
 
+    snippets.sort();
+
     assert!(
         snippets.len() > 10,
         "Found too few snippets in {all_path:?}"

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -111,6 +111,11 @@ quick_start = [ # These examples don't have exactly the same implementation.
 "archetypes/bar_chart" = [ # On Windows this logs f64 instead of u64 unless a numpy array with explicit type is used.
   "py",
 ]
+"archetypes/ellipsoid3d_simple" = [ # TODO(#3206): examples use different RNGs
+  "cpp",
+  "py",
+  "rust",
+]
 "archetypes/mesh3d_partial_updates" = [
   "cpp",
   "py",


### PR DESCRIPTION
### What

New example to replace the snowman.

Check twitter for a screenshot: https://x.com/rerundotio/status/1823354486850469913 :)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7164?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7164?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7164)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.