### PR TITLE
Make the recordings panel resizable

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -392,13 +392,21 @@ impl AppState {
                 // before drawing the blueprint panel.
                 ui.spacing_mut().item_spacing.y = 0.0;
 
-                let pre_cursor = ui.cursor();
-                recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
-                let any_recording_shows = pre_cursor == ui.cursor();
+                egui::TopBottomPanel::top("recording_panel")
+                    .frame(egui::Frame::none())
+                    .resizable(true)
+                    .min_height(90.0)
+                    .default_height(210.0)
+                    .max_height(ui.available_height() - 90.0) // Leave space for blueprint panel
+                    .show_inside(ui, |ui| {
+                        let pre_cursor = ui.cursor();
+                        recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
+                        let any_recording_shows = pre_cursor == ui.cursor();
 
-                if any_recording_shows {
-                    ui.add_space(4.0);
-                }
+                        if any_recording_shows {
+                            ui.add_space(4.0);
+                        }
+                    });
 
                 if !show_welcome {
                     blueprint_tree.show(&ctx, &viewport_blueprint, ui);

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -1,4 +1,5 @@
 use ahash::HashMap;
+use egui::NumExt as _;
 
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
@@ -392,21 +393,26 @@ impl AppState {
                 // before drawing the blueprint panel.
                 ui.spacing_mut().item_spacing.y = 0.0;
 
-                egui::TopBottomPanel::top("recording_panel")
-                    .frame(egui::Frame::none())
-                    .resizable(true)
-                    .min_height(90.0)
-                    .default_height(210.0)
-                    .max_height(ui.available_height() - 90.0) // Leave space for blueprint panel
-                    .show_inside(ui, |ui| {
-                        let pre_cursor = ui.cursor();
-                        recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
-                        let any_recording_shows = pre_cursor == ui.cursor();
+                let resizable = ctx.store_context.bundle.recordings().count() > 3;
 
-                        if any_recording_shows {
-                            ui.add_space(4.0);
-                        }
-                    });
+                if resizable {
+                    // Don't shrink either recordings panel or blueprint panel below this height
+                    let min_height_each = 90.0_f32.at_most(ui.available_height() / 2.0);
+
+                    egui::TopBottomPanel::top("recording_panel")
+                        .frame(egui::Frame::none())
+                        .resizable(resizable)
+                        .min_height(min_height_each)
+                        .default_height(210.0)
+                        .max_height(ui.available_height() - min_height_each)
+                        .show_inside(ui, |ui| {
+                            recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
+                        });
+                } else {
+                    recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
+                }
+
+                ui.add_space(4.0);
 
                 if !show_welcome {
                     blueprint_tree.show(&ctx, &viewport_blueprint, ui);

--- a/crates/viewer/re_viewer/src/ui/recordings_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/recordings_panel.rs
@@ -34,7 +34,6 @@ pub fn recordings_panel_ui(
     egui::ScrollArea::both()
         .id_source("recordings_scroll_area")
         .auto_shrink([false, true])
-        .max_height(300.)
         .show(ui, |ui| {
             ui.panel_content(|ui| {
                 re_ui::list_item::list_item_scope(ui, "recording panel", |ui| {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/3421

![resizable-panel](https://github.com/user-attachments/assets/7615c653-bea3-4326-a739-82d189b673df)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7180?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7180?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7180)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.