### PR TITLE
[WIP] Datastore UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,6 +4457,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_datastore_ui"
+version = "0.19.0-alpha.1+dev"
+dependencies = [
+ "egui",
+ "re_chunk_store",
+ "re_data_ui",
+ "re_entity_db",
+ "re_types",
+ "re_ui",
+ "re_viewer_context",
+]
+
+[[package]]
 name = "re_dev_tools"
 version = "0.19.0-alpha.1+dev"
 dependencies = [
@@ -5254,6 +5267,7 @@ dependencies = [
  "re_data_loader",
  "re_data_source",
  "re_data_ui",
+ "re_datastore_ui",
  "re_edit_ui",
  "re_entity_db",
  "re_error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4461,9 +4461,14 @@ name = "re_datastore_ui"
 version = "0.19.0-alpha.1+dev"
 dependencies = [
  "egui",
+ "egui_extras",
+ "itertools 0.13.0",
  "re_chunk_store",
  "re_data_ui",
  "re_entity_db",
+ "re_format",
+ "re_format_arrow",
+ "re_log_types",
  "re_types",
  "re_ui",
  "re_viewer_context",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ re_tuid = { path = "crates/utils/re_tuid", version = "=0.19.0-alpha.1", default-
 re_blueprint_tree = { path = "crates/viewer/re_blueprint_tree", version = "=0.19.0-alpha.1", default-features = false }
 re_context_menu = { path = "crates/viewer/re_context_menu", version = "=0.19.0-alpha.1", default-features = false }
 re_data_ui = { path = "crates/viewer/re_data_ui", version = "=0.19.0-alpha.1", default-features = false }
+re_datastore_ui = { path = "crates/viewer/re_datastore_ui", version = "=0.19.0-alpha.1", default-features = false }
 re_edit_ui = { path = "crates/viewer/re_edit_ui", version = "=0.19.0-alpha.1", default-features = false }
 re_renderer = { path = "crates/viewer/re_renderer", version = "=0.19.0-alpha.1", default-features = false }
 re_renderer_examples = { path = "crates/viewer/re_renderer_examples", version = "=0.19.0-alpha.1", default-features = false }

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -479,6 +479,18 @@ impl ChunkStore {
         self.chunks_per_chunk_id.values()
     }
 
+    /// Get a chunk based on its ID.
+    #[inline]
+    pub fn chunk(&self, id: &ChunkId) -> Option<&Arc<Chunk>> {
+        self.chunks_per_chunk_id.get(id)
+    }
+
+    /// Get the number of chunks.
+    #[inline]
+    pub fn num_chunks(&self) -> usize {
+        self.chunks_per_chunk_id.len()
+    }
+
     /// Lookup the _latest_ arrow [`ArrowDataType`] used by a specific [`re_types_core::Component`].
     #[inline]
     pub fn lookup_datatype(&self, component_name: &ComponentName) -> Option<&ArrowDataType> {

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -106,7 +106,7 @@ impl std::fmt::Display for DisplayIntervalUnit {
 
 //TODO(john) move this and the Display impl upstream into arrow2
 #[repr(transparent)]
-struct DisplayDatatype<'a>(&'a DataType);
+pub struct DisplayDatatype<'a>(pub &'a DataType);
 
 impl std::fmt::Display for DisplayDatatype<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/crates/viewer/re_datastore_ui/Cargo.toml
+++ b/crates/viewer/re_datastore_ui/Cargo.toml
@@ -22,8 +22,13 @@ all-features = true
 re_chunk_store.workspace = true
 re_data_ui.workspace = true
 re_entity_db.workspace = true
+re_format.workspace = true
+re_format_arrow.workspace = true
+re_log_types.workspace = true
 re_types.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true
 
 egui.workspace = true
+egui_extras.workspace = true
+itertools.workspace = true

--- a/crates/viewer/re_datastore_ui/Cargo.toml
+++ b/crates/viewer/re_datastore_ui/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+authors.workspace = true
+description = "Display the contents of the datastore."
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "re_datastore_ui"
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+include = ["../../LICENSE-APACHE", "../../LICENSE-MIT", "**/*.rs", "Cargo.toml"]
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+re_chunk_store.workspace = true
+re_data_ui.workspace = true
+re_entity_db.workspace = true
+re_types.workspace = true
+re_ui.workspace = true
+re_viewer_context.workspace = true
+
+egui.workspace = true

--- a/crates/viewer/re_datastore_ui/README.md
+++ b/crates/viewer/re_datastore_ui/README.md
@@ -1,0 +1,10 @@
+# re_datastore_ui
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_datastore_ui.svg?speculative-link)](https://crates.io/crates/re_data_ui)
+[![Documentation](https://docs.rs/re_datastore_ui/badge.svg?speculative-link)](https://docs.rs/re_data_ui)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Provides a UI for the datastore.

--- a/crates/viewer/re_datastore_ui/src/datastore_ui.rs
+++ b/crates/viewer/re_datastore_ui/src/datastore_ui.rs
@@ -1,10 +1,457 @@
-use re_viewer_context::ViewerContext;
+use std::sync::Arc;
 
-#[derive(Default)]
-pub struct DatastoreUi;
+use egui_extras::{Column, TableRow};
+use itertools::Itertools;
+
+use re_chunk_store::external::re_chunk::external::arrow2;
+use re_chunk_store::external::re_chunk::external::arrow2::array::Utf8Array;
+use re_chunk_store::{Chunk, ChunkStore};
+use re_log_types::{StoreKind, TimeZone};
+use re_types::datatypes::TimeInt;
+use re_types::SizeBytes as _;
+use re_ui::{list_item, UiExt as _};
+use re_viewer_context::{UiLayout, ViewerContext};
+
+fn outer_frame() -> egui::Frame {
+    egui::Frame {
+        inner_margin: egui::Margin::same(5.0),
+        ..Default::default()
+    }
+}
+
+pub struct DatastoreUi {
+    store_kind: StoreKind,
+    focused_chunk: Option<Arc<Chunk>>,
+}
+
+impl Default for DatastoreUi {
+    fn default() -> Self {
+        Self {
+            store_kind: StoreKind::Recording,
+            focused_chunk: None,
+        }
+    }
+}
 
 impl DatastoreUi {
-    pub fn ui(&mut self, _ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
-        ui.label("Datastore UI goes here.");
+    pub fn ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
+        if let Some(focused_chunk) = self.focused_chunk.clone() {
+            self.chunk_ui(ctx, ui, &focused_chunk);
+        } else {
+            self.chunk_store_ui(
+                ui,
+                match self.store_kind {
+                    StoreKind::Recording => ctx.recording_store(),
+                    StoreKind::Blueprint => ctx.blueprint_store(),
+                },
+            );
+        }
+    }
+
+    fn chunk_store_ui(&mut self, ui: &mut egui::Ui, chunk_store: &ChunkStore) {
+        self.chunk_store_info_ui(ui, chunk_store);
+
+        let chunks = chunk_store.iter_chunks().collect_vec();
+
+        let header_ui = |mut row: TableRow<'_, '_>| {
+            row.col(|ui| {
+                ui.strong("ID");
+            });
+
+            row.col(|ui| {
+                ui.strong("EntityPath");
+            });
+
+            row.col(|ui| {
+                ui.strong("Sorted");
+            });
+
+            row.col(|ui| {
+                ui.strong("Rows");
+            });
+
+            row.col(|ui| {
+                ui.strong("Timelines");
+            });
+
+            row.col(|ui| {
+                ui.strong("Components");
+            });
+        };
+
+        let row_ui = |mut row: TableRow<'_, '_>| {
+            let chunk = chunks[row.index()];
+            row.col(|ui| {
+                if ui.button(chunk.id().to_string()).clicked() {
+                    self.focused_chunk = Some(Arc::clone(chunk));
+                }
+            });
+
+            row.col(|ui| {
+                ui.label(chunk.entity_path().to_string());
+            });
+
+            row.col(|ui| {
+                ui.label(if chunk.is_sorted() { "yes" } else { "no" });
+            });
+
+            row.col(|ui| {
+                ui.label(chunk.num_rows().to_string());
+            });
+
+            //TODO: make that a filter and show static vs. timeline count here
+            row.col(|ui| {
+                ui.label(
+                    chunk
+                        .timelines()
+                        .keys()
+                        .map(|timeline| timeline.name().as_str())
+                        .join(", "),
+                );
+            });
+
+            //TODO: make that a filter and show component as tooltip.
+            row.col(|ui| {
+                ui.label(
+                    chunk
+                        .components()
+                        .keys()
+                        .map(|name| name.short_name())
+                        .join(", "),
+                );
+            });
+        };
+
+        egui::ScrollArea::horizontal()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
+                outer_frame().show(ui, |ui| {
+                    //TODO: `TableBuilder` should have a custom ID API.
+                    //TODO: btw, set unique UIs in dataframe view as well.
+                    ui.push_id("chunk_list", |ui| {
+                        let table_builder = egui_extras::TableBuilder::new(ui)
+                            .columns(Column::auto_with_initial_suggestion(200.0).clip(true), 6)
+                            .resizable(true)
+                            .vscroll(true)
+                            //TODO(ab): remove when https://github.com/emilk/egui/pull/4817 is merged/released
+                            .max_scroll_height(f32::INFINITY)
+                            .auto_shrink([false, false])
+                            .striped(true);
+
+                        table_builder
+                            .header(re_ui::DesignTokens::table_line_height(), header_ui)
+                            .body(|body| {
+                                body.rows(
+                                    re_ui::DesignTokens::table_line_height(),
+                                    chunks.len(),
+                                    row_ui,
+                                );
+                            });
+                    });
+                });
+            });
+    }
+
+    fn chunk_store_info_ui(&mut self, ui: &mut egui::Ui, chunk_store: &ChunkStore) {
+        let chunk_store_stats_ui = |ui: &mut egui::Ui| {
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("ID").value_text(chunk_store.id().to_string()),
+            );
+
+            //TODO: config
+
+            let stats = chunk_store.stats().total();
+            list_item::ListItem::new()
+                .interactive(false)
+                .show_hierarchical_with_children(
+                    ui,
+                    "stats".into(),
+                    true,
+                    list_item::LabelContent::new("Stats"),
+                    |ui| {
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Chunk count")
+                                .value_text(stats.num_chunks.to_string()),
+                        );
+
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Heap size")
+                                .value_text(re_format::format_bytes(stats.total_size_bytes as f64)),
+                        );
+
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Rows")
+                                .value_text(stats.num_rows.to_string()),
+                        );
+
+                        ui.list_item_flat_noninteractive(
+                            list_item::PropertyContent::new("Events")
+                                .value_text(stats.num_events.to_string()),
+                        );
+                    },
+                );
+        };
+
+        outer_frame().show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.selectable_toggle(|ui| {
+                    ui.selectable_value(&mut self.store_kind, StoreKind::Recording, "Recording");
+                    ui.selectable_value(&mut self.store_kind, StoreKind::Blueprint, "Blueprint");
+                });
+            });
+
+            list_item::list_item_scope(ui, "chunk_store_stats", |ui| {
+                list_item::ListItem::new()
+                    .interactive(false)
+                    .show_hierarchical_with_children(
+                        ui,
+                        "chunk_store_stats".into(),
+                        false,
+                        list_item::LabelContent::new("Chunk store stats"),
+                        chunk_store_stats_ui,
+                    );
+            });
+        });
+    }
+
+    fn chunk_ui(&mut self, ctx: &ViewerContext<'_>, ui: &mut egui::Ui, chunk: &Arc<Chunk>) {
+        self.chunk_info_ui(ui, chunk);
+
+        let row_ids = chunk.row_ids().collect_vec();
+        let time_columns = chunk.timelines().values().collect_vec();
+        let component_names = chunk.component_names().collect_vec();
+
+        let header_ui = |mut row: TableRow<'_, '_>| {
+            row.col(|ui| {
+                ui.strong("Row ID");
+            });
+
+            time_columns.iter().for_each(|time_column| {
+                row.col(|ui| {
+                    ui.strong(time_column.timeline().name().as_str());
+                });
+            });
+
+            for component_name in &component_names {
+                row.col(|ui| {
+                    //TODO: tooltip: arrow schema
+                    ui.strong(component_name.short_name()).on_hover_ui(|ui| {
+                        //TODO(#1809): I wish there was a central place to look up for datatype
+                        let datatype = ctx
+                            .recording_store()
+                            .lookup_datatype(component_name)
+                            .or_else(|| ctx.blueprint_store().lookup_datatype(component_name));
+
+                        if let Some(datatype) = datatype {
+                            UiLayout::Tooltip.data_label(
+                                ui,
+                                re_format_arrow::DisplayDatatype(datatype).to_string(),
+                            );
+                        } else {
+                            ui.error_label("Couldn't find a type definition.");
+                        }
+                    });
+                });
+            }
+        };
+
+        let row_ui = |mut row: TableRow<'_, '_>| {
+            let row_index = row.index();
+            let row_id = row_ids[row_index];
+
+            row.col(|ui| {
+                ui.label(row_id.to_string());
+            });
+
+            for time_column in time_columns.iter() {
+                row.col(|ui| {
+                    let time = TimeInt::from(time_column.times_raw()[row_index]);
+
+                    //TODO: use the user's timezone
+                    ui.label(time_column.timeline().typ().format(time, TimeZone::Utc));
+                });
+            }
+
+            for component_name in &component_names {
+                row.col(|ui| {
+                    let component_data = chunk.component_batch_raw(component_name, row_index);
+                    if let Some(Ok(data)) = component_data {
+                        arrow_ui(ui, UiLayout::List, &*data);
+                    } else {
+                        //TODO: handle error here
+                        ui.label("-");
+                    }
+                });
+            }
+        };
+
+        egui::ScrollArea::horizontal()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
+                outer_frame().show(ui, |ui| {
+                    //TODO: `TableBuilder` should have a custom ID API.
+                    //TODO: btw, set unique UIs in dataframe view as well.
+                    ui.push_id("chunk", |ui| {
+                        let table_builder = egui_extras::TableBuilder::new(ui)
+                            .columns(
+                                Column::auto_with_initial_suggestion(200.0).clip(true),
+                                1 + time_columns.len() + component_names.len(),
+                            )
+                            .resizable(true)
+                            .vscroll(true)
+                            //TODO(ab): remove when https://github.com/emilk/egui/pull/4817 is merged/released
+                            .max_scroll_height(f32::INFINITY)
+                            .auto_shrink([false, false])
+                            .striped(true);
+
+                        table_builder
+                            .header(re_ui::DesignTokens::table_line_height(), header_ui)
+                            .body(|body| {
+                                body.rows(
+                                    re_ui::DesignTokens::table_line_height(),
+                                    row_ids.len(),
+                                    row_ui,
+                                );
+                            });
+                    });
+                });
+            });
+    }
+
+    fn chunk_info_ui(&mut self, ui: &mut egui::Ui, chunk: &Arc<Chunk>) {
+        let chunk_stats_ui = |ui: &mut egui::Ui| {
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("ID").value_text(chunk.id().to_string()),
+            );
+
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("Entity")
+                    .value_text(chunk.entity_path().to_string()),
+            );
+
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("Row count")
+                    .value_text(chunk.num_rows().to_string()),
+            );
+
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("Heap size")
+                    .value_text(re_format::format_bytes(chunk.heap_size_bytes() as f64)),
+            );
+
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("Sorted").value_text(if chunk.is_sorted() {
+                    "yes"
+                } else {
+                    "no"
+                }),
+            );
+
+            ui.list_item_flat_noninteractive(
+                list_item::PropertyContent::new("Static").value_text(if chunk.is_static() {
+                    "yes"
+                } else {
+                    "no"
+                }),
+            );
+        };
+
+        outer_frame().show(ui, |ui| {
+            ui.horizontal(|ui| {
+                if ui.button("Back").clicked() {
+                    self.focused_chunk = None;
+                }
+
+                if ui.button("Copy").clicked() {
+                    let s = chunk.to_string();
+                    ui.output_mut(|o| o.copied_text = s);
+                }
+
+                // ui.help_hover_button().on_hover_ui(|ui| {
+                //     list_item::list_item_scope(ui, "chunk_stats", chunk_stats_ui);
+                // });
+
+                // ui.scope(|ui| {
+                //     ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                //     ui.label(format!(
+                //         "ID: {} | Entity path: {} | Row count: {} | Heap size: {} | Sorted: {} | Static: {}",
+                //         chunk.id().to_string(),
+                //         chunk.entity_path().to_string(),
+                //         chunk.num_rows(),
+                //         re_format::format_bytes(chunk.heap_size_bytes() as f64),
+                //         if chunk.is_sorted() { "yes" } else { "no" },
+                //         if chunk.is_static() { "yes" } else { "no" },
+                //     ));
+            });
+
+            list_item::list_item_scope(ui, "chunk_stats", |ui| {
+                list_item::ListItem::new()
+                    .interactive(false)
+                    .show_hierarchical_with_children(
+                        ui,
+                        "chunk_stats".into(),
+                        false,
+                        list_item::LabelContent::new("Chunk stats"),
+                        chunk_stats_ui,
+                    );
+            });
+        });
+    }
+}
+
+//TODO: adapted from `re_data_ui`
+fn arrow_ui(
+    ui: &mut egui::Ui,
+    ui_layout: UiLayout,
+    array: &dyn arrow2::array::Array,
+) -> egui::Response {
+    use re_types::SizeBytes as _;
+
+    // Special-treat text.
+    // Note: we match on the raw data here, so this works for any component containing text.
+    if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i32>>() {
+        if utf8.len() == 1 {
+            let string = utf8.value(0);
+            return ui_layout.data_label(ui, string);
+        }
+    }
+    if let Some(utf8) = array.as_any().downcast_ref::<Utf8Array<i64>>() {
+        if utf8.len() == 1 {
+            let string = utf8.value(0);
+            return ui_layout.data_label(ui, string);
+        }
+    }
+
+    let num_bytes = array.total_size_bytes();
+    if num_bytes < 3000 {
+        //TODO: had to add that to avoid a panic
+        if array.is_empty() {
+            return ui_layout.data_label(ui, "[]");
+        }
+
+        // Print small items:
+        let mut string = String::new();
+        let display = arrow2::array::get_display(array, "null");
+        if display(&mut string, 0).is_ok() {
+            return ui_layout.data_label(ui, &string);
+        }
+    }
+
+    // Fallback:
+    let bytes = re_format::format_bytes(num_bytes as _);
+
+    // TODO(emilk): pretty-print data type
+    let data_type_formatted = format!("{:?}", array.data_type());
+
+    if data_type_formatted.len() < 20 {
+        // e.g. "4.2 KiB of Float32"
+        ui_layout.data_label(ui, &format!("{bytes} of {data_type_formatted}"))
+    } else {
+        // Huge datatype, probably a union horror show
+        ui_layout.label(ui, format!("{bytes} of data"))
     }
 }

