### PR TITLE
Remove `Datatype` and `DatatypeBatch` 

### DIFF
--- a/crates/store/re_types/src/lib.rs
+++ b/crates/store/re_types/src/lib.rs
@@ -227,7 +227,7 @@ pub mod components {
 
 /// The low-level datatypes that [`components`] are built from.
 ///
-/// They all implement the [`Datatype`] trait.
+/// They all implement the [`Loggable`] trait.
 pub mod datatypes {
 
     // Some datatypes are so fundamental and used everywhere that we want them to be exposed

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -95,8 +95,8 @@ pub use self::{
     },
     arrow_buffer::ArrowBuffer,
     arrow_string::ArrowString,
-    loggable::{Component, ComponentName, ComponentNameSet, Datatype, DatatypeName, Loggable},
-    loggable_batch::{ComponentBatch, DatatypeBatch, LoggableBatch, MaybeOwnedComponentBatch},
+    loggable::{Component, ComponentName, ComponentNameSet, DatatypeName, Loggable},
+    loggable_batch::{ComponentBatch, LoggableBatch, MaybeOwnedComponentBatch},
     result::{
         DeserializationError, DeserializationResult, ResultExt, SerializationError,
         SerializationResult, _Backtrace,

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -9,7 +9,7 @@
 //! When multiple instances of a [`Component`] are put together in an array, they yield a
 //! [`ComponentBatch`]: the atomic unit of (de)serialization.
 //!
-//! Internally, [`Component`]s are implemented using many different [`Datatype`]s.
+//! Internally, [`Component`]s are implemented using many different [`Loggable`]s.
 //!
 //! ## Feature flags
 #![doc = document_features::document_features!()]
@@ -117,7 +117,7 @@ pub mod archetypes;
 /// There are also re-exported by `re_types`.
 pub mod components;
 
-/// Fundamental [`Datatype`]s that are implemented in `re_types_core` directly for convenience and
+/// Fundamental datatypes that are implemented in `re_types_core` directly for convenience and
 /// dependency optimization.
 ///
 /// There are also re-exported by `re_types`.

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 #[allow(unused_imports)] // used in docstrings
-use crate::{Archetype, ComponentBatch, DatatypeBatch, LoggableBatch};
+use crate::{Archetype, ComponentBatch, LoggableBatch};
 
 // ---
 
@@ -126,14 +126,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
         })
     }
 }
-
-/// A [`Datatype`] describes plain old data that can be used by any number of [`Component`]s.
-///
-/// Any [`Loggable`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically implements
-/// [`Datatype`].
-pub trait Datatype: Loggable<Name = DatatypeName> {}
-
-impl<L: Loggable<Name = DatatypeName>> Datatype for L {}
 
 /// A [`Component`] describes semantic data that can be used by any number of [`Archetype`]s.
 ///

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -14,13 +14,12 @@ use crate::{Archetype, ComponentBatch, LoggableBatch};
 /// Internally, Arrow, and by extension Rerun, only deal with arrays of data.
 /// We refer to individual entries in these arrays as instances.
 ///
-/// [`Datatype`] and [`Component`] are specialization of the [`Loggable`] trait that are
-/// automatically implemented based on the type used for [`Loggable::Name`].
+/// [`Component`] is a specialization of the [`Loggable`] trait where [`Loggable::Name`] ==
+/// [`ComponentName`].
 ///
-/// Implementing the [`Loggable`] trait (and by extension [`Datatype`]/[`Component`])
-/// automatically derives the [`LoggableBatch`] implementation (and by extension
-/// [`DatatypeBatch`]/[`ComponentBatch`]), which makes it possible to work with lists' worth of data
-/// in a generic fashion.
+/// Implementing the [`Loggable`] trait (and by extension [`Component`]) automatically derives the
+/// [`LoggableBatch`] implementation (and by extension [`ComponentBatch`]), which makes it possible to
+/// work with lists' worth of data in a generic fashion.
 pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     type Name: std::fmt::Display;
 

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -1,4 +1,4 @@
-use crate::{Component, ComponentName, Datatype, DatatypeName, Loggable, SerializationResult};
+use crate::{Component, ComponentName, Loggable, SerializationResult};
 
 #[allow(unused_imports)] // used in docstrings
 use crate::Archetype;
