### PR TITLE
Add `send_columns` examples for images, fix rust `send_columns`  handling of listarrays

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/image.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/image.fbs
@@ -20,6 +20,7 @@ namespace rerun.archetypes;
 /// \cpp If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
 ///
 /// \example archetypes/image_simple image="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/1200w.png"
+/// \example archetypes/image_send_columns title= image="Advanced usage of `send_columns` to send multiple images at once" image="https://static.rerun.io/image_send_columns/321455161d79e2c45d6f5a6f175d6f765f418897/1200w.png"
 table Image (
   "attr.rust.derive": "PartialEq",
   "attr.cpp.no_field_ctors",

--- a/crates/store/re_types/definitions/rerun/components/blob.fbs
+++ b/crates/store/re_types/definitions/rerun/components/blob.fbs
@@ -3,6 +3,7 @@ namespace rerun.components;
 // ---
 
 /// A binary blob of data.
+/// \rs Ref-counted internally and therefore cheap to clone.
 table Blob (
   "attr.arrow.transparent",
   "attr.python.aliases": "bytes, npt.NDArray[np.uint8]",

--- a/crates/store/re_types/definitions/rerun/datatypes/blob.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/blob.fbs
@@ -3,6 +3,7 @@ namespace rerun.datatypes;
 // ---
 
 /// A binary blob of data.
+/// \rs Ref-counted internally and therefore cheap to clone.
 table Blob (
   "attr.docs.unreleased",
   "attr.arrow.transparent",

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -90,13 +90,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     }
 ///
 ///     // Log the ImageFormat and indicator once, as static.
-///     let format = rerun::components::ImageFormat::from(rerun::datatypes::ImageFormat {
-///         width: width as _,
-///         height: height as _,
-///         pixel_format: None,
-///         color_model: Some(rerun::datatypes::ColorModel::RGB),
-///         channel_datatype: Some(rerun::datatypes::ChannelDatatype::U8),
-///     });
+///     let format = rerun::components::ImageFormat::rgb8([width as _, height as _]);
 ///     rec.log_component_batches(
 ///         "images",
 ///         true,

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -99,7 +99,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     });
 ///     rec.log_component_batches(
 ///         "images",
-///         false, // TODO: static=true,
+///         true,
 ///         [&format as _, &rerun::Image::indicator() as _],
 ///     )?;
 ///

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -79,7 +79,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     let width = 300;
 ///     let height = 200;
 ///     let mut images = Array::<u8, _>::zeros((times.len(), height, width, 3).f())
-///         .as_standard_layout() // Make sure the data is layed out as we expect it.
+///         .as_standard_layout() // Make sure the data is laid out as we expect it.
 ///         .into_owned();
 ///     images.slice_mut(s![.., .., .., 2]).fill(255);
 ///     for &t in &times {

--- a/crates/store/re_types/src/components/blob.rs
+++ b/crates/store/re_types/src/components/blob.rs
@@ -19,6 +19,7 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A binary blob of data.
+/// Ref-counted internally and therefore cheap to clone.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Blob(pub crate::datatypes::Blob);

