### PR TITLE
Unpin `wasm-bindgen` and `mimalloc` in published crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ document-features = "0.2.8"
 ehttp = "0.5.0"
 enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
-fixed = { version = "<1.28", default-features = false } # 1.28+ is MSRV 1.79+
+fixed = { version = "<1.28", default-features = false }            # 1.28+ is MSRV 1.79+
 flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
@@ -177,9 +177,9 @@ half = "2.3.1"
 hexasphere = "14.1.0"
 image = { version = "0.25", default-features = false }
 indent = "0.1"
-indexmap = "2.1" # Version chosen to align with other dependencies
-indicatif = "0.17.7" # Progress bar
-infer = "0.15" # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
+indexmap = "2.1"                                                   # Version chosen to align with other dependencies
+indicatif = "0.17.7"                                               # Progress bar
+infer = "0.15"                                                     # infer MIME type by checking the magic number signaturefer MIME type by checking the magic number signature
 insta = "1.23"
 itertools = "0.13"
 js-sys = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,10 @@ log = "0.4"
 log-once = "0.4"
 lz4_flex = "0.11"
 memory-stats = "1.1"
-mimalloc = "=0.1.37" # TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
+# TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
+# This version is not pinned to avoid creating version requirement conflicts,
+# but other packages pin it to exactly "=0.1.37"
+mimalloc = "0.1.37"
 mime_guess2 = "2.0" # infer MIME type by file extension, and map mime to file extension
 mint = "0.5.9"
 mp4 = "0.14.0"
@@ -264,8 +267,11 @@ uuid = "1.1"
 vec1 = "1.8"
 walkdir = "2.0"
 # NOTE: `rerun_js/web-viewer/build-wasm.mjs` is HIGHLY sensitive to changes in `wasm-bindgen`.
-#       Whenever updating `wasm-bindgen`, make sure that the build script still works.
-wasm-bindgen = "=0.2.93"
+#       Whenever updating `wasm-bindgen`, update this and the narrower dependency specifications in
+#       `crates/viewer/re_viewer/Cargo.toml`, and make sure that the build script still works.
+#       Do not make this an `=` dependency, because that may break Rust users’ builds when a newer
+#       version is released, even if they are not building the web viewer.
+wasm-bindgen = "0.2.93"
 wasm-bindgen-cli-support = "=0.2.93"
 wasm-bindgen-futures = "0.4.33"
 web-sys = "0.3"

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -66,7 +66,9 @@ rerun = { workspace = true, features = [
 ] }
 
 document-features.workspace = true
-mimalloc.workspace = true
+# TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
+# When the bug is fixed, change this back to `mimalloc.workspace = true`.
+mimalloc = "=0.1.37"
 
 
 [build-dependencies]

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -120,7 +120,10 @@ js-sys.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 wasm-bindgen-futures.workspace = true
-wasm-bindgen.workspace = true
+# NOTE: `rerun_js/web-viewer/build-wasm.mjs` is HIGHLY sensitive to changes in `wasm-bindgen`.
+#       Whenever updating `wasm-bindgen`, update this and the broader dependency specifications in
+#       the root `/Cargo.toml`, and make sure that the build script still works.
+wasm-bindgen = "=0.2.93"
 web-sys = { workspace = true, features = [
   "History",
   "Location",

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -54,7 +54,9 @@ arrow2 = { workspace = true, features = ["io_ipc", "io_print", "arrow"] }
 crossbeam.workspace = true
 document-features.workspace = true
 itertools = { workspace = true }
-mimalloc = { workspace = true, features = ["local_dynamic_tls"] }
+# TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
+# When the bug is fixed, change this back to `mimalloc = { workspace = true, …`.
+mimalloc = { version = "=0.1.37", features = ["local_dynamic_tls"] }
 once_cell.workspace = true
 parking_lot.workspace = true
 pyo3 = { workspace = true, features = ["abi3-py38"] }


### PR DESCRIPTION
### What

Fixes #7347.

Exact dependency versions (`dependencies.foo = "=1.2.3"`) make a Cargo package unavoidably incompatible with future versions of other packages. Therefore, libraries published to crates.io should not contain them.

This PR removes most uses of exact versions by adjusting the `mimalloc` and `wasm-bindgen` dependencies as follows:

* In the workspace `Cargo.toml`, use ordinary or-newer (caret) dependency version specifications.
* In the specific packages which are built as binaries or dynamic libraries, specify `=`.

This way, `re_sdk` as a library (and `rerun` without the `native_viewer` feature, and `re_viewer` not built for wasm) won't conflict with any other packages.

Each of the newly duplicated dependency specifications has a comment documenting under what conditions it and its kin should be changed or removed.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7348?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7348?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [X] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [X] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7348)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.