### PR TITLE
Install sdk_info.h even if RERUN_INSTALL_RERUN_C option is OFF

### DIFF
--- a/rerun_cpp/CMakeLists.txt
+++ b/rerun_cpp/CMakeLists.txt
@@ -153,8 +153,12 @@ install(TARGETS rerun_sdk
     INCLUDES DESTINATION include
 )
 
+# Some public headers are shared by both the C++ and C sdk, so we install
+# them with the C++ headers also if RERUN_INSTALL_RERUN_C is OFF
+set(RERUN_PATTERN_HEADER_SHARED_BETWEEN_CXX_AND_C "sdk_info.h")
+
 # Add all C++ headers to the install.
-install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp" PATTERN ${RERUN_PATTERN_HEADER_SHARED_BETWEEN_CXX_AND_C})
 
 option(RERUN_INSTALL_RERUN_C "Install rerun_c file." ON)
 
@@ -168,7 +172,7 @@ endif()
 if(RERUN_INSTALL_RERUN_C)
     # CMake doesn't allow installing imported targets which is why we need to add this as a file.
     get_target_property(RERUN_C_LIB_LOCATION rerun_c IMPORTED_LOCATION)
-    install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.h")
+    install(DIRECTORY "${RERUN_CPP_SOURCE_DIR}/" TYPE INCLUDE FILES_MATCHING PATTERN "*.h" PATTERN ${RERUN_PATTERN_HEADER_SHARED_BETWEEN_CXX_AND_C} EXCLUDE)
     install(FILES ${RERUN_C_LIB_LOCATION} DESTINATION lib)
 endif()
 


### PR DESCRIPTION
### What

Since rerun 0.18, the C++ public headers now include the `rerun/c/sdk_info.h` header, so the  `rerun/c/sdk_info.h` file needs to be installed even if the C static library is not installed, i.e. if `RERUN_INSTALL_RERUN_C` CMake option is set to `OFF`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7246?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7246?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7246)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.