### PR TITLE
Improve fallback provider for timeseries `Name` component

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/lib.rs
+++ b/crates/viewer/re_space_view_time_series/src/lib.rs
@@ -74,10 +74,7 @@ pub enum PlotSeriesKind {
 #[derive(Clone, Debug)]
 pub struct PlotSeries {
     /// Label of the series.
-    ///
-    /// If `None`, it means no label was logged or overridden. In this case, it should be derived
-    /// from the entity path.
-    pub label: Option<String>,
+    pub label: String,
 
     pub color: egui::Color32,
 

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -78,7 +78,28 @@ impl TypedComponentFallbackProvider<StrokeWidth> for SeriesLineSystem {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(SeriesLineSystem => [Color, StrokeWidth]);
+impl TypedComponentFallbackProvider<Name> for SeriesLineSystem {
+    fn fallback_for(&self, ctx: &QueryContext<'_>) -> Name {
+        let state = ctx.view_state.downcast_ref::<TimeSeriesSpaceViewState>();
+
+        state
+            .ok()
+            .and_then(|state| {
+                state
+                    .default_names_for_entities
+                    .get(ctx.target_entity_path)
+                    .map(|name| name.clone().into())
+            })
+            .or_else(|| {
+                ctx.target_entity_path
+                    .last()
+                    .map(|part| part.ui_string().into())
+            })
+            .unwrap_or_default()
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(SeriesLineSystem => [Color, StrokeWidth, Name]);
 
 impl SeriesLineSystem {
     fn load_scalars(&mut self, ctx: &ViewContext<'_>, query: &ViewQuery<'_>) {

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -388,7 +388,7 @@ impl SeriesLineSystem {
                 .iter()
                 .find(|chunk| !chunk.is_empty())
                 .and_then(|chunk| chunk.component_mono::<Name>(0)?.ok())
-                .map(|name| name.0.to_string());
+                .unwrap_or_else(|| self.fallback_for(&query_ctx));
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             let aggregator = results
@@ -445,7 +445,7 @@ impl SeriesLineSystem {
                 points,
                 ctx.recording_store(),
                 view_query,
-                series_name,
+                series_name.into(),
                 aggregator,
                 all_series,
             );

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -78,7 +78,28 @@ impl TypedComponentFallbackProvider<MarkerSize> for SeriesPointSystem {
     }
 }
 
-re_viewer_context::impl_component_fallback_provider!(SeriesPointSystem => [Color, MarkerSize]);
+impl TypedComponentFallbackProvider<Name> for SeriesPointSystem {
+    fn fallback_for(&self, ctx: &QueryContext<'_>) -> Name {
+        let state = ctx.view_state.downcast_ref::<TimeSeriesSpaceViewState>();
+
+        state
+            .ok()
+            .and_then(|state| {
+                state
+                    .default_names_for_entities
+                    .get(ctx.target_entity_path)
+                    .map(|name| name.clone().into())
+            })
+            .or_else(|| {
+                ctx.target_entity_path
+                    .last()
+                    .map(|part| part.ui_string().into())
+            })
+            .unwrap_or_default()
+    }
+}
+
+re_viewer_context::impl_component_fallback_provider!(SeriesPointSystem => [Color, MarkerSize, Name]);
 
 impl SeriesPointSystem {
     fn load_scalars(&mut self, ctx: &ViewContext<'_>, query: &ViewQuery<'_>) {

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -467,7 +467,7 @@ impl SeriesPointSystem {
                 .iter()
                 .find(|chunk| !chunk.is_empty())
                 .and_then(|chunk| chunk.component_mono::<Name>(0)?.ok())
-                .map(|name| name.0.to_string());
+                .unwrap_or_else(|| self.fallback_for(&query_ctx));
 
             // Now convert the `PlotPoints` into `Vec<PlotSeries>`
             points_to_series(
@@ -476,7 +476,7 @@ impl SeriesPointSystem {
                 points,
                 ctx.recording_store(),
                 view_query,
-                series_name,
+                series_name.into(),
                 // Aggregation for points is not supported.
                 re_types::components::AggregationPolicy::Off,
                 all_series,

--- a/crates/viewer/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_time_series/src/space_view_class.rs
@@ -435,7 +435,7 @@ Display time series data in a plot.
             *state.scalar_range.start_mut() = f64::INFINITY;
             *state.scalar_range.end_mut() = f64::NEG_INFINITY;
 
-            // This is stored in state such that default providers may access it
+            // Needed by for the visualizers' fallback provider.
             state.default_names_for_entities = EntityPath::short_names_with_disambiguation(
                 all_plot_series
                     .iter()
@@ -462,24 +462,17 @@ Display time series data in a plot.
                 let id = egui::Id::new(series.entity_path.hash());
                 plot_item_id_to_entity_path.insert(id, series.entity_path.clone());
 
-                let label = series
-                    .label
-                    .as_ref()
-                    .or_else(|| state.default_names_for_entities.get(&series.entity_path))
-                    .cloned()
-                    .unwrap_or_else(|| "unknown".to_owned());
-
                 match series.kind {
                     PlotSeriesKind::Continuous => plot_ui.line(
                         Line::new(points)
-                            .name(label)
+                            .name(&series.label)
                             .color(color)
                             .width(2.0 * series.radius_ui)
                             .id(id),
                     ),
                     PlotSeriesKind::Scatter(scatter_attrs) => plot_ui.points(
                         Points::new(points)
-                            .name(label)
+                            .name(&series.label)
                             .color(color)
                             .radius(series.radius_ui)
                             .shape(scatter_attrs.marker.into())

--- a/crates/viewer/re_space_view_time_series/src/util.rs
+++ b/crates/viewer/re_space_view_time_series/src/util.rs
@@ -78,81 +78,6 @@ pub fn determine_time_range(
     time_range
 }
 
-#[allow(clippy::needless_pass_by_value)]
-#[inline(never)] // Better callstacks on crashes
-fn add_series_runs(
-    series_label: String,
-    points: Vec<PlotPoint>,
-    entity_path: &EntityPath,
-    aggregator: AggregationPolicy,
-    aggregation_factor: f64,
-    min_time: i64,
-    all_series: &mut Vec<PlotSeries>,
-) {
-    re_tracing::profile_function!();
-
-    let num_points = points.len();
-    let mut attrs = points[0].attrs.clone();
-    let mut series: PlotSeries = PlotSeries {
-        label: series_label.clone(),
-        color: attrs.color,
-        radius_ui: attrs.radius_ui,
-        points: Vec::with_capacity(num_points),
-        kind: attrs.kind,
-        entity_path: entity_path.clone(),
-        aggregator,
-        aggregation_factor,
-        min_time,
-    };
-
-    for (i, p) in points.into_iter().enumerate() {
-        if p.attrs == attrs {
-            // Same attributes, just add to the current series.
-
-            series.points.push((p.time, p.value));
-        } else {
-            // Attributes changed since last point, break up the current run into a
-            // its own series, and start the next one.
-
-            attrs = p.attrs;
-            let prev_series = std::mem::replace(
-                &mut series,
-                PlotSeries {
-                    label: series_label.clone(),
-                    color: attrs.color,
-                    radius_ui: attrs.radius_ui,
-                    kind: attrs.kind,
-                    points: Vec::with_capacity(num_points - i),
-                    entity_path: entity_path.clone(),
-                    aggregator,
-                    aggregation_factor,
-                    min_time,
-                },
-            );
-
-            let cur_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
-            let prev_continuous = matches!(prev_series.kind, PlotSeriesKind::Continuous);
-
-            let prev_point = *prev_series.points.last().unwrap();
-            all_series.push(prev_series);
-
-            // If the previous point was continuous and the current point is continuous
-            // too, then we want the 2 segments to appear continuous even though they
-            // are actually split from a data standpoint.
-            if cur_continuous && prev_continuous {
-                series.points.push(prev_point);
-            }
-
-            // Add the point that triggered the split to the new segment.
-            series.points.push((p.time, p.value));
-        }
-    }
-
-    if !series.points.is_empty() {
-        all_series.push(series);
-    }
-}
-
 // We have a bunch of raw points, and now we need to group them into individual series.
 // A series is a continuous run of points with identical attributes: each time
 // we notice a change in attributes, we need a new series.
@@ -272,4 +197,79 @@ pub fn apply_aggregation(
     );
 
     (actual_aggregation_factor, points)
+}
+
+#[allow(clippy::needless_pass_by_value)]
+#[inline(never)] // Better callstacks on crashes
+fn add_series_runs(
+    series_label: String,
+    points: Vec<PlotPoint>,
+    entity_path: &EntityPath,
+    aggregator: AggregationPolicy,
+    aggregation_factor: f64,
+    min_time: i64,
+    all_series: &mut Vec<PlotSeries>,
+) {
+    re_tracing::profile_function!();
+
+    let num_points = points.len();
+    let mut attrs = points[0].attrs.clone();
+    let mut series: PlotSeries = PlotSeries {
+        label: series_label.clone(),
+        color: attrs.color,
+        radius_ui: attrs.radius_ui,
+        points: Vec::with_capacity(num_points),
+        kind: attrs.kind,
+        entity_path: entity_path.clone(),
+        aggregator,
+        aggregation_factor,
+        min_time,
+    };
+
+    for (i, p) in points.into_iter().enumerate() {
+        if p.attrs == attrs {
+            // Same attributes, just add to the current series.
+
+            series.points.push((p.time, p.value));
+        } else {
+            // Attributes changed since last point, break up the current run into a
+            // its own series, and start the next one.
+
+            attrs = p.attrs;
+            let prev_series = std::mem::replace(
+                &mut series,
+                PlotSeries {
+                    label: series_label.clone(),
+                    color: attrs.color,
+                    radius_ui: attrs.radius_ui,
+                    kind: attrs.kind,
+                    points: Vec::with_capacity(num_points - i),
+                    entity_path: entity_path.clone(),
+                    aggregator,
+                    aggregation_factor,
+                    min_time,
+                },
+            );
+
+            let cur_continuous = matches!(attrs.kind, PlotSeriesKind::Continuous);
+            let prev_continuous = matches!(prev_series.kind, PlotSeriesKind::Continuous);
+
+            let prev_point = *prev_series.points.last().unwrap();
+            all_series.push(prev_series);
+
+            // If the previous point was continuous and the current point is continuous
+            // too, then we want the 2 segments to appear continuous even though they
+            // are actually split from a data standpoint.
+            if cur_continuous && prev_continuous {
+                series.points.push(prev_point);
+            }
+
+            // Add the point that triggered the split to the new segment.
+            series.points.push((p.time, p.value));
+        }
+    }
+
+    if !series.points.is_empty() {
+        all_series.push(series);
+    }
 }


### PR DESCRIPTION
### What

#7140 improved the handling of timeseries label, but made the visualisers UI for `Name` not very nice. This PR fixes this.

<img width="476" alt="image" src="https://github.com/user-attachments/assets/5984b18d-d725-4bba-9fa1-cb9d58a1546e">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7203?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7203?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7203)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.