### PR TITLE
Remove `LoggableBatch::num_instances`

### DIFF
--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -214,14 +214,9 @@ impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponent<A> {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        1
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
         let datatype = arrow2::datatypes::DataType::Null;
-        Ok(arrow2::array::NullArray::new(datatype, self.num_instances()).boxed())
+        Ok(arrow2::array::NullArray::new(datatype, 1).boxed())
     }
 }
 
@@ -256,14 +251,9 @@ impl crate::LoggableBatch for NamedIndicatorComponent {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        1
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
         let datatype = arrow2::datatypes::DataType::Null;
-        Ok(arrow2::array::NullArray::new(datatype, self.num_instances()).boxed())
+        Ok(arrow2::array::NullArray::new(datatype, 1).boxed())
     }
 }
 

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -24,9 +24,6 @@ pub trait LoggableBatch {
     /// The fully-qualified name of this batch, e.g. `rerun.datatypes.Vec2D`.
     fn name(&self) -> Self::Name;
 
-    /// The number of component instances stored into this batch.
-    fn num_instances(&self) -> usize;
-
     /// Serializes the batch into an Arrow array.
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 }
@@ -91,11 +88,6 @@ impl<'a> LoggableBatch for MaybeOwnedComponentBatch<'a> {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        self.as_ref().num_instances()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         self.as_ref().to_arrow()
     }
@@ -111,11 +103,6 @@ impl<L: Clone + Loggable> LoggableBatch for L {
     #[inline]
     fn name(&self) -> Self::Name {
         L::name()
-    }
-
-    #[inline]
-    fn num_instances(&self) -> usize {
-        1
     }
 
     #[inline]
@@ -137,11 +124,6 @@ impl<L: Clone + Loggable> LoggableBatch for Option<L> {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        self.is_some() as usize
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -160,11 +142,6 @@ impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -180,11 +157,6 @@ impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
     #[inline]
     fn name(&self) -> Self::Name {
         L::name()
-    }
-
-    #[inline]
-    fn num_instances(&self) -> usize {
-        self.len()
     }
 
     #[inline]
@@ -209,11 +181,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        N
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -229,11 +196,6 @@ impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
     #[inline]
     fn name(&self) -> Self::Name {
         L::name()
-    }
-
-    #[inline]
-    fn num_instances(&self) -> usize {
-        N
     }
 
     #[inline]
@@ -258,11 +220,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [L] {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        self.len()
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -278,11 +235,6 @@ impl<'a, L: Loggable> LoggableBatch for &'a [Option<L>] {
     #[inline]
     fn name(&self) -> Self::Name {
         L::name()
-    }
-
-    #[inline]
-    fn num_instances(&self) -> usize {
-        self.len()
     }
 
     #[inline]
@@ -307,11 +259,6 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [L; N] {
     }
 
     #[inline]
-    fn num_instances(&self) -> usize {
-        N
-    }
-
-    #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
@@ -327,11 +274,6 @@ impl<'a, L: Loggable, const N: usize> LoggableBatch for &'a [Option<L>; N] {
     #[inline]
     fn name(&self) -> Self::Name {
         L::name()
-    }
-
-    #[inline]
-    fn num_instances(&self) -> usize {
-        N
     }
 
     #[inline]


### PR DESCRIPTION
`LoggableBatch::num_instances` is a deprecated remnant from the `InstanceKey` days that doesn't make sense anymore.

The number of instances is the length of the top-level `ComponentBatch` array, always.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7258?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7258?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7258)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.