### PR TITLE
Fix some component UI

### DIFF
--- a/crates/viewer/re_edit_ui/src/datatype_editors/enum_combobox.rs
+++ b/crates/viewer/re_edit_ui/src/datatype_editors/enum_combobox.rs
@@ -48,7 +48,7 @@ fn edit_view_enum_impl<EnumT: re_types_core::reflection::Enum>(
 
         response_with_changes_of_inner(combobox_response)
     } else {
-        ui.label(current_value.to_string())
+        ui.add(egui::Label::new(current_value.to_string()).truncate())
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/colormap.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/colormap.rs
@@ -1,5 +1,5 @@
 use re_types::reflection::Enum as _;
-use re_ui::{list_item, UiExt};
+use re_ui::list_item;
 
 use crate::{
     gpu_bridge::{get_or_create_texture, render_image},
@@ -136,18 +136,21 @@ pub fn colormap_edit_or_view_ui(
         inner_response.response
     } else {
         let map: re_types::components::Colormap = **map;
-        if let Some(render_ctx) = ctx.render_ctx {
-            ui.list_item_flat_noninteractive(
-                list_item::PropertyContent::new(map.to_string())
-                    .min_desired_width(MIN_WIDTH)
-                    .value_fn(|ui, _| {
-                        if let Err(err) = colormap_preview_ui(render_ctx, ui, map) {
-                            re_log::error_once!("Failed to paint colormap preview: {err}");
-                        }
-                    }),
-            )
+        let colormap_response = if let Some(render_ctx) = ctx.render_ctx {
+            let result = colormap_preview_ui(render_ctx, ui, map);
+            if let Err(err) = &result {
+                re_log::error_once!("Failed to paint colormap preview: {err}");
+            }
+            result.ok()
         } else {
-            ui.list_item_flat_noninteractive(list_item::LabelContent::new(map.to_string()))
+            None
+        };
+
+        let label_response = ui.add(egui::Label::new(map.to_string()).truncate());
+
+        match colormap_response {
+            Some(colormap_response) => colormap_response | label_response,
+            None => label_response,
         }
     }
 }


### PR DESCRIPTION
### What

This PR fixes the UI for enum components and `Colormap`, which was broken by #7171

<img width="486" alt="image" src="https://github.com/user-attachments/assets/e86b22e7-01a7-40f5-b744-940e52b443e4">

<br/><br/>

Note/PSA: we still have a bunch of components that are not truncating correctly, but most have quite narrow UI, so we can live with it for bit.

<img width="291" alt="image" src="https://github.com/user-attachments/assets/00c38da5-e7f6-42b3-94c0-f6ebc8af4551">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7174?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7174?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7174)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.