### PR TITLE
Remove unused `Loggable::extended_arrow_datatype`

### DIFF
--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     result::_Backtrace, DeserializationResult, ResultExt as _, SerializationResult, SizeBytes,
 };
@@ -40,21 +38,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     ) -> SerializationResult<Box<dyn ::arrow2::array::Array>>
     where
         Self: 'a;
-
-    // --- Optional metadata methods ---
-
-    /// The underlying [`arrow2::datatypes::DataType`], including datatype extensions.
-    ///
-    /// The default implementation will simply wrap [`Self::arrow_datatype`] in an extension called
-    /// [`Self::name`], which is what you want in most cases.
-    #[inline]
-    fn extended_arrow_datatype() -> arrow2::datatypes::DataType {
-        arrow2::datatypes::DataType::Extension(
-            Self::name().to_string(),
-            Arc::new(Self::arrow_datatype()),
-            None,
-        )
-    }
 
     // --- Optional serialization methods ---
 

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -64,8 +64,14 @@ impl Loggable for Tuid {
         ];
         let validity = None;
 
+        let datatype = arrow2::datatypes::DataType::Extension(
+            Self::name().to_string(),
+            Arc::new(Self::arrow_datatype()),
+            None,
+        );
+
         // TODO(cmc): We use the extended type here because we rely on it for formatting.
-        Ok(StructArray::new(Self::extended_arrow_datatype(), values, validity).boxed())
+        Ok(StructArray::new(datatype, values, validity).boxed())
     }
 
     fn from_arrow(array: &dyn ::arrow2::array::Array) -> crate::DeserializationResult<Vec<Self>> {


### PR DESCRIPTION
Title.

---

Part of a lot of clean up I want to while we head towards:
* https://github.com/rerun-io/rerun/issues/7245
* #3741 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7260?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7260?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7260)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.