### PR TITLE
Mark required components only be there if they're not logged as empty array

### DIFF
--- a/crates/viewer/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
@@ -184,9 +184,14 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
                 continue;
             }
 
-            for component_name in event.diff.chunk.component_names() {
-                if let Some(index) = self.required_components_indices.get(&component_name) {
-                    required_components_bitmap.set(*index, true);
+            for (component_name, list_array) in event.diff.chunk.components() {
+                if let Some(index) = self.required_components_indices.get(component_name) {
+                    // The component might be present, but logged completely empty.
+                    // That shouldn't count towards filling "having the required component present"!
+                    // (Note: This happens frequently now with `Transform3D`'s component which always get logged, thus tripping of the `AxisLengthDetector`!)` )
+                    if !list_array.values().is_empty() {
+                        required_components_bitmap.set(*index, true);
+                    }
                 }
             }
 


### PR DESCRIPTION
### What

We eagerly marked components as "present" for applicability check even if they were just logged as empty arrays.
Not a problem until now: Transform logs all its components always, including the axis length.
Present of axis lengths then led the heuristic to place transform axises eagerly!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7205?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7205?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7205)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.