### PR TITLE
Fix gamma (srgb EOTF) for GLTF via `Asset3D` embedded rgb(a) textures

### DIFF
--- a/crates/viewer/re_renderer/src/importer/gltf.rs
+++ b/crates/viewer/re_renderer/src/importer/gltf.rs
@@ -67,7 +67,9 @@ pub fn load_gltf_from_buffer(
             if image.format == gltf::image::Format::R8G8B8 {
                 re_log::debug!("Converting Rgb8 to Rgba8");
                 (
-                    wgpu::TextureFormat::Rgba8UnormSrgb,
+                    // Don't use `Rgba8UnormSrgb`, Mesh shader assumes it has to do the conversion itself!
+                    // This is done so we can handle non-premultiplied alpha.
+                    wgpu::TextureFormat::Rgba8Unorm,
                     crate::pad_rgb_to_rgba(&image.pixels, 255),
                 )
             } else {
@@ -149,7 +151,9 @@ fn map_format(format: gltf::image::Format) -> Option<wgpu::TextureFormat> {
         Format::R8 => Some(TextureFormat::R8Unorm),
         Format::R8G8 => Some(TextureFormat::Rg8Unorm),
         Format::R8G8B8 => None,
-        Format::R8G8B8A8 => Some(TextureFormat::Rgba8UnormSrgb),
+        // Don't use `Rgba8UnormSrgb`, Mesh shader assumes it has to do the conversion itself!
+        // This is done so we can handle non-premultiplied alpha.
+        Format::R8G8B8A8 => Some(TextureFormat::Rgba8Unorm),
 
         Format::R16 => Some(TextureFormat::R16Unorm),
         Format::R16G16 => Some(TextureFormat::Rg16Unorm),


### PR DESCRIPTION
### What

Fix gltf loader assuming that the mesh shader doesn't apply the EOTF, when it fact it does (i.e. it calls `linear_from_srgb`)

Reference - via raw_mesh which was unaffected:
<img width="389" alt="image" src="https://github.com/user-attachments/assets/7bef7f91-ed84-47d6-a39c-4ea8883cad51">

Before:
<img width="567" alt="image" src="https://github.com/user-attachments/assets/0194606b-4484-40cf-96a6-2f675a703a95">

After:
<img width="453" alt="image" src="https://github.com/user-attachments/assets/9cbca921-2ad1-40de-9e8e-c70c8d58c5c4">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7251?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7251?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7251)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.