### PR TITLE
Fix `re_types_core::datatypes::TimeInt::MIN` and avoid using it for `TimeDragValue`

### DIFF
--- a/crates/store/re_types_core/src/datatypes/time_int_ext.rs
+++ b/crates/store/re_types_core/src/datatypes/time_int_ext.rs
@@ -1,7 +1,8 @@
 use super::TimeInt;
 
 impl TimeInt {
-    pub const MIN: Self = Self(i64::MIN);
+    // matches `re_log_types::TimeInt::MIN`
+    pub const MIN: Self = Self(i64::MIN + 1);
     pub const MAX: Self = Self(i64::MAX);
 }
 

--- a/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_list_mode.rs
@@ -2,8 +2,7 @@ use std::ops::RangeInclusive;
 
 use re_chunk_store::external::re_chunk::ComponentName;
 use re_chunk_store::ChunkStore;
-use re_log_types::external::re_types_core::datatypes::TimeInt;
-use re_log_types::{EntityPath, ResolvedTimeRange, TimeType, TimeZone, Timeline};
+use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, TimeType, TimeZone, Timeline};
 use re_ui::UiExt;
 use re_viewer_context::TimeDragValue;
 
@@ -178,7 +177,7 @@ impl ChunkListMode {
                     };
                 }
                 ChunkListQueryMode::Range(range) => {
-                    let (mut min, mut max) = (range.min().into(), range.max().into());
+                    let (mut min, mut max) = (range.min(), range.max());
                     ui.label("from:");
                     match time_typ {
                         TimeType::Time => {

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -540,15 +540,16 @@ fn visible_history_boundary_ui(
             let low_bound_override = if low_bound {
                 None
             } else {
-                Some(other_boundary_absolute - current_time)
+                Some((other_boundary_absolute - current_time).into())
             };
 
-            match time_type {
+            let mut edit_value = (*value).into();
+            let response = match time_type {
                 TimeType::Time => Some(
                     time_drag_value
                         .temporal_drag_value_ui(
                             ui,
-                            value,
+                            &mut edit_value,
                             false,
                             low_bound_override,
                             ctx.app_options.time_zone,
@@ -561,27 +562,30 @@ fn visible_history_boundary_ui(
                 ),
                 TimeType::Sequence => Some(
                     time_drag_value
-                        .sequence_drag_value_ui(ui, value, false, low_bound_override)
+                        .sequence_drag_value_ui(ui, &mut edit_value, false, low_bound_override)
                         .on_hover_text(
                             "Number of frames before/after the current time to use a time \
                         range boundary",
                         ),
                 ),
-            }
+            };
+            *value = edit_value.into();
+            response
         }
         TimeRangeBoundary::Absolute(value) => {
             // see note above
             let low_bound_override = if low_bound {
                 None
             } else {
-                Some(other_boundary_absolute)
+                Some(other_boundary_absolute.into())
             };
 
-            match time_type {
+            let mut edit_value = (*value).into();
+            let response = match time_type {
                 TimeType::Time => {
                     let (drag_resp, base_time_resp) = time_drag_value.temporal_drag_value_ui(
                         ui,
-                        value,
+                        &mut edit_value,
                         true,
                         low_bound_override,
                         ctx.app_options.time_zone,
@@ -595,10 +599,12 @@ fn visible_history_boundary_ui(
                 }
                 TimeType::Sequence => Some(
                     time_drag_value
-                        .sequence_drag_value_ui(ui, value, true, low_bound_override)
+                        .sequence_drag_value_ui(ui, &mut edit_value, true, low_bound_override)
                         .on_hover_text("Absolute frame number to use as time range boundary"),
                 ),
-            }
+            };
+            *value = edit_value.into();
+            response
         }
         TimeRangeBoundary::Infinite => None,
     };

--- a/crates/viewer/re_space_view_dataframe/src/query_kind_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/query_kind_ui.rs
@@ -43,8 +43,7 @@ impl UiQueryKind {
                         *time
                     } else {
                         TimeInt::MAX
-                    }
-                    .into();
+                    };
 
                     changed |= match time_type {
                         TimeType::Time => time_drag_value
@@ -63,7 +62,7 @@ impl UiQueryKind {
                     };
 
                     if changed {
-                        *self = Self::LatestAt { time: time.into() };
+                        *self = Self::LatestAt { time };
                     }
                 }
             });
@@ -101,15 +100,15 @@ impl UiQueryKind {
                         ui.add_space(-4.0);
 
                         let mut from = if let Self::TimeRange { from, .. } = self {
-                            (*from).into()
+                            *from
                         } else {
-                            (*time_drag_value.range.start()).into()
+                            time_drag_value.min_time()
                         };
 
                         let mut to = if let Self::TimeRange { to, .. } = self {
-                            (*to).into()
+                            *to
                         } else {
-                            (*time_drag_value.range.end()).into()
+                            time_drag_value.max_time()
                         };
 
                         list_item::list_item_scope(ui, "time_range_custom_scope", |ui| {
@@ -165,10 +164,7 @@ impl UiQueryKind {
                         });
 
                         if changed {
-                            *self = Self::TimeRange {
-                                from: from.into(),
-                                to: to.into(),
-                            };
+                            *self = Self::TimeRange { from, to };
                         }
 
                         if should_display_time_range {


### PR DESCRIPTION
### What

This PR does two things:
1. fix `re_types_core::datatypes::TimeIn::MIN`, which was different from `re_log_types::TimeInt::MIN` (`i64::MIN` instead of `i64::MIN+1`, the former being reserved for `static`).
2. use `re_log_types::TimeInt` for `TimeDragValue`.

Background for (2): the visible time range feature in selection panel heavily relies on `re_types_core::datatypes::TimeInt` because it uses blueprint codegen'd structures. Historically, this leaked into `TimeDragValue`, which originated there. Now `TimeDragValue` is used in several other places (which is why it was moved to `re_viewer_context`), so it best uses the "correct" `TimeInt` for its API.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7334?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7334?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7334)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.