### PR TITLE
Fix serialization of UTF8List, causing VisualizerOverride to be broken

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
@@ -31,7 +31,14 @@ class Utf8ListExt:
             if len(data) == 0:
                 array = []
             elif isinstance(data[0], Utf8List):
-                array = [[str(datum.value) for datum in data]]  # type: ignore[union-attr]
+                # List of Utf8List!
+                array = [datum.value for datum in data]  # type: ignore[union-attr]
+            elif isinstance(data[0], Sequence):
+                # It's a nested sequence. Might still be a string though since strings are sequences.
+                if isinstance(data[0], str):
+                    array = [[str(datum) for datum in data]]
+                else:
+                    array = [[str(item) for item in sub_array] for sub_array in data]  # type: ignore[union-attr]
             else:
                 array = [[str(datum) for datum in data]]
         else:

--- a/rerun_py/tests/unit/test_utf8list.py
+++ b/rerun_py/tests/unit/test_utf8list.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import rerun.blueprint.datatypes as datatypes
+
+
+def test_utf8list() -> None:
+    # An array of string should be interpreted as a batch of a single Utf8List, which contains the provided strings.
+    list_with_two_strings = ["String One", "String Two"]
+    list_of_list_with_two_strings = [list_with_two_strings]
+    assert (
+        datatypes.Utf8ListBatch(list_with_two_strings).as_arrow_array()
+        == datatypes.Utf8ListBatch(list_of_list_with_two_strings).as_arrow_array()
+    )
+
+    # A single Utf8List, an array of a single Utf8List should be the same as above
+    single_utf8list = datatypes.Utf8List(["String One", "String Two"])
+    list_with_single_utf8list = [single_utf8list]
+
+    assert (
+        datatypes.Utf8ListBatch(list_with_two_strings).as_arrow_array()
+        == datatypes.Utf8ListBatch(single_utf8list).as_arrow_array()
+    )
+    assert (
+        datatypes.Utf8ListBatch(single_utf8list).as_arrow_array()
+        == datatypes.Utf8ListBatch(list_with_single_utf8list).as_arrow_array()
+    )
+
+    # A list of string arrays should be interpreted as a list of Utf8List
+    two_string_arrays = [["1.1", "1.2"], ["2.1", "2.2"]]
+    two_utf8_arrays = [datatypes.Utf8List(["1.1", "1.2"]), datatypes.Utf8List(["2.1", "2.2"])]
+    assert (
+        datatypes.Utf8ListBatch(two_string_arrays).as_arrow_array()
+        == datatypes.Utf8ListBatch(two_utf8_arrays).as_arrow_array()
+    )
+
+    # A single string should be interpreted as a batch of a single Utf8List, which contains a single string
+    single_string = "Hello"
+    array_of_single_string = [single_string]
+    array_of_array_of_single_string = [array_of_single_string]
+    assert (
+        datatypes.Utf8ListBatch(single_string).as_arrow_array()
+        == datatypes.Utf8ListBatch(array_of_single_string).as_arrow_array()
+    )
+
+    assert (
+        datatypes.Utf8ListBatch(array_of_single_string).as_arrow_array()
+        == datatypes.Utf8ListBatch(array_of_array_of_single_string).as_arrow_array()
+    )


### PR DESCRIPTION
### What

Add tests for various utf8list cases

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7207?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7207?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7207)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.