### PR TITLE
BGR(A) image format support

### DIFF
--- a/crates/store/re_types/definitions/rerun/datatypes/color_model.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/color_model.fbs
@@ -15,4 +15,10 @@ enum ColorModel: ubyte{
 
     /// Red, Green, Blue, Alpha
     RGBA = 3,
+
+    /// Blue, Green, Red
+    BGR,
+
+    /// Blue, Green, Red, Alpha
+    BGRA,
 }

--- a/crates/store/re_types/src/archetypes/image_ext.rs
+++ b/crates/store/re_types/src/archetypes/image_ext.rs
@@ -39,10 +39,10 @@ impl Image {
 
         let is_shape_correct = match color_model {
             ColorModel::L => non_empty_dim_inds.len() == 2,
-            ColorModel::RGB => {
+            ColorModel::RGB | ColorModel::BGR => {
                 non_empty_dim_inds.len() == 3 && shape[non_empty_dim_inds[2]].size == 3
             }
-            ColorModel::RGBA => {
+            ColorModel::RGBA | ColorModel::BGRA => {
                 non_empty_dim_inds.len() == 3 && shape[non_empty_dim_inds[2]].size == 4
             }
         };

--- a/crates/store/re_types/src/datatypes/color_model.rs
+++ b/crates/store/re_types/src/datatypes/color_model.rs
@@ -35,12 +35,20 @@ pub enum ColorModel {
     /// Red, Green, Blue, Alpha
     #[allow(clippy::upper_case_acronyms)]
     RGBA = 3,
+
+    /// Blue, Green, Red
+    #[allow(clippy::upper_case_acronyms)]
+    BGR = 4,
+
+    /// Blue, Green, Red, Alpha
+    #[allow(clippy::upper_case_acronyms)]
+    BGRA = 5,
 }
 
 impl ::re_types_core::reflection::Enum for ColorModel {
     #[inline]
     fn variants() -> &'static [Self] {
-        &[Self::L, Self::RGB, Self::RGBA]
+        &[Self::L, Self::RGB, Self::RGBA, Self::BGR, Self::BGRA]
     }
 
     #[inline]
@@ -49,6 +57,8 @@ impl ::re_types_core::reflection::Enum for ColorModel {
             Self::L => "Grayscale luminance intencity/brightness/value, sometimes called `Y`",
             Self::RGB => "Red, Green, Blue",
             Self::RGBA => "Red, Green, Blue, Alpha",
+            Self::BGR => "Blue, Green, Red",
+            Self::BGRA => "Blue, Green, Red, Alpha",
         }
     }
 }
@@ -71,6 +81,8 @@ impl std::fmt::Display for ColorModel {
             Self::L => write!(f, "L"),
             Self::RGB => write!(f, "RGB"),
             Self::RGBA => write!(f, "RGBA"),
+            Self::BGR => write!(f, "BGR"),
+            Self::BGRA => write!(f, "BGRA"),
         }
     }
 }
