### PR TITLE
Dataframe queries 0: bootstrap & data model

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,11 +88,11 @@ Of course, this will only take us so far. In the future we plan on caching queri
 Here is an overview of the crates included in the project:
 
 <picture>
-  <img src="https://static.rerun.io/crates/0973a21dff25026ed999e7d70d7c177cd2621514/full.png" alt="">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/0973a21dff25026ed999e7d70d7c177cd2621514/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/0973a21dff25026ed999e7d70d7c177cd2621514/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/0973a21dff25026ed999e7d70d7c177cd2621514/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/0973a21dff25026ed999e7d70d7c177cd2621514/1200w.png">
+  <img src="https://static.rerun.io/crates/4f5569b318a5b8d7b0e9ab6e34e672c58ac5c63e/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/crates/4f5569b318a5b8d7b0e9ab6e34e672c58ac5c63e/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/crates/4f5569b318a5b8d7b0e9ab6e34e672c58ac5c63e/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/crates/4f5569b318a5b8d7b0e9ab6e34e672c58ac5c63e/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/crates/4f5569b318a5b8d7b0e9ab6e34e672c58ac5c63e/1200w.png">
 </picture>
 
 
@@ -163,6 +163,7 @@ Update instructions:
 |----------------------|--------------------------------------------------------------------------|
 | re_entity_db         | In-memory storage of Rerun entities                                      |
 | re_query             | Querying data in the re_chunk_store                                      |
