### PR TITLE
Use `<url>` for links in python docs

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ lod = "lod"     # level-of-detail
 ND = "ND"       # np.NDArray
 somes = "somes" # many `Some`
 teh = "teh"     # part of @teh-cmc
+trak = "trak"   # mp4 crate spelling
 
 # Use the more common spelling
 adaptor = "adapter"

--- a/crates/build/re_types_builder/src/codegen/python/views.rs
+++ b/crates/build/re_types_builder/src/codegen/python/views.rs
@@ -141,7 +141,7 @@ should be applied. The value is a list of component or component batches to appl
 
 Important note: the path must be a fully qualified entity path starting at the root. The override paths
 do not yet support `$origin` relative paths or glob expressions.
-This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].".to_owned(),)
+This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.".to_owned(),)
     ];
     for field in &obj.fields {
         let doc_content = field.docs.lines_for(objects, Target::Python);

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -583,7 +583,7 @@ fn batching_thread(config: ChunkBatcherConfig, rx_cmd: Receiver<Command>, tx_chu
     );
 
     // Set to `true` when a flush is triggered for a reason other than hitting the time threshold,
-    // so that the next tick will not unncessarily fire early.
+    // so that the next tick will not unnecessarily fire early.
     let mut skip_next_tick = false;
 
     use crossbeam::select;

--- a/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/tensor.fbs
@@ -9,7 +9,7 @@ namespace rerun.archetypes;
 ///
 /// \py It's not currently possible to use `send_columns` with tensors since construction
 /// \py of `rerun.components.TensorDataBatch` does not support more than a single element.
-/// \py This will be addressed as part of https://github.com/rerun-io/rerun/issues/6832.
+/// \py This will be addressed as part of <https://github.com/rerun-io/rerun/issues/6832>.
 ///
 /// \example archetypes/tensor_simple title="Simple tensor" image="https://static.rerun.io/tensor_simple/baacb07712f7b706e3c80e696f70616c6c20b367/1200w.png"
 table Tensor (

--- a/crates/store/re_types/definitions/rerun/datatypes/tensor_data.fbs
+++ b/crates/store/re_types/definitions/rerun/datatypes/tensor_data.fbs
@@ -13,7 +13,7 @@ namespace rerun.datatypes;
 ///
 /// \py It's not currently possible to use `send_columns` with tensors since construction
 /// \py of `rerun.components.TensorDataBatch` does not support more than a single element.
-/// \py This will be addressed as part of https://github.com/rerun-io/rerun/issues/6832.
+/// \py This will be addressed as part of <https://github.com/rerun-io/rerun/issues/6832>.
 table TensorData (
   "attr.python.aliases": "npt.ArrayLike",
   "attr.python.array_aliases": "npt.ArrayLike",

--- a/examples/python/controlnet/controlnet.py
+++ b/examples/python/controlnet/controlnet.py
@@ -2,7 +2,7 @@
 """
 Example running ControlNet conditioned on Canny edges.
 
-Based on https://huggingface.co/docs/diffusers/using-diffusers/controlnet.
+Based on <https://huggingface.co/docs/diffusers/using-diffusers/controlnet>.
 """
 
 from __future__ import annotations

--- a/examples/python/depth_guided_stable_diffusion/depth_guided_stable_diffusion/__main__.py
+++ b/examples/python/depth_guided_stable_diffusion/depth_guided_stable_diffusion/__main__.py
@@ -2,7 +2,7 @@
 """
 Example running Depth Guided Stable Diffusion 2.0.
 
-For more info see: https://github.com/Stability-AI/stablediffusion
+For more info see <https://github.com/Stability-AI/stablediffusion>
 """
 
 from __future__ import annotations

--- a/examples/python/face_tracking/face_tracking.py
+++ b/examples/python/face_tracking/face_tracking.py
@@ -89,7 +89,7 @@ class FaceDetectorLogger:
     """
     Logger for the MediaPipe Face Detection solution.
 
-    https://developers.google.com/mediapipe/solutions/vision/face_detector
+    <https://developers.google.com/mediapipe/solutions/vision/face_detector>
     """
 
     MODEL_PATH: Final = (MODEL_DIR / "blaze_face_short_range.tflite").resolve()
@@ -158,7 +158,7 @@ class FaceLandmarkerLogger:
     """
     Logger for the MediaPipe Face Landmark Detection solution.
 
-    https://developers.google.com/mediapipe/solutions/vision/face_landmarker
+    <https://developers.google.com/mediapipe/solutions/vision/face_landmarker>
     """
 
     MODEL_PATH: Final = (MODEL_DIR / "face_landmarker.task").resolve()

--- a/examples/python/gesture_detection/gesture_detection.py
+++ b/examples/python/gesture_detection/gesture_detection.py
@@ -57,7 +57,7 @@ class GestureDetectorLogger:
     This class provides logging and utility functions for handling gesture recognition.
 
     For more information on MediaPipe Gesture Detection:
-    https://developers.google.com/mediapipe/solutions/vision/gesture_recognizer
+    <https://developers.google.com/mediapipe/solutions/vision/gesture_recognizer>
     """
 
     # URL to the pre-trained MediaPipe Gesture Detection model

--- a/examples/python/lidar/lidar/download_dataset.py
+++ b/examples/python/lidar/lidar/download_dataset.py
@@ -58,7 +58,7 @@ def download_minisplit(root_dir: pathlib.Path) -> None:
     """
     Download nuScenes minisplit.
 
-    Adopted from https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb
+    Adopted from <https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb>
     """
     zip_file_path = pathlib.Path("./v1.0-mini.tgz")
     if not zip_file_path.is_file():

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
@@ -58,7 +58,7 @@ def download_minisplit(root_dir: pathlib.Path) -> None:
     """
     Download nuScenes minisplit.
 
-    Adopted from https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb
+    Adopted from <https://colab.research.google.com/github/nutonomy/nuscenes-devkit/blob/master/python-sdk/tutorials/nuscenes_tutorial.ipynb>
     """
     zip_file_path = pathlib.Path("./v1.0-mini.tgz")
     if not zip_file_path.is_file():

--- a/examples/python/rgbd/rgbd.py
+++ b/examples/python/rgbd/rgbd.py
@@ -133,7 +133,7 @@ def download_progress(url: str, dst: Path) -> None:
     """
     Download file with tqdm progress bar.
 
-    From: https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51
+    From: <https://gist.github.com/yanqd0/c13ed29e29432e3cf3e7c38467f42f51>
     """
     resp = requests.get(url, stream=True)
     if resp.status_code != 200:

--- a/examples/python/ros_node/main.py
+++ b/examples/python/ros_node/main.py
@@ -4,7 +4,7 @@ Simple example of a ROS node that republishes some common types to Rerun.
 
 The solution here is mostly a toy example to show how ROS concepts can be
 mapped to Rerun. Fore more information on future improved ROS support,
-see the tracking issue: https://github.com/rerun-io/rerun/issues/1537
+see the tracking issue: <https://github.com/rerun-io/rerun/issues/1537>.
 
 NOTE: Unlike many of the other examples, this example requires a system installation of ROS
 in addition to the packages from requirements.txt.

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -30,7 +30,7 @@ class AsComponents(Protocol):
 
     Note: the `num_instances()` function is an optional part of this interface. The method does not need to be
     implemented as it is only used after checking for its existence. (There is unfortunately no way to express this
-    correctly with the Python typing system, see https://github.com/python/typing/issues/601).
+    correctly with the Python typing system, see <https://github.com/python/typing/issues/601>).
     """
 
     def as_component_batches(self) -> Iterable[ComponentBatchLike]:

--- a/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/tensor.py
@@ -23,7 +23,7 @@ class Tensor(TensorExt, Archetype):
 
     It's not currently possible to use `send_columns` with tensors since construction
     of `rerun.components.TensorDataBatch` does not support more than a single element.
-    This will be addressed as part of https://github.com/rerun-io/rerun/issues/6832.
+    This will be addressed as part of <https://github.com/rerun-io/rerun/issues/6832>.
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -78,7 +78,7 @@ class SpaceView:
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
 
         """
         self.id = uuid.uuid4()

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/bar_chart_view.py
@@ -87,7 +87,7 @@ class BarChartView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
         plot_legend:
             Configures the legend of the plot.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial2d_view.py
@@ -114,7 +114,7 @@ class Spatial2DView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
         background:
             Configuration for the background of the view.
         visual_bounds:

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/spatial3d_view.py
@@ -109,7 +109,7 @@ class Spatial3DView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
         background:
             Configuration for the background of the view.
         time_ranges:

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/tensor_view.py
@@ -112,7 +112,7 @@ class TensorView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
         slice_selection:
             How to select the slice of the tensor to show.
         scalar_mapping:

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_document_view.py
@@ -124,7 +124,7 @@ class TextDocumentView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
 
         """
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/text_log_view.py
@@ -90,7 +90,7 @@ class TextLogView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
 
         """
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/time_series_view.py
@@ -126,7 +126,7 @@ class TimeSeriesView(SpaceView):
 
             Important note: the path must be a fully qualified entity path starting at the root. The override paths
             do not yet support `$origin` relative paths or glob expressions.
-            This will be addressed in: [https://github.com/rerun-io/rerun/issues/6673][].
+            This will be addressed in <https://github.com/rerun-io/rerun/issues/6673>.
         axis_y:
             Configures the vertical axis of the plot.
         plot_legend:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -42,7 +42,7 @@ class TensorData(TensorDataExt):
 
     It's not currently possible to use `send_columns` with tensors since construction
     of `rerun.components.TensorDataBatch` does not support more than a single element.
-    This will be addressed as part of https://github.com/rerun-io/rerun/issues/6832.
+    This will be addressed as part of <https://github.com/rerun-io/rerun/issues/6832>.
     """
 
     # __init__ can be found in tensor_data_ext.py

--- a/rerun_py/rerun_sdk/rerun/legacy_notebook.py
+++ b/rerun_py/rerun_sdk/rerun/legacy_notebook.py
@@ -80,7 +80,7 @@ def as_html(
     height : int
         The height of the viewer in pixels.
     app_url : str
-        Alternative HTTP url to find the Rerun web viewer. This will default to using https://app.rerun.io
+        Alternative HTTP url to find the Rerun web viewer. This will default to using `https://app.rerun.io`
         or localhost if [rerun.start_web_viewer_server][] has been called.
     timeout_ms : int
         The number of milliseconds to wait for the Rerun web viewer to load.
@@ -152,7 +152,7 @@ def legacy_notebook_show(
     height : int
         The height of the viewer in pixels.
     app_url : str
-        Alternative HTTP url to find the Rerun web viewer. This will default to using https://app.rerun.io
+        Alternative HTTP url to find the Rerun web viewer. This will default to using `https://app.rerun.io`
         or localhost if [rerun.start_web_viewer_server][] has been called.
     timeout_ms : int
         The number of milliseconds to wait for the Rerun web viewer to load.

--- a/rerun_py/rerun_sdk/rerun/recording_stream.py
+++ b/rerun_py/rerun_sdk/rerun/recording_stream.py
@@ -189,7 +189,7 @@ class RecordingStream:
     ```
     WARNING: if using a RecordingStream as a context manager, yielding from a generator function
     while holding the context open will leak the context and likely cause your program to send data
-    to the wrong stream. See: https://github.com/rerun-io/rerun/issues/6238. You can work around this
+    to the wrong stream. See: <https://github.com/rerun-io/rerun/issues/6238>. You can work around this
     by using the [`rerun.recording_stream_generator_ctx`][] decorator.
 
     See also: [`rerun.get_data_recording`][], [`rerun.get_global_data_recording`][],

--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -203,7 +203,7 @@ def serve(
     The WebSocket server will buffer all log data in memory so that late connecting viewers will get all the data.
     You can limit the amount of data buffered by the WebSocket server with the `server_memory_limit` argument.
     Once reached, the earliest logged data will be dropped.
-    Note that this means that static data may be dropped if logged early (see https://github.com/rerun-io/rerun/issues/5531).
+    Note that this means that static data may be dropped if logged early (see <https://github.com/rerun-io/rerun/issues/5531>).
 
     This function returns immediately.
 

--- a/scripts/ci/compare.py
+++ b/scripts/ci/compare.py
@@ -3,7 +3,7 @@
 """
 Compare sizes of a list of files.
 
-This produces the format for use in https://github.com/benchmark-action/github-action-benchmark.
+This produces the format for use in <https://github.com/benchmark-action/github-action-benchmark>.
 
 Use the script:
     python3 scripts/ci/compare.py --help

--- a/scripts/ci/count_bytes.py
+++ b/scripts/ci/count_bytes.py
@@ -3,7 +3,7 @@
 """
 Measure sizes of a list of files.
 
-This produces the format for use in https://github.com/benchmark-action/github-action-benchmark.
+This produces the format for use in <https://github.com/benchmark-action/github-action-benchmark>.
 
 Use the script:
     python3 scripts/ci/count_bytes.py --help

--- a/scripts/ci/count_dependencies.py
+++ b/scripts/ci/count_dependencies.py
@@ -3,7 +3,7 @@
 """
 Count the total number of dependencies of a file (recursively).
 
-This produces the format for use in https://github.com/benchmark-action/github-action-benchmark.
+This produces the format for use in <https://github.com/benchmark-action/github-action-benchmark>.
 
 Use the script:
     python3 scripts/ci/count_dependencies.py -p rerun --all-features

--- a/scripts/ci/dag.py
+++ b/scripts/ci/dag.py
@@ -15,7 +15,7 @@ class RateLimiter:
 
     Starts at `max_tokens`, and refills one token every `refill_interval_sec / max_tokens`.
 
-    This implementation attempts to mimic https://github.com/rust-lang/crates.io/blob/e66c852d3db3f0dfafa1f9a01e7806f0b2ad1465/src/rate_limiter.rs
+    This implementation attempts to mimic <https://github.com/rust-lang/crates.io/blob/e66c852d3db3f0dfafa1f9a01e7806f0b2ad1465/src/rate_limiter.rs>
     """
 
     def __init__(self, max_tokens: int, refill_interval_sec: float):

--- a/scripts/ci/render_bench.py
+++ b/scripts/ci/render_bench.py
@@ -4,7 +4,7 @@
 Render benchmark graphs and other tracked metrics from data in GCS.
 
 To use this script, you must be authenticated with GCS,
-see https://cloud.google.com/docs/authentication/client-libraries for more information.
+see <https://cloud.google.com/docs/authentication/client-libraries> for more information.
 
 Install dependencies:
     google-cloud-storage==2.9.0


### PR DESCRIPTION
Fixes warning in https://github.com/rerun-io/rerun/actions/runs/10662695291/job/29550372867?pr=7319

> WARNING -  mkdocs_autorefs: common/blueprint_apis.md: Could not find cross-reference target ’https://github.com/rerun-io/rerun/issues/6673'

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7325?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7325?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7325)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.