### PR TITLE
Fix wrong edit UI for `Colormap`

### DIFF
--- a/crates/viewer/re_edit_ui/src/lib.rs
+++ b/crates/viewer/re_edit_ui/src/lib.rs
@@ -70,7 +70,7 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_edit_or_view::<Name>(edit_singleline_string);
     registry.add_multiline_edit_or_view::<Name>(edit_multiline_string);
 
-    // `Colormap` _is_ an enum, but it's custom editor is far better.
+    // `Colormap` _is_ an enum, but its custom editor is far better.
     registry.add_singleline_edit_or_view::<Colormap>(colormap_edit_or_view_ui);
 
     // TODO(#6974): Enums editors trivial and always the same, provide them automatically!

--- a/crates/viewer/re_edit_ui/src/lib.rs
+++ b/crates/viewer/re_edit_ui/src/lib.rs
@@ -30,7 +30,7 @@ use re_types::{
     },
     Loggable as _,
 };
-
+use re_viewer_context::gpu_bridge::colormap_edit_or_view_ui;
 // ----
 
 /// Registers all editors of this crate in the component UI registry.
@@ -70,10 +70,12 @@ pub fn register_editors(registry: &mut re_viewer_context::ComponentUiRegistry) {
     registry.add_singleline_edit_or_view::<Name>(edit_singleline_string);
     registry.add_multiline_edit_or_view::<Name>(edit_multiline_string);
 
+    // `Colormap` _is_ an enum, but it's custom editor is far better.
+    registry.add_singleline_edit_or_view::<Colormap>(colormap_edit_or_view_ui);
+
     // TODO(#6974): Enums editors trivial and always the same, provide them automatically!
     registry.add_singleline_edit_or_view::<AggregationPolicy>(edit_view_enum);
     registry.add_singleline_edit_or_view::<BackgroundKind>(edit_view_enum);
-    registry.add_singleline_edit_or_view::<Colormap>(edit_view_enum);
     registry.add_singleline_edit_or_view::<Corner2D>(edit_view_enum);
     registry.add_singleline_edit_or_view::<FillMode>(edit_view_enum);
     registry.add_singleline_edit_or_view::<MagnificationFilter>(edit_view_enum);

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/colormap.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/colormap.rs
@@ -101,7 +101,7 @@ fn colormap_variant_ui(
 }
 
 pub fn colormap_edit_or_view_ui(
-    render_ctx: Option<&re_renderer::RenderContext>,
+    ctx: &crate::ViewerContext<'_>,
     ui: &mut egui::Ui,
     map: &mut MaybeMutRef<'_, re_types::components::Colormap>,
 ) -> egui::Response {
@@ -114,10 +114,10 @@ pub fn colormap_edit_or_view_ui(
                 return ui.label("<no variants>");
             };
 
-            let mut response = colormap_variant_ui(render_ctx, ui, first, map);
+            let mut response = colormap_variant_ui(ctx.render_ctx, ui, first, map);
 
             for option in iter {
-                response |= colormap_variant_ui(render_ctx, ui, option, map);
+                response |= colormap_variant_ui(ctx.render_ctx, ui, option, map);
             }
 
             response
@@ -136,7 +136,7 @@ pub fn colormap_edit_or_view_ui(
         inner_response.response
     } else {
         let map: re_types::components::Colormap = **map;
-        if let Some(render_ctx) = render_ctx {
+        if let Some(render_ctx) = ctx.render_ctx {
             ui.list_item_flat_noninteractive(
                 list_item::PropertyContent::new(map.to_string())
                     .min_desired_width(MIN_WIDTH)

--- a/tests/python/release_checklist/check_colormap_edit_ui.py
+++ b/tests/python/release_checklist/check_colormap_edit_ui.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import numpy as np
+import rerun as rr
+import rerun.blueprint as rrb
+
+README = """\
+# Colormap edit UI
+
+- Click on the depth image.
+- In the selection panel, check that the `Colormap` menu (in the `Visualizers` section) includes nice previews of the colormaps.
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
+
+
+def log_depth_image() -> None:
+    depth_image = 65535 * np.ones((200, 300), dtype=np.uint16)
+    depth_image[50:150, 50:150] = 20000
+    depth_image[130:180, 100:280] = 45000
+    rr.log("depth", rr.DepthImage(depth_image, meter=10_000.0))
+
+
+def blueprint() -> rrb.BlueprintLike:
+    return rrb.Horizontal(
+        rrb.TextDocumentView(origin="readme"),
+        rrb.Spatial2DView(origin="/depth"),
+    )
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
+
+    log_readme()
+    log_depth_image()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What

![image](https://github.com/user-attachments/assets/d5919dca-2b82-432a-b243-fcb434f782e9)

👇🏻 

<img width="317" alt="image" src="https://github.com/user-attachments/assets/5d0606d8-4c46-41ac-bcf5-6f90f48c3d00">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7171?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7171?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7171)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.