--- a/crates/store/re_types/src/components/image_format_ext.rs
+++ b/crates/store/re_types/src/components/image_format_ext.rs
@@ -1,0 +1,64 @@
+use super::ImageFormat;
+use crate::datatypes::{self, ChannelDatatype, ColorModel, PixelFormat};
+
+impl ImageFormat {
+    /// Create a new depth image format with the given resolution and datatype.
+    #[inline]
+    pub fn depth([width, height]: [u32; 2], datatype: ChannelDatatype) -> Self {
+        datatypes::ImageFormat::depth([width, height], datatype).into()
+    }
+
+    /// Create a new segmentation image format with the given resolution and datatype.
+    #[inline]
+    pub fn segmentation([width, height]: [u32; 2], datatype: ChannelDatatype) -> Self {
+        datatypes::ImageFormat::segmentation([width, height], datatype).into()
+    }
+
+    /// Create a new rgb image format with 8 bit per channel with the given resolution.
+    #[inline]
+    pub fn rgb8([width, height]: [u32; 2]) -> Self {
+        datatypes::ImageFormat::rgb8([width, height]).into()
+    }
+
+    /// Create a new rgba image format with 8 bit per channel with the given resolution.
+    #[inline]
+    pub fn rgba8([width, height]: [u32; 2]) -> Self {
+        datatypes::ImageFormat::rgba8([width, height]).into()
+    }
+
+    /// From a speicifc pixel format.
+    #[inline]
+    pub fn from_pixel_format([width, height]: [u32; 2], pixel_format: PixelFormat) -> Self {
+        datatypes::ImageFormat::from_pixel_format([width, height], pixel_format).into()
+    }
+
+    /// Determine if the image format has an alpha channel.
+    #[inline]
+    pub fn has_alpha(&self) -> bool {
+        self.0.has_alpha()
+    }
+
+    /// Determine if the image format represents floating point data.
+    #[inline]
+    pub fn is_float(&self) -> bool {
+        self.0.is_float()
+    }
+
+    /// Number of bytes for the whole image.
+    #[inline]
+    pub fn num_bytes(&self) -> usize {
+        self.0.num_bytes()
+    }
+
+    /// The color model represented by this image format.
+    #[inline]
+    pub fn color_model(&self) -> ColorModel {
+        self.0.color_model()
+    }
+
+    /// The datatype represented by this image format.
+    #[inline]
+    pub fn datatype(&self) -> ChannelDatatype {
+        self.0.datatype()
+    }
+}

--- a/crates/store/re_types/src/components/mod.rs
+++ b/crates/store/re_types/src/components/mod.rs
@@ -29,6 +29,7 @@ mod half_size3d;
 mod half_size3d_ext;
 mod image_buffer;
 mod image_format;
+mod image_format_ext;
 mod image_plane_distance;
 mod image_plane_distance_ext;
 mod keypoint_id;

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -19,6 +19,7 @@ use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A binary blob of data.
+/// Ref-counted internally and therefore cheap to clone.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Blob(pub ::re_types_core::ArrowBuffer<u8>);

--- a/crates/store/re_types/src/datatypes/blob_ext.rs
+++ b/crates/store/re_types/src/datatypes/blob_ext.rs
@@ -1,5 +1,19 @@
 use super::Blob;
 
