### PR TITLE
Fix fallback for Pinhole resolution

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_2d.rs
@@ -177,7 +177,7 @@ impl SpatialSpaceView2D {
         // necessary to properly handle overrides, defaults, or fallbacks. We don't actually use the image_plane_distance
         // so it doesnt technically matter.
         state.pinhole_at_origin =
-            query_pinhole_legacy(ctx.recording(), &ctx.current_query(), query.space_origin);
+            query_pinhole_legacy(ctx, &ctx.current_query(), query.space_origin);
 
         let (mut response, painter) =
             ui.allocate_painter(ui.available_size(), egui::Sense::click_and_drag());

--- a/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -143,7 +143,7 @@ impl DepthImageVisualizer {
         re_tracing::profile_function!();
 
         let Some(intrinsics) = query_pinhole_legacy(
-            ctx.recording(),
+            ctx.viewer_ctx,
             ctx.query,
             &twod_in_threed_info.parent_pinhole,
         ) else {


### PR DESCRIPTION
### What
* We regressed https://github.com/rerun-io/rerun/issues/3852 during Tensor -> Image migration

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7187?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7187?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7187)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.