### PR TITLE
Fix secondary plot components ignoring blueprint defaults

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -297,9 +297,10 @@ impl SeriesLineSystem {
                     })
                 }
 
-                if let Some(all_color_chunks) = results.get_required_chunks(&Color::name()) {
+                {
+                    let all_color_chunks = results.get_optional_chunks(&Color::name());
                     if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
-                        re_tracing::profile_scope!("override fast path");
+                        re_tracing::profile_scope!("override/default fast path");
 
                         let color = all_color_chunks[0]
                             .iter_primitive::<u32>(&Color::name())
@@ -337,12 +338,12 @@ impl SeriesLineSystem {
 
                 debug_assert_eq!(StrokeWidth::arrow_datatype(), ArrowDatatype::Float32);
 
-                if let Some(all_stroke_width_chunks) =
-                    results.get_required_chunks(&StrokeWidth::name())
                 {
+                    let all_stroke_width_chunks = results.get_optional_chunks(&StrokeWidth::name());
+
                     if all_stroke_width_chunks.len() == 1 && all_stroke_width_chunks[0].is_static()
                     {
-                        re_tracing::profile_scope!("override fast path");
+                        re_tracing::profile_scope!("override/default fast path");
 
                         let stroke_width = all_stroke_width_chunks[0]
                             .iter_primitive::<f32>(&StrokeWidth::name())

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -313,9 +313,11 @@ impl SeriesPointSystem {
                     })
                 }
 
-                if let Some(all_color_chunks) = results.get_required_chunks(&Color::name()) {
+                {
+                    let all_color_chunks = results.get_optional_chunks(&Color::name());
+
                     if all_color_chunks.len() == 1 && all_color_chunks[0].is_static() {
-                        re_tracing::profile_scope!("override fast path");
+                        re_tracing::profile_scope!("override/default fast path");
 
                         let color = all_color_chunks[0]
                             .iter_primitive::<u32>(&Color::name())
@@ -353,11 +355,11 @@ impl SeriesPointSystem {
 
                 debug_assert_eq!(MarkerSize::arrow_datatype(), ArrowDatatype::Float32);
 
-                if let Some(all_marker_size_chunks) =
-                    results.get_required_chunks(&MarkerSize::name())
                 {
+                    let all_marker_size_chunks = results.get_optional_chunks(&MarkerSize::name());
+
                     if all_marker_size_chunks.len() == 1 && all_marker_size_chunks[0].is_static() {
-                        re_tracing::profile_scope!("override fast path");
+                        re_tracing::profile_scope!("override/default fast path");
 
                         let marker_size = all_marker_size_chunks[0]
                             .iter_primitive::<f32>(&MarkerSize::name())
@@ -401,13 +403,14 @@ impl SeriesPointSystem {
             {
                 re_tracing::profile_scope!("fill marker shapes");
 
-                if let Some(all_marker_shapes_chunks) =
-                    results.get_required_chunks(&MarkerShape::name())
                 {
+                    let all_marker_shapes_chunks =
+                        results.get_optional_chunks(&MarkerShape::name());
+
                     if all_marker_shapes_chunks.len() == 1
                         && all_marker_shapes_chunks[0].is_static()
                     {
-                        re_tracing::profile_scope!("override fast path");
+                        re_tracing::profile_scope!("override/default fast path");
 
                         let marker_shape = all_marker_shapes_chunks[0]
                             .iter_component::<MarkerShape>()

--- a/tests/python/release_checklist/check_latest_at_partial_updates.py
+++ b/tests/python/release_checklist/check_latest_at_partial_updates.py
@@ -65,9 +65,10 @@ def blueprint() -> rrb.BlueprintLike:
                 ),
             ]
         ),
-        rrb.BlueprintPanel(state="collapsed"),
-        rrb.TimePanel(state="collapsed"),
-        rrb.SelectionPanel(state="collapsed"),
+        # NOTE: It looks nice but it's very annoying when going through several checklists.
+        # rrb.BlueprintPanel(state="collapsed"),
+        # rrb.TimePanel(state="collapsed"),
+        # rrb.SelectionPanel(state="collapsed"),
     )
 
 

--- a/tests/python/release_checklist/check_range_partial_updates.py
+++ b/tests/python/release_checklist/check_range_partial_updates.py
@@ -98,9 +98,10 @@ def blueprint() -> rrb.BlueprintLike:
             ],
             grid_columns=3,
         ),
-        rrb.BlueprintPanel(state="collapsed"),
-        rrb.TimePanel(state="collapsed"),
-        rrb.SelectionPanel(state="collapsed"),
+        # NOTE: It looks nice but it's very annoying when going through several checklists.
+        # rrb.BlueprintPanel(state="collapsed"),
+        # rrb.TimePanel(state="collapsed"),
+        # rrb.SelectionPanel(state="collapsed"),
     )
 
 


### PR DESCRIPTION
Title.

`check_blueprint_overrides` before:
![image](https://github.com/user-attachments/assets/3d2bb47e-e8d4-48eb-8342-8a10ea89b305)


`check_blueprint_overrides` after:
![image](https://github.com/user-attachments/assets/16b697a5-7ecc-4b70-bc80-793c72772d01)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7302?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7302?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7302)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.