### PR TITLE
Deal with invalidation parallelism-induced memleak

### DIFF
--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -119,7 +119,7 @@ impl std::fmt::Debug for Caches {
                 let cache = cache.read();
                 strings.push(format!(
                     "  [{cache_key:?} (pending_invalidation_min={:?})]",
-                    cache.pending_invalidation.map(|t| cache_key
+                    cache.pending_invalidations.first().map(|&t| cache_key
                         .timeline
                         .format_time_range_utc(&ResolvedTimeRange::new(t, TimeInt::MAX))),
                 ));
@@ -310,7 +310,7 @@ impl ChunkStoreSubscriber for Caches {
 
                 for (key, cache) in caches_latest_at.iter() {
                     if key.entity_path == entity_path && key.component_name == component_name {
-                        cache.write().pending_invalidation = Some(TimeInt::STATIC);
+                        cache.write().pending_invalidations.insert(TimeInt::STATIC);
                     }
                 }
 
@@ -335,7 +335,7 @@ impl ChunkStoreSubscriber for Caches {
 
                 if let Some(cache) = caches_latest_at.get(&key) {
                     let mut cache = cache.write();
-                    cache.pending_invalidation = Some(time);
+                    cache.pending_invalidations.insert(time);
                 }
             }
 


### PR DESCRIPTION
This is just a port of the [exact same fix that was implemented in the old cache](https://github.com/rerun-io/rerun/blob/d65ca5003c8a15001156750ad3b1361637901a79/crates/re_query/src/latest_at/query.rs#L275-L315), adapted for chunks.

And with that, we are now leak free for both long-running latest and range workloads!

Long running `face_tracking` (latest-at):
![image](https://github.com/user-attachments/assets/d8089375-c457-44bb-83eb-6e2d1bbe77db)

Long running `plot_dashboard_stress` (range):
![image](https://github.com/user-attachments/assets/4d164a4f-26a1-4da9-b54a-a6ddaa377bc1)


- DNM: requires https://github.com/rerun-io/rerun/pull/7181

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7182?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7182?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7182)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.