### PR TITLE
Deduplicate space view label processing code

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -119,33 +119,23 @@ impl Arrows2DVisualizer {
             self.data
                 .add_bounding_box(entity_path.hash(), obj_space_bounding_box, world_from_obj);
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many arrows but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && num_instances > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(
-                        obj_space_bounding_box.center().truncate(),
-                    ))
-                } else {
+            self.data.ui_labels.extend(process_labels_2d(
+                entity_path,
+                num_instances,
+                obj_space_bounding_box.center().truncate(),
+                {
                     // Take middle point of every arrow.
                     let origins = clamped_or(data.origins, &Position2D::ZERO);
-                    itertools::Either::Right(itertools::izip!(data.vectors, origins).map(
-                        |(vector, origin)| {
-                            // `0.45` rather than `0.5` to account for cap and such
-                            glam::Vec2::from(origin.0) + glam::Vec2::from(vector.0) * 0.45
-                        },
-                    ))
-                };
-
-                self.data.ui_labels.extend(process_labels_2d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    world_from_obj,
-                ));
-            }
+                    itertools::izip!(data.vectors, origins).map(|(vector, origin)| {
+                        // `0.45` rather than `0.5` to account for cap and such
+                        glam::Vec2::from(origin.0) + glam::Vec2::from(vector.0) * 0.45
+                    })
+                },
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                world_from_obj,
+            ));
         }
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -120,25 +120,21 @@ impl Arrows3DVisualizer {
             self.data
                 .add_bounding_box(entity_path.hash(), obj_space_bounding_box, world_from_obj);
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many arrows but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && num_instances > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(obj_space_bounding_box.center()))
-                } else {
+            {
+                let label_positions = {
                     // Take middle point of every arrow.
                     let origins = clamped_or(data.origins, &Position3D::ZERO);
 
-                    itertools::Either::Right(itertools::izip!(data.vectors, origins).map(
-                        |(vector, origin)| {
-                            // `0.45` rather than `0.5` to account for cap and such
-                            glam::Vec3::from(origin.0) + glam::Vec3::from(vector.0) * 0.45
-                        },
-                    ))
+                    itertools::izip!(data.vectors, origins).map(|(vector, origin)| {
+                        // `0.45` rather than `0.5` to account for cap and such
+                        glam::Vec3::from(origin.0) + glam::Vec3::from(vector.0) * 0.45
+                    })
                 };
 
                 self.data.ui_labels.extend(process_labels_3d(
                     entity_path,
+                    num_instances,
+                    obj_space_bounding_box.center(),
                     label_positions,
                     &data.labels,
                     &colors,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -153,30 +153,19 @@ impl Boxes3DVisualizer {
                 .bounding_boxes
                 .push((entity_path.hash(), world_space_bounding_box));
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many boxes but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && num_instances > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(world_space_bounding_box.center()))
-                } else {
-                    // Take center point of every box.
-                    itertools::Either::Right(
-                        ent_context
-                            .transform_info
-                            .clamped_reference_from_instances()
-                            .map(|t| t.translation.into()),
-                    )
-                };
-
-                self.0.ui_labels.extend(process_labels_3d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    glam::Affine3A::IDENTITY,
-                ));
-            }
+            self.0.ui_labels.extend(process_labels_3d(
+                entity_path,
+                num_instances,
+                world_space_bounding_box.center(),
+                ent_context
+                    .transform_info
+                    .clamped_reference_from_instances()
+                    .map(|t| t.translation.into()),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                glam::Affine3A::IDENTITY,
+            ));
         }
 
         Ok(())

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -194,30 +194,19 @@ impl Ellipsoids3DVisualizer {
                 .bounding_boxes
                 .push((entity_path.hash(), world_space_bounding_box));
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many boxes but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && num_instances > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(world_space_bounding_box.center()))
-                } else {
-                    // Take center point of every box.
-                    itertools::Either::Right(
-                        ent_context
-                            .transform_info
-                            .clamped_reference_from_instances()
-                            .map(|t| t.translation.into()),
-                    )
-                };
-
-                self.0.ui_labels.extend(process_labels_3d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    glam::Affine3A::IDENTITY,
-                ));
-            }
+            self.0.ui_labels.extend(process_labels_3d(
+                entity_path,
+                num_instances,
+                world_space_bounding_box.center(),
+                ent_context
+                    .transform_info
+                    .clamped_reference_from_instances()
+                    .map(|t| t.translation.into()),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                glam::Affine3A::IDENTITY,
+            ));
         }
 
         Ok(())

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -106,34 +106,23 @@ impl Lines2DVisualizer {
             self.data
                 .add_bounding_box(entity_path.hash(), obj_space_bounding_box, world_from_obj);
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many strips but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && data.strips.len() > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(
-                        obj_space_bounding_box.center().truncate(),
-                    ))
-                } else {
-                    // Take middle point of every strip.
-                    itertools::Either::Right(data.strips.iter().map(|strip| {
-                        strip
-                            .iter()
-                            .copied()
-                            .map(glam::Vec2::from)
-                            .sum::<glam::Vec2>()
-                            / (strip.len() as f32)
-                    }))
-                };
-
-                self.data.ui_labels.extend(process_labels_2d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    world_from_obj,
-                ));
-            }
+            self.data.ui_labels.extend(process_labels_2d(
+                entity_path,
+                num_instances,
+                obj_space_bounding_box.center().truncate(),
+                data.strips.iter().map(|strip| {
+                    strip
+                        .iter()
+                        .copied()
+                        .map(glam::Vec2::from)
+                        .sum::<glam::Vec2>()
+                        / (strip.len() as f32)
+                }),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                world_from_obj,
+            ));
         }
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -113,32 +113,23 @@ impl Lines3DVisualizer {
             self.data
                 .add_bounding_box(entity_path.hash(), obj_space_bounding_box, world_from_obj);
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many strips but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && data.strips.len() > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(obj_space_bounding_box.center()))
-                } else {
-                    // Take middle point of every strip.
-                    itertools::Either::Right(data.strips.iter().map(|strip| {
-                        strip
-                            .iter()
-                            .copied()
-                            .map(glam::Vec3::from)
-                            .sum::<glam::Vec3>()
-                            / (strip.len() as f32)
-                    }))
-                };
-
-                self.data.ui_labels.extend(process_labels_3d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    world_from_obj,
-                ));
-            }
+            self.data.ui_labels.extend(process_labels_3d(
+                entity_path,
+                num_instances,
+                obj_space_bounding_box.center(),
+                data.strips.iter().map(|strip| {
+                    strip
+                        .iter()
+                        .copied()
+                        .map(glam::Vec3::from)
+                        .sum::<glam::Vec3>()
+                        / (strip.len() as f32)
+                }),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                world_from_obj,
+            ));
         }
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/mod.rs
@@ -27,7 +27,7 @@ pub use segmentation_images::SegmentationImageVisualizer;
 pub use transform3d_arrows::{add_axis_arrows, AxisLengthDetector, Transform3DArrowsVisualizer};
 pub use utilities::{
     entity_iterator, process_labels_3d, textured_rect_from_image, SpatialViewVisualizerData,
-    UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
+    UiLabel, UiLabelTarget,
 };
 
 // ---

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -128,28 +128,16 @@ impl Points2DVisualizer {
 
             load_keypoint_connections(line_builder, ent_context, entity_path, &keypoints)?;
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many points but only a single label, place the single label at the middle of the visualization.
-                let label_positions = if data.labels.len() == 1 && data.positions.len() > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    itertools::Either::Left(std::iter::once(
-                        obj_space_bounding_box.center().truncate(),
-                    ))
-                } else {
-                    itertools::Either::Right(
-                        data.positions.iter().map(|p| glam::vec2(p.x(), p.y())),
-                    )
-                };
-
-                self.data.ui_labels.extend(process_labels_2d(
-                    entity_path,
-                    label_positions,
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    world_from_obj,
-                ));
-            }
+            self.data.ui_labels.extend(process_labels_2d(
+                entity_path,
+                num_instances,
+                obj_space_bounding_box.center().truncate(),
+                data.positions.iter().map(|p| glam::vec2(p.x(), p.y())),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                world_from_obj,
+            ));
         }
 
         Ok(())

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -134,26 +134,16 @@ impl Points3DVisualizer {
 
             load_keypoint_connections(line_builder, ent_context, entity_path, &keypoints)?;
 
-            if data.labels.len() == 1 || num_instances <= super::MAX_NUM_LABELS_PER_ENTITY {
-                // If there's many points but only a single label, place the single label at the middle of the visualization.
-                let obj_space_bbox_center;
-                let label_positions = if data.labels.len() == 1 && positions.len() > 1 {
-                    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
-                    obj_space_bbox_center = [obj_space_bounding_box.center()];
-                    &obj_space_bbox_center
-                } else {
-                    positions
-                };
-
-                self.data.ui_labels.extend(process_labels_3d(
-                    entity_path,
-                    label_positions.iter().copied(),
-                    &data.labels,
-                    &colors,
-                    &annotation_infos,
-                    world_from_obj,
-                ));
-            }
+            self.data.ui_labels.extend(process_labels_3d(
+                entity_path,
+                num_instances,
+                obj_space_bounding_box.center(),
+                positions.iter().copied(),
+                &data.labels,
+                &colors,
+                &annotation_infos,
+                world_from_obj,
+            ));
         }
 
         Ok(())

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
@@ -1,4 +1,8 @@
-use itertools::izip;
+#![allow(clippy::too_many_arguments)]
+
+use std::iter;
+
+use itertools::{izip, Either};
 
 use re_entity_db::InstancePathHash;
 use re_log_types::{EntityPath, Instance};
