### PR TITLE
Speed up data density graph by rendering them more coarsly

### DIFF
--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -30,6 +30,8 @@ const MARGIN_X: f32 = 2.0;
 /// Higher = slower, but more accurate.
 const DENSITIES_PER_UI_PIXEL: f32 = 1.0;
 
+const DEBUG_PAINT: bool = false;
+
 // ----------------------------------------------------------------------------
 
 /// Persistent data for painting the data density graph.
@@ -476,6 +478,17 @@ pub fn build_density_graph<'a>(
         re_tracing::profile_scope!("add_data");
 
         let can_render_individual_events = total_events < config.max_total_chunk_events;
+
+        if DEBUG_PAINT {
+            ui.ctx().debug_painter().debug_rect(
+                row_rect,
+                egui::Color32::LIGHT_BLUE,
+                format!(
+                    "{} chunks, {total_events} events, render individual: {can_render_individual_events}",
+                    chunk_ranges.len()
+                ),
+            );
+        }
 
         for (chunk, time_range, num_events_in_chunk) in chunk_ranges {
             re_tracing::profile_scope!("chunk_range");

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -478,6 +478,8 @@ pub fn build_density_graph<'a>(
         let can_render_individual_events = total_events < config.max_total_chunk_events;
 
         for (chunk, time_range, num_events_in_chunk) in chunk_ranges {
+            re_tracing::profile_scope!("chunk_range");
+
             let should_render_individual_events = can_render_individual_events
                 && if chunk.is_timeline_sorted(&timeline) {
                     num_events_in_chunk < config.max_events_in_sorted_chunk

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -544,8 +544,8 @@ impl Default for DensityGraphBuilderConfig {
             // It does not seem to matter how many chunks there are, only how many total events we're showing.
             //
             // We want to stay around 1ms if possible, preferring to instead spend our frame budget on actually
-            // visualizing the data, so we undershoot the limit here by a good amount:
-            max_total_chunk_events: 50_000,
+            // visualizing the data, and we also want to support multiple data density graphs on the screen at once.
+            max_total_chunk_events: 10_000,
 
             // For individual chunks, the limits are completely arbitrary, and help preserve visual clarity of the data
             // when there are too many events in a given chunk.

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -479,7 +479,7 @@ pub fn build_density_graph<'a>(
 
         for (chunk, time_range, num_events_in_chunk) in chunk_ranges {
             let should_render_individual_events = can_render_individual_events
-                && if chunk.is_time_sorted() {
+                && if chunk.is_timeline_sorted(&timeline) {
                     num_events_in_chunk < config.max_events_in_sorted_chunk
                 } else {
                     num_events_in_chunk < config.max_events_in_unsorted_chunk


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/7223

We would render individual points a bit too often before. Even though it would only take 0.5ms on a laptop, there could be a lot of density graphs on the screen at once, and the milliseconds would add up quickly - especially on Wasm, where everything is slower.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7229?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7229?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7229)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.