### PR TITLE
Typo fix - Rust - re_tracing

### DIFF
--- a/crates/utils/re_tracing/src/lib.rs
+++ b/crates/utils/re_tracing/src/lib.rs
@@ -24,7 +24,7 @@ macro_rules! profile_function {
     };
 }
 
-/// Create a profile scope based on the function name, if the given confition holds true.
+/// Create a profile scope based on the function name, if the given condition holds true.
 ///
 /// Call this at the very top of a potentially expensive function.
 #[macro_export]
@@ -44,7 +44,7 @@ macro_rules! profile_scope {
     };
 }
 
-/// Create a profiling scope with a custom name, if the given confition holds true.
+/// Create a profiling scope with a custom name, if the given condition holds true.
 #[macro_export]
 macro_rules! profile_scope_if {
     ($($arg: tt)*) => {


### PR DESCRIPTION
### What
Fixing a typo in the rust code of re_tracing

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7234?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7234?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7234)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.