### PR TITLE
Fix url to event.rs in `rerun analytics details`

### DIFF
--- a/crates/utils/re_analytics/src/cli.rs
+++ b/crates/utils/re_analytics/src/cli.rs
@@ -82,7 +82,7 @@ const DETAILS: &str = "
 
     What data is collected?
     - The exact set of analytics events and parameters can be found here:
-      https://github.com/rerun-io/rerun/blob/GIT_HASH/crates/re_analytics/src/event.rs
+      https://github.com/rerun-io/rerun/blob/GIT_HASH/crates/utils/re_analytics/src/event.rs
     - We collect high level events about the usage of the Rerun Viewer. For example:
       - The event 'Viewer Opened' helps us estimate how often Rerun is used.
       - The event 'Data Source Connected' helps us understand if users tend to use live


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

This PR fixes the broken url to `re_analytics/src/event.rs` shown when running `rerun analytics details`.

Before:
```
$ pixi run rerun analytics details
✨ Pixi task (rerun in default): cargo run --package rerun-cli --no-default-features --features native_viewer -- analytics details
    Finished dev [optimized + debuginfo] target(s) in 0.30s
     Running `target/debug/rerun analytics details`
[2024-08-19T13:04:15Z DEBUG rerun::commands::entrypoint] Detected 16 cores. Using 14 compute threads.

    * Anonymous Usage Data Collection in Rerun *

    Opting out:
    - Run `rerun analytics disable` to opt out of all usage data collection.

    What data is collected?
    - The exact set of analytics events and parameters can be found here:
      https://github.com/rerun-io/rerun/blob/v0.19.0-alpha.1+dev/crates/re_analytics/src/event.rs
    - We collect high level events about the usage of the Rerun Viewer. For example:
      - The event 'Viewer Opened' helps us estimate how often Rerun is used.
      - The event 'Data Source Connected' helps us understand if users tend to use live
        data sources or recordings most, which helps us prioritize features.
    - We associate events with:
        - Metadata about the Rerun build (version, target platform, etc).
        - A persistent random id that is used to associate events from
          multiple sessions together. To regenerate it run `rerun analytics clear`.
    - We may associate these events with a hashed `application_id` and `recording_id`,
      so that we can understand if users are more likely to look at few applications often,
      or tend to use Rerun for many temporary scripts. Again, this helps us prioritize.
    - We may for instance add events that help us understand how well the auto-layout works.

    What data is not collected?
    - No Personally Identifiable Information, such as user name or IP address, is collected.
      - This assumes you don't manually and explicitly associate your email with
        the analytics events using the analytics helper cli.
        (Don't do this, it's just meant for internal use for the Rerun team.)
    - No user data logged to Rerun is collected.
      - In some cases we collect secure hashes of user provided names (e.g. `application_id`),
        but take great care do this only when we have a clear understanding of why it's needed
        and it won't risk leaking anything potentially proprietary.

    Why do we collect data?
    - To improve the Rerun open source library.

    Usage data we do collect will be sent to and stored in servers within the EU.

    You can audit the actual data being sent out by inspecting the Rerun data directory directly.
    Find out its location by running `rerun analytics config`.

```

After:
```
$ pixi run rerun analytics details
✨ Pixi task (rerun in default): cargo run --package rerun-cli --no-default-features --features native_viewer -- analytics details
    Finished dev [optimized + debuginfo] target(s) in 0.31s
     Running `target/debug/rerun analytics details`
[2024-08-19T13:08:38Z DEBUG rerun::commands::entrypoint] Detected 16 cores. Using 14 compute threads.

    * Anonymous Usage Data Collection in Rerun *

    Opting out:
    - Run `rerun analytics disable` to opt out of all usage data collection.

    What data is collected?
    - The exact set of analytics events and parameters can be found here:
      https://github.com/rerun-io/rerun/blob/v0.19.0-alpha.1+dev/crates/utils/re_analytics/src/event.rs
    - We collect high level events about the usage of the Rerun Viewer. For example:
      - The event 'Viewer Opened' helps us estimate how often Rerun is used.
      - The event 'Data Source Connected' helps us understand if users tend to use live
        data sources or recordings most, which helps us prioritize features.
    - We associate events with:
        - Metadata about the Rerun build (version, target platform, etc).
        - A persistent random id that is used to associate events from
          multiple sessions together. To regenerate it run `rerun analytics clear`.
    - We may associate these events with a hashed `application_id` and `recording_id`,
      so that we can understand if users are more likely to look at few applications often,
      or tend to use Rerun for many temporary scripts. Again, this helps us prioritize.
    - We may for instance add events that help us understand how well the auto-layout works.

    What data is not collected?
    - No Personally Identifiable Information, such as user name or IP address, is collected.
      - This assumes you don't manually and explicitly associate your email with
        the analytics events using the analytics helper cli.
        (Don't do this, it's just meant for internal use for the Rerun team.)
    - No user data logged to Rerun is collected.
      - In some cases we collect secure hashes of user provided names (e.g. `application_id`),
        but take great care do this only when we have a clear understanding of why it's needed
        and it won't risk leaking anything potentially proprietary.

    Why do we collect data?
    - To improve the Rerun open source library.

    Usage data we do collect will be sent to and stored in servers within the EU.

    You can audit the actual data being sent out by inspecting the Rerun data directory directly.
    Find out its location by running `rerun analytics config`.

```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7230?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7230?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7230)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.