+| re_dataframe         | The Rerun public data APIs.                                              |
 | re_types             | The built-in Rerun data types, component types, and archetypes.          |
 | re_types_blueprint   | The core traits and types that power Rerun's Blueprint sub-system.       |
 | re_log_encoding      | Helpers for encoding and transporting Rerun log messages                 |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4826,6 +4826,7 @@ dependencies = [
  "re_chunk",
  "re_format",
  "re_log",
+ "re_log_encoding",
  "re_log_types",
  "re_tracing",
  "re_types",
@@ -4972,6 +4973,33 @@ dependencies = [
  "re_ui",
  "re_viewer_context",
  "unindent",
+]
+
+[[package]]
+name = "re_dataframe"
+version = "0.19.0-alpha.1+dev"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "backtrace",
+ "indent",
+ "itertools 0.13.0",
+ "nohash-hasher",
+ "parking_lot",
+ "paste",
+ "re_arrow2",
+ "re_chunk",
+ "re_chunk_store",
+ "re_error",
+ "re_format",
+ "re_log",
+ "re_log_types",
+ "re_query",
+ "re_tracing",
+ "re_types",
+ "re_types_core",
+ "seq-macro",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -830,6 +830,11 @@ impl Chunk {
         self.num_rows() == 0
     }
 
+    #[inline]
+    pub fn row_ids_array(&self) -> &ArrowStructArray {
+        &self.row_ids
+    }
+
     /// Returns the [`RowId`]s in their raw-est form: a tuple of (times, counters) arrays.
     #[inline]
     pub fn row_ids_raw(&self) -> (&ArrowPrimitiveArray<u64>, &ArrowPrimitiveArray<u64>) {
@@ -995,6 +1000,16 @@ impl TimeColumn {
     }
 
     #[inline]
+    pub fn times_array(&self) -> &ArrowPrimitiveArray<i64> {
+        &self.times
+    }
+
+    #[inline]
+    pub fn times_raw(&self) -> &[i64] {
+        self.times.values().as_slice()
+    }
+
+    #[inline]
     pub fn times(&self) -> impl DoubleEndedIterator<Item = TimeInt> + '_ {
         self.times
             .values()
@@ -1002,11 +1017,6 @@ impl TimeColumn {
             .iter()
             .copied()
             .map(TimeInt::new_temporal)
-    }
-
-    #[inline]
-    pub fn times_raw(&self) -> &[i64] {
-        self.times.values().as_slice()
     }
 
     #[inline]

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -31,12 +31,14 @@ deadlock_detection = ["parking_lot/deadlock_detection"]
 re_chunk.workspace = true
 re_format.workspace = true
 re_log = { workspace = true, features = ["setup"] }
+re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_tracing.workspace = true
 re_types_core.workspace = true
 
 # External dependencies:
 ahash.workspace = true
+anyhow.workspace = true
 arrow2 = { workspace = true, features = ["compute_concatenate"] }
 document-features.workspace = true
 indent.workspace = true

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -1,0 +1,499 @@
+//! All the APIs used specifically for `re_dataframe`.
+
+#![allow(unused_imports)]
+
+use std::collections::BTreeSet;
+
+use ahash::HashSet;
+use arrow2::datatypes::{DataType as ArrowDatatype, Field as ArrowField};
+use itertools::Itertools as _;
+
+use re_chunk::LatestAtQuery;
+use re_log_types::ResolvedTimeRange;
+use re_log_types::{EntityPath, TimeInt, Timeline};
+use re_types_core::{ArchetypeName, ComponentName, Loggable as _};
+
+use crate::ChunkStore;
+
+// Used all over in docstrings.
+#[allow(unused_imports)]
+use crate::RowId;
+
+// --- Descriptors ---
+
+// TODO(#6889): At some point all these descriptors needs to be interned and have handles or
+// something. And of course they need to be codegen. But we'll get there once we're back to
+// natively tagged components.
+
+// Describes any kind of column.
+//
+// See:
+// * [`ControlColumnDescriptor`]
+// * [`TimeColumnDescriptor`]
+// * [`ComponentColumnDescriptor`]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ColumnDescriptor {
+    Control(ControlColumnDescriptor),
+    Time(TimeColumnDescriptor),
+    Component(ComponentColumnDescriptor),
+}
+
+impl ColumnDescriptor {
+    #[inline]
+    pub fn entity_path(&self) -> Option<&EntityPath> {
+        match self {
+            Self::Component(descr) => Some(&descr.entity_path),
+            Self::Control(_) | Self::Time(_) => None,
+        }
+    }
+
+    #[inline]
+    pub fn datatype(&self) -> &ArrowDatatype {
+        match self {
+            Self::Control(descr) => &descr.datatype,
+            Self::Component(descr) => &descr.datatype,
+            Self::Time(descr) => &descr.datatype,
+        }
+    }
+
+    #[inline]
+    pub fn to_arrow_field(&self) -> ArrowField {
+        match self {
+            Self::Control(descr) => descr.to_arrow_field(),
+            Self::Time(descr) => descr.to_arrow_field(),
+            Self::Component(descr) => descr.to_arrow_field(),
+        }
+    }
+}
+
+/// Describes a column used to control Rerun's behavior, such as `RowId`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ControlColumnDescriptor {
+    /// Semantic name associated with this data.
+    ///
+    /// Example: `rerun.controls.RowId`.
+    pub component_name: ComponentName,
+
+    /// The Arrow datatype of the column.
+    pub datatype: ArrowDatatype,
+}
+
+impl PartialOrd for ControlColumnDescriptor {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ControlColumnDescriptor {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let Self {
+            component_name,
+            datatype: _,
+        } = self;
+        component_name.cmp(&other.component_name)
+    }
+}
+
+impl ControlColumnDescriptor {
+    #[inline]
+    pub fn to_arrow_field(&self) -> ArrowField {
+        let Self {
+            component_name,
+            datatype,
+        } = self;
+
+        ArrowField::new(
+            component_name.to_string(),
+            datatype.clone(),
+            false, /* nullable */
+        )
+    }
+}
+
+/// Describes a time column, such as `log_time`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TimeColumnDescriptor {
+    /// The timeline this column is associated with.
+    pub timeline: Timeline,
+
+    /// The Arrow datatype of the column.
+    pub datatype: ArrowDatatype,
+}
+
+impl PartialOrd for TimeColumnDescriptor {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for TimeColumnDescriptor {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let Self {
+            timeline,
+            datatype: _,
+        } = self;
+        timeline.cmp(&other.timeline)
+    }
+}
+
+impl TimeColumnDescriptor {
+    #[inline]
+    pub fn to_arrow_field(&self) -> ArrowField {
+        let Self { timeline, datatype } = self;
+        ArrowField::new(
+            timeline.name().to_string(),
+            datatype.clone(),
+            false, /* nullable */
+        )
+    }
+}
+
+/// Describes a data/component column, such as `Position3D`.
+//
+// TODO(#6889): Fully sorbetize this thing? `ArchetypeName` and such don't make sense in that
+// context. And whatever `archetype_field_name` ends up being, it needs interning.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ComponentColumnDescriptor {
+    /// The path of the entity.
+    pub entity_path: EntityPath,
+
+    /// Optional name of the `Archetype` associated with this data.
+    ///
+    /// `None` if the data wasn't logged through an archetype.
+    ///
+    /// Example: `rerun.archetypes.Points3D`.
+    pub archetype_name: Option<ArchetypeName>,
+
+    /// Optional name of the field within `Archetype` associated with this data.
+    ///
+    /// `None` if the data wasn't logged through an archetype.
+    ///
+    /// Example: `positions`.
+    pub archetype_field_name: Option<String>,
+
+    /// Semantic name associated with this data.
+    ///
+    /// This is fully implied by `archetype_name` and `archetype_field`, but
+    /// included for semantic convenience.
+    ///
+    /// Example: `rerun.components.Position3D`.
+    pub component_name: ComponentName,
+
+    /// The Arrow datatype of the column.
+    pub datatype: ArrowDatatype,
+
+    /// Whether this column represents static data.
+    pub is_static: bool,
+}
+
+impl PartialOrd for ComponentColumnDescriptor {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ComponentColumnDescriptor {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let Self {
+            entity_path,
+            archetype_name,
+            archetype_field_name,
+            component_name,
+            datatype: _,
+            is_static: _,
+        } = self;
+
+        entity_path
+            .cmp(&other.entity_path)
+            .then_with(|| component_name.cmp(&other.component_name))
+            .then_with(|| archetype_name.cmp(&other.archetype_name))
+            .then_with(|| archetype_field_name.cmp(&other.archetype_field_name))
+    }
+}
+
+impl std::fmt::Display for ComponentColumnDescriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            entity_path,
+            archetype_name,
+            archetype_field_name,
+            component_name,
+            datatype: _,
+            is_static,
+        } = self;
+
+        let s = match (archetype_name, component_name, archetype_field_name) {
+            (None, component_name, None) => component_name.to_string(),
+            (Some(archetype_name), component_name, None) => format!(
+                "{entity_path}@{}::{}",
+                archetype_name.short_name(),
+                component_name.short_name(),
+            ),
+            (None, component_name, Some(archetype_field_name)) => format!(
+                "{entity_path}@{}#{archetype_field_name}",
+                component_name.short_name(),
+            ),
+            (Some(archetype_name), component_name, Some(archetype_field_name)) => format!(
+                "{entity_path}@{}::{}#{archetype_field_name}",
+                archetype_name.short_name(),
+                component_name.short_name(),
+            ),
+        };
+
+        if *is_static {
+            f.write_fmt(format_args!("|{s}|"))
+        } else {
+            f.write_str(&s)
+        }
+    }
+}
+
+impl ComponentColumnDescriptor {
+    #[inline]
+    pub fn new<C: re_types_core::Component>(entity_path: EntityPath) -> Self {
+        Self {
+            entity_path,
+            archetype_name: None,
+            archetype_field_name: None,
+            component_name: C::name(),
+            datatype: C::arrow_datatype(),
+            // TODO(cmc): one of the many reasons why using `ComponentColumnDescriptor` for this
+            // gets a bit weird… Good enough for now though.
+            is_static: false,
+        }
+    }
+
+    #[inline]
+    pub fn to_arrow_field(&self) -> ArrowField {
+        let Self {
+            entity_path,
+            archetype_name,
+            archetype_field_name,
+            component_name,
+            datatype,
+            is_static,
+        } = self;
+
+        ArrowField::new(
+            component_name.short_name().to_owned(),
+            datatype.clone(),
+            false, /* nullable */
+        )
+        // TODO(#6889): This needs some proper sorbetization -- I just threw these names randomly.
+        .with_metadata(
+            [
+                (*is_static).then_some(("sorbet.is_static".to_owned(), "yes".to_owned())),
+                Some(("sorbet.path".to_owned(), entity_path.to_string())),
+                Some((
+                    "sorbet.semantic_type".to_owned(),
+                    component_name.short_name().to_owned(),
+                )),
+                archetype_name.map(|name| {
+                    (
+                        "sorbet.semantic_family".to_owned(),
+                        name.short_name().to_owned(),
+                    )
+                }),
+                archetype_field_name
+                    .as_ref()
+                    .map(|name| ("sorbet.logical_type".to_owned(), name.to_owned())),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        )
+    }
+}
+
+// --- Queries ---
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum QueryExpression {
+    LatestAt(LatestAtQueryExpression),
+    Range(RangeQueryExpression),
+}
+
+impl From<LatestAtQueryExpression> for QueryExpression {
+    #[inline]
+    fn from(query: LatestAtQueryExpression) -> Self {
+        Self::LatestAt(query)
+    }
+}
+
+impl From<RangeQueryExpression> for QueryExpression {
+    #[inline]
+    fn from(query: RangeQueryExpression) -> Self {
+        Self::Range(query)
+    }
+}
+
+impl QueryExpression {
+    #[inline]
+    pub fn entity_path_expr(&self) -> &EntityPathExpression {
+        match self {
+            Self::LatestAt(query) => &query.entity_path_expr,
+            Self::Range(query) => &query.entity_path_expr,
+        }
+    }
+}
+
+impl std::fmt::Display for QueryExpression {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LatestAt(query) => query.fmt(f),
+            Self::Range(query) => query.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LatestAtQueryExpression {
+    /// The entity path expression to query.
+    ///
+    /// Example: `world/camera/**`
+    pub entity_path_expr: EntityPathExpression,
+
+    /// The timeline to query.
+    ///
+    /// Example: `frame`.
+    pub timeline: Timeline,
+
+    /// The time at which to query.
+    ///
+    /// Example: `18`.
+    pub at: TimeInt,
+}
+
+impl std::fmt::Display for LatestAtQueryExpression {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            entity_path_expr,
+            timeline,
+            at,
+        } = self;
+
+        f.write_fmt(format_args!(
+            "latest state for '{entity_path_expr}' at {} on {:?}",
+            timeline.typ().format_utc(*at),
+            timeline.name(),
+        ))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RangeQueryExpression {
+    /// The entity path expression to query.
+    ///
+    /// Example: `world/camera/**`
+    pub entity_path_expr: EntityPathExpression,
+
+    /// The timeline to query.
+    ///
+    /// Example `frame`
+    pub timeline: Timeline,
+
+    /// The time range to query.
+    pub time_range: ResolvedTimeRange,
+
+    /// The point-of-view of the query, as described by its [`ComponentColumnDescriptor`].
+    ///
+    /// In a range query results, each non-null value of the point-of-view component column
+    /// will generate a row in the result.
+    ///
+    /// Note that a component can be logged multiple times at the same timestamp (e.g. something
+    /// happened multiple times during a single frame), in which case the results will contain
+    /// multiple rows at a given timestamp.
+    //
+    // TODO(cmc): issue for multi-pov support
+    pub pov: ComponentColumnDescriptor,
+    //
+    // TODO(cmc): custom join policy support
+}
+
+impl std::fmt::Display for RangeQueryExpression {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            entity_path_expr,
+            timeline,
+            time_range,
+            pov,
+        } = self;
+
+        f.write_fmt(format_args!(
+            "{entity_path_expr} ranging {}..={} on {:?} as seen from {pov}",
+            timeline.typ().format_utc(time_range.min()),
+            timeline.typ().format_utc(time_range.max()),
+            timeline.name(),
+        ))
+    }
+}
+
+/// An expression to select one or more entities to query.
+///
+/// Example: `world/camera/**`
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EntityPathExpression {
+    pub path: EntityPath,
+
+    /// If true, ALSO include children and grandchildren of this path (recursive rule).
+    pub include_subtree: bool,
+}
+
+impl std::fmt::Display for EntityPathExpression {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            path,
+            include_subtree,
+        } = self;
+
+        f.write_fmt(format_args!(
+            "{path}{}{}",
+            if path.is_root() { "" } else { "/" },
+            if *include_subtree { "**" } else { "" }
+        ))
+    }
+}
+
+impl EntityPathExpression {
+    #[inline]
+    pub fn matches(&self, path: &EntityPath) -> bool {
+        if self.include_subtree {
+            path.starts_with(&self.path)
+        } else {
+            path == &self.path
+        }
+    }
+}
+
+impl<S: AsRef<str>> From<S> for EntityPathExpression {
+    #[inline]
+    fn from(s: S) -> Self {
+        let s = s.as_ref();
+        if s == "/**" {
+            Self {
+                path: EntityPath::root(),
+                include_subtree: true,
+            }
+        } else if let Some(path) = s.strip_suffix("/**") {
+            Self {
+                path: EntityPath::parse_forgiving(path),
+                include_subtree: true,
+            }
+        } else {
+            Self {
+                path: EntityPath::parse_forgiving(s),
+                include_subtree: false,
+            }
+        }
+    }
+}

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -280,9 +280,14 @@ impl ComponentColumnDescriptor {
             is_static,
         } = self;
 