--- a/crates/viewer/re_datastore_ui/src/datastore_ui.rs
+++ b/crates/viewer/re_datastore_ui/src/datastore_ui.rs
@@ -1,0 +1,10 @@
+use re_viewer_context::ViewerContext;
+
+#[derive(Default)]
+pub struct DatastoreUi;
+
+impl DatastoreUi {
+    pub fn ui(&mut self, _ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
+        ui.label("Datastore UI goes here.");
+    }
+}

--- a/crates/viewer/re_datastore_ui/src/lib.rs
+++ b/crates/viewer/re_datastore_ui/src/lib.rs
@@ -1,0 +1,3 @@
+mod datastore_ui;
+
+pub use datastore_ui::DatastoreUi;

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -38,13 +38,14 @@ analytics = ["dep:re_analytics"]
 
 [dependencies]
 # Internal:
-re_build_info.workspace = true
 re_blueprint_tree.workspace = true
+re_build_info.workspace = true
 re_chunk.workspace = true
+re_chunk_store.workspace = true
 re_data_loader.workspace = true
 re_data_source.workspace = true
-re_chunk_store.workspace = true
 re_data_ui.workspace = true
+re_datastore_ui.workspace = true
 re_edit_ui.workspace = true
 re_entity_db.workspace = true
 re_error.workspace = true

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -45,6 +45,12 @@ pub struct AppState {
     #[serde(skip)]
     welcome_screen: crate::ui::WelcomeScreen,
 
+    #[serde(skip)]
+    datastore_ui: re_datastore_ui::DatastoreUi,
+
+    #[serde(skip)]
+    pub(crate) show_datastore_ui: bool,
+
     /// Storage for the state of each `SpaceView`
     ///
     /// This is stored here for simplicity. An exclusive reference for that is passed to the users,
@@ -75,6 +81,8 @@ impl Default for AppState {
             blueprint_panel: re_time_panel::TimePanel::new_blueprint_panel(),
             blueprint_tree: Default::default(),
             welcome_screen: Default::default(),
+            datastore_ui: Default::default(),
+            show_datastore_ui: false,
             view_states: Default::default(),
             selection_state: Default::default(),
             focused_item: Default::default(),
@@ -149,6 +157,8 @@ impl AppState {
             blueprint_panel,
             blueprint_tree,
             welcome_screen,
+            datastore_ui,
+            show_datastore_ui,
             view_states,
             selection_state,
             focused_item,
@@ -327,118 +337,127 @@ impl AppState {
             focused_item,
         };
 
-        //
-        // Blueprint time panel
-        //
+        if *show_datastore_ui {
+            datastore_ui.ui(&ctx, ui);
+        } else {
+            //
+            // Blueprint time panel
+            //
 
-        if app_options.inspect_blueprint_timeline {
-            blueprint_panel.show_panel(
+            if app_options.inspect_blueprint_timeline {
+                blueprint_panel.show_panel(
+                    &ctx,
+                    &viewport_blueprint,
+                    ctx.store_context.blueprint,
+                    blueprint_cfg,
+                    ui,
+                    PanelState::Expanded,
+                );
+            }
+
+            //
+            // Time panel
+            //
+
+            time_panel.show_panel(
                 &ctx,
                 &viewport_blueprint,
-                ctx.store_context.blueprint,
-                blueprint_cfg,
+                ctx.recording(),
+                ctx.rec_cfg,
                 ui,
-                PanelState::Expanded,
+                app_blueprint.time_panel_state(),
             );
-        }
 
-        //
-        // Time panel
-        //
+            //
+            // Selection Panel
+            //
 
-        time_panel.show_panel(
-            &ctx,
-            &viewport_blueprint,
-            ctx.recording(),
-            ctx.rec_cfg,
-            ui,
-            app_blueprint.time_panel_state(),
-        );
+            selection_panel.show_panel(
+                &ctx,
+                &viewport_blueprint,
+                view_states,
+                ui,
+                app_blueprint.selection_panel_state().is_expanded(),
+            );
 
-        //
-        // Selection Panel
-        //
+            //
+            // Left panel (recordings and blueprint)
+            //
 
-        selection_panel.show_panel(
-            &ctx,
-            &viewport_blueprint,
-            view_states,
-            ui,
-            app_blueprint.selection_panel_state().is_expanded(),
-        );
+            let left_panel = egui::SidePanel::left("blueprint_panel")
+                .resizable(true)
+                .frame(egui::Frame {
+                    fill: ui.visuals().panel_fill,
+                    ..Default::default()
+                })
+                .min_width(120.0)
+                .default_width(default_blueprint_panel_width(
+                    ui.ctx().screen_rect().width(),
+                ));
 
-        //
-        // Left panel (recordings and blueprint)
-        //
+            let show_welcome =
+                store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
 
-        let left_panel = egui::SidePanel::left("blueprint_panel")
-            .resizable(true)
-            .frame(egui::Frame {
-                fill: ui.visuals().panel_fill,
+            left_panel.show_animated_inside(
+                ui,
+                app_blueprint.blueprint_panel_state().is_expanded(),
+                |ui: &mut egui::Ui| {
+                    // ListItem don't need vertical spacing so we disable it, but restore it
+                    // before drawing the blueprint panel.
+                    ui.spacing_mut().item_spacing.y = 0.0;
+
+                    let resizable = ctx.store_context.bundle.recordings().count() > 3;
+
+                    if resizable {
+                        // Don't shrink either recordings panel or blueprint panel below this height
+                        let min_height_each = 90.0_f32.at_most(ui.available_height() / 2.0);
+
+                        egui::TopBottomPanel::top("recording_panel")
+                            .frame(egui::Frame::none())
+                            .resizable(resizable)
+                            .show_separator_line(false)
+                            .min_height(min_height_each)
+                            .default_height(210.0)
+                            .max_height(ui.available_height() - min_height_each)
+                            .show_inside(ui, |ui| {
+                                recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
+                            });
+                    } else {
+                        recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
+                    }
+
+                    ui.add_space(4.0);
+
+                    if !show_welcome {
+                        blueprint_tree.show(&ctx, &viewport_blueprint, ui);
+                    }
+                },
+            );
+
+            //
+            // Viewport
+            //
+
+            let viewport_frame = egui::Frame {
+                fill: ui.style().visuals.panel_fill,
                 ..Default::default()
-            })
-            .min_width(120.0)
-            .default_width(default_blueprint_panel_width(
-                ui.ctx().screen_rect().width(),
-            ));
+            };
 
-        let show_welcome =
-            store_context.blueprint.app_id() == Some(&StoreHub::welcome_screen_app_id());
-
-        left_panel.show_animated_inside(
-            ui,
-            app_blueprint.blueprint_panel_state().is_expanded(),
-            |ui: &mut egui::Ui| {
-                // ListItem don't need vertical spacing so we disable it, but restore it
-                // before drawing the blueprint panel.
-                ui.spacing_mut().item_spacing.y = 0.0;
-
-                let resizable = ctx.store_context.bundle.recordings().count() > 3;
-
-                if resizable {
-                    // Don't shrink either recordings panel or blueprint panel below this height
-                    let min_height_each = 90.0_f32.at_most(ui.available_height() / 2.0);
-
-                    egui::TopBottomPanel::top("recording_panel")
-                        .frame(egui::Frame::none())
-                        .resizable(resizable)
-                        .show_separator_line(false)
-                        .min_height(min_height_each)
-                        .default_height(210.0)
-                        .max_height(ui.available_height() - min_height_each)
-                        .show_inside(ui, |ui| {
-                            recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
-                        });
-                } else {
-                    recordings_panel_ui(&ctx, rx, ui, welcome_screen_state);
-                }
-
-                ui.add_space(4.0);
-
-                if !show_welcome {
-                    blueprint_tree.show(&ctx, &viewport_blueprint, ui);
-                }
-            },
-        );
-
-        //
-        // Viewport
-        //
-
-        let viewport_frame = egui::Frame {
-            fill: ui.style().visuals.panel_fill,
-            ..Default::default()
-        };
-
-        egui::CentralPanel::default()
-            .frame(viewport_frame)
-            .show_inside(ui, |ui| {
-                if show_welcome {
-                    welcome_screen.ui(ui, command_sender, welcome_screen_state, is_history_enabled);
-                } else {
-                    viewport.viewport_ui(ui, &ctx, view_states);
-                }
-            });
+            egui::CentralPanel::default()
+                .frame(viewport_frame)
+                .show_inside(ui, |ui| {
+                    if show_welcome {
+                        welcome_screen.ui(
+                            ui,
+                            command_sender,
+                            welcome_screen_state,
+                            is_history_enabled,
+                        );
+                    } else {
+                        viewport.viewport_ui(ui, &ctx, view_states);
+                    }
+                });
+        }
 
         //
         // Other UI things

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -243,7 +243,7 @@ fn connection_status_ui(ui: &mut egui::Ui, rx: &ReceiveSet<re_log_types::LogMsg>
 }
 
 /// Lay out the panel button right-to-left
-fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui::Ui) {
+fn panel_buttons_r2l(app: &mut App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui::Ui) {
     #[cfg(target_arch = "wasm32")]
     if app.is_fullscreen_allowed() {
         let icon = if app.is_fullscreen_mode() {
@@ -308,6 +308,10 @@ fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui:
     {
         app_blueprint.toggle_blueprint_panel(&app.command_sender);
     }
+
+    // datastore UI
+    ui.medium_icon_toggle_button(&re_ui::icons::RECORDING, &mut app.state.show_datastore_ui)
+        .on_hover_text("Show/hide the datastore UI");
 }
 
 /// Shows clickable website link as an image (text doesn't look as nice)

--- a/crates/viewer/re_viewer_context/src/viewer_context.rs
+++ b/crates/viewer/re_viewer_context/src/viewer_context.rs
@@ -99,6 +99,12 @@ impl<'a> ViewerContext<'a> {
         self.store_context.recording.store()
     }
 
+    /// The chunk store of the active blueprint.
+    #[inline]
+    pub fn blueprint_store(&self) -> &re_chunk_store::ChunkStore {
+        self.store_context.blueprint.store()
+    }
+
     /// The `StoreId` of the active recording.
     #[inline]
     pub fn recording_id(&self) -> &re_log_types::StoreId {


### PR DESCRIPTION
### What

Some in-viewer UI for the `ChunkStore` and its content.

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