+impl Blob {
+    /// Returns a new [`Blob`] that is a slice of this buffer starting at `offset`.
+    ///
+    /// Doing so allows the same memory region to be shared between buffers.
+    /// Note that you can beforehand `clone` the [`Blob`] to get a new buffer that shares the same memory.
+    ///
+    /// # Panics
+    /// Panics iff `offset + length` is larger than `len`.
+    #[inline]
+    pub fn sliced(self, range: std::ops::Range<usize>) -> Self {
+        self.0.sliced(range).into()
+    }
+}
+
 impl From<Vec<u8>> for Blob {
     fn from(bytes: Vec<u8>) -> Self {
         Self(bytes.into())

--- a/crates/store/re_types/src/datatypes/image_format_ext.rs
+++ b/crates/store/re_types/src/datatypes/image_format_ext.rs
@@ -25,6 +25,30 @@ impl ImageFormat {
         }
     }
 
+    /// Create a new rgb image format with 8 bit per channel with the given resolution.
+    #[inline]
+    pub fn rgb8([width, height]: [u32; 2]) -> Self {
+        Self {
+            width,
+            height,
+            pixel_format: None,
+            channel_datatype: Some(ChannelDatatype::U8),
+            color_model: Some(ColorModel::RGB),
+        }
+    }
+
+    /// Create a new rgba image format with 8 bit per channel with the given resolution.
+    #[inline]
+    pub fn rgba8([width, height]: [u32; 2]) -> Self {
+        Self {
+            width,
+            height,
+            pixel_format: None,
+            channel_datatype: Some(ChannelDatatype::U8),
+            color_model: Some(ColorModel::RGBA),
+        }
+    }
+
     /// From a speicifc pixel format.
     #[inline]
     pub fn from_pixel_format([width, height]: [u32; 2], pixel_format: PixelFormat) -> Self {

--- a/crates/store/re_types_core/src/arrow_buffer.rs
+++ b/crates/store/re_types_core/src/arrow_buffer.rs
@@ -54,6 +54,17 @@ impl<T> ArrowBuffer<T> {
     pub fn into_inner(self) -> Buffer<T> {
         self.0
     }
+
+    /// Returns a new [`Buffer`] that is a slice of this buffer starting at `offset`.
+    ///
+    /// Doing so allows the same memory region to be shared between buffers.
+    ///
+    /// # Panics
+    /// Panics iff `offset + length` is larger than `len`.
+    #[inline]
+    pub fn sliced(self, range: std::ops::Range<usize>) -> Self {
+        Self(self.0.sliced(range.start, range.len()))
+    }
 }
 
 impl<T: bytemuck::Pod> ArrowBuffer<T> {

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -32,7 +32,7 @@ Compressing images can save a lot of bandwidth and memory.
  * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
  * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Image.html)
 
-## Example
+## Examples
 
 ### image_simple
 
@@ -45,4 +45,10 @@ snippet: archetypes/image_simple
   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/1200w.png">
   <img src="https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/full.png">
 </picture>
+
+### image_send_columns
+
+snippet: archetypes/image_send_columns
+
+<img src="Advanced usage of `send_columns` to send multiple images at once">
 

--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -1,0 +1,54 @@
+// Send multiple images at once using `send_columns`.
+
+#include <numeric>
+#include <rerun.hpp>
+
+int main() {
+    auto rec = rerun::RecordingStream("rerun_example_image_send_columns");
+    rec.spawn().exit_on_failure();
+
+    // Timeline on which the images are distributed.
+    std::vector<int64_t> times(20);
+    std::iota(times.begin(), times.end(), 0);
+
+    // Create a batch of images with a moving rectangle.
+    const size_t width = 300, height = 200;
+    std::vector<uint8_t> images(times.size() * height * width * 3, 0);
+    for (size_t t = 0; t < times.size(); ++t) {
+        for (size_t y = 0; y < height; ++y) {
+            for (size_t x = 0; x < width; ++x) {
+                size_t idx = (t * height * width + y * width + x) * 3;
+                images[idx + 2] = 255; // Blue background
+                if (y >= 50 && y < 150 && x >= t * 10 && x < t * 10 + 100) {
+                    images[idx + 1] = 255; // Turkoise rectangle
+                }
+            }
+        }
+    }
+
+    // Log the ImageFormat and indicator once, as static.
+    auto format = rerun::components::ImageFormat(
+        {width, height},
+        rerun::ColorModel::RGB,
+        rerun::ChannelDatatype::U8
+    );
+    rec.log(
+        "images",
+        rerun::borrow(&format, 1),
+        rerun::Image::IndicatorComponent()
+    ); // TODO: make static
+
+    // Split up the image data into several components referencing the underlying data.
+    const size_t image_size_in_bytes = width * height * 3;
+    std::vector<rerun::components::ImageBuffer> image_data(times.size());
+    for (size_t i = 0; i < times.size(); ++i) {
+        image_data[i] = rerun::borrow(images.data() + i * image_size_in_bytes, image_size_in_bytes);
+    }
+
+    // Send all images at once.
+    rec.send_columns(
+        "images",
+        rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+        rerun::borrow(image_data)
+    );
+}

--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -32,7 +32,7 @@ int main() {
         rerun::ColorModel::RGB,
         rerun::ChannelDatatype::U8
     );
-    rec.log_static("images", rerun::borrow(&format, 1), rerun::Image::IndicatorComponent());
+    rec.log_static("images", rerun::borrow(&format), rerun::Image::IndicatorComponent());
 
     // Split up the image data into several components referencing the underlying data.
     const size_t image_size_in_bytes = width * height * 3;

--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -20,7 +20,7 @@ int main() {
                 size_t idx = (t * height * width + y * width + x) * 3;
                 images[idx + 2] = 255; // Blue background
                 if (y >= 50 && y < 150 && x >= t * 10 && x < t * 10 + 100) {
-                    images[idx + 1] = 255; // Turkoise rectangle
+                    images[idx + 1] = 255; // Turquoise rectangle
                 }
             }
         }

--- a/docs/snippets/all/archetypes/image_send_columns.cpp
+++ b/docs/snippets/all/archetypes/image_send_columns.cpp
@@ -32,11 +32,7 @@ int main() {
         rerun::ColorModel::RGB,
         rerun::ChannelDatatype::U8
     );
-    rec.log(
-        "images",
-        rerun::borrow(&format, 1),
-        rerun::Image::IndicatorComponent()
-    ); // TODO: make static
+    rec.log_static("images", rerun::borrow(&format, 1), rerun::Image::IndicatorComponent());
 
     // Split up the image data into several components referencing the underlying data.
     const size_t image_size_in_bytes = width * height * 3;

--- a/docs/snippets/all/archetypes/image_send_columns.py
+++ b/docs/snippets/all/archetypes/image_send_columns.py
@@ -1,8 +1,4 @@
-"""
-Send multiple images at once using `send_columns`.
-
-This is useful when several images over time are already consecutive in memory.
-"""
+"""Send multiple images at once using `send_columns`."""
 
 import numpy as np
 import rerun as rr

--- a/docs/snippets/all/archetypes/image_send_columns.py
+++ b/docs/snippets/all/archetypes/image_send_columns.py
@@ -1,0 +1,32 @@
+"""
+Send multiple images at once using `send_columns`.
+
+This is useful when several images over time are already consecutive in memory.
+"""
+
+import numpy as np
+import rerun as rr
+
+rr.init("rerun_example_image_send_columns", spawn=True)
+
+# Timeline on which the images are distributed.
+times = np.arange(0, 20)
+
+# Create a batch of images with a moving rectangle.
+width, height = 300, 200
+images = np.zeros((len(times), height, width, 3), dtype=np.uint8)
+images[:, :, :, 2] = 255
+for t in times:
+    images[t, 50:150, (t * 10) : (t * 10 + 100), 1] = 255
+
+# Log the ImageFormat and indicator once, as static.
+format_static = rr.components.ImageFormat(width=width, height=height, color_model="RGB", channel_datatype="U8")
+rr.log("images", [format_static, rr.Image.indicator()])  # TODO:, static=True)
+
+# Send all images at once.
+rr.send_columns(
+    "images",
+    times=[rr.TimeSequenceColumn("step", times)],
+    # Reshape the images so `ImageBufferBatch` can tell that this is several blobs.
+    components=[rr.components.ImageBufferBatch(images.reshape(len(times), -1))],
+)

--- a/docs/snippets/all/archetypes/image_send_columns.py
+++ b/docs/snippets/all/archetypes/image_send_columns.py
@@ -17,7 +17,7 @@ for t in times:
 
 # Log the ImageFormat and indicator once, as static.
 format_static = rr.components.ImageFormat(width=width, height=height, color_model="RGB", channel_datatype="U8")
-rr.log("images", [format_static, rr.Image.indicator()])  # TODO:, static=True)
+rr.log("images", [format_static, rr.Image.indicator()], static=True)
 
 # Send all images at once.
 rr.send_columns(

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     rec.log_component_batches(
         "images",
-        false, // TODO: static=true,
+        true,
         [&format as _, &rerun::Image::indicator() as _],
     )?;
 

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let width = 300;
     let height = 200;
     let mut images = Array::<u8, _>::zeros((times.len(), height, width, 3).f())
-        .as_standard_layout() // Make sure the data is layed out as we expect it.
+        .as_standard_layout() // Make sure the data is laid out as we expect it.
         .into_owned();
     images.slice_mut(s![.., .., .., 2]).fill(255);
     for &t in &times {

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -1,0 +1,57 @@
+use ndarray::{s, Array, ShapeBuilder};
+use rerun::Archetype as _;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_image_send_columns").spawn()?;
+
+    // Timeline on which the images are distributed.
+    let times = (0..20).collect::<Vec<i64>>();
+
+    // Create a batch of images with a moving rectangle.
+    let width = 300;
+    let height = 200;
+    let mut images = Array::<u8, _>::zeros((times.len(), height, width, 3).f())
+        .as_standard_layout() // Make sure the data is layed out as we expect it.
+        .into_owned();
+    images.slice_mut(s![.., .., .., 2]).fill(255);
+    for &t in &times {
+        let t = t as usize;
+        images
+            .slice_mut(s![t, 50..150, (t * 10)..(t * 10 + 100), 1])
+            .fill(255);
+    }
+
+    // Log the ImageFormat and indicator once, as static.
+    let format = rerun::components::ImageFormat::from(rerun::datatypes::ImageFormat {
+        width: width as _,
+        height: height as _,
+        pixel_format: None,
+        color_model: Some(rerun::datatypes::ColorModel::RGB),
+        channel_datatype: Some(rerun::datatypes::ChannelDatatype::U8),
+    });
+    rec.log_component_batches(
+        "images",
+        false, // TODO: static=true,
+        [&format as _, &rerun::Image::indicator() as _],
+    )?;
+
+    // Split up the image data into several components referencing the underlying data.
+    let image_size_in_bytes = width * height * 3;
+    let blob = rerun::datatypes::Blob::from(images.into_raw_vec());
+    let image_column = times
+        .iter()
+        .map(|&t| {
+            let byte_offset = image_size_in_bytes * (t as usize);
+            rerun::components::ImageBuffer::from(
+                blob.clone() // Clone is only a reference count increase, not a full copy.
+                    .sliced(byte_offset..(byte_offset + image_size_in_bytes)),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    // Send all images at once.
+    let timeline_values = rerun::TimeColumn::new_sequence("step", times);
+    rec.send_columns("images", [timeline_values], [&image_column as _])?;
+
+    Ok(())
+}

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -22,13 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Log the ImageFormat and indicator once, as static.
-    let format = rerun::components::ImageFormat::from(rerun::datatypes::ImageFormat {
-        width: width as _,
-        height: height as _,
-        pixel_format: None,
-        color_model: Some(rerun::datatypes::ColorModel::RGB),
-        channel_datatype: Some(rerun::datatypes::ChannelDatatype::U8),
-    });
+    let format = rerun::components::ImageFormat::rgb8([width as _, height as _]);
     rec.log_component_batches(
         "images",
         true,

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -172,6 +172,11 @@ quick_start = [ # These examples don't have exactly the same implementation.
   "py",
   "rust",
 ]
+"archetypes/image_send_columns" = [ # This mixes `log` and `send_columns`. Since `log` is suspect to delays by the batcher, this test gets flaky.
+  "cpp",
+  "py",
+  "rust",
+]
 "archetypes/mesh3d_instancing" = [ # TODO(#3235): Slight floating point differences in deg to rad conversion.
   "cpp",
   "py",

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -107,11 +107,7 @@ namespace rerun::archetypes {
     ///         rerun::ColorModel::RGB,
     ///         rerun::ChannelDatatype::U8
     ///     );
-    ///     rec.log(
-    ///         "images",
-    ///         rerun::borrow(&format, 1),
-    ///         rerun::Image::IndicatorComponent()
-    ///     ); // TODO: make static
+    ///     rec.log_static("images", rerun::borrow(&format, 1), rerun::Image::IndicatorComponent());
     ///
     ///     // Split up the image data into several components referencing the underlying data.
     ///     const size_t image_size_in_bytes = width * height * 3;

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -38,7 +38,7 @@ namespace rerun::archetypes {
     /// data can be passed in without a copy from raw pointers or by reference from `std::vector`/`std::array`/c-arrays.
     /// If needed, this "borrow-behavior" can be extended by defining your own `rerun::CollectionAdapter`.
     ///
-    /// ## Example
+    /// ## Examples
     ///
     /// ### image_simple:
     /// ![image](https://static.rerun.io/image_simple/06ba7f8582acc1ffb42a7fd0006fad7816f3e4e4/full.png)
@@ -68,6 +68,64 @@ namespace rerun::archetypes {
     ///     }
     ///
     ///     rec.log("image", rerun::Image::from_rgb24(data, {WIDTH, HEIGHT}));
+    /// }
+    /// ```
+    ///
+    /// ### image_send_columns:
+    /// ![example image](Advanced usage of `send_columns` to send multiple images at once)
+    ///
+    /// ```cpp
+    /// #include <numeric>
+    /// #include <rerun.hpp>
+    ///
+    /// int main() {
+    ///     auto rec = rerun::RecordingStream("rerun_example_image_send_columns");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     // Timeline on which the images are distributed.
+    ///     std::vector<int64_t> times(20);
+    ///     std::iota(times.begin(), times.end(), 0);
+    ///
+    ///     // Create a batch of images with a moving rectangle.
+    ///     const size_t width = 300, height = 200;
+    ///     std::vector<uint8_t> images(times.size() * height * width * 3, 0);
+    ///     for (size_t t = 0; t <times.size(); ++t) {
+    ///         for (size_t y = 0; y <height; ++y) {
+    ///             for (size_t x = 0; x <width; ++x) {
+    ///                 size_t idx = (t * height * width + y * width + x) * 3;
+    ///                 images[idx + 2] = 255; // Blue background
+    ///                 if (y>= 50 && y <150 && x>= t * 10 && x <t * 10 + 100) {
+    ///                     images[idx + 1] = 255; // Turkoise rectangle
+    ///                 }
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     // Log the ImageFormat and indicator once, as static.
+    ///     auto format = rerun::components::ImageFormat(
+    ///         {width, height},
+    ///         rerun::ColorModel::RGB,
+    ///         rerun::ChannelDatatype::U8
+    ///     );
+    ///     rec.log(
+    ///         "images",
+    ///         rerun::borrow(&format, 1),
+    ///         rerun::Image::IndicatorComponent()
+    ///     ); // TODO: make static
+    ///
+    ///     // Split up the image data into several components referencing the underlying data.
+    ///     const size_t image_size_in_bytes = width * height * 3;
+    ///     std::vector<rerun::components::ImageBuffer> image_data(times.size());
+    ///     for (size_t i = 0; i <times.size(); ++i) {
+    ///         image_data[i] = rerun::borrow(images.data() + i * image_size_in_bytes, image_size_in_bytes);
+    ///     }
+    ///
+    ///     // Send all images at once.
+    ///     rec.send_columns(
+    ///         "images",
+    ///         rerun::TimeColumn::from_sequence_points("step", std::move(times)),
+    ///         rerun::borrow(image_data)
+    ///     );
     /// }
     /// ```
     struct Image {

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -95,7 +95,7 @@ namespace rerun::archetypes {
     ///                 size_t idx = (t * height * width + y * width + x) * 3;
     ///                 images[idx + 2] = 255; // Blue background
     ///                 if (y>= 50 && y <150 && x>= t * 10 && x <t * 10 + 100) {
-    ///                     images[idx + 1] = 255; // Turkoise rectangle
+    ///                     images[idx + 1] = 255; // Turquoise rectangle
     ///                 }
     ///             }
     ///         }

--- a/rerun_cpp/src/rerun/archetypes/image.hpp
+++ b/rerun_cpp/src/rerun/archetypes/image.hpp
@@ -107,7 +107,7 @@ namespace rerun::archetypes {
     ///         rerun::ColorModel::RGB,
     ///         rerun::ChannelDatatype::U8
     ///     );
-    ///     rec.log_static("images", rerun::borrow(&format, 1), rerun::Image::IndicatorComponent());
+    ///     rec.log_static("images", rerun::borrow(&format), rerun::Image::IndicatorComponent());
     ///
     ///     // Split up the image data into several components referencing the underlying data.
     ///     const size_t image_size_in_bytes = width * height * 3;

--- a/rerun_cpp/src/rerun/collection.hpp
+++ b/rerun_cpp/src/rerun/collection.hpp
@@ -148,7 +148,7 @@ namespace rerun {
         /// Since `rerun::Collection` does not provide write access, data is guaranteed to be unchanged by
         /// any function or operation taking on a `Collection`.
         template <typename T>
-        static Collection<TElement> borrow(const T* data, size_t num_instances) {
+        static Collection<TElement> borrow(const T* data, size_t num_instances = 1) {
             static_assert(
                 sizeof(T) == sizeof(TElement),
                 "T & TElement are not binary compatible: Size mismatch."
@@ -175,7 +175,7 @@ namespace rerun {
         ///
         /// Since `rerun::Collection` does not provide write access, data is guaranteed to be unchanged by
         /// any function or operation taking on a `rerun::Collection`.
-        static Collection borrow(const void* data, size_t num_instances) {
+        static Collection borrow(const void* data, size_t num_instances = 1) {
             return borrow(reinterpret_cast<const TElement*>(data), num_instances);
         }
 
@@ -422,7 +422,7 @@ namespace rerun {
     /// Since `rerun::Collection` does not provide write access, data is guaranteed to be unchanged by
     /// any function or operation taking on a `Collection`.
     template <typename TElement>
-    inline Collection<TElement> borrow(const TElement* data, size_t num_instances) {
+    inline Collection<TElement> borrow(const TElement* data, size_t num_instances = 1) {
         return Collection<TElement>::borrow(data, num_instances);
     }
 

--- a/rerun_cpp/src/rerun/components/image_format.hpp
+++ b/rerun_cpp/src/rerun/components/image_format.hpp
@@ -14,6 +14,23 @@ namespace rerun::components {
     struct ImageFormat {
         rerun::datatypes::ImageFormat image_format;
 
+      public: // START of extensions from image_format_ext.cpp:
+        /// From a specific pixel format.
+        ImageFormat(rerun::WidthHeight resolution, datatypes::PixelFormat pixel_format)
+            : image_format(resolution, pixel_format) {}
+
+        /// Create a new image format for depth or segmentation images with the given resolution and datatype.
+        ImageFormat(rerun::WidthHeight resolution, datatypes::ChannelDatatype datatype)
+            : image_format(resolution, datatype) {}
+
+        ImageFormat(
+            rerun::WidthHeight resolution, datatypes::ColorModel color_model,
+            datatypes::ChannelDatatype datatype
+        )
+            : image_format(resolution, color_model, datatype) {}
+
+        // END of extensions from image_format_ext.cpp, start of generated code:
+
       public:
         ImageFormat() = default;
 

--- a/rerun_cpp/src/rerun/components/image_format_ext.cpp
+++ b/rerun_cpp/src/rerun/components/image_format_ext.cpp
@@ -1,0 +1,23 @@
+#if 0
+
+namespace rerun::components {
+    // <CODEGEN_COPY_TO_HEADER>
+
+    /// From a specific pixel format.
+    ImageFormat(rerun::WidthHeight resolution, datatypes::PixelFormat pixel_format)
+        : image_format(resolution, pixel_format) {}
+
+    /// Create a new image format for depth or segmentation images with the given resolution and datatype.
+    ImageFormat(rerun::WidthHeight resolution, datatypes::ChannelDatatype datatype)
+        : image_format(resolution, datatype) {}
+
+    ImageFormat(
+        rerun::WidthHeight resolution, datatypes::ColorModel color_model,
+        datatypes::ChannelDatatype datatype
+    )
+        : image_format(resolution, color_model, datatype) {}
+
+    // </CODEGEN_COPY_TO_HEADER>
+} // namespace rerun::components
+
+#endif

--- a/rerun_py/rerun_sdk/rerun/archetypes/image.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image.py
@@ -78,7 +78,7 @@ class Image(ImageExt, Archetype):
 
     # Log the ImageFormat and indicator once, as static.
     format_static = rr.components.ImageFormat(width=width, height=height, color_model="RGB", channel_datatype="U8")
-    rr.log("images", [format_static, rr.Image.indicator()])  # TODO:, static=True)
+    rr.log("images", [format_static, rr.Image.indicator()], static=True)
 
     # Send all images at once.
     rr.send_columns(


### PR DESCRIPTION
### What

* New `send_columns` snippets for image, demonstrating to send several images at once efficiently
* C++ convenience methods for image format component
* Rust slicing of blobs
* Rust `send_columns` no longer assumes that an encountered `ListArray` is already the list array for the column
    * this broke any `send_columns` call for any component batch that's internally a list array 

Unfortunately, the snippet isn't fully deterministic and can't be compared cross language since the due to the batcher on `log` calls, log may arrive before or after `send_columns`

https://github.com/user-attachments/assets/c9af069e-cd64-40c5-b543-54055bea3e42


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7172?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7172?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7172)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.