### PR TITLE
Fix missing `ShowLabels` from check_all_components_ui

### DIFF
--- a/tests/python/release_checklist/check_all_components_ui.py
+++ b/tests/python/release_checklist/check_all_components_ui.py
@@ -139,13 +139,27 @@ ALL_COMPONENTS: dict[str, TestCase] = {
     ),
     "ImagePlaneDistanceBatch": TestCase(batch=[100.0, 200.0, 300.0]),
     "KeypointIdBatch": TestCase(batch=[5, 6, 7]),
-    "LineStrip2DBatch": TestCase(batch=[((0, 0), (1, 1), (2, 2)), ((3, 3), (4, 4), (5, 5)), ((6, 6), (7, 7), (8, 8))]),
+    "LineStrip2DBatch": TestCase(
+        batch=[
+            ((0, 0), (1, 1), (2, 2)),
+            ((3, 3), (4, 4), (5, 5)),
+            ((6, 6), (7, 7), (8, 8)),
+        ]
+    ),
     "LineStrip3DBatch": TestCase(
-        batch=[((0, 0, 0), (1, 1, 1), (2, 2, 2)), ((3, 3, 3), (4, 4, 4), (5, 5, 5)), ((6, 6, 6), (7, 7, 7), (8, 8, 8))]
+        batch=[
+            ((0, 0, 0), (1, 1, 1), (2, 2, 2)),
+            ((3, 3, 3), (4, 4, 4), (5, 5, 5)),
+            ((6, 6, 6), (7, 7, 7), (8, 8, 8)),
+        ]
     ),
     "MagnificationFilterBatch": TestCase(rr.components.MagnificationFilter.Linear),
     "MarkerShapeBatch": TestCase(
-        batch=[rr.components.MarkerShape.Plus, rr.components.MarkerShape.Cross, rr.components.MarkerShape.Circle]
+        batch=[
+            rr.components.MarkerShape.Plus,
+            rr.components.MarkerShape.Cross,
+            rr.components.MarkerShape.Circle,
+        ]
     ),
     "MarkerSizeBatch": TestCase(batch=[5.0, 1.0, 2.0]),
     "MediaTypeBatch": TestCase("application/jpg"),
@@ -170,6 +184,7 @@ ALL_COMPONENTS: dict[str, TestCase] = {
     "RotationQuatBatch": TestCase(batch=((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0))),
     "ScalarBatch": TestCase(3),
     "Scale3DBatch": TestCase(batch=[(1, 2, 3), (4, 5, 6), (7, 8, 9)]),
+    "ShowLabelsBatch": TestCase(alternatives=[True, False]),
     "StrokeWidthBatch": TestCase(2.0),
     "TensorDataBatch": TestCase(
         alternatives=[


### PR DESCRIPTION
Title.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
