### PR TITLE
Improve video data loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,6 +4499,7 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "re_types",
+ "re_video",
  "thiserror",
  "walkdir",
 ]

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -32,6 +32,7 @@ re_log.workspace = true
 re_smart_channel.workspace = true
 re_tracing.workspace = true
 re_types = { workspace = true, features = ["image"] }
+re_video.workspace = true
 
 ahash.workspace = true
 anyhow.workspace = true

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -213,6 +213,8 @@ fn load_video(
 ) -> Result<impl ExactSizeIterator<Item = Chunk>, DataLoaderError> {
     re_tracing::profile_function!();
 
+    re_log::warn_once!("Video support in Rerun is experimental!");
+
     timepoint.insert(
         re_log_types::Timeline::new_temporal("video"),
         re_log_types::TimeInt::new_temporal(0),
@@ -237,19 +239,6 @@ fn load_video(
             &re_types::archetypes::AssetVideo::from_file_contents(contents, media_type),
         )
         .build()?];
-
-    rows.push(
-        Chunk::builder(EntityPath::parse_forgiving("README"))
-            .with_archetype(
-                RowId::new(),
-                timepoint.clone(),
-                &re_types::archetypes::TextDocument::from_markdown(
-                    // TODO(#7298): stabilize video support
-                    "Video support in Rerun is experimental!",
-                ),
-            )
-            .build()?,
-    );
 
     for i in 0..duration_s {
         // We need some breadcrumbs of timepoints because the video doesn't have a duration yet.


### PR DESCRIPTION
### What

- Logs the video indicator instead of the README text
- Reads video metadata to log the exact length of the video druation

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7309?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7309?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7309)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.