### PR TITLE
Add columnar APIs to the Python docs

### DIFF
--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -113,6 +113,17 @@ SECTION_TABLE: Final[list[Section]] = [
             "reset_time",
         ],
     ),
+    Section(
+        title="Columnar API",
+        func_list=[
+            "send_columns",
+        ],
+        class_list=[
+            "TimeNanosColumn",
+            "TimeSecondsColumn",
+            "TimeSequenceColumn",
+        ],
+    ),
     ################################################################################
     # These sections don't have tables, but generate pages containing all the archetypes, components, datatypes
     Section(

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -37,6 +37,12 @@ from ._log import (
     log_file_from_path as log_file_from_path,
     new_entity_path as new_entity_path,
 )
+from ._send_columns import (
+    TimeNanosColumn as TimeNanosColumn,
+    TimeSecondsColumn as TimeSecondsColumn,
+    TimeSequenceColumn as TimeSequenceColumn,
+    send_columns as send_columns,
+)
 from .any_value import (
     AnyValues as AnyValues,
 )
@@ -138,12 +144,6 @@ from .script_helpers import (
     script_add_args as script_add_args,
     script_setup as script_setup,
     script_teardown as script_teardown,
-)
-from .send_columns import (
-    TimeNanosColumn as TimeNanosColumn,
-    TimeSecondsColumn as TimeSecondsColumn,
-    TimeSequenceColumn as TimeSequenceColumn,
-    send_columns as send_columns,
 )
 from .sinks import (
     connect as connect,

--- a/rerun_py/rerun_sdk/rerun/_send_columns.py
+++ b/rerun_py/rerun_sdk/rerun/_send_columns.py
@@ -27,14 +27,26 @@ class TimeSequenceColumn(TimeColumnLike):
     """
     A column of time values that are represented as an integer sequence.
 
-    Equivalent to `rr.set_time_sequence`.
+    Columnar equivalent to [rr.set_time_sequence][rerun.set_time_sequence].
     """
 
     def __init__(self, timeline: str, times: Iterable[int]):
+        """
+        Create a column of integer sequence time values.
+
+        Parameters
+        ----------
+        timeline:
+            The name of the timeline.
+        times:
+            An iterable of integer time values.
+
+        """
         self.timeline = timeline
         self.times = times
 
     def timeline_name(self) -> str:
+        """Returns the name of the timeline."""
         return self.timeline
 
     def as_arrow_array(self) -> pa.Array:
@@ -43,16 +55,28 @@ class TimeSequenceColumn(TimeColumnLike):
 
 class TimeSecondsColumn(TimeColumnLike):
     """
-    A column of time values that are represented as an floating point seconds.
+    A column of time values that are represented as floating point seconds.
 
-    Equivalent to `rr.set_time_seconds`.
+    Columnar equivalent to [rr.set_time_seconds][rerun.set_time_seconds].
     """
 
     def __init__(self, timeline: str, times: Iterable[float]):
+        """
+        Create a column of floating point seconds time values.
+
+        Parameters
+        ----------
+        timeline:
+            The name of the timeline.
+        times:
+            An iterable of floating point second time values.
+
+        """
         self.timeline = timeline
         self.times = times
 
     def timeline_name(self) -> str:
+        """Returns the name of the timeline."""
         return self.timeline
 
     def as_arrow_array(self) -> pa.Array:
@@ -61,16 +85,28 @@ class TimeSecondsColumn(TimeColumnLike):
 
 class TimeNanosColumn(TimeColumnLike):
     """
-    A column of time values that are represented as an integer nanoseconds.
+    A column of time values that are represented as integer nanoseconds.
 
-    Equivalent to `rr.set_time_nanos`.
+    Columnar equivalent to [rr.set_time_nanos][rerun.set_time_nanos].
     """
 
     def __init__(self, timeline: str, times: Iterable[int]):
+        """
+        Create a column of integer nanoseconds time values.
+
+        Parameters
+        ----------
+        timeline:
+            The name of the timeline.
+        times:
+            An iterable of integer nanosecond time values.
+
+        """
         self.timeline = timeline
         self.times = times
 
     def timeline_name(self) -> str:
+        """Returns the name of the timeline."""
         return self.timeline
 
     def as_arrow_array(self) -> pa.Array:
@@ -89,7 +125,7 @@ def send_columns(
     strict: bool | None = None,
 ) -> None:
     r"""
-    Directly log a columns of data to Rerun.
+    Send columnar data to Rerun.
 
     Unlike the regular `log` API, which is row-oriented, this API lets you submit the data
     in a columnar form. Each `TimeColumnLike` and `ComponentColumnLike` object represents a column


### PR DESCRIPTION
### What

This PR adds the columnar API to the python docs.

I had to rename the `send_columns.py` file to `_send_columns.py`, because:
- `rerun.send_columns` is ambiguous (is that the submodule or the function that `__init__.py` re-exports?
- mkdocs is thus confused
- all such module (aka whose content is reexported in the top `rerun` namespace) should be named as private (leading `_`)

Also added/modified a few docstrings to make the docs nicer.

<img width="718" alt="image" src="https://github.com/user-attachments/assets/eaa86d58-a19d-49ea-95c9-1d4bc1a23223">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
