### PR TITLE
Handle compaction events in latest-at cache subscriber

### DIFF
--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use re_chunk::Chunk;
 use re_log_types::StoreId;
@@ -120,14 +120,14 @@ pub struct ChunkStoreDiff {
     // deallocated.
     pub chunk: Arc<Chunk>,
 
-    /// Reports which [`ChunkId`]s were merged into a new [`ChunkId`] (srcs, dst) during a compaction.
+    /// Reports which [`Chunk`]s were merged into a new [`ChunkId`] (srcs, dst) during a compaction.
     ///
     /// This is only specified if an addition to the store triggered a compaction.
     /// When that happens, it is guaranteed that [`ChunkStoreDiff::chunk`] will be present in the
     /// set of source chunks below, since it was compacted on arrival.
     ///
     /// A corollary to that is that the destination [`ChunkId`] must have never been seen before.
-    pub compacted: Option<(BTreeSet<ChunkId>, ChunkId)>,
+    pub compacted: Option<(BTreeMap<ChunkId, Arc<Chunk>>, ChunkId)>,
 }
 
 impl PartialEq for ChunkStoreDiff {
@@ -146,7 +146,10 @@ impl Eq for ChunkStoreDiff {}
 
 impl ChunkStoreDiff {
     #[inline]
-    pub fn addition(chunk: Arc<Chunk>, compacted: Option<(BTreeSet<ChunkId>, ChunkId)>) -> Self {
+    pub fn addition(
+        chunk: Arc<Chunk>,
+        compacted: Option<(BTreeMap<ChunkId, Arc<Chunk>>, ChunkId)>,
+    ) -> Self {
         Self {
             kind: ChunkStoreDiffKind::Addition,
             chunk,

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -241,12 +241,12 @@ impl ChunkStore {
             );
             if let Some(elected_chunk) = &elected_chunk {
                 // NOTE: The chunk that we've just added has been compacted already!
-                let srcs = std::iter::once(non_compacted_chunk.id())
+                let srcs = std::iter::once((non_compacted_chunk.id(), non_compacted_chunk))
                     .chain(
                         self.remove_chunk(elected_chunk.id())
                             .into_iter()
                             .filter(|diff| diff.kind == crate::ChunkStoreDiffKind::Deletion)
-                            .map(|diff| diff.chunk.id()),
+                            .map(|diff| (diff.chunk.id(), diff.chunk)),
                     )
                     .collect();
                 let dst = chunk_or_compacted.id();

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -236,7 +236,7 @@ impl ChunkStoreSubscriber for Caches {
                         compacted_events.extend(
                             compacted
                                 .iter()
-                                .flat_map(|(compacted_chunk_ids, _)| compacted_chunk_ids),
+                                .flat_map(|(compacted_chunks, _)| compacted_chunks.keys().copied()),
                         );
                     }
                 }
@@ -260,11 +260,9 @@ impl ChunkStoreSubscriber for Caches {
 
                             compacted_events.insert(chunk.id());
                             // If a compaction was triggered, make sure to drop the original chunks too.
-                            compacted_events.extend(
-                                compacted
-                                    .iter()
-                                    .flat_map(|(compacted_chunk_ids, _)| compacted_chunk_ids),
-                            );
+                            compacted_events.extend(compacted.iter().flat_map(
+                                |(compacted_chunks, _)| compacted_chunks.keys().copied(),
+                            ));
                         }
                     }
                 }


### PR DESCRIPTION
This is the exact same thing as #7161, except it's for latest-at (and requires a bit more care, because latest-at is weird).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7161?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7161?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7161)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.