@@ -33,12 +33,6 @@ pub trait LoggableBatch {
     /// Serializes the batch into an Arrow array.
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 }
-
-/// A [`DatatypeBatch`] represents an array's worth of [`Datatype`] instances.
-///
-/// Any [`LoggableBatch`] with a [`Loggable::Name`] set to [`DatatypeName`] automatically
-/// implements [`DatatypeBatch`].
-pub trait DatatypeBatch: LoggableBatch<Name = DatatypeName> {}
 
 /// A [`ComponentBatch`] represents an array's worth of [`Component`] instances.
 ///
@@ -143,8 +137,6 @@ impl<L: Clone + Loggable> LoggableBatch for L {
     }
 }
 
-impl<D: Datatype> DatatypeBatch for D {}
-
 impl<C: Component> ComponentBatch for C {}
 
 // --- Unary Option ---
@@ -173,8 +165,6 @@ impl<L: Clone + Loggable> LoggableBatch for Option<L> {
     }
 }
 
-impl<D: Datatype> DatatypeBatch for Option<D> {}
-
 impl<C: Component> ComponentBatch for Option<C> {}
 
 // --- Vec ---
@@ -202,8 +192,6 @@ impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
 }
-
-impl<D: Datatype> DatatypeBatch for Vec<D> {}
 
 impl<C: Component> ComponentBatch for Vec<C> {}
 
@@ -236,8 +224,6 @@ impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
     }
 }
 
-impl<D: Datatype> DatatypeBatch for Vec<Option<D>> {}
-
 impl<C: Component> ComponentBatch for Vec<Option<C>> {}
 
 // --- Array ---
@@ -265,8 +251,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
 }
-
-impl<D: Datatype, const N: usize> DatatypeBatch for [D; N] {}
 
 impl<C: Component, const N: usize> ComponentBatch for [C; N] {}
 
@@ -299,8 +283,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
     }
 }
 
-impl<D: Datatype, const N: usize> DatatypeBatch for [Option<D>; N] {}
-
 impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {}
 
 // --- Slice ---
@@ -328,8 +310,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [L] {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
 }
-
-impl<'a, D: Datatype> DatatypeBatch for &'a [D] {}
 
 impl<'a, C: Component> ComponentBatch for &'a [C] {}
 
@@ -362,8 +342,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [Option<L>] {
     }
 }
 
-impl<'a, D: Datatype> DatatypeBatch for &'a [Option<D>] {}
-
 impl<'a, C: Component> ComponentBatch for &'a [Option<C>] {}
 
 // --- ArrayRef ---
@@ -391,8 +369,6 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [L; N] {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
 }
-
-impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [D; N] {}
 
 impl<'a, C: Component, const N: usize> ComponentBatch for &'a [C; N] {}
 
@@ -424,7 +400,5 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [Option<L>; N] {
         )
     }
 }
-
-impl<'a, D: Datatype, const N: usize> DatatypeBatch for &'a [Option<D>; N] {}
 
 impl<'a, C: Component, const N: usize> ComponentBatch for &'a [Option<C>; N] {}

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -90,9 +90,9 @@ pub mod time {
 pub use time::{Time, TimePoint, Timeline};
 
 pub use re_types_core::{
-    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch, ComponentName, Datatype,
-    DatatypeBatch, DatatypeName, GenericIndicatorComponent, Loggable, LoggableBatch,
-    MaybeOwnedComponentBatch, NamedIndicatorComponent, SizeBytes,
+    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch, ComponentName, DatatypeName,
+    GenericIndicatorComponent, Loggable, LoggableBatch, MaybeOwnedComponentBatch,
+    NamedIndicatorComponent, SizeBytes,
 };
 
 #[cfg(feature = "data_loaders")]

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -38,7 +38,7 @@ impl rerun::AsComponents for CustomPoints3D {
 
 // ---
 
-/// A custom [`rerun::Component`] that is backed by a builtin [`rerun::Float32`] scalar [`rerun::Datatype`].
+/// A custom [`rerun::Component`] that is backed by a builtin [`rerun::Float32`] scalar.
 #[derive(Debug, Clone, Copy)]
 struct Confidence(rerun::Float32);
 


### PR DESCRIPTION
Remove unused old traits.

Part of a lot of clean up I want to while we head towards:
* https://github.com/rerun-io/rerun/issues/7245
* #3741 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7256?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7256?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7256)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.