### PR TITLE
Dataframe queries 4: paginated dense range

### DIFF
--- a/crates/store/re_dataframe/examples/range_paginated.rs
+++ b/crates/store/re_dataframe/examples/range_paginated.rs
@@ -55,6 +55,11 @@ fn main() -> anyhow::Result<()> {
 
         let query_handle = engine.range(&query, None /* columns */);
         println!("{query}:");
+        println!(
+            "num_chunks:{} num_rows:{}",
+            query_handle.num_chunks(),
+            query_handle.num_rows()
+        );
 
         let (offset, len) = (0, 4);
         println!("offset:{offset} len:{len}");

--- a/crates/store/re_dataframe/examples/range_paginated.rs
+++ b/crates/store/re_dataframe/examples/range_paginated.rs
@@ -1,0 +1,100 @@
+#![allow(clippy::unwrap_used)]
+
+use itertools::Itertools as _;
+
+use re_chunk_store::{
+    ChunkStore, ChunkStoreConfig, ComponentColumnDescriptor, RangeQueryExpression, Timeline,
+    VersionPolicy,
+};
+use re_dataframe::{QueryEngine, RecordBatch};
+use re_log_types::{ResolvedTimeRange, StoreKind};
+
+fn main() -> anyhow::Result<()> {
+    let args = std::env::args().collect_vec();
+
+    let get_arg = |i| {
+        let Some(value) = args.get(i) else {
+            eprintln!(
+                "Usage: {} <path_to_rrd_with_position3ds> <entity_path_pov> [entity_path_expr]",
+                args.first().map_or("$BIN", |s| s.as_str())
+            );
+            std::process::exit(1);
+        };
+        value
+    };
+
+    let path_to_rrd = get_arg(1);
+    let entity_path_pov = get_arg(2).as_str();
+    let entity_path_expr = args.get(3).map_or("/**", |s| s.as_str());
+
+    let stores = ChunkStore::from_rrd_filepath(
+        &ChunkStoreConfig::ALL_DISABLED,
+        path_to_rrd,
+        VersionPolicy::Warn,
+    )?;
+
+    for (store_id, store) in &stores {
+        if store_id.kind != StoreKind::Recording {
+            continue;
+        }
+
+        let cache = re_dataframe::external::re_query::Caches::new(store);
+        let engine = QueryEngine {
+            store,
+            cache: &cache,
+        };
+
+        let query = RangeQueryExpression {
+            entity_path_expr: entity_path_expr.into(),
+            timeline: Timeline::log_tick(),
+            time_range: ResolvedTimeRange::new(0, 30),
+            pov: ComponentColumnDescriptor::new::<re_types::components::Position3D>(
+                entity_path_pov.into(),
+            ),
+        };
+
+        let query_handle = engine.range(&query, None /* columns */);
+        println!("{query}:");
+
+        let (offset, len) = (0, 4);
+        println!("offset:{offset} len:{len}");
+        concat_and_print(query_handle.get(offset, len));
+
+        let (offset, len) = (2, 4);
+        println!("offset:{offset} len:{len}");
+        concat_and_print(query_handle.get(offset, len));
+
+        let (offset, len) = (10, 5);
+        println!("offset:{offset} len:{len}");
+        concat_and_print(query_handle.get(offset, len));
+
+        let (offset, len) = (0, 15);
+        println!("offset:{offset} len:{len}");
+        concat_and_print(query_handle.get(offset, len));
+    }
+
+    Ok(())
+}
+
+fn concat_and_print(chunks: Vec<RecordBatch>) {
+    use re_chunk::external::arrow2::{
+        chunk::Chunk as ArrowChunk, compute::concatenate::concatenate,
+    };
+
+    let chunk = chunks.into_iter().reduce(|acc, chunk| RecordBatch {
+        schema: chunk.schema.clone(),
+        data: ArrowChunk::new(
+            acc.data
+                .iter()
+                .zip(chunk.data.iter())
+                .map(|(l, r)| concatenate(&[&**l, &**r]).unwrap())
+                .collect(),
+        ),
+    });
+
+    if let Some(chunk) = chunk {
+        println!("{chunk}");
+    } else {
+        println!("<empty>");
+    }
+}

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -195,7 +195,7 @@ impl RangeQueryHandle<'_> {
         //
         // TODO(cmc): should keep an extra sorted datastructure and use a binsearch instead.
         while (cur_offset + cur_pov_chunk.num_rows() as u64) < offset {
-            cur_offset += offset + cur_pov_chunk.num_rows() as u64;
+            cur_offset += cur_pov_chunk.num_rows() as u64;
 
             let Some(next_pov_chunk) = pov_chunks.next().cloned() else {
                 return results;

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -49,7 +49,7 @@ struct RangeQuerytHandleState {
     /// These are already sorted and vertically sliced according to the query.
     pov_chunks: Option<Vec<Chunk>>,
 
-    /// Tracks the current page index. Used for [`Self::next_page`].
+    /// Tracks the current page index. Used for [`RangeQueryHandle::next_page`].
     //
     // NOTE: The state is behind a `OnceLock`, the atomic just make some things simpler down the road.
     cur_page: AtomicU64,
@@ -210,7 +210,7 @@ impl RangeQueryHandle<'_> {
             0
         };
 
-        // Repeatly compute dense ranges until we've returned `len` rows.
+        // Repeatedly compute dense ranges until we've returned `len` rows.
         while len > 0 {
             cur_pov_chunk = cur_pov_chunk.row_sliced(offset as _, len as _);
             results.extend(self.dense_batch_at_pov(&cur_pov_chunk));

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -227,6 +227,23 @@ impl RangeQueryHandle<'_> {
         results
     }
 
+    /// How many chunks / natural pages of data will be returned?
+    #[inline]
+    pub fn num_chunks(&self) -> u64 {
+        self.init()
+            .pov_chunks
+            .as_ref()
+            .map_or(0, |pov_chunks| pov_chunks.len() as _)
+    }
+
+    /// How many rows of data will be returned?
+    #[inline]
+    pub fn num_rows(&self) -> u64 {
+        self.init().pov_chunks.as_ref().map_or(0, |pov_chunks| {
+            pov_chunks.iter().map(|chunk| chunk.num_rows() as u64).sum()
+        })
+    }
+
     fn dense_batch_at_pov(&self, pov_chunk: &Chunk) -> Option<RecordBatch> {
         let pov_time_column = pov_chunk.timelines().get(&self.query.timeline)?;
         let columns = self.schema();


### PR DESCRIPTION
Implements the paginated dense range dataframe APIs.

If there's no off-by-one anywhere in there, I will eat my hat.
Getting this in the hands of people is the highest prio though, I'll add tests later.

![image](https://github.com/user-attachments/assets/e865ba62-21db-41c1-9899-35a0e7aea134)
![image](https://github.com/user-attachments/assets/32934ba8-2673-401a-aafc-409dfbe9b2c5)


* Fixes #7284 

---

Dataframe APIs PR series:
- #7338
- #7339
- #7340
- #7341
- #7345

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7338?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7338?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7338)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.