### PR TITLE
Ignore `RowId` in zipping iterators

### DIFF
--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -8,6 +8,7 @@ mod heuristics;
 mod query;
 mod results_ext;
 mod screenshot;
+mod time_key;
 mod view_property_ui;
 
 pub use heuristics::suggest_space_view_for_each_entity;
@@ -18,6 +19,7 @@ pub use results_ext::{
     HybridLatestAtResults, HybridResults, HybridResultsChunkIter, RangeResultsExt,
 };
 pub use screenshot::ScreenshotMode;
+pub use time_key::TimeKey;
 pub use view_property_ui::view_property_ui;
 
 pub mod external {

--- a/crates/viewer/re_space_view/src/results_ext.rs
+++ b/crates/viewer/re_space_view/src/results_ext.rs
@@ -291,8 +291,7 @@ impl RangeResultsExt for RangeResults {
 impl RangeResultsExt for HybridRangeResults {
     #[inline]
     fn get_required_chunks(&self, component_name: &ComponentName) -> Option<Cow<'_, [Chunk]>> {
-        if self.overrides.contains(component_name) {
-            let unit = self.overrides.get(component_name)?;
+        if let Some(unit) = self.overrides.get(component_name) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk()).into_static();
             Some(Cow::Owned(vec![chunk]))
@@ -303,10 +302,7 @@ impl RangeResultsExt for HybridRangeResults {
 
     #[inline]
     fn get_optional_chunks(&self, component_name: &ComponentName) -> Cow<'_, [Chunk]> {
-        if self.overrides.contains(component_name) {
-            let Some(unit) = self.overrides.get(component_name) else {
-                return Cow::Owned(Vec::new());
-            };
+        if let Some(unit) = self.overrides.get(component_name) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk()).into_static();
             Cow::Owned(vec![chunk])
@@ -334,8 +330,7 @@ impl RangeResultsExt for HybridRangeResults {
 impl<'a> RangeResultsExt for HybridLatestAtResults<'a> {
     #[inline]
     fn get_required_chunks(&self, component_name: &ComponentName) -> Option<Cow<'_, [Chunk]>> {
-        if self.overrides.contains(component_name) {
-            let unit = self.overrides.get(component_name)?;
+        if let Some(unit) = self.overrides.get(component_name) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk()).into_static();
             Some(Cow::Owned(vec![chunk]))
@@ -346,10 +341,7 @@ impl<'a> RangeResultsExt for HybridLatestAtResults<'a> {
 
     #[inline]
     fn get_optional_chunks(&self, component_name: &ComponentName) -> Cow<'_, [Chunk]> {
-        if self.overrides.contains(component_name) {
-            let Some(unit) = self.overrides.get(component_name) else {
-                return Cow::Owned(Vec::new());
-            };
+        if let Some(unit) = self.overrides.get(component_name) {
             // Because this is an override we always re-index the data as static
             let chunk = Arc::unwrap_or_clone(unit.clone().into_chunk()).into_static();
             Cow::Owned(vec![chunk])

--- a/crates/viewer/re_space_view/src/time_key.rs
+++ b/crates/viewer/re_space_view/src/time_key.rs
@@ -1,0 +1,46 @@
+use re_chunk_store::RowId;
+use re_log_types::TimeInt;
+
+/// Time and row id for some piece of data.
+///
+/// The `Ord` for this ignores `row_id`.
+/// This is so that our zipping iterators will ignore the row id when comparing.
+/// This is important for static data, especially when it comes to overrides.
+/// If you override some static data (e.g. point cloud radius), the row id should be ignored,
+/// otherwise the zipping iterators will say the override came _after_ the original data,
+/// and so by latest-at semantics, the override will be ignored.
+#[derive(Clone, Copy, Debug)]
+pub struct TimeKey {
+    pub time: TimeInt,
+    pub row_id: RowId,
+}
+
+impl From<(TimeInt, RowId)> for TimeKey {
+    #[inline]
+    fn from((time, row_id): (TimeInt, RowId)) -> Self {
+        Self { time, row_id }
+    }
+}
+
+impl PartialEq for TimeKey {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl Eq for TimeKey {}
+
+impl PartialOrd for TimeKey {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.time.cmp(&other.time))
+    }
+}
+
+impl Ord for TimeKey {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.time.cmp(&other.time)
+    }
+}

--- a/crates/viewer/re_space_view/src/time_key.rs
+++ b/crates/viewer/re_space_view/src/time_key.rs
@@ -9,6 +9,8 @@ use re_log_types::TimeInt;
 /// If you override some static data (e.g. point cloud radius), the row id should be ignored,
 /// otherwise the zipping iterators will say the override came _after_ the original data,
 /// and so by latest-at semantics, the override will be ignored.
+///
+/// See <https://github.com/rerun-io/rerun/pull/7199> for more.
 #[derive(Clone, Copy, Debug)]
 pub struct TimeKey {
     pub time: TimeInt,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -1,7 +1,7 @@
-use re_chunk_store::RowId;
-use re_log_types::{hash::Hash64, Instance, TimeInt};
+use re_log_types::{hash::Hash64, Instance};
 use re_renderer::renderer::MeshInstance;
 use re_renderer::RenderContext;
+use re_space_view::TimeKey;
 use re_types::{
     archetypes::Asset3D,
     components::{Blob, MediaType},
@@ -33,7 +33,7 @@ impl Default for Asset3DVisualizer {
 }
 
 struct Asset3DComponentData {
-    index: (TimeInt, RowId),
+    index: TimeKey,
 
     blob: ArrowBuffer<u8>,
     media_type: Option<ArrowString>,
@@ -58,7 +58,7 @@ impl Asset3DVisualizer {
                 media_type: data.media_type.clone().map(Into::into),
             };
 
-            let primary_row_id = data.index.1;
+            let primary_row_id = data.index.row_id;
             let picking_instance_hash = re_entity_db::InstancePathHash::entity_all(entity_path);
             let outline_mask_ids = ent_context.highlight.index_outline_mask(Instance::ALL);
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -282,7 +282,7 @@ impl VisualizerSystem for DepthImageVisualizer {
 
                         Some(DepthImageComponentData {
                             image: ImageInfo {
-                                buffer_row_id: index.1,
+                                buffer_row_id: index.row_id,
                                 buffer: buffer.clone().into(),
                                 format: first_copied(format.as_deref())?.0,
                                 kind: ImageKind::Depth,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
@@ -144,7 +144,7 @@ impl EncodedImageVisualizer {
         let all_media_types = results.iter_as(timeline, MediaType::name());
         let all_opacities = results.iter_as(timeline, Opacity::name());
 
-        for ((_time, tensor_data_row_id), blobs, media_types, opacities) in re_query::range_zip_1x2(
+        for (index, blobs, media_types, opacities) in re_query::range_zip_1x2(
             all_blobs_indexed,
             all_media_types.string(),
             all_opacities.primitive::<f32>(),
@@ -156,7 +156,7 @@ impl EncodedImageVisualizer {
 
             let image = ctx.viewer_ctx.cache.entry(|c: &mut ImageDecodeCache| {
                 c.entry(
-                    tensor_data_row_id,
+                    index.row_id,
                     blob,
                     media_type.as_ref().map(|mt| mt.as_str()),
                 )

--- a/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
@@ -165,7 +165,7 @@ impl ImageVisualizer {
 
             Some(ImageComponentData {
                 image: ImageInfo {
-                    buffer_row_id: index.1,
+                    buffer_row_id: index.row_id,
                     buffer: buffer.clone().into(),
                     format: first_copied(formats.as_deref())?.0,
                     kind: ImageKind::Color,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -1,7 +1,7 @@
-use re_chunk_store::RowId;
-use re_log_types::{hash::Hash64, Instance, TimeInt};
+use re_log_types::{hash::Hash64, Instance};
 use re_renderer::renderer::MeshInstance;
 use re_renderer::RenderContext;
+use re_space_view::TimeKey;
 use re_types::{
     archetypes::Mesh3D,
     components::{
@@ -40,7 +40,7 @@ impl Default for Mesh3DVisualizer {
 }
 
 struct Mesh3DComponentData<'a> {
-    index: (TimeInt, RowId),
+    index: TimeKey,
     query_result_hash: Hash64,
 
     vertex_positions: &'a [Position3D],
@@ -69,7 +69,7 @@ impl Mesh3DVisualizer {
         let entity_path = ctx.target_entity_path;
 
         for data in data {
-            let primary_row_id = data.index.1;
+            let primary_row_id = data.index.row_id;
             let picking_instance_hash = re_entity_db::InstancePathHash::entity_all(entity_path);
             let outline_mask_ids = ent_context.highlight.index_outline_mask(Instance::ALL);
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
@@ -109,7 +109,7 @@ impl VisualizerSystem for SegmentationImageVisualizer {
                     let buffer = buffers.first()?;
                     Some(SegmentationImageComponentData {
                         image: ImageInfo {
-                            buffer_row_id: index.1,
+                            buffer_row_id: index.row_id,
                             buffer: buffer.clone().into(),
                             format: first_copied(formats.as_deref())?.0,
                             kind: ImageKind::Segmentation,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -4,6 +4,7 @@ use re_chunk_store::{LatestAtQuery, RangeQuery};
 use re_log_types::{TimeInt, Timeline};
 use re_space_view::{
     latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data, HybridResults,
+    TimeKey,
 };
 use re_types::Archetype;
 use re_viewer_context::{
@@ -200,7 +201,7 @@ where
 
 // ---
 
-use re_chunk::{Chunk, ChunkComponentIterItem, ComponentName, RowId};
+use re_chunk::{Chunk, ChunkComponentIterItem, ComponentName};
 use re_chunk_store::external::{re_chunk, re_chunk::external::arrow2};
 
 /// Iterate `chunks` as indexed deserialized batches.
@@ -211,10 +212,12 @@ pub fn iter_component<'a, C: re_types::Component>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), ChunkComponentIterItem<C>)> + 'a {
+) -> impl Iterator<Item = (TimeKey, ChunkComponentIterItem<C>)> + 'a {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_component::<C>()
         )
     })
@@ -228,10 +231,12 @@ pub fn iter_primitive<'a, T: arrow2::types::NativeType>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), &'a [T])> + 'a {
+) -> impl Iterator<Item = (TimeKey, &'a [T])> + 'a {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_primitive::<T>(&component_name)
         )
     })
@@ -245,13 +250,15 @@ pub fn iter_primitive_array<'a, const N: usize, T: arrow2::types::NativeType>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), &'a [[T; N]])> + 'a
+) -> impl Iterator<Item = (TimeKey, &'a [[T; N]])> + 'a
 where
     [T; N]: bytemuck::Pod,
 {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_primitive_array::<N, T>(&component_name)
         )
     })
@@ -265,13 +272,15 @@ pub fn iter_primitive_array_list<'a, const N: usize, T: arrow2::types::NativeTyp
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), Vec<&'a [[T; N]]>)> + 'a
+) -> impl Iterator<Item = (TimeKey, Vec<&'a [[T; N]]>)> + 'a
 where
     [T; N]: bytemuck::Pod,
 {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_primitive_array_list::<N, T>(&component_name)
         )
     })
@@ -285,10 +294,12 @@ pub fn iter_string<'a>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowString>)> + 'a {
+) -> impl Iterator<Item = (TimeKey, Vec<re_types::ArrowString>)> + 'a {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_string(&component_name)
         )
     })
@@ -302,10 +313,12 @@ pub fn iter_buffer<'a, T: arrow2::types::NativeType>(
     chunks: &'a std::borrow::Cow<'a, [Chunk]>,
     timeline: Timeline,
     component_name: ComponentName,
-) -> impl Iterator<Item = ((TimeInt, RowId), Vec<re_types::ArrowBuffer<T>>)> + 'a {
+) -> impl Iterator<Item = (TimeKey, Vec<re_types::ArrowBuffer<T>>)> + 'a {
     chunks.iter().flat_map(move |chunk| {
         itertools::izip!(
-            chunk.iter_component_indices(&timeline, &component_name),
+            chunk
+                .iter_component_indices(&timeline, &component_name)
+                .map(TimeKey::from),
             chunk.iter_buffer(&component_name)
         )
     })

--- a/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
@@ -119,7 +119,7 @@ impl TextLogSystem {
 
         let all_frames = izip!(all_timepoints, all_frames);
 
-        for (timepoint, ((data_time, row_id), bodies, levels, colors)) in all_frames {
+        for (timepoint, (index, bodies, levels, colors)) in all_frames {
             let levels = levels.as_deref().unwrap_or(&[]).iter().cloned().map(Some);
             let colors = colors
                 .unwrap_or(&[])
@@ -136,9 +136,9 @@ impl TextLogSystem {
 
             for (text, level, color) in results {
                 self.entries.push(Entry {
-                    row_id,
+                    row_id: index.row_id,
                     entity_path: data_result.entity_path.clone(),
-                    time: data_time,
+                    time: index.time,
                     timepoint: timepoint.clone(),
                     color,
                     body: text.clone().into(),

--- a/tests/python/release_checklist/check_static_override.py
+++ b/tests/python/release_checklist/check_static_override.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import rerun as rr
+
+README = """\
+# Data override check
+
+- Verify that you can set a default point radius
+- Verify that you can override point color
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
+
+    log_readme()
+
+    # Logged as static because https://github.com/rerun-io/rerun/pull/7199
+    rr.log("points", rr.Points3D([[0, 0, 0], [1, 1, 1]]), static=True)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)

--- a/tests/python/release_checklist/check_static_override.py
+++ b/tests/python/release_checklist/check_static_override.py
@@ -11,6 +11,7 @@ README = """\
 
 - Verify that you can set a default point radius
 - Verify that you can override point color
+- Verify that you see three points are visible
 """
 
 
@@ -25,6 +26,8 @@ def run(args: Namespace) -> None:
 
     # Logged as static because https://github.com/rerun-io/rerun/pull/7199
     rr.log("points", rr.Points3D([[0, 0, 0], [1, 1, 1]]), static=True)
+    # Log it again, to ensure that the newest one is visible
+    rr.log("points", rr.Points3D([[0, 0, 0], [1, 1, 1], [2, 2, 2]]), static=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Bug
Run OPF and try to override the point cloud radius. You cannot. Nor set a fallback.

### Cause
All overrides and defaults are "made static" (https://github.com/rerun-io/rerun/blob/afdca6876d2234148c977685bf357ead59b2b809/crates/store/re_chunk/src/chunk.rs#L208-L212) so that their `TimeInt` is always less or equal to the real recording data. This is so that the latest-at zipping iterator will make use of it.

However, if the recording data is also static, we get `TimeInt::STATIC` for both the override and the real data. The zipping iterator then goes to use the `RowId` as a tie-breaker, and THIS IS WRONG. Because the overriding was usually done after the logging of the data, its `RowId` is higher.

### Solultion
The solution is to ignore the `RowId` during the zipping.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7199?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7199?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7199)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.