### PR TITLE
Remove `Loggable{Batch}::arrow_field`

### DIFF
--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -221,25 +221,13 @@ impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponent<A> {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        let name = self.name().to_string();
-        arrow2::datatypes::Field::new(
-            name.clone(),
-            arrow2::datatypes::DataType::Extension(
-                name,
-                Arc::new(arrow2::datatypes::DataType::Null),
-                None,
-            ),
-            false,
-        )
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
-        Ok(
-            arrow2::array::NullArray::new(arrow2::datatypes::DataType::Null, self.num_instances())
-                .boxed(),
-        )
+        let datatype = arrow2::datatypes::DataType::Extension(
+            self.name().to_string(),
+            Arc::new(arrow2::datatypes::DataType::Null),
+            None,
+        );
+        Ok(arrow2::array::NullArray::new(datatype, self.num_instances()).boxed())
     }
 }
 
@@ -279,25 +267,13 @@ impl crate::LoggableBatch for NamedIndicatorComponent {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        let name = self.name().to_string();
-        arrow2::datatypes::Field::new(
-            name.clone(),
-            arrow2::datatypes::DataType::Extension(
-                name,
-                Arc::new(arrow2::datatypes::DataType::Null),
-                None,
-            ),
-            false,
-        )
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
-        Ok(
-            arrow2::array::NullArray::new(arrow2::datatypes::DataType::Null, self.num_instances())
-                .boxed(),
-        )
+        let datatype = arrow2::datatypes::DataType::Extension(
+            self.name().to_string(),
+            Arc::new(arrow2::datatypes::DataType::Null),
+            None,
+        );
+        Ok(arrow2::array::NullArray::new(datatype, self.num_instances()).boxed())
     }
 }
 

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -68,7 +68,14 @@ pub trait AsComponents {
                 comp_batch
                     .as_ref()
                     .to_arrow()
-                    .map(|array| (comp_batch.as_ref().arrow_field(), array))
+                    .map(|array| {
+                        let field = arrow2::datatypes::Field::new(
+                            comp_batch.name().to_string(),
+                            array.data_type().clone(),
+                            false,
+                        );
+                        (field, array)
+                    })
                     .with_context(comp_batch.as_ref().name())
             })
             .collect()

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -31,7 +31,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
 
     /// Given an iterator of options of owned or reference values to the current
     /// [`Loggable`], serializes them into an Arrow array.
-    /// The Arrow array's datatype will match [`Loggable::arrow_field`].
     ///
     /// When using Rerun's builtin components & datatypes, this can only fail if the data
     /// exceeds the maximum number of entries in an Arrow array (2^31 for standard arrays,
@@ -57,25 +56,10 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
         )
     }
 
-    /// The underlying [`arrow2::datatypes::Field`], including datatype extensions.
-    ///
-    /// The default implementation will simply wrap [`Self::extended_arrow_datatype`] in a
-    /// [`arrow2::datatypes::Field`], which is what you want in most cases (e.g. because you want
-    /// to declare the field as nullable).
-    #[inline]
-    fn arrow_field() -> arrow2::datatypes::Field {
-        arrow2::datatypes::Field::new(
-            Self::name().to_string(),
-            Self::extended_arrow_datatype(),
-            false,
-        )
-    }
-
     // --- Optional serialization methods ---
 
     /// Given an iterator of owned or reference values to the current [`Loggable`], serializes
     /// them into an Arrow array.
-    /// The Arrow array's datatype will match [`Loggable::arrow_field`].
     ///
     /// When using Rerun's builtin components & datatypes, this can only fail if the data
     /// exceeds the maximum number of entries in an Arrow array (2^31 for standard arrays,
@@ -94,9 +78,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     // --- Optional deserialization methods ---
 
     /// Given an Arrow array, deserializes it into a collection of [`Loggable`]s.
-    ///
-    /// This will _never_ fail if the Arrow array's datatype matches the one returned by
-    /// [`Loggable::arrow_field`].
     #[inline]
     fn from_arrow(data: &dyn ::arrow2::array::Array) -> DeserializationResult<Vec<Self>> {
         re_tracing::profile_function!();
@@ -112,9 +93,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     }
 
     /// Given an Arrow array, deserializes it into a collection of optional [`Loggable`]s.
-    ///
-    /// This will _never_ fail if the Arrow array's datatype matches the one returned by
-    /// [`Loggable::arrow_field`].
     fn from_arrow_opt(
         data: &dyn ::arrow2::array::Array,
     ) -> DeserializationResult<Vec<Option<Self>>> {

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -27,9 +27,6 @@ pub trait LoggableBatch {
     /// The number of component instances stored into this batch.
     fn num_instances(&self) -> usize;
 
-    /// The underlying [`arrow2::datatypes::Field`], including datatype extensions.
-    fn arrow_field(&self) -> arrow2::datatypes::Field;
-
     /// Serializes the batch into an Arrow array.
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 }
@@ -99,11 +96,6 @@ impl<'a> LoggableBatch for MaybeOwnedComponentBatch<'a> {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        self.as_ref().arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         self.as_ref().to_arrow()
     }
@@ -124,11 +116,6 @@ impl<L: Clone + Loggable> LoggableBatch for L {
     #[inline]
     fn num_instances(&self) -> usize {
         1
-    }
-
-    #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
     }
 
     #[inline]
@@ -155,11 +142,6 @@ impl<L: Clone + Loggable> LoggableBatch for Option<L> {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -183,11 +165,6 @@ impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -208,11 +185,6 @@ impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
     #[inline]
     fn num_instances(&self) -> usize {
         self.len()
-    }
-
-    #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
     }
 
     #[inline]
@@ -242,11 +214,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -267,11 +234,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
     #[inline]
     fn num_instances(&self) -> usize {
         N
-    }
-
-    #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
     }
 
     #[inline]
@@ -301,11 +263,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [L] {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -326,11 +283,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [Option<L>] {
     #[inline]
     fn num_instances(&self) -> usize {
         self.len()
-    }
-
-    #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
     }
 
     #[inline]
@@ -360,11 +312,6 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [L; N] {
     }
 
     #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -385,11 +332,6 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [Option<L>; N] {
     #[inline]
     fn num_instances(&self) -> usize {
         N
-    }
-
-    #[inline]
-    fn arrow_field(&self) -> arrow2::datatypes::Field {
-        L::arrow_field()
     }
 
     #[inline]


### PR DESCRIPTION
It doesn't make any sense for a `ComponentBatch` to have any say in what the final `ArrowField` should look like.

An `ArrowField` is a `Chunk`/`RecordBatch`/`Schema`-level concern that only makes sense during IO/transport/FFI/storage/etc, and which requires external context that a single `ComponentBatch` on its own has no idea of. 

---

Part of a lot of clean up I want to while we head towards:
* https://github.com/rerun-io/rerun/issues/7245
* #3741 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
