### PR TITLE
Fix main (`cargo insta review`)

### DIFF
--- a/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
@@ -4,6 +4,6 @@ expression: "[format!(\"{NUM_SCALARS} scalars\"),\n        format!(\"{} in total
 ---
 [
     "1048576 scalars",
-    "41.5 MiB in total",
-    "42 B per row",
+    "37.5 MiB in total",
+    "38 B per row",
 ]


### PR DESCRIPTION
`main` broke following the `re_arrow2` update... for the best possible reason :upside_down_face: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
