### PR TITLE
Clear source before adding receiver in history

### DIFF
--- a/crates/viewer/re_viewer/src/history.rs
+++ b/crates/viewer/re_viewer/src/history.rs
@@ -175,6 +175,9 @@ fn handle_popstate(
             continue;
         };
 
+        command_sender.send_system(SystemCommand::ClearSourceAndItsStores(
+            receiver.source().clone(),
+        ));
         command_sender.send_system(SystemCommand::AddReceiver(receiver));
 
         re_log::debug!("popstate: add receiver {url:?}");


### PR DESCRIPTION
### What

- Closes https://github.com/rerun-io/rerun/issues/7201

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7202?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7202?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7202)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.