### PR TITLE
Fix `AssetVideo` 

### DIFF
--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video_ext.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from .. import datatypes
 from ..error_utils import catch_and_log_exceptions
-
-if TYPE_CHECKING:
-    from ..components import MediaType
 
 
 class AssetVideoExt:
@@ -44,6 +41,8 @@ class AssetVideoExt:
             If the media type cannot be guessed, the viewer won't be able to render the asset.
 
         """
+
+        from ..components import MediaType
 
         with catch_and_log_exceptions(context=self.__class__.__name__):
             if (path is None) == (contents is None):


### PR DESCRIPTION
### What

Fixes https://github.com/rerun-io/rerun/actions/runs/10667949540/job/29567116641

I'm going to start running `full-check` on PRs that change types more often...

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7332?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7332?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7332)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.