### PR TITLE
Correct dependency on `puffin` to 0.19.1, preventing a possible build failure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,7 @@ pollster = "0.3"
 prettyplease = "0.2"
 proc-macro2 = { version = "1.0", default-features = false }
 profiling = { version = "1.0.12", default-features = false }
-puffin = "0.19"
+puffin = "0.19.1"
 puffin_http = "0.16"
 pyo3 = "0.20.2"
 pyo3-build-config = "0.20.2"


### PR DESCRIPTION
### What

`re_tracing::profile_function_if` uses `puffin::profile_function_if`, which only exists in `puffin` 0.19.1 and not 0.19.0. This incorrect version would cause a compilation failure for users updating to Rerun 0.18 who already have `puffin` 0.19.0 in their lock file.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [X] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7221?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7221?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [X] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [X] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7221)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.