@@ -147,6 +159,8 @@ impl ::re_types_core::Loggable for ColorModel {
                 Some(1) => Ok(Some(Self::L)),
                 Some(2) => Ok(Some(Self::RGB)),
                 Some(3) => Ok(Some(Self::RGBA)),
+                Some(4) => Ok(Some(Self::BGR)),
+                Some(5) => Ok(Some(Self::BGRA)),
                 None => Ok(None),
                 Some(invalid) => Err(DeserializationError::missing_union_arm(
                     Self::arrow_datatype(),

--- a/crates/store/re_types/src/datatypes/color_model_ext.rs
+++ b/crates/store/re_types/src/datatypes/color_model_ext.rs
@@ -8,8 +8,8 @@ impl ColorModel {
     pub fn num_channels(self) -> usize {
         match self {
             Self::L => 1,
-            Self::RGB => 3,
-            Self::RGBA => 4,
+            Self::RGB | Self::BGR => 3,
+            Self::RGBA | Self::BGRA => 4,
         }
     }
 
@@ -17,8 +17,8 @@ impl ColorModel {
     #[inline]
     pub fn has_alpha(&self) -> bool {
         match self {
-            Self::L | Self::RGB => false,
-            Self::RGBA => true,
+            Self::L | Self::RGB | Self::BGR => false,
+            Self::RGBA | Self::BGRA => true,
         }
     }
 }

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -421,6 +421,52 @@ fn image_pixel_value_ui(
                     None
                 }
             }
+
+            ColorModel::BGR => {
+                if let Some([b, g, r]) = {
+                    if let [Some(b), Some(g), Some(r)] = [
+                        image.get_xyc(x, y, 0),
+                        image.get_xyc(x, y, 1),
+                        image.get_xyc(x, y, 2),
+                    ] {
+                        Some([r, g, b])
+                    } else {
+                        None
+                    }
+                } {
+                    match (b, g, r) {
+                        (TensorElement::U8(b), TensorElement::U8(g), TensorElement::U8(r)) => {
+                            Some(format!("B: {b}, G: {g}, R: {r}, #{b:02X}{g:02X}{r:02X}"))
+                        }
+                        _ => Some(format!("B: {b}, G: {g}, R: {r}")),
+                    }
+                } else {
+                    None
+                }
+            }
+
+            ColorModel::BGRA => {
+                if let (Some(b), Some(g), Some(r), Some(a)) = (
+                    image.get_xyc(x, y, 0),
+                    image.get_xyc(x, y, 1),
+                    image.get_xyc(x, y, 2),
+                    image.get_xyc(x, y, 3),
+                ) {
+                    match (b, g, r, a) {
+                        (
+                            TensorElement::U8(b),
+                            TensorElement::U8(g),
+                            TensorElement::U8(r),
+                            TensorElement::U8(a),
+                        ) => Some(format!(
+                            "B: {b}, G: {g}, R: {r}, A: {a}, #{r:02X}{g:02X}{b:02X}{a:02X}"
+                        )),
+                        _ => Some(format!("B: {b}, G: {g}, R: {r}, A: {a}")),
+                    }
+                } else {
+                    None
+                }
+            }
         },
     };
 

--- a/crates/viewer/re_renderer/shader/rectangle.wgsl
+++ b/crates/viewer/re_renderer/shader/rectangle.wgsl
@@ -59,6 +59,9 @@ struct UniformBuffer {
 
     /// Boolean: multiply RGB with alpha before filtering
     multiply_rgb_with_alpha: u32,
+
+    /// Boolean: swizzle RGBA to BGRA
+    bgra_to_rgba: u32,
 };
 
 @group(1) @binding(0)

--- a/crates/viewer/re_renderer/shader/rectangle_fs.wgsl
+++ b/crates/viewer/re_renderer/shader/rectangle_fs.wgsl
@@ -28,6 +28,11 @@ fn decode_color(sampled_value: vec4f) -> vec4f {
     // Normalize the value first, otherwise premultiplying alpha and linear space conversion won't make sense.
     var rgba = normalize_range(sampled_value);
 
+    // BGR(A) -> RGB(A)
+    if rect_info.bgra_to_rgba != 0u {
+        rgba = rgba.bgra;
+    }
+
     // Convert to linear space
     if rect_info.decode_srgb != 0u {
         if all(vec3f(0.0) <= rgba.rgb) && all(rgba.rgb <= vec3f(1.0)) {

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -232,7 +232,7 @@ pub fn required_shader_decode(image_format: &ImageFormat) -> Option<ShaderDecodi
 
 /// Creates a [`Texture2DCreationDesc`] for creating a texture from an [`ImageInfo`].
 ///
-/// The resulting texture has requirements as describe by [`required_shader_decode`] and [`required_shader_bgr_conversion`].
+/// The resulting texture has requirements as describe by [`required_shader_decode`].
 ///
 /// TODO(andreas): The consumer needs to be aware of bgr and chroma downsampling conversions.
 /// It would be much better if we had a separate `re_renderer`/gpu driven conversion pipeline for this

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/mod.rs
@@ -6,7 +6,8 @@ mod re_renderer_callback;
 
 pub use colormap::{colormap_edit_or_view_ui, colormap_to_re_renderer};
 pub use image_to_gpu::{
-    image_data_range_heuristic, image_to_gpu, texture_creation_desc_from_color_image,
+    image_data_range_heuristic, image_to_gpu, required_shader_decode,
+    texture_creation_desc_from_color_image,
 };
 pub use re_renderer_callback::new_renderer_callback;
 

--- a/docs/content/reference/types/datatypes/color_model.md
+++ b/docs/content/reference/types/datatypes/color_model.md
@@ -12,6 +12,8 @@ This combined with [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference
 * L
 * RGB
 * RGBA
+* BGR
+* BGRA
 
 ## API reference links
  * 🌊 [C++ API docs for `ColorModel`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)

--- a/docs/snippets/all/archetypes/image_advanced.py
+++ b/docs/snippets/all/archetypes/image_advanced.py
@@ -33,6 +33,5 @@ rr.log("from_pillow_rgb", rr.Image(image_rgb))
 # Read with OpenCV
 image = cv2.imread(file_path)
 
-# OpenCV uses BGR ordering, so we need to convert to RGB.
-image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-rr.log("from_opencv", rr.Image(image))
+# OpenCV uses BGR ordering, we need to make this known to Rerun.
+rr.log("from_opencv", rr.Image(image, color_model="BGR"))

--- a/examples/python/arkit_scenes/arkit_scenes/__main__.py
+++ b/examples/python/arkit_scenes/arkit_scenes/__main__.py
@@ -225,7 +225,6 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
         rr.set_time_seconds("time", float(frame_timestamp))
         # load the lowres image and depth
         bgr = cv2.imread(f"{lowres_image_dir}/{video_id}_{frame_timestamp}.png")
-        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
         depth = cv2.imread(f"{lowres_depth_dir}/{video_id}_{frame_timestamp}.png", cv2.IMREAD_ANYDEPTH)
 
         high_res_exists: bool = (image_dir / f"{video_id}_{frame_timestamp}.png").exists() and include_highres
@@ -240,7 +239,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
                 LOWRES_POSED_ENTITY_PATH,
             )
 
-            rr.log(f"{LOWRES_POSED_ENTITY_PATH}/rgb", rr.Image(rgb).compress(jpeg_quality=95))
+            rr.log(f"{LOWRES_POSED_ENTITY_PATH}/bgr", rr.Image(bgr, color_model="BGR").compress(jpeg_quality=95))
             rr.log(f"{LOWRES_POSED_ENTITY_PATH}/depth", rr.DepthImage(depth, meter=1000))
 
         # log the high res camera
@@ -260,9 +259,7 @@ def log_arkit(recording_path: Path, include_highres: bool) -> None:
             highres_bgr = cv2.imread(f"{image_dir}/{video_id}_{frame_timestamp}.png")
             highres_depth = cv2.imread(f"{depth_dir}/{video_id}_{frame_timestamp}.png", cv2.IMREAD_ANYDEPTH)
 
-            highres_rgb = cv2.cvtColor(highres_bgr, cv2.COLOR_BGR2RGB)
-
-            rr.log(f"{HIGHRES_ENTITY_PATH}/rgb", rr.Image(highres_rgb).compress(jpeg_quality=75))
+            rr.log(f"{HIGHRES_ENTITY_PATH}/bgr", rr.Image(highres_bgr, color_model="BGR").compress(jpeg_quality=75))
             rr.log(f"{HIGHRES_ENTITY_PATH}/depth", rr.DepthImage(highres_depth, meter=1000))
 
 
@@ -293,9 +290,9 @@ def main() -> None:
                 # For this to work, the origin of the 2D views has to be a pinhole camera,
                 # this way the viewer knows how to project the 3D annotations into the 2D views.
                 rrb.Spatial2DView(
-                    name="RGB",
+                    name="BGR",
                     origin=primary_camera_entity,
-                    contents=["$origin/rgb", "/world/annotations/**"],
+                    contents=["$origin/bgr", "/world/annotations/**"],
                 ),
                 rrb.Spatial2DView(
                     name="Depth",

--- a/examples/python/face_tracking/face_tracking.py
+++ b/examples/python/face_tracking/face_tracking.py
@@ -357,15 +357,12 @@ def run_from_video_capture(vid: int | str, max_dim: int | None, max_frame_count:
                 # On some platforms it always returns zero, so we compute from the frame counter and fps
                 frame_time_nano = int(frame_idx * 1000 / fps * 1e6)
 
-            # convert to rgb
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
             # log data
             rr.set_time_sequence("frame_nr", frame_idx)
             rr.set_time_nanos("frame_time", frame_time_nano)
             detector.detect_and_log(frame, frame_time_nano)
             landmarker.detect_and_log(frame, frame_time_nano)
-            rr.log("video/image", rr.Image(frame))
+            rr.log("video/image", rr.Image(frame, color_model="BGR"))
 
     except KeyboardInterrupt:
         pass
@@ -379,12 +376,11 @@ def run_from_sample_image(path: Path, max_dim: int | None, num_faces: int) -> No
     """Run the face detector on a single image."""
     image = cv2.imread(str(path))
     image = resize_image(image, max_dim)
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     logger = FaceDetectorLogger(video_mode=False)
     landmarker = FaceLandmarkerLogger(video_mode=False, num_faces=num_faces)
     logger.detect_and_log(image, 0)
     landmarker.detect_and_log(image, 0)
-    rr.log("video/image", rr.Image(image))
+    rr.log("video/image", rr.Image(image, color_model="BGR"))
 
 
 def main() -> None:

--- a/examples/python/gesture_detection/gesture_detection.py
+++ b/examples/python/gesture_detection/gesture_detection.py
@@ -192,10 +192,11 @@ def run_from_sample_image(path: Path | str) -> None:
     """Run the gesture recognition on a single image."""
     image = cv2.imread(str(path))
     # image = resize_image(image, max_dim)
-    show_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    rr.log("media/image", rr.Image(show_image))
+    rr.log("media/image", rr.Image(image, color_model="BGR"))
+
+    detect_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     logger = GestureDetectorLogger(video_mode=False)
-    logger.detect_and_log(show_image, 0)
+    logger.detect_and_log(detect_image, 0)
 
 
 def run_from_video_capture(vid: int | str, max_frame_count: int | None) -> None:
@@ -236,14 +237,11 @@ def run_from_video_capture(vid: int | str, max_frame_count: int | None) -> None:
                 # On some platforms it always returns zero, so we compute from the frame counter and fps
                 frame_time_nano = int(frame_idx * 1000 / fps * 1e6)
 
-            # convert to rgb
-            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-
             # log data
             rr.set_time_sequence("frame_nr", frame_idx)
             rr.set_time_nanos("frame_time", frame_time_nano)
             detector.detect_and_log(frame, frame_time_nano)
-            rr.log("media/video", rr.Image(frame).compress(jpeg_quality=75))
+            rr.log("media/video", rr.Image(frame, color_model="BGR").compress(jpeg_quality=75))
 
     except KeyboardInterrupt:
         pass

--- a/examples/python/human_pose_tracking/human_pose_tracking.py
+++ b/examples/python/human_pose_tracking/human_pose_tracking.py
@@ -77,15 +77,14 @@ def track_pose(video_path: str, model_path: str, *, segment: bool, max_frame_cou
                 break
 
             mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=bgr_frame.data)
-            rgb = cv2.cvtColor(bgr_frame.data, cv2.COLOR_BGR2RGB)
             rr.set_time_seconds("time", bgr_frame.time)
             rr.set_time_sequence("frame_idx", bgr_frame.idx)
 
             results = pose_landmarker.detect_for_video(mp_image, int(bgr_frame.time * 1000))
-            h, w, _ = rgb.shape
+            h, w, _ = bgr_frame.data.shape
             landmark_positions_2d = read_landmark_positions_2d(results, w, h)
 
-            rr.log("video/rgb", rr.Image(rgb).compress(jpeg_quality=75))
+            rr.log("video/bgr", rr.Image(bgr_frame.data, color_model="BGR").compress(jpeg_quality=75))
             if landmark_positions_2d is not None:
                 rr.log(
                     "video/pose/points",
@@ -237,7 +236,7 @@ def main() -> None:
                 rrb.Spatial3DView(origin="person", name="3D pose"),
             ),
             rrb.Vertical(
-                rrb.Spatial2DView(origin="video/rgb", name="Raw video"),
+                rrb.Spatial2DView(origin="video/bgr", name="Raw video"),
                 rrb.TextDocumentView(origin="description", name="Description"),
                 row_shares=[2, 3],
             ),

--- a/examples/python/live_camera_edge_detection/live_camera_edge_detection.py
+++ b/examples/python/live_camera_edge_detection/live_camera_edge_detection.py
@@ -42,8 +42,7 @@ def run_canny(num_frames: int | None) -> None:
         frame_nr += 1
 
         # Log the original image
-        rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-        rr.log("image/rgb", rr.Image(rgb))
+        rr.log("image/rgb", rr.Image(img, color_model="BGR"))
 
         # Convert to grayscale
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)

--- a/examples/python/ocr/ocr.py
+++ b/examples/python/ocr/ocr.py
@@ -365,7 +365,7 @@ def detect_and_log_layouts(file_path: str) -> None:
     else:
         # read image
         img = cv2.imread(file_path)
-        image_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+        image_rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)  # Rerun can handle BGR as well, but `ocr_model_pp` expects RGB
         images.append(image_rgb.astype(np.uint8))
 
     # Extracte the layout from each image

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -44,13 +44,11 @@ def parse_timestamp(filename: str) -> datetime:
     return datetime.fromtimestamp(float(time))
 
 
-def read_image_rgb(buf: bytes) -> npt.NDArray[np.uint8]:
+def read_image_bgr(buf: bytes) -> npt.NDArray[np.uint8]:
     """Decode an image provided in `buf`, and interpret it as RGB data."""
     np_buf: npt.NDArray[np.uint8] = np.ndarray(shape=(1, len(buf)), dtype=np.uint8, buffer=buf)
-    # OpenCV reads images in BGR rather than RGB format
-    img_bgr = cv2.imdecode(np_buf, cv2.IMREAD_COLOR)
-    img_rgb: npt.NDArray[Any] = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
-    return img_rgb
+    img_bgr: npt.NDArray[Any] = cv2.imdecode(np_buf, cv2.IMREAD_COLOR)
+    return img_bgr
 
 
 def read_depth_image(buf: bytes) -> npt.NDArray[Any]:
@@ -85,8 +83,8 @@ def log_nyud_data(recording_path: Path, subset_idx: int, frames: int) -> None:
 
             if f.filename.endswith(".ppm"):
                 buf = archive.read(f)
-                img_rgb = read_image_rgb(buf)
-                rr.log("world/camera/image/rgb", rr.Image(img_rgb).compress(jpeg_quality=95))
+                img_bgr = read_image_bgr(buf)
+                rr.log("world/camera/image/rgb", rr.Image(img_bgr, color_model="BGR").compress(jpeg_quality=95))
 
             elif f.filename.endswith(".pgm"):
                 buf = archive.read(f)

--- a/examples/python/segment_anything_model/segment_anything_model.py
+++ b/examples/python/segment_anything_model/segment_anything_model.py
@@ -138,6 +138,7 @@ def load_image(image_uri: str) -> cv2.typing.MatLike:
     else:
         image = cv2.imread(image_uri, cv2.IMREAD_COLOR)
 
+    # Rerun can handle BGR as well, but SAM requires RGB.
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
     return image
 

--- a/examples/python/structure_from_motion/structure_from_motion/__main__.py
+++ b/examples/python/structure_from_motion/structure_from_motion/__main__.py
@@ -162,8 +162,7 @@ def read_and_log_sparse_reconstruction(dataset_path: Path, filter_output: bool, 
         if resize:
             bgr = cv2.imread(str(image_file))
             bgr = cv2.resize(bgr, resize)
-            rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
-            rr.log("camera/image", rr.Image(rgb).compress(jpeg_quality=75))
+            rr.log("camera/image", rr.Image(bgr, color_model="BGR").compress(jpeg_quality=75))
         else:
             rr.log("camera/image", rr.EncodedImage(path=dataset_path / "images" / image.name))
 

--- a/rerun_cpp/src/rerun/datatypes/color_model.hpp
+++ b/rerun_cpp/src/rerun/datatypes/color_model.hpp
@@ -33,6 +33,12 @@ namespace rerun::datatypes {
 
         /// Red, Green, Blue, Alpha
         RGBA = 3,
+
+        /// Blue, Green, Red
+        BGR = 4,
+
+        /// Blue, Green, Red, Alpha
+        BGRA = 5,
     };
 } // namespace rerun::datatypes
 

--- a/rerun_cpp/src/rerun/image_utils.hpp
+++ b/rerun_cpp/src/rerun/image_utils.hpp
@@ -137,8 +137,10 @@ namespace rerun {
         switch (color_model) {
             case datatypes::ColorModel::L:
                 return 1;
+            case datatypes::ColorModel::BGR:
             case datatypes::ColorModel::RGB:
                 return 3;
+            case datatypes::ColorModel::BGRA:
             case datatypes::ColorModel::RGBA:
                 return 4;
         }

--- a/rerun_notebook/package-lock.json
+++ b/rerun_notebook/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../rerun_js/web-viewer": {
       "name": "@rerun-io/web-viewer",
-      "version": "0.18.0-alpha.1+dev",
+      "version": "0.19.0-alpha.1+dev",
       "license": "MIT",
       "devDependencies": {
         "dts-buddy": "^0.3.0",

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -81,7 +81,7 @@ class ImageExt:
             `1x480x640x3x1` is treated as a `480x640x3`.
             You also need to specify the `color_model` of it (e.g. "RGB").
         color_model:
-            L, RGB, RGBA, etc, specifying how to interpret `image`.
+            L, RGB, RGBA, BGR, BGRA, etc, specifying how to interpret `image`.
         pixel_format:
             NV12, YUV420, etc. For chroma-downsampling.
             Requires `width`, `height`, and `bytes`.
@@ -207,9 +207,9 @@ class ImageExt:
             if channels == 1:
                 color_model = ColorModel.L
             elif channels == 3:
-                color_model = ColorModel.RGB  # TODO(#2340): change default to BGR
+                color_model = ColorModel.RGB
             elif channels == 4:
-                color_model = ColorModel.RGBA  # TODO(#2340): change default to BGRA
+                color_model = ColorModel.RGBA
             else:
                 _send_warning_or_raise(f"Expected 1, 3, or 4 channels; got {channels}")
         else:
@@ -278,10 +278,9 @@ class ImageExt:
             if image_format.pixel_format is not None:
                 raise ValueError(f"Cannot JPEG compress an image with pixel_format {image_format.pixel_format}")
 
-            if image_format.color_model not in (ColorModel.L, ColorModel.RGB):
-                # TODO(#2340): BGR support!
+            if image_format.color_model not in (ColorModel.L, ColorModel.RGB, ColorModel.BGR):
                 raise ValueError(
-                    f"Cannot JPEG compress an image of type {image_format.color_model}. Only L (monochrome) and RGB are supported."
+                    f"Cannot JPEG compress an image of type {image_format.color_model}. Only L (monochrome), RGB and BGR are supported."
                 )
 
             if image_format.channel_datatype != ChannelDatatype.U8:
@@ -308,7 +307,12 @@ class ImageExt:
             else:
                 image = buf.reshape(image_format.height, image_format.width, 3)
 
-            mode = str(image_format.color_model)
+            # PIL doesn't understand BGR.
+            if image_format.color_model == ColorModel.BGR:
+                mode = "RGB"
+                image = image[:, :, ::-1]
+            else:
+                mode = str(image_format.color_model)
 
             pil_image = PILImage.fromarray(image, mode=mode)
             output = BytesIO()

--- a/rerun_py/rerun_sdk/rerun/datatypes/color_model.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color_model.py
@@ -36,6 +36,12 @@ class ColorModel(Enum):
     RGBA = 3
     """Red, Green, Blue, Alpha"""
 
+    BGR = 4
+    """Blue, Green, Red"""
+
+    BGRA = 5
+    """Blue, Green, Red, Alpha"""
+
     @classmethod
     def auto(cls, val: str | int | ColorModel) -> ColorModel:
         """Best-effort converter, including a case-insensitive string matcher."""
@@ -57,7 +63,7 @@ class ColorModel(Enum):
         return self.name
 
 
-ColorModelLike = Union[ColorModel, Literal["L", "RGB", "RGBA", "l", "rgb", "rgba"], int]
+ColorModelLike = Union[ColorModel, Literal["BGR", "BGRA", "L", "RGB", "RGBA", "bgr", "bgra", "l", "rgb", "rgba"], int]
 ColorModelArrayLike = Union[ColorModelLike, Sequence[ColorModelLike]]
 
 

--- a/tests/python/release_checklist/check_bgr.py
+++ b/tests/python/release_checklist/check_bgr.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from io import BytesIO
+from uuid import uuid4
+
+import numpy as np
+import requests
+import rerun as rr
+import rerun.blueprint as rrb
+from PIL import Image
+
+README = """\
+# BGR Support
+
+This checks whether BGR images with various datatypes are supported.
+
+### Action
+All images should look the same (and sane).
+
+"""
+
+types = [
+    # Skipping on i8, since it would look different.
+    ("u8", np.uint8),
+    ("u16", np.uint16),
+    ("u32", np.uint32),
+    ("u64", np.uint64),
+    ("i16", np.int16),
+    ("i32", np.int32),
+    ("i64", np.int64),
+    ("f16", np.float16),
+    ("f32", np.float32),
+    ("f64", np.float64),
+]
+
+
+def blueprint() -> rrb.BlueprintLike:
+    entities = [f"bgr_{type}" for (type, _) in types] + [f"bgra_{type}" for (type, _) in types] + ["rgb_u8"]
+    return rrb.Grid(contents=[rrb.Spatial2DView(origin=path) for path in entities])
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
+
+
+def run_bgr_images(sample_image_rgb_u8: np.ndarray) -> None:
+    # We're being explicit about datatypes & datamodels on all calls to avoid confunsion.
+
+    # Show the original image as a reference:
+    rr.log("rgb_u8", rr.Image(sample_image_rgb_u8, color_model="RGB", datatype="u8"))
+
+    sample_image_bgr_u8 = sample_image_rgb_u8[:, :, ::-1]
+    sample_image_bgra_u8 = np.insert(sample_image_bgr_u8, 3, 255, axis=2)
+
+    for datatype, dtype in types:
+        sample_image_bgr = np.asarray(sample_image_bgr_u8, dtype=dtype)
+        rr.log(f"bgr_{datatype}", rr.Image(sample_image_bgr, color_model="BGR", datatype=datatype))
+        sample_image_bgra = np.asarray(sample_image_bgra_u8, dtype=dtype)
+        rr.log(f"bgra_{datatype}", rr.Image(sample_image_bgra, color_model="BGRA", datatype=datatype))
+
+
+def download_example_image_as_rgb() -> np.ndarray:
+    # Download this recreation of the lena image (via https://mortenhannemose.github.io/lena/):
+    # https://mortenhannemose.github.io/assets/img/Lena_512.png
+    url = "https://mortenhannemose.github.io/assets/img/Lena_512.png"
+    response = requests.get(url)
+    image = Image.open(BytesIO(response.content))
+    image = image.convert("RGB")
+    return np.array(image)
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4(), default_blueprint=blueprint())
+
+    sample_image_rgb_u8 = download_example_image_as_rgb()
+    log_readme()
+    run_bgr_images(sample_image_rgb_u8)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/2340

Adds a checklist item that goes through all the different format to make sure they run properly - this looks a bit overzealous, but in fact we are using the fact that wgpu has special support for 8bit bgr images in order to support them on meshes (this detail is tbf untested as of now!), so going through our formats in a test has quite some merit.
(aaalso I think it's the only place where we actually check now that all datatypes still work fine 😳 )

![image](https://github.com/user-attachments/assets/49b3b8a3-469d-48ce-a6b6-3205f682d902)
("ethnically sourced lena picture", courtesy of Morten Rieger, https://mortenhannemose.github.io/lena/) 


Speaking of meshes: the mesh texture support story is now spelled out better, showing warnings and ignoring textures if they're in an unsupported format.



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7238?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7238?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7238)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.