### PR TITLE
Fix broken unsetting of blueprint components

### DIFF
--- a/crates/viewer/re_space_view/src/view_property_ui.rs
+++ b/crates/viewer/re_space_view/src/view_property_ui.rs
@@ -209,7 +209,7 @@ If no default blueprint was set or it didn't set any value for this field, this 
 
     let response = ui
         .add_enabled(
-            component_array.is_none(),
+            component_array.is_some(),
             egui::Button::new("Unset"),
         )
         .on_hover_text(

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -549,19 +549,17 @@ impl ComponentUiRegistry {
     ) {
         re_tracing::profile_function!(component_name.full_name());
 
-        let create_fallback = || {
-            fallback_provider
-                .fallback_for(ctx, component_name)
-                .map_err(|_err| format!("No fallback value available for {component_name}."))
-        };
-
-        let component_raw = if let Some(array) = component_array {
-            array.to_boxed()
+        // Use a fallback if there's either no component data at all or the component array is empty.
+        let component_raw = if let Some(component_raw) =
+            component_array.and_then(|array| (!array.is_empty()).then(|| array.to_boxed()))
+        {
+            component_raw
         } else {
-            match create_fallback() {
+            match fallback_provider.fallback_for(ctx, component_name) {
                 Ok(value) => value,
-                Err(error_text) => {
-                    re_log::error_once!("{error_text}");
+                Err(err) => {
+                    let error_text = format!("No fallback value available for {component_name}.");
+                    re_log::error_once!("{error_text} ({err})");
                     ui.error_label(&error_text);
                     return;
                 }


### PR DESCRIPTION
### What

* 'unset' on view properties showed up in an inverted fashion
* edit ui didn't handle zero arrays correctly anymore

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7196?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7196?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7196)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.