### PR TITLE
Fix VisualizerOverrides serializer and improved error handling

### DIFF
--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list.py
@@ -29,7 +29,9 @@ class Utf8List(Utf8ListExt):
         # You can define your own __init__ function as a member of Utf8ListExt in utf8list_ext.py
         self.__attrs_init__(value=value)
 
-    value: list[str] = field()
+    value: list[str] = field(
+        converter=Utf8ListExt.value__field_converter_override,  # type: ignore[misc]
+    )
 
 
 if TYPE_CHECKING:

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list_ext.py
@@ -12,7 +12,7 @@ class Utf8ListExt:
     """Extension for [Utf8List][rerun.blueprint.datatypes.Utf8List]."""
 
     @staticmethod
-    def visualizers__field_converter_override(value: str | list[str]) -> list[str]:
+    def value__field_converter_override(value: str | list[str]) -> list[str]:
         if isinstance(value, str):
             return [value]
         return value

--- a/rerun_py/tests/unit/test_utf8list.py
+++ b/rerun_py/tests/unit/test_utf8list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import rerun.blueprint.components as components
 import rerun.blueprint.datatypes as datatypes
 
 
@@ -37,6 +38,7 @@ def test_utf8list() -> None:
     single_string = "Hello"
     array_of_single_string = [single_string]
     array_of_array_of_single_string = [array_of_single_string]
+
     assert (
         datatypes.Utf8ListBatch(single_string).as_arrow_array()
         == datatypes.Utf8ListBatch(array_of_single_string).as_arrow_array()
@@ -45,4 +47,15 @@ def test_utf8list() -> None:
     assert (
         datatypes.Utf8ListBatch(array_of_single_string).as_arrow_array()
         == datatypes.Utf8ListBatch(array_of_array_of_single_string).as_arrow_array()
+    )
+
+    # A component delegating through to the underlying datatype should behave the same
+    assert (
+        components.VisualizerOverrides(single_string).as_arrow_array().storage
+        == datatypes.Utf8ListBatch(array_of_array_of_single_string).as_arrow_array().storage
+    )
+
+    assert (
+        components.VisualizerOverrides(list_with_two_strings).as_arrow_array().storage
+        == datatypes.Utf8ListBatch(list_of_list_with_two_strings).as_arrow_array().storage
     )

--- a/tests/python/release_checklist/check_blueprint_overrides.py
+++ b/tests/python/release_checklist/check_blueprint_overrides.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+from argparse import Namespace
+from uuid import uuid4
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+README = """\
+# Blueprint overrides
+
+This checks that overrides work as expected when sent via blueprint APIs.
+
+Expected behavior:
+* The `sin` plot should be a blue line (set via defaults)
+* The `cos` plot should be a green points with cross markers (set via overrides)
+"""
+
+
+def log_readme() -> None:
+    rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), static=True)
+
+
+def log_plots() -> None:
+    from math import cos, sin, tau
+
+    for t in range(0, int(tau * 2 * 10.0)):
+        rr.set_time_sequence("frame_nr", t)
+
+        sin_of_t = sin(float(t) / 10.0)
+        rr.log("plots/sin", rr.Scalar(sin_of_t))
+
+        cos_of_t = cos(float(t) / 10.0)
+        rr.log("plots/cos", rr.Scalar(cos_of_t))
+
+    rr.send_blueprint(
+        rrb.Blueprint(
+            rrb.Grid(
+                rrb.TextDocumentView(origin="readme", name="Instructions"),
+                rrb.TimeSeriesView(
+                    name="Plots",
+                    defaults=[rr.components.Color([0, 0, 255])],
+                    overrides={
+                        "plots/cos": [
+                            rrb.VisualizerOverrides("SeriesPoint"),
+                            rr.components.Color([0, 255, 0]),
+                            # TODDO(#6670): This should just be `rr.components.MarkerShape.Cross`
+                            rr.components.MarkerShapeBatch("cross"),
+                        ],
+                    },
+                ),
+            )
+        )
+    )
+
+
+def run(args: Namespace) -> None:
+    rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
+
+    log_readme()
+    log_plots()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive release checklist")
+    rr.script_add_args(parser)
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7287

The field-converter ended up misnamed likely during a component type refactor.
- Add new unit-test for the specific case
- Add new check for valid field converts.
- Fix the field converter itself
- Add a release checklist that uses the override functionality.

Also if VisualizerOverrides is bad, we now handle it more gracefully instead of spamming warnings.

![image](https://github.com/user-attachments/assets/5d557e25-8e09-40a4-9afe-251b95e9d4b4)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7288?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7288?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7288)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.