@@ -37,19 +41,22 @@ pub const MAX_NUM_LABELS_PER_ENTITY: usize = 30;
 
 /// Produces 3D ui labels from component data.
 ///
-/// Does nothing if there's no positions or no labels passed.
-/// Otherwise, produces one label per position passed.
+/// See [`process_labels()`] for further documentation.
 pub fn process_labels_3d<'a>(
     entity_path: &'a EntityPath,
-    positions: impl Iterator<Item = glam::Vec3> + 'a,
+    num_instances: usize,
+    overall_position: glam::Vec3,
+    instance_positions: impl Iterator<Item = glam::Vec3> + 'a,
     labels: &'a [re_types::ArrowString],
     colors: &'a [egui::Color32],
     annotation_infos: &'a ResolvedAnnotationInfos,
     world_from_obj: glam::Affine3A,
 ) -> impl Iterator<Item = UiLabel> + 'a {
-    process_labels_common(
+    process_labels(
         entity_path,
-        positions,
+        num_instances,
+        overall_position,
+        instance_positions,
         labels,
         colors,
         annotation_infos,
@@ -59,19 +66,22 @@ pub fn process_labels_3d<'a>(
 
 /// Produces 2D ui labels from component data.
 ///
-/// Does nothing if there's no positions or no labels passed.
-/// Otherwise, produces one label per position passed.
+/// See [`process_labels()`] for further documentation.
 pub fn process_labels_2d<'a>(
     entity_path: &'a EntityPath,
-    positions: impl Iterator<Item = glam::Vec2> + 'a,
+    num_instances: usize,
+    overall_position: glam::Vec2,
+    instance_positions: impl Iterator<Item = glam::Vec2> + 'a,
     labels: &'a [re_types::ArrowString],
     colors: &'a [egui::Color32],
     annotation_infos: &'a ResolvedAnnotationInfos,
     world_from_obj: glam::Affine3A,
 ) -> impl Iterator<Item = UiLabel> + 'a {
-    process_labels_common(
+    process_labels(
         entity_path,
-        positions,
+        num_instances,
+        overall_position,
+        instance_positions,
         labels,
         colors,
         annotation_infos,
@@ -82,14 +92,40 @@ pub fn process_labels_2d<'a>(
     )
 }
 
-fn process_labels_common<'a, P>(
+/// Produces ui labels from component data, allowing the caller to produce [`UiLabelTarget`]s
+/// as they see fit.
+///
+/// Implements policy for displaying a single label vs. per-instance labels, or hiding labels.
+///
+/// * `num_instances` should be equal to the length of `instance_positions`.
+/// * `overall_position` is the position where a single shared label will be displayed if it is.
+///   This is typically the center of the bounding box of the entity.
+/// * The number of per-instance labels actually drawn is the minimum of the lengths of
+///   `instance_positions` and `labels`.
+pub fn process_labels<'a, P: 'a>(
     entity_path: &'a EntityPath,
-    positions: impl Iterator<Item = P> + 'a,
+    num_instances: usize,
+    overall_position: P,
+    instance_positions: impl Iterator<Item = P> + 'a,
     labels: &'a [re_types::ArrowString],
     colors: &'a [egui::Color32],
     annotation_infos: &'a ResolvedAnnotationInfos,
     target_from_position: impl Fn(P) -> UiLabelTarget + 'a,
 ) -> impl Iterator<Item = UiLabel> + 'a {
+    if labels.len() > 1 && num_instances > MAX_NUM_LABELS_PER_ENTITY {
+        // Too many labels. Don't draw them.
+        return Either::Left(iter::empty());
+    }
+
+    // If there's many instances but only a single label, place the single label at the
+    // overall_position (which is usually a bounding box center).
+    // TODO(andreas): A smoothed over time (+ discontinuity detection) bounding box would be great.
+    let label_positions = if labels.len() == 1 && num_instances > 1 {
+        Either::Left(std::iter::once(overall_position))
+    } else {
+        Either::Right(instance_positions)
+    };
+
     let labels = izip!(
         annotation_infos.iter(),
         labels.iter().map(Some).chain(std::iter::repeat(None))
@@ -98,14 +134,19 @@ fn process_labels_common<'a, P>(
 
     let colors = clamped_or(colors, &egui::Color32::WHITE);
 
-    itertools::izip!(positions, labels, colors)
-        .enumerate()
-        .filter_map(move |(i, (position, label, color))| {
-            label.map(|label| UiLabel {
-                text: label,
-                color: *color,
-                target: target_from_position(position),
-                labeled_instance: InstancePathHash::instance(entity_path, Instance::from(i as u64)),
-            })
-        })
+    Either::Right(
+        itertools::izip!(label_positions, labels, colors)
+            .enumerate()
+            .filter_map(move |(i, (position, label, color))| {
+                label.map(|label| UiLabel {
+                    text: label,
+                    color: *color,
+                    target: target_from_position(position),
+                    labeled_instance: InstancePathHash::instance(
+                        entity_path,
+                        Instance::from(i as u64),
+                    ),
+                })
+            }),
+    )
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/mod.rs
@@ -3,8 +3,6 @@ mod labels;
 mod spatial_view_visualizer;
 mod textured_rect;
 
-pub use labels::{
-    process_labels_2d, process_labels_3d, UiLabel, UiLabelTarget, MAX_NUM_LABELS_PER_ENTITY,
-};
+pub use labels::{process_labels, process_labels_2d, process_labels_3d, UiLabel, UiLabelTarget};
 pub use spatial_view_visualizer::SpatialViewVisualizerData;
 pub use textured_rect::textured_rect_from_image;


### PR DESCRIPTION
### What

* Combine code of `process_labels_3d` and `process_labels_2d` into one core function, `process_labels`.
* Move all copies of the code deciding how many labels to show into `process_labels`.

This is a (hopefully) pure refactoring which removes duplicate code and should also make #3465 easier to implement.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7208?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7208?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [X] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [X] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7208)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.