### PR TITLE
Fix `MarkerSize` handling

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -165,6 +165,9 @@ impl SeriesPointSystem {
             value: 0.0,
             attrs: PlotPointAttrs {
                 color: fallback_color.into(),
+                // NOTE: arguably, the `MarkerSize` value should be twice the `radius_ui`. We do
+                // stick to the semantics of `MarkerSize` == radius for backward compatibility and
+                // because markers need a decent radius value to be at all legible.
                 radius_ui: **fallback_size,
                 kind: PlotSeriesKind::Scatter(ScatterAttrs {
                     marker: fallback_shape,
@@ -343,7 +346,8 @@ impl SeriesPointSystem {
                         if let Some(marker_size) = marker_size {
                             points
                                 .iter_mut()
-                                .for_each(|p| p.attrs.radius_ui = marker_size * 0.5);
+                                // `marker_size` is a radius, see NOTE above
+                                .for_each(|p| p.attrs.radius_ui = marker_size);
                         }
                     } else {
                         re_tracing::profile_scope!("standard path");
@@ -364,7 +368,8 @@ impl SeriesPointSystem {
                             if let Some(marker_size) =
                                 marker_sizes.and_then(|marker_sizes| marker_sizes.first().copied())
                             {
-                                points[i].attrs.radius_ui = marker_size * 0.5;
+                                // `marker_size` is a radius, see NOTE above
+                                points[i].attrs.radius_ui = marker_size;
                             }
                         });
                     }


### PR DESCRIPTION
### What

Fix a bug where `MarkerSize` would lead to differently sized marker depending on if the value came from the fallback or an override.

In fixing that, we also decide that `MarkerSize` is interpreted as a radius, for backward compatibility and because markers need to be big for legibility.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7186?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7186?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7186)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.