### PR TITLE
Actually build and install the wheel in contrib CI

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -1,4 +1,4 @@
-name: Reusable Build and Test Wheels
+name: Reusable Build and Test Wheels (contrib)
 
 on:
   workflow_call:

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -56,6 +56,35 @@ jobs:
           pixi-version: v0.25.0
           environments: wheel-test-min
 
+      - name: Build rerun-cli
+        env:
+          # this stops `re_web_viewer_server/build.rs` from running
+          RERUN_IS_PUBLISHING: true
+        run: |
+          cargo build \
+            --locked \
+            -p rerun-cli \
+            --no-default-features \
+            --features native_viewer,web_viewer \
+            --release \
+            --target x86_64-unknown-linux-gnu
+
+      - name: Copy rerun-cli to wheel foldcer
+        run: |
+          cp target/release/rerun rerun_py/rerun_sdk/rerun_cli
+
+      - name: Build the wheel
+        run: |
+          pixi run python scripts/ci/build_and_upload_wheels.py \
+            --mode pr \
+            --target x86_64-unknown-linux-gnu \
+            --dir unused \
+            --compat manylinux_2_34
+
+      - name: Install built wheel
+        run: |
+          pixi run python scripts/ci/pixi_install_wheel.py --feature python-pypi --package rerun-sdk --dir dist/x86_64-unknown-linux-gnu
+
       - name: Run e2e test
         run: pixi run -e wheel-test-min RUST_LOG=debug scripts/run_python_e2e_test.py --no-build # rerun-sdk is already built and installed
 


### PR DESCRIPTION
### What
Our contributor CI has been broken because it was still using a pre-installed 0.17 rerun-sdk.

Example of broken CI:
https://github.com/rerun-io/rerun/actions/runs/10636563349/job/29488889930

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7323?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7323?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7323)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.