### PR TITLE
Fix `Chunk::component_batch_raw` not checking the bitmap first

### DIFF
--- a/crates/store/re_chunk/src/helpers.rs
+++ b/crates/store/re_chunk/src/helpers.rs
@@ -21,15 +21,17 @@ impl Chunk {
         component_name: &ComponentName,
         row_index: usize,
     ) -> Option<ChunkResult<Box<dyn ArrowArray>>> {
-        self.components.get(component_name).map(|list_array| {
+        self.components.get(component_name).and_then(|list_array| {
             if list_array.len() > row_index {
-                Ok(list_array.value(row_index))
+                list_array
+                    .is_valid(row_index)
+                    .then(|| Ok(list_array.value(row_index)))
             } else {
-                Err(crate::ChunkError::IndexOutOfBounds {
+                Some(Err(crate::ChunkError::IndexOutOfBounds {
                     kind: "row".to_owned(),
                     len: list_array.len(),
                     index: row_index,
-                })
+                }))
             }
         })
     }


### PR DESCRIPTION
@abey79 discovered the issue when doing the Chunk Store UI.

Before:
![image](https://github.com/user-attachments/assets/3d117e0f-426a-4889-91da-81a8424aa4c7)

After:
![image](https://github.com/user-attachments/assets/aba46949-2fbc-442f-a5bd-0a7f3e9b11b4)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
