### PR TITLE
Default `RERUN_CHUNK_MAX_BYTES` to 384kiB instead of 4MiB

### DIFF
--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -96,9 +96,12 @@ impl ChunkStoreConfig {
     pub const DEFAULT: Self = Self {
         enable_changelog: true,
 
-        // Empirical testing shows that 4MiB is good middle-ground, big tensors and buffers can
-        // become a bit too costly to concatenate beyond that.
-        chunk_max_bytes: 4 * 1024 * 1024,
+        // This gives us 64 bytes per row (assuming a default limit of 4096 rows), which is enough to
+        // fit a couple scalar columns + a RowId column + a handful of timeline columns.
+        //
+        // A few megabytes turned out to be way too costly to concatenate in real-time in the
+        // Viewer (see <https://github.com/rerun-io/rerun/issues/7222>).
+        chunk_max_bytes: 8 * 8 * 4096,
 
         // Empirical testing shows that 4096 is the threshold after which we really start to get
         // dimishing returns space and compute wise.

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -96,12 +96,13 @@ impl ChunkStoreConfig {
     pub const DEFAULT: Self = Self {
         enable_changelog: true,
 
-        // This gives us 64 bytes per row (assuming a default limit of 4096 rows), which is enough to
-        // fit a couple scalar columns + a RowId column + a handful of timeline columns.
+        // This gives us 96 bytes per row (assuming a default limit of 4096 rows), which is enough to
+        // fit a couple scalar columns, a RowId column, a handful of timeline columns, all the
+        // necessary offsets, etc.
         //
         // A few megabytes turned out to be way too costly to concatenate in real-time in the
         // Viewer (see <https://github.com/rerun-io/rerun/issues/7222>).
-        chunk_max_bytes: 8 * 8 * 4096,
+        chunk_max_bytes: 12 * 8 * 4096,
 
         // Empirical testing shows that 4096 is the threshold after which we really start to get
         // dimishing returns space and compute wise.


### PR DESCRIPTION
* Fixes https://github.com/rerun-io/rerun/issues/7222

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7263?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7263?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7263)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.