### PR TITLE
Fix 2D objects in 3D affecting bounding box and thus causing flickering of automatic pinhole plane distance

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
+++ b/crates/viewer/re_space_view_spatial/src/scene_bounding_boxes.rs
@@ -3,7 +3,7 @@ use nohash_hasher::IntMap;
 use re_log_types::EntityPathHash;
 use re_viewer_context::VisualizerCollection;
 
-use crate::visualizers::SpatialViewVisualizerData;
+use crate::{view_kind::SpatialSpaceViewKind, visualizers::SpatialViewVisualizerData};
 
 #[derive(Clone)]
 pub struct SceneBoundingBoxes {
@@ -30,7 +30,12 @@ impl Default for SceneBoundingBoxes {
 }
 
 impl SceneBoundingBoxes {
-    pub fn update(&mut self, ui: &egui::Ui, visualizers: &VisualizerCollection) {
+    pub fn update(
+        &mut self,
+        ui: &egui::Ui,
+        visualizers: &VisualizerCollection,
+        space_kind: SpatialSpaceViewKind,
+    ) {
         re_tracing::profile_function!();
 
         let previous = self.current;
@@ -42,6 +47,17 @@ impl SceneBoundingBoxes {
                 .data()
                 .and_then(|d| d.downcast_ref::<SpatialViewVisualizerData>())
             {
+                // If we're in a 3D space, but the visualizer is distintivly 2D, don't count it towards the bounding box.
+                // These visualizers show up when we're on a pinhole camera plane which itself is heuristically fed by the
+                // bounding box, creating a feedback loop if we were to add it here.
+                if space_kind == SpatialSpaceViewKind::ThreeD
+                    && data
+                        .preferred_view_kind
+                        .map_or(true, |kind| kind != space_kind)
+                {
+                    continue;
+                }
+
                 for (entity, bbox) in &data.bounding_boxes {
                     self.per_entity
                         .entry(*entity)

--- a/crates/viewer/re_space_view_spatial/src/ui.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui.rs
@@ -97,10 +97,12 @@ impl SpatialSpaceViewState {
         &mut self,
         ui: &egui::Ui,
         system_output: &re_viewer_context::SystemExecutionOutput,
+        space_kind: SpatialSpaceViewKind,
     ) -> Result<(), SpaceViewSystemExecutionError> {
         re_tracing::profile_function!();
 
-        self.bounding_boxes.update(ui, &system_output.view_systems);
+        self.bounding_boxes
+            .update(ui, &system_output.view_systems, space_kind);
 
         let view_systems = &system_output.view_systems;
 

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -264,7 +264,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         re_tracing::profile_function!();
 
         let state = state.downcast_mut::<SpatialSpaceViewState>()?;
-        state.update_frame_statistics(ui, &system_output)?;
+        state.update_frame_statistics(ui, &system_output, SpatialSpaceViewKind::TwoD)?;
 
         self.view_2d(ctx, ui, state, query, system_output)
     }

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -437,7 +437,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         re_tracing::profile_function!();
 
         let state = state.downcast_mut::<SpatialSpaceViewState>()?;
-        state.update_frame_statistics(ui, &system_output)?;
+        state.update_frame_statistics(ui, &system_output, SpatialSpaceViewKind::ThreeD)?;
 
         self.view_3d(ctx, ui, state, query, system_output)
     }


### PR DESCRIPTION
### What

If you have only a pinhole camera with some 2D objects in your scene, the viewer wasn't able to decide where to place that pinhole because the only source of bounding box information were those projected 2d elements.

We now simply ignore 2d visualizers when putting together the scene bounding box - since a little while this is a separate step that combines bounding boxes per entity per visualizer, making this pretty easy!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