+        // TODO(cmc): figure out who's in charge of adding the outer list layer.
         ArrowField::new(
             component_name.short_name().to_owned(),
-            datatype.clone(),
+            ArrowDatatype::List(std::sync::Arc::new(ArrowField::new(
+                "item",
+                datatype.clone(),
+                true, /* nullable */
+            ))),
             false, /* nullable */
         )
         // TODO(#6889): This needs some proper sorbetization -- I just threw these names randomly.

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -14,6 +14,7 @@
 #![doc = document_features::document_features!()]
 //!
 
+mod dataframe;
 mod events;
 mod gc;
 mod query;
@@ -22,6 +23,10 @@ mod store;
 mod subscribers;
 mod writes;
 
+pub use self::dataframe::{
+    ColumnDescriptor, ComponentColumnDescriptor, ControlColumnDescriptor, LatestAtQueryExpression,
+    QueryExpression, RangeQueryExpression, TimeColumnDescriptor,
+};
 pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::stats::{ChunkStoreChunkStats, ChunkStoreStats};
@@ -35,10 +40,13 @@ pub use re_chunk::{
     UnitChunkShared,
 };
 #[doc(no_inline)]
+pub use re_log_encoding::decoder::VersionPolicy;
+#[doc(no_inline)]
 pub use re_log_types::{ResolvedTimeRange, TimeInt, TimeType, Timeline};
 
 pub mod external {
     pub use re_chunk;
+    pub use re_log_encoding;
 }
 
 // ---

