### PR TITLE
Use an ImageBuffer/ImageFormat for Mesh3D albedo texture

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/mesh3d.fbs
@@ -49,7 +49,10 @@ table Mesh3D (
   ///
   /// Currently supports only sRGB(A) textures, ignoring alpha.
   /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
-  albedo_texture: rerun.components.TensorData ("attr.rerun.component_optional", nullable, order: 3400);
+  albedo_texture_buffer: rerun.components.ImageBuffer ("attr.rerun.component_optional", nullable, order: 3400);
+
+  /// The format of the `albedo_texture_buffer`, if any.
+  albedo_texture_format: rerun.components.ImageFormat ("attr.rerun.component_optional", nullable, order: 3450);
 
   /// Optional class Ids for the vertices.
   ///

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -131,6 +131,9 @@ pub struct Mesh3D {
     /// Optional albedo texture.
     ///
     /// Used with the [`components::Texcoord2D`][crate::components::Texcoord2D] of the mesh.
+    ///
+    /// Currently supports only sRGB(A) textures, ignoring alpha.
+    /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
     pub albedo_texture_buffer: Option<crate::components::ImageBuffer>,
 
     /// The format of the `albedo_texture_buffer`, if any.
@@ -495,6 +498,9 @@ impl Mesh3D {
     /// Optional albedo texture.
     ///
     /// Used with the [`components::Texcoord2D`][crate::components::Texcoord2D] of the mesh.
+    ///
+    /// Currently supports only sRGB(A) textures, ignoring alpha.
+    /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
     #[inline]
     pub fn with_albedo_texture_buffer(
         mut self,

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -131,10 +131,10 @@ pub struct Mesh3D {
     /// Optional albedo texture.
     ///
     /// Used with the [`components::Texcoord2D`][crate::components::Texcoord2D] of the mesh.
-    ///
-    /// Currently supports only sRGB(A) textures, ignoring alpha.
-    /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
-    pub albedo_texture: Option<crate::components::TensorData>,
+    pub albedo_texture_buffer: Option<crate::components::ImageBuffer>,
+
+    /// The format of the `albedo_texture_buffer`, if any.
+    pub albedo_texture_format: Option<crate::components::ImageFormat>,
 
     /// Optional class Ids for the vertices.
     ///
@@ -151,7 +151,8 @@ impl ::re_types_core::SizeBytes for Mesh3D {
             + self.vertex_colors.heap_size_bytes()
             + self.vertex_texcoords.heap_size_bytes()
             + self.albedo_factor.heap_size_bytes()
-            + self.albedo_texture.heap_size_bytes()
+            + self.albedo_texture_buffer.heap_size_bytes()
+            + self.albedo_texture_format.heap_size_bytes()
             + self.class_ids.heap_size_bytes()
     }
 
@@ -163,7 +164,8 @@ impl ::re_types_core::SizeBytes for Mesh3D {
             && <Option<Vec<crate::components::Color>>>::is_pod()
             && <Option<Vec<crate::components::Texcoord2D>>>::is_pod()
             && <Option<crate::components::AlbedoFactor>>::is_pod()
-            && <Option<crate::components::TensorData>>::is_pod()
+            && <Option<crate::components::ImageBuffer>>::is_pod()
+            && <Option<crate::components::ImageFormat>>::is_pod()
             && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }
@@ -180,18 +182,19 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Color".into(),
             "rerun.components.Texcoord2D".into(),
             "rerun.components.AlbedoFactor".into(),
-            "rerun.components.TensorData".into(),
+            "rerun.components.ImageBuffer".into(),
+            "rerun.components.ImageFormat".into(),
             "rerun.components.ClassId".into(),
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 10usize]> =
     once_cell::sync::Lazy::new(|| {
         [
             "rerun.components.Position3D".into(),
@@ -201,14 +204,15 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
             "rerun.components.Color".into(),
             "rerun.components.Texcoord2D".into(),
             "rerun.components.AlbedoFactor".into(),
-            "rerun.components.TensorData".into(),
+            "rerun.components.ImageBuffer".into(),
+            "rerun.components.ImageFormat".into(),
             "rerun.components.ClassId".into(),
         ]
     });
 
 impl Mesh3D {
-    /// The total number of components in the archetype: 1 required, 3 recommended, 5 optional
-    pub const NUM_COMPONENTS: usize = 9usize;
+    /// The total number of components in the archetype: 1 required, 3 recommended, 6 optional
+    pub const NUM_COMPONENTS: usize = 10usize;
 }
 
 /// Indicator component for the [`Mesh3D`] [`::re_types_core::Archetype`]
@@ -335,16 +339,26 @@ impl ::re_types_core::Archetype for Mesh3D {
         } else {
             None
         };
-        let albedo_texture = if let Some(array) = arrays_by_name.get("rerun.components.TensorData")
-        {
-            <crate::components::TensorData>::from_arrow_opt(&**array)
-                .with_context("rerun.archetypes.Mesh3D#albedo_texture")?
-                .into_iter()
-                .next()
-                .flatten()
-        } else {
-            None
-        };
+        let albedo_texture_buffer =
+            if let Some(array) = arrays_by_name.get("rerun.components.ImageBuffer") {
+                <crate::components::ImageBuffer>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.Mesh3D#albedo_texture_buffer")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+            } else {
+                None
+            };
+        let albedo_texture_format =
+            if let Some(array) = arrays_by_name.get("rerun.components.ImageFormat") {
+                <crate::components::ImageFormat>::from_arrow_opt(&**array)
+                    .with_context("rerun.archetypes.Mesh3D#albedo_texture_format")?
+                    .into_iter()
+                    .next()
+                    .flatten()
+            } else {
+                None
+            };
         let class_ids = if let Some(array) = arrays_by_name.get("rerun.components.ClassId") {
             Some({
                 <crate::components::ClassId>::from_arrow_opt(&**array)
@@ -364,7 +378,8 @@ impl ::re_types_core::Archetype for Mesh3D {
             vertex_colors,
             vertex_texcoords,
             albedo_factor,
-            albedo_texture,
+            albedo_texture_buffer,
+            albedo_texture_format,
             class_ids,
         })
     }
@@ -392,7 +407,10 @@ impl ::re_types_core::AsComponents for Mesh3D {
             self.albedo_factor
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.albedo_texture
+            self.albedo_texture_buffer
+                .as_ref()
+                .map(|comp| (comp as &dyn ComponentBatch).into()),
+            self.albedo_texture_format
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch).into()),
             self.class_ids
@@ -418,7 +436,8 @@ impl Mesh3D {
             vertex_colors: None,
             vertex_texcoords: None,
             albedo_factor: None,
-            albedo_texture: None,
+            albedo_texture_buffer: None,
+            albedo_texture_format: None,
             class_ids: None,
         }
     }
@@ -476,15 +495,22 @@ impl Mesh3D {
     /// Optional albedo texture.
     ///
     /// Used with the [`components::Texcoord2D`][crate::components::Texcoord2D] of the mesh.
-    ///
-    /// Currently supports only sRGB(A) textures, ignoring alpha.
-    /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
     #[inline]
-    pub fn with_albedo_texture(
+    pub fn with_albedo_texture_buffer(
         mut self,
-        albedo_texture: impl Into<crate::components::TensorData>,
+        albedo_texture_buffer: impl Into<crate::components::ImageBuffer>,
     ) -> Self {
-        self.albedo_texture = Some(albedo_texture.into());
+        self.albedo_texture_buffer = Some(albedo_texture_buffer.into());
+        self
+    }
+
+    /// The format of the `albedo_texture_buffer`, if any.
+    #[inline]
+    pub fn with_albedo_texture_format(
+        mut self,
+        albedo_texture_format: impl Into<crate::components::ImageFormat>,
+    ) -> Self {
+        self.albedo_texture_format = Some(albedo_texture_format.into());
         self
     }
 

--- a/crates/store/re_types/src/archetypes/mesh3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d_ext.rs
@@ -1,4 +1,8 @@
-use crate::{components::TriangleIndices, datatypes::UVec3D};
+use crate::{
+    archetypes,
+    components::{self, TriangleIndices},
+    datatypes::UVec3D,
+};
 
 use super::Mesh3D;
 
@@ -18,6 +22,22 @@ pub enum Mesh3DError {
 }
 
 impl Mesh3D {
+    /// Use this image as the albedo texture.
+    pub fn with_albedo_texture_image(self, image: archetypes::Image) -> Self {
+        self.with_albedo_texture_format(image.format)
+            .with_albedo_texture_buffer(image.buffer)
+    }
+
+    /// Use this image as the albedo texture.
+    pub fn with_albedo_texture(
+        self,
+        image_format: impl Into<components::ImageFormat>,
+        image_buffer: impl Into<components::ImageBuffer>,
+    ) -> Self {
+        self.with_albedo_texture_format(image_format)
+            .with_albedo_texture_buffer(image_buffer)
+    }
+
     /// Check that this is a valid mesh, e.g. that the vertex indices are within bounds
     /// and that we have the same number of positions and normals (if any).
     pub fn sanity_check(&self) -> Result<(), Mesh3DError> {

--- a/crates/store/re_types/src/archetypes/mesh3d_ext.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d_ext.rs
@@ -23,7 +23,8 @@ pub enum Mesh3DError {
 
 impl Mesh3D {
     /// Use this image as the albedo texture.
-    pub fn with_albedo_texture_image(self, image: archetypes::Image) -> Self {
+    pub fn with_albedo_texture_image(self, image: impl Into<archetypes::Image>) -> Self {
+        let image = image.into();
         self.with_albedo_texture_format(image.format)
             .with_albedo_texture_buffer(image.buffer)
     }

--- a/crates/store/re_types/src/tensor_data.rs
+++ b/crates/store/re_types/src/tensor_data.rs
@@ -3,14 +3,8 @@
 
 use half::f16;
 
-#[cfg(feature = "image")]
-use crate::datatypes::TensorDimension;
-
 #[allow(unused_imports)] // Used for docstring links
 use crate::datatypes::TensorData;
-
-// Much of the following duplicates code from: `crates/re_components/src/tensor.rs`, which
-// will eventually go away as the Tensor migration is completed.
 
 // ----------------------------------------------------------------------------
 
@@ -61,20 +55,6 @@ impl From<std::io::Error> for TensorImageLoadError {
     fn from(err: std::io::Error) -> Self {
         Self::ReadError(std::sync::Arc::new(err))
     }
-}
-
-/// Errors when converting [`TensorData`] to [`image`] images.
-#[cfg(feature = "image")]
-#[derive(thiserror::Error, Debug)]
-pub enum TensorImageSaveError {
-    #[error("Expected image-shaped tensor, got {0:?}")]
-    ShapeNotAnImage(Vec<TensorDimension>),
-
-    #[error("Cannot convert tensor with {0} channels and datatype {1} to an image")]
-    UnsupportedChannelsDtype(u64, TensorDataType),
-
-    #[error("The tensor data did not match tensor dimensions")]
-    BadData,
 }
 
 // ----------------------------------------------------------------------------

--- a/crates/store/re_types/tests/mesh3d.rs
+++ b/crates/store/re_types/tests/mesh3d.rs
@@ -3,26 +3,14 @@ use std::collections::HashMap;
 use re_types::{
     archetypes::Mesh3D,
     components::{ClassId, Position3D, Texcoord2D, TriangleIndices, Vector3D},
-    datatypes::{Rgba32, TensorBuffer, TensorData, TensorDimension, UVec3D, Vec2D, Vec3D},
+    datatypes::{Rgba32, UVec3D, Vec2D, Vec3D},
     Archetype as _, AsComponents as _,
 };
 
 #[test]
 fn roundtrip() {
-    let tensor_data: re_types::components::TensorData = TensorData {
-        shape: vec![
-            TensorDimension {
-                size: 2,
-                name: Some("height".into()),
-            },
-            TensorDimension {
-                size: 3,
-                name: Some("width".into()),
-            },
-        ],
-        buffer: TensorBuffer::U8(vec![1, 2, 3, 4, 5, 6].into()),
-    }
-    .into();
+    let texture_format = re_types::components::ImageFormat::rgb8([2, 3]);
+    let texture_buffer = re_types::components::ImageBuffer::from(vec![0x42_u8; 2 * 3 * 3]);
 
     let expected = Mesh3D {
         vertex_positions: vec![
@@ -46,7 +34,8 @@ fn roundtrip() {
             Texcoord2D(Vec2D([2.0, 3.0])), //
         ]),
         albedo_factor: Some(Rgba32::from_unmultiplied_rgba(0xEE, 0x11, 0x22, 0x33).into()),
-        albedo_texture: Some(tensor_data.clone()),
+        albedo_texture_format: Some(texture_format),
+        albedo_texture_buffer: Some(texture_buffer.clone()),
         class_ids: Some(vec![
             ClassId::from(126), //
             ClassId::from(127), //
@@ -60,7 +49,7 @@ fn roundtrip() {
         .with_vertex_texcoords([[0.0, 1.0], [2.0, 3.0]])
         .with_albedo_factor(0xEE112233)
         .with_class_ids([126, 127])
-        .with_albedo_texture(tensor_data);
+        .with_albedo_texture(texture_format, texture_buffer);
     similar_asserts::assert_eq!(expected, arch);
 
     let expected_extensions: HashMap<_, _> = [

--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -72,18 +72,10 @@ pub fn tensor_ui(
 
     if ui_layout.is_single_line() {
         ui.horizontal(|ui| {
-            let shape = match tensor.image_height_width_channels() {
-                Some([h, w, c]) => vec![
-                    TensorDimension::height(h),
-                    TensorDimension::width(w),
-                    TensorDimension::depth(c),
-                ],
-                None => tensor.shape.clone(),
-            };
             let text = format!(
                 "{}, {}",
                 tensor.dtype(),
-                format_tensor_shape_single_line(&shape)
+                format_tensor_shape_single_line(&tensor.shape)
             );
             ui_layout.label(ui, text).on_hover_ui(|ui| {
                 tensor_summary_ui(ui, tensor, &tensor_stats);

--- a/crates/viewer/re_renderer/shader/instanced_mesh.wgsl
+++ b/crates/viewer/re_renderer/shader/instanced_mesh.wgsl
@@ -64,7 +64,8 @@ fn vs_main(in_vertex: VertexIn, in_instance: InstanceIn) -> VertexOut {
 
 @fragment
 fn fs_main_shaded(in: VertexOut) -> @location(0) vec4f {
-    let albedo = textureSample(albedo_texture, trilinear_sampler, in.texcoord).rgb
+    let texture = linear_from_srgb(textureSample(albedo_texture, trilinear_sampler, in.texcoord).rgb);
+    let albedo = texture
                  * in.color.rgb
                  * material.albedo_factor.rgb
                  + in.additive_tint_rgb;

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -5,7 +5,8 @@ use re_renderer::RenderContext;
 use re_types::{
     archetypes::Mesh3D,
     components::{
-        AlbedoFactor, ClassId, Color, Position3D, TensorData, Texcoord2D, TriangleIndices, Vector3D,
+        AlbedoFactor, ClassId, Color, ImageBuffer, ImageFormat, Position3D, Texcoord2D,
+        TriangleIndices, Vector3D,
     },
     Loggable as _,
 };
@@ -50,7 +51,8 @@ struct Mesh3DComponentData<'a> {
 
     triangle_indices: Option<&'a [TriangleIndices]>,
     albedo_factor: Option<&'a AlbedoFactor>,
-    albedo_texture: Option<TensorData>,
+    albedo_buffer: Option<ImageBuffer>,
+    albedo_format: Option<ImageFormat>,
 
     class_ids: &'a [ClassId],
 }
@@ -106,8 +108,8 @@ impl Mesh3DVisualizer {
                             vertex_texcoords: (!vertex_texcoords.is_empty())
                                 .then_some(vertex_texcoords),
                             albedo_factor: data.albedo_factor.copied(),
-                            // NOTE: not actually cloning anything.
-                            albedo_texture: data.albedo_texture.clone(),
+                            albedo_texture_buffer: data.albedo_buffer.clone(), // shallow clone
+                            albedo_texture_format: data.albedo_format,
                             class_ids: (!data.class_ids.is_empty())
                                 .then(|| data.class_ids.to_owned()),
                         },
@@ -201,21 +203,21 @@ impl VisualizerSystem for Mesh3DVisualizer {
                 let all_vertex_texcoords = results.iter_as(timeline, Texcoord2D::name());
                 let all_triangle_indices = results.iter_as(timeline, TriangleIndices::name());
                 let all_albedo_factors = results.iter_as(timeline, AlbedoFactor::name());
-                // TODO(#6386): we have to deserialize here because `TensorData` is still a complex
-                // type at this point.
-                let all_albedo_textures = results.iter_as(timeline, TensorData::name());
+                let all_albedo_buffers = results.iter_as(timeline, ImageBuffer::name());
+                let all_albedo_formats = results.iter_as(timeline, ImageFormat::name());
                 let all_class_ids = results.iter_as(timeline, ClassId::name());
 
                 let query_result_hash = results.query_result_hash();
 
-                let data = re_query::range_zip_1x7(
+                let data = re_query::range_zip_1x8(
                     all_vertex_positions_indexed,
                     all_vertex_normals.primitive_array::<3, f32>(),
                     all_vertex_colors.primitive::<u32>(),
                     all_vertex_texcoords.primitive_array::<2, f32>(),
                     all_triangle_indices.primitive_array::<3, u32>(),
                     all_albedo_factors.primitive::<u32>(),
-                    all_albedo_textures.component::<TensorData>(),
+                    all_albedo_buffers.component::<ImageBuffer>(),
+                    all_albedo_formats.component::<ImageFormat>(),
                     all_class_ids.primitive::<u16>(),
                 )
                 .map(
@@ -227,7 +229,8 @@ impl VisualizerSystem for Mesh3DVisualizer {
                         vertex_texcoords,
                         triangle_indices,
                         albedo_factors,
-                        albedo_textures,
+                        albedo_buffers,
+                        albedo_formats,
                         class_ids,
                     )| {
                         Mesh3DComponentData {
@@ -247,8 +250,8 @@ impl VisualizerSystem for Mesh3DVisualizer {
                                     bytemuck::cast_slice(albedo_factors)
                                 })
                                 .first(),
-                            // NOTE: not actually cloning anything.
-                            albedo_texture: albedo_textures.unwrap_or_default().first().cloned(),
+                            albedo_buffer: albedo_buffers.unwrap_or_default().first().cloned(), // shallow clone
+                            albedo_format: albedo_formats.unwrap_or_default().first().copied(),
                             class_ids: class_ids
                                 .map_or(&[], |class_ids| bytemuck::cast_slice(class_ids)),
                         }

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -215,7 +215,7 @@ fn image_decode_srgb_gamma_heuristic(
     }
 }
 
-fn texture_creation_desc_from_color_image<'a>(
+pub fn texture_creation_desc_from_color_image<'a>(
     image: &'a ImageInfo,
     debug_name: &'a str,
 ) -> Texture2DCreationDesc<'a> {

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -5,7 +5,9 @@ mod image_to_gpu;
 mod re_renderer_callback;
 
 pub use colormap::{colormap_edit_or_view_ui, colormap_to_re_renderer};
-pub use image_to_gpu::{image_data_range_heuristic, image_to_gpu};
+pub use image_to_gpu::{
+    image_data_range_heuristic, image_to_gpu, texture_creation_desc_from_color_image,
+};
 pub use re_renderer_callback::new_renderer_callback;
 
 use crate::TensorStats;

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -16,7 +16,7 @@ an instance of the mesh will be drawn for each transform.
 
 **Recommended**: [`TriangleIndices`](../components/triangle_indices.md), [`Vector3D`](../components/vector3d.md)
 
-**Optional**: [`Color`](../components/color.md), [`Texcoord2D`](../components/texcoord2d.md), [`AlbedoFactor`](../components/albedo_factor.md), [`TensorData`](../components/tensor_data.md), [`ClassId`](../components/class_id.md)
+**Optional**: [`Color`](../components/color.md), [`Texcoord2D`](../components/texcoord2d.md), [`AlbedoFactor`](../components/albedo_factor.md), [`ImageBuffer`](../components/image_buffer.md), [`ImageFormat`](../components/image_format.md), [`ClassId`](../components/class_id.md)
 
 ## Shown in
 * [Spatial3DView](../views/spatial3d_view.md)

--- a/docs/content/reference/types/components/image_buffer.md
+++ b/docs/content/reference/types/components/image_buffer.md
@@ -21,4 +21,5 @@ To interpret the contents of this buffer, see, [`components.ImageFormat`](https:
 
 * [`DepthImage`](../archetypes/depth_image.md)
 * [`Image`](../archetypes/image.md)
+* [`Mesh3D`](../archetypes/mesh3d.md)
 * [`SegmentationImage`](../archetypes/segmentation_image.md)

--- a/docs/content/reference/types/components/image_format.md
+++ b/docs/content/reference/types/components/image_format.md
@@ -19,4 +19,5 @@ The metadata describing the contents of a [`components.ImageBuffer`](https://rer
 
 * [`DepthImage`](../archetypes/depth_image.md)
 * [`Image`](../archetypes/image.md)
+* [`Mesh3D`](../archetypes/mesh3d.md)
 * [`SegmentationImage`](../archetypes/segmentation_image.md)

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -25,5 +25,4 @@ which stores a contiguous array of typed values.
 ## Used by
 
 * [`BarChart`](../archetypes/bar_chart.md)
-* [`Mesh3D`](../archetypes/mesh3d.md)
 * [`Tensor`](../archetypes/tensor.md)

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.cpp
@@ -14,7 +14,7 @@ namespace rerun {
     ) {
         using namespace archetypes;
         std::vector<ComponentBatch> cells;
-        cells.reserve(9);
+        cells.reserve(10);
 
         {
             auto result = ComponentBatch::from_loggable(archetype.vertex_positions);
@@ -46,8 +46,13 @@ namespace rerun {
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }
-        if (archetype.albedo_texture.has_value()) {
-            auto result = ComponentBatch::from_loggable(archetype.albedo_texture.value());
+        if (archetype.albedo_texture_buffer.has_value()) {
+            auto result = ComponentBatch::from_loggable(archetype.albedo_texture_buffer.value());
+            RR_RETURN_NOT_OK(result.error);
+            cells.push_back(std::move(result.value));
+        }
+        if (archetype.albedo_texture_format.has_value()) {
+            auto result = ComponentBatch::from_loggable(archetype.albedo_texture_format.value());
             RR_RETURN_NOT_OK(result.error);
             cells.push_back(std::move(result.value));
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -9,8 +9,9 @@
 #include "../components/albedo_factor.hpp"
 #include "../components/class_id.hpp"
 #include "../components/color.hpp"
+#include "../components/image_buffer.hpp"
+#include "../components/image_format.hpp"
 #include "../components/position3d.hpp"
-#include "../components/tensor_data.hpp"
 #include "../components/texcoord2d.hpp"
 #include "../components/triangle_indices.hpp"
 #include "../components/vector3d.hpp"
@@ -130,10 +131,10 @@ namespace rerun::archetypes {
         /// Optional albedo texture.
         ///
         /// Used with the `components::Texcoord2D` of the mesh.
-        ///
-        /// Currently supports only sRGB(A) textures, ignoring alpha.
-        /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
-        std::optional<rerun::components::TensorData> albedo_texture;
+        std::optional<rerun::components::ImageBuffer> albedo_texture_buffer;
+
+        /// The format of the `albedo_texture_buffer`, if any.
+        std::optional<rerun::components::ImageFormat> albedo_texture_format;
 
         /// Optional class Ids for the vertices.
         ///
@@ -194,11 +195,17 @@ namespace rerun::archetypes {
         /// Optional albedo texture.
         ///
         /// Used with the `components::Texcoord2D` of the mesh.
-        ///
-        /// Currently supports only sRGB(A) textures, ignoring alpha.
-        /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
-        Mesh3D with_albedo_texture(rerun::components::TensorData _albedo_texture) && {
-            albedo_texture = std::move(_albedo_texture);
+        Mesh3D with_albedo_texture_buffer(rerun::components::ImageBuffer _albedo_texture_buffer
+        ) && {
+            albedo_texture_buffer = std::move(_albedo_texture_buffer);
+            // See: https://github.com/rerun-io/rerun/issues/4027
+            RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
+        }
+
+        /// The format of the `albedo_texture_buffer`, if any.
+        Mesh3D with_albedo_texture_format(rerun::components::ImageFormat _albedo_texture_format
+        ) && {
+            albedo_texture_format = std::move(_albedo_texture_format);
             // See: https://github.com/rerun-io/rerun/issues/4027
             RR_WITH_MAYBE_UNINITIALIZED_DISABLED(return std::move(*this);)
         }

--- a/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/mesh3d.hpp
@@ -131,6 +131,9 @@ namespace rerun::archetypes {
         /// Optional albedo texture.
         ///
         /// Used with the `components::Texcoord2D` of the mesh.
+        ///
+        /// Currently supports only sRGB(A) textures, ignoring alpha.
+        /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
         std::optional<rerun::components::ImageBuffer> albedo_texture_buffer;
 
         /// The format of the `albedo_texture_buffer`, if any.
@@ -195,6 +198,9 @@ namespace rerun::archetypes {
         /// Optional albedo texture.
         ///
         /// Used with the `components::Texcoord2D` of the mesh.
+        ///
+        /// Currently supports only sRGB(A) textures, ignoring alpha.
+        /// (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
         Mesh3D with_albedo_texture_buffer(rerun::components::ImageBuffer _albedo_texture_buffer
         ) && {
             albedo_texture_buffer = std::move(_albedo_texture_buffer);

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -184,6 +184,9 @@ class Mesh3D(Mesh3DExt, Archetype):
     #
     # Used with the [`components.Texcoord2D`][rerun.components.Texcoord2D] of the mesh.
     #
+    # Currently supports only sRGB(A) textures, ignoring alpha.
+    # (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
+    #
     # (Docstring intentionally commented out to hide this field from the docs)
 
     albedo_texture_format: components.ImageFormatBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d.py
@@ -108,7 +108,8 @@ class Mesh3D(Mesh3DExt, Archetype):
             vertex_colors=None,  # type: ignore[arg-type]
             vertex_texcoords=None,  # type: ignore[arg-type]
             albedo_factor=None,  # type: ignore[arg-type]
-            albedo_texture=None,  # type: ignore[arg-type]
+            albedo_texture_buffer=None,  # type: ignore[arg-type]
+            albedo_texture_format=None,  # type: ignore[arg-type]
             class_ids=None,  # type: ignore[arg-type]
         )
 
@@ -174,17 +175,23 @@ class Mesh3D(Mesh3DExt, Archetype):
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 
-    albedo_texture: components.TensorDataBatch | None = field(
+    albedo_texture_buffer: components.ImageBufferBatch | None = field(
         metadata={"component": "optional"},
         default=None,
-        converter=components.TensorDataBatch._optional,  # type: ignore[misc]
+        converter=components.ImageBufferBatch._optional,  # type: ignore[misc]
     )
     # Optional albedo texture.
     #
     # Used with the [`components.Texcoord2D`][rerun.components.Texcoord2D] of the mesh.
     #
-    # Currently supports only sRGB(A) textures, ignoring alpha.
-    # (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
+    # (Docstring intentionally commented out to hide this field from the docs)
+
+    albedo_texture_format: components.ImageFormatBatch | None = field(
+        metadata={"component": "optional"},
+        default=None,
+        converter=components.ImageFormatBatch._optional,  # type: ignore[misc]
+    )
+    # The format of the `albedo_texture_buffer`, if any.
     #
     # (Docstring intentionally commented out to hide this field from the docs)
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/mesh3d_ext.py
@@ -1,9 +1,43 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from rerun.components.image_format import ImageFormat
+from rerun.datatypes.channel_datatype import ChannelDatatype
+from rerun.datatypes.color_model import ColorModel
 
 from .. import datatypes
-from ..error_utils import catch_and_log_exceptions
+from ..error_utils import _send_warning_or_raise, catch_and_log_exceptions
+
+if TYPE_CHECKING:
+    ImageLike = Union[
+        npt.NDArray[np.float16],
+        npt.NDArray[np.float32],
+        npt.NDArray[np.float64],
+        npt.NDArray[np.int16],
+        npt.NDArray[np.int32],
+        npt.NDArray[np.int64],
+        npt.NDArray[np.int8],
+        npt.NDArray[np.uint16],
+        npt.NDArray[np.uint32],
+        npt.NDArray[np.uint64],
+        npt.NDArray[np.uint8],
+    ]
+
+
+def _to_numpy(tensor: ImageLike) -> npt.NDArray[Any]:
+    # isinstance is 4x faster than catching AttributeError
+    if isinstance(tensor, np.ndarray):
+        return tensor
+
+    try:
+        # Make available to the cpu
+        return tensor.numpy(force=True)  # type: ignore[union-attr]
+    except AttributeError:
+        return np.array(tensor, copy=False)
 
 
 class Mesh3DExt:
@@ -17,7 +51,7 @@ class Mesh3DExt:
         vertex_normals: datatypes.Vec3DArrayLike | None = None,
         vertex_colors: datatypes.Rgba32ArrayLike | None = None,
         vertex_texcoords: datatypes.Vec2DArrayLike | None = None,
-        albedo_texture: datatypes.TensorDataLike | None = None,
+        albedo_texture: ImageLike | None = None,
         albedo_factor: datatypes.Rgba32Like | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ):
@@ -44,12 +78,38 @@ class Mesh3DExt:
         albedo_texture:
             Optional albedo texture. Used with `vertex_texcoords` on `Mesh3D`.
             Currently supports only sRGB(A) textures, ignoring alpha.
-            (meaning that the tensor must have 3 or 4 channels and use the `u8` format)
+            (meaning that the texture must have 3 or 4 channels)
         class_ids:
             Optional class Ids for the vertices.
             The class ID provides colors and labels if not specified explicitly.
 
         """
+
+        albedo_texture_buffer = None
+        albedo_texture_format = None
+
+        if albedo_texture is not None:
+            albedo_texture = _to_numpy(albedo_texture)
+
+            if len(albedo_texture.shape) != 3:
+                _send_warning_or_raise("Bad albedo texture shape: {albedo_texture.shape}")
+            else:
+                h = albedo_texture.shape[0]
+                w = albedo_texture.shape[1]
+                c = albedo_texture.shape[2]
+                if c not in (3, 4):
+                    _send_warning_or_raise("Bad albedo texture shape: {albedo_texture.shape}")
+                else:
+                    color_model = ColorModel.RGB if c == 3 else ColorModel.RGBA
+                    try:
+                        datatype = ChannelDatatype.from_np_dtype(albedo_texture.dtype)
+                        albedo_texture_buffer = albedo_texture.tobytes()
+                        albedo_texture_format = ImageFormat(
+                            width=w, height=h, color_model=color_model, channel_datatype=datatype
+                        )
+                    except KeyError:
+                        _send_warning_or_raise(f"Unsupported dtype {albedo_texture.dtype} for Mesh3D:s albedo texture")
+
         with catch_and_log_exceptions(context=self.__class__.__name__):
             self.__attrs_init__(
                 vertex_positions=vertex_positions,
@@ -57,7 +117,8 @@ class Mesh3DExt:
                 vertex_normals=vertex_normals,
                 vertex_colors=vertex_colors,
                 vertex_texcoords=vertex_texcoords,
-                albedo_texture=albedo_texture,
+                albedo_texture_buffer=albedo_texture_buffer,
+                albedo_texture_format=albedo_texture_format,
                 albedo_factor=albedo_factor,
                 class_ids=class_ids,
             )


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/7056

<img width="300" alt="Screenshot 2024-08-14 at 19 25 43" src="https://github.com/user-attachments/assets/683d7074-115f-424f-9a55-91851a820de7">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7190?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7190?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7190)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.