--- a/crates/store/re_dataframe/Cargo.toml
+++ b/crates/store/re_dataframe/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "re_dataframe"
+authors.workspace = true
+description = "High-level query APIs"
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+
+[features]
+default = []
+
+
+[dependencies]
+# Rerun dependencies:
+re_chunk.workspace = true
+re_chunk_store.workspace = true
+re_error.workspace = true
+re_format.workspace = true
+re_log.workspace = true
+re_log_types.workspace = true
+re_query.workspace = true
+re_tracing.workspace = true
+re_types_core.workspace = true
+
+# External dependencies:
+ahash.workspace = true
+anyhow.workspace = true
+arrow2.workspace = true
+backtrace.workspace = true
+indent.workspace = true
+itertools.workspace = true
+nohash-hasher.workspace = true
+parking_lot.workspace = true
+paste.workspace = true
+seq-macro.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+re_types.workspace = true

--- a/crates/store/re_dataframe/README.md
+++ b/crates/store/re_dataframe/README.md
@@ -1,0 +1,10 @@
+# re_dataframe
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_dataframe.svg)](https://crates.io/crates/re_dataframe)
+[![Documentation](https://docs.rs/re_dataframe/badge.svg)](https://docs.rs/re_dataframe)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+The Rerun public data APIs. Get dataframes back from your Rerun datastore.

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -1,0 +1,167 @@
+use re_chunk::TransportChunk;
+use re_chunk_store::{
+    ChunkStore, ColumnDescriptor, LatestAtQueryExpression, QueryExpression, RangeQueryExpression,
+};
+use re_query::Caches;
+
+// ---
+
+// TODO(#3741): `arrow2` has no concept of a `RecordBatch`, so for now we just use our trustworthy
+// `TransportChunk` type until we migrate to `arrow-rs`.
+// `TransportChunk` maps 1:1 to `RecordBatch` so the switch (and the compatibility layer in the meantime)
+// will be trivial.
+// TODO(cmc): add an `arrow` feature to transportchunk in a follow-up pr and call it a day.
+pub type RecordBatch = TransportChunk;
+
+pub struct LatestAtQueryHandle<'a>(&'a ());
+pub struct RangeQueryHandle<'a>(&'a ());
+
+/// A generic handle to a query that is ready to be executed.
+pub enum QueryHandle<'a> {
+    LatestAt(LatestAtQueryHandle<'a>),
+    Range(RangeQueryHandle<'a>),
+}
+
+impl<'a> From<LatestAtQueryHandle<'a>> for QueryHandle<'a> {
+    #[inline]
+    fn from(query: LatestAtQueryHandle<'a>) -> Self {
+        Self::LatestAt(query)
+    }
+}
+
+impl<'a> From<RangeQueryHandle<'a>> for QueryHandle<'a> {
+    #[inline]
+    fn from(query: RangeQueryHandle<'a>) -> Self {
+        Self::Range(query)
+    }
+}
+
+// --- Queries ---
+
+/// A handle to our user-facing query engine.
+///
+/// See the following methods:
+/// * [`QueryEngine::schema`]: get the complete schema of the recording.
+/// * [`QueryEngine::latest_at`]: get a snapshot of the latest state of a dataset at specific point in time.
+/// * [`QueryEngine::range`]: get successive dense snapshots of the latest state of a dataset over
+///   a range of time.
+//
+// TODO(cmc): This needs to be a refcounted type that can be easily be passed around: the ref has
+// got to go. But for that we need to generally introduce `ChunkStoreHandle` and `QueryCacheHandle`
+// first, and this is not as straightforward as it seems.
+pub struct QueryEngine<'a> {
+    pub store: &'a ChunkStore,
+    pub cache: &'a Caches,
+}
+
+impl QueryEngine<'_> {
+    /// Returns the full schema of the store.
+    ///
+    /// This will include a column descriptor for every timeline and every component on every
+    /// entity that has been written to the store so far.
+    ///
+    /// The order of the columns to guaranteed to be in a specific order:
+    /// * first, the control columns in lexical order (`RowId`);
+    /// * second, the time columns in lexical order (`frame_nr`, `log_time`, ...);
+    /// * third, the component columns in lexical order (`Color`, `Radius, ...`).
+    #[inline]
+    #[allow(clippy::unimplemented, clippy::needless_pass_by_value)]
+    pub fn schema(&self) -> Vec<ColumnDescriptor> {
+        _ = self;
+        unimplemented!("TODO(cmc)")
+    }
+
+    /// Returns the filtered schema for the given query expression.
+    ///
+    /// This will only include columns which may contain non-empty values from the perspective of
+    /// the query semantics.
+    ///
+    /// The order of the columns is guaranteed to be in a specific order:
+    /// * first, the control columns in lexical order (`RowId`);
+    /// * second, the time columns in lexical order (`frame_nr`, `log_time`, ...);
+    /// * third, the component columns in lexical order (`Color`, `Radius, ...`).
+    ///
+    /// This does not run a full-blown query, but rather just inspects [`Chunk`]-level metadata,
+    /// which can lead to false positives, but makes this very cheap to compute.
+    #[inline]
+    #[allow(clippy::unimplemented, clippy::needless_pass_by_value)]
+    pub fn schema_for_query(&self, query: &QueryExpression) -> Vec<ColumnDescriptor> {
+        _ = self;
+        _ = query;
+        unimplemented!("TODO(cmc)")
+    }
+
+    /// Creates a new appropriate [`QueryHandle`].
+    ///
+    /// This is simply a helper for:
+    /// * [`Self::latest_at`]
+    /// * [`Self::range`]
+    #[inline]
+    #[allow(clippy::unimplemented, clippy::needless_pass_by_value)]
+    pub fn query(
+        &self,
+        query: &QueryExpression,
+        columns: Option<Vec<ColumnDescriptor>>,
+    ) -> QueryHandle<'_> {
+        _ = self;
+        _ = query;
+        _ = columns;
+        unimplemented!("TODO(cmc)")
+    }
+
+    /// Creates a new [`LatestAtQueryHandle`], which can be used to perform a latest-at query.
+    ///
+    /// Creating a handle is very cheap as it doesn't perform any kind of querying.
+    ///
+    /// If `columns` is specified, the schema of the result will strictly follow this specification.
+    /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
+    /// data will be null for the entire column.
+    /// If `columns` is left unspecified, the schema of the returned result will correspond to what's returned by
+    /// [`Self::schema_for_query`].
+    /// Seel also [`LatestAtQueryHandle::schema`].
+    ///
+    /// Because data is often logged concurrently across multiple timelines, the non-primary timelines
+    /// are still valid data-columns to include in the result. So a user could, for example, query
+    /// for a range of data on the `frame` timeline, but still include the `log_time` timeline in
+    /// the result.
+    #[inline]
+    #[allow(clippy::unimplemented, clippy::needless_pass_by_value)]
+    pub fn latest_at(
+        &self,
+        query: &LatestAtQueryExpression,
+        columns: Option<Vec<ColumnDescriptor>>,
+    ) -> LatestAtQueryHandle<'_> {
+        _ = self;
+        _ = query;
+        _ = columns;
+        unimplemented!("TODO(cmc)")
+    }
+
+    /// Creates a new [`RangeQueryHandle`], which can be used to perform a range query.
+    ///
+    /// Creating a handle is very cheap as it doesn't perform any kind of querying.
+    ///
+    /// If `columns` is specified, the schema of the result will strictly follow this specification.
+    /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
+    /// data will be null for the entire column.
+    /// If `columns` is left unspecified, the schema of the returned result will correspond to what's returned by
+    /// [`Self::schema_for_query`].
+    /// Seel also [`RangeQueryHandle::schema`].
+    ///
+    /// Because data is often logged concurrently across multiple timelines, the non-primary timelines
+    /// are still valid data-columns to include in the result. So a user could, for example, query
+    /// for a range of data on the `frame` timeline, but still include the `log_time` timeline in
+    /// the result.
+    #[inline]
+    #[allow(clippy::unimplemented, clippy::needless_pass_by_value)]
+    pub fn range(
+        &self,
+        query: &RangeQueryExpression,
+        columns: Option<Vec<ColumnDescriptor>>,
+    ) -> RangeQueryHandle<'_> {
+        _ = self;
+        _ = query;
+        _ = columns;
+        unimplemented!("TODO(cmc)")
+    }
+}

--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -1,0 +1,11 @@
+//! The Rerun public data APIs. Get dataframes back from your Rerun datastore.
+
+mod engine;
+
+pub use self::engine::{QueryEngine, QueryHandle, RecordBatch};
+
+pub mod external {
+    pub use re_chunk;
+    pub use re_chunk_store;
+    pub use re_query;
+}

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -78,6 +78,23 @@ pub struct EntityPathRule {
     pub include_subtree: bool,
 }
 
+impl std::fmt::Display for EntityPathRule {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            raw_expression: _,
+            path,
+            include_subtree,
+        } = self;
+
+        f.write_fmt(format_args!(
+            "{path}{}{}",
+            if path.is_root() { "" } else { "/" },
+            if *include_subtree { "**" } else { "" }
+        ))
+    }
+}
+
 impl PartialEq for EntityPathRule {
     fn eq(&self, other: &Self) -> bool {
         self.raw_expression == other.raw_expression

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -68,6 +68,7 @@ impl CacheKey {
     }
 }
 
+// TODO(cmc): this needs to be renamed to `QueryCache` as this will slowly become part of the public API now.
 pub struct Caches {
     /// The [`StoreId`] of the associated [`ChunkStore`].
     pub(crate) store_id: StoreId,


### PR DESCRIPTION
All the boilerplate for the new `re_dataframe`.

Also introduces all the new types:
* `QueryExpression`, `LatestAtQueryExpression`, `RangeQueryExpression`
* `QueryHandle`, `LatestAtQueryHandle` (unimplemented), `RangeQueryHandle` (unimplemented)
* `ColumnDescriptor`, `ControlColumnDescriptor`, `TimeColumnDescriptor`, `ComponentColumnDescriptor`

No actual code logic, just definitions.

* Part of #7284 

---

Dataframe APIs PR series:
- #7338
- #7339
- #7340
- #7341
- #7345

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7338?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7338?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7338)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.