### PR TITLE
Dataframe queries: support sparsely encoded dictionary arrays

### DIFF
--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -1,10 +1,14 @@
 use arrow2::{
-    array::{Array as ArrowArray, BooleanArray as ArrowBooleanArray, ListArray as ArrowListArray},
+    array::{
+        Array as ArrowArray, BooleanArray as ArrowBooleanArray,
+        DictionaryArray as ArrowDictionaryArray, ListArray as ArrowListArray,
+        PrimitiveArray as ArrowPrimitiveArray,
+    },
     bitmap::Bitmap as ArrowBitmap,
-    datatypes::DataType as ArrowDataType,
+    datatypes::DataType as ArrowDatatype,
     offset::Offsets as ArrowOffsets,
 };
-use itertools::Itertools as _;
+use itertools::Itertools;
 
 // ---
 
@@ -29,7 +33,7 @@ pub fn arrays_to_list_array_opt(arrays: &[Option<&dyn ArrowArray>]) -> Option<Ar
 ///
 /// Returns an empty list if `arrays` is empty.
 pub fn arrays_to_list_array(
-    array_datatype: ArrowDataType,
+    array_datatype: ArrowDatatype,
     arrays: &[Option<&dyn ArrowArray>],
 ) -> Option<ArrowListArray<i32>> {
     let arrays_dense = arrays.iter().flatten().copied().collect_vec();
@@ -64,6 +68,103 @@ pub fn arrays_to_list_array(
         data,
         validity.into(),
     ))
+}
+
+/// Create a sparse dictionary-array out of an array of (potentially) duplicated arrays.
+///
+/// The `Idx` is used as primary key to drive the deduplication process.
+/// Returns `None` if any of the specified `arrays` doesn't match the given `array_datatype`.
+///
+/// Returns an empty dictionary if `arrays` is empty.
+//
+// TODO(cmc): Ideally I would prefer to just use the array's underlying pointer as primary key, but
+// this has proved extremely brittle in practice. Maybe once we move to arrow-rs.
+// TODO(cmc): A possible improvement would be to pick the smallest key datatype possible based
+// on the cardinality of the input arrays.
+pub fn arrays_to_dictionary<Idx: Copy + Eq>(
+    array_datatype: ArrowDatatype,
+    arrays: &[Option<(Idx, &dyn ArrowArray)>],
+) -> Option<ArrowDictionaryArray<u32>> {
+    // Dedupe the input arrays based on the given primary key.
+    let arrays_dense_deduped = {
+        let mut cur_index: Option<Idx> = None;
+        arrays
+            .iter()
+            .flatten()
+            .copied()
+            .filter_map(move |(index, array)| {
+                if Some(index) == cur_index {
+                    None
+                } else {
+                    cur_index = Some(index);
+                    Some(array)
+                }
+            })
+            .collect_vec()
+    };
+
+    // Compute the keys for the final dictionary, using that same primary key.
+    let keys = {
+        let mut cur_index: Option<Idx> = None;
+        let mut cur_key = 0;
+        arrays
+            .iter()
+            .map(move |opt| {
+                opt.map(|(index, _array)| {
+                    if Some(index) == cur_index {
+                        cur_key
+                    } else if cur_index.is_some() && Some(index) != cur_index {
+                        cur_index = Some(index);
+                        cur_key += 1;
+                        cur_key
+                    } else {
+                        cur_index = Some(index);
+                        cur_key
+                    }
+                })
+            })
+            .collect_vec()
+    };
+
+    // Concatenate the underlying data as usual, except only the _unique_ values!
+    let data = if arrays_dense_deduped.is_empty() {
+        arrow2::array::new_empty_array(array_datatype.clone())
+    } else {
+        arrow2::compute::concatenate::concatenate(&arrays_dense_deduped)
+            .map_err(|err| {
+                re_log::warn_once!("failed to concatenate arrays: {err}");
+                err
+            })
+            .ok()?
+    };
+
+    // We still need the underlying data to be a list-array, so the dictionary's keys can index
+    // into this list-array.
+    let data = {
+        let datatype = ArrowListArray::<i32>::default_datatype(array_datatype);
+
+        #[allow(clippy::unwrap_used)] // yes, these are indeed lengths
+        let offsets =
+            ArrowOffsets::try_from_lengths(arrays_dense_deduped.iter().map(|array| array.len()))
+                .unwrap();
+
+        ArrowListArray::<i32>::new(datatype, offsets.into(), data, None)
+    };
+
+    let datatype = ArrowDatatype::Dictionary(
+        arrow2::datatypes::IntegerType::UInt32,
+        std::sync::Arc::new(data.data_type().clone()),
+        false, // is_sorted
+    );
+
+    // And finally we build our dictionary, which indexes into our concatenated list-array of
+    // unique values.
+    ArrowDictionaryArray::try_new(
+        datatype,
+        ArrowPrimitiveArray::<u32>::from(keys),
+        data.to_boxed(),
+    )
+    .ok()
 }
 
 /// Given a sparse `ArrowListArray` (i.e. an array with a validity bitmap that contains at least

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -142,7 +142,7 @@ pub fn arrays_to_dictionary<Idx: Copy + Eq>(
     let datatype = ArrowDatatype::Dictionary(
         arrow2::datatypes::IntegerType::UInt32,
         std::sync::Arc::new(data.data_type().clone()),
-        false, // is_sorted
+        true, // is_sorted
     );
 
     // And finally we build our dictionary, which indexes into our concatenated list-array of

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -55,11 +55,11 @@ impl ColumnDescriptor {
     }
 
     #[inline]
-    pub fn to_arrow_field(&self) -> ArrowField {
+    pub fn to_arrow_field(&self, datatype: Option<ArrowDatatype>) -> ArrowField {
         match self {
             Self::Control(descr) => descr.to_arrow_field(),
             Self::Time(descr) => descr.to_arrow_field(),
-            Self::Component(descr) => descr.to_arrow_field(),
+            Self::Component(descr) => descr.to_arrow_field(datatype),
         }
     }
 }
@@ -268,7 +268,7 @@ impl ComponentColumnDescriptor {
     }
 
     #[inline]
-    pub fn to_arrow_field(&self) -> ArrowField {
+    pub fn to_arrow_field(&self, wrapped_datatype: Option<ArrowDatatype>) -> ArrowField {
         let Self {
             entity_path,
             archetype_name,
@@ -278,14 +278,14 @@ impl ComponentColumnDescriptor {
             is_static,
         } = self;
 
+        // NOTE: Only the system doing the actual packing knows the final datatype with all of
+        // its wrappers (is it a component array? is it a list? is it a dict?).
+        let datatype = wrapped_datatype.unwrap_or_else(|| datatype.clone());
+
         // TODO(cmc): figure out who's in charge of adding the outer list layer.
         ArrowField::new(
             component_name.short_name().to_owned(),
-            ArrowDatatype::List(std::sync::Arc::new(ArrowField::new(
-                "item",
-                datatype.clone(),
-                true, /* nullable */
-            ))),
+            datatype,
             false, /* nullable */
         )
         // TODO(#6889): This needs some proper sorbetization -- I just threw these names randomly.

--- a/crates/store/re_dataframe/src/latest_at.rs
+++ b/crates/store/re_dataframe/src/latest_at.rs
@@ -97,16 +97,6 @@ impl LatestAtQueryHandle<'_> {
 
         let columns = self.schema();
 
-        let schema = ArrowSchema {
-            fields: columns
-                .iter()
-                .map(ColumnDescriptor::to_arrow_field)
-                .collect(),
-
-            // TODO(#6889): properly some sorbet stuff we want to get in there at some point.
-            metadata: Default::default(),
-        };
-
         let all_units: HashMap<&ComponentColumnDescriptor, UnitChunkShared> = {
             re_tracing::profile_scope!("queries");
 
@@ -201,11 +191,18 @@ impl LatestAtQueryHandle<'_> {
                             ),
                     ),
                 })
-                .collect()
+                .collect_vec()
         };
 
         RecordBatch {
-            schema,
+            schema: ArrowSchema {
+                fields: columns
+                    .iter()
+                    .zip(packed_arrays.iter())
+                    .map(|(descr, arr)| descr.to_arrow_field(Some(arr.data_type().clone())))
+                    .collect(),
+                metadata: Default::default(),
+            },
             data: ArrowChunk::new(packed_arrays),
         }
     }

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -356,7 +356,8 @@ impl RangeQueryHandle<'_> {
             schema: ArrowSchema {
                 fields: columns
                     .iter()
-                    .map(ColumnDescriptor::to_arrow_field)
+                    .zip(packed_arrays.iter())
+                    .map(|(descr, arr)| descr.to_arrow_field(Some(arr.data_type().clone())))
                     .collect(),
                 metadata: Default::default(),
             },

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -2,13 +2,13 @@ use std::sync::{atomic::AtomicU64, OnceLock};
 
 use ahash::HashMap;
 use arrow2::{
-    array::{Array as ArrowArray, ListArray as ArrowListArray},
+    array::{Array as ArrowArray, DictionaryArray as ArrowDictionaryArray},
     chunk::Chunk as ArrowChunk,
     datatypes::Schema as ArrowSchema,
 };
 use itertools::Itertools;
 
-use re_chunk::{Chunk, LatestAtQuery, RangeQuery};
+use re_chunk::{Chunk, LatestAtQuery, RangeQuery, RowId, TimeInt};
 use re_chunk_store::{ColumnDescriptor, ComponentColumnDescriptor, RangeQueryExpression};
 
 use crate::{QueryEngine, RecordBatch};
@@ -253,7 +253,7 @@ impl RangeQueryHandle<'_> {
         // see if this ever becomes an issue before going down this road.
         //
         // TODO(cmc): Opportunities for parallelization, if it proves to be a net positive in practice.
-        let list_arrays: HashMap<&ComponentColumnDescriptor, ArrowListArray<i32>> = {
+        let dict_arrays: HashMap<&ComponentColumnDescriptor, ArrowDictionaryArray<u32>> = {
             re_tracing::profile_scope!("queries");
 
             columns
@@ -279,24 +279,39 @@ impl RangeQueryHandle<'_> {
                                 .components
                                 .get(&descr.component_name)
                                 .and_then(|unit| {
-                                    unit.component_batch_raw(&descr.component_name).clone()
+                                    unit.component_batch_raw(&descr.component_name).clone().map(
+                                        |array| {
+                                            (
+                                                unit.index(&query.timeline())
+                                                    // NOTE: technically cannot happen, but better than unwrapping.
+                                                    .unwrap_or((TimeInt::STATIC, RowId::ZERO)),
+                                                array,
+                                            )
+                                        },
+                                    )
                                 })
                         })
                         .collect_vec();
                     let arrays = arrays
                         .iter()
-                        .map(|array| array.as_ref().map(|array| &**array as &dyn ArrowArray))
+                        .map(|array| {
+                            array
+                                .as_ref()
+                                .map(|(index, array)| (index, &**array as &dyn ArrowArray))
+                        })
                         .collect_vec();
 
-                    let list_array =
-                        re_chunk::util::arrays_to_list_array(descr.datatype.clone(), &arrays);
+                    let dict_array = {
+                        re_tracing::profile_scope!("concat");
+                        re_chunk::util::arrays_to_dictionary(descr.datatype.clone(), &arrays)
+                    };
 
                     if cfg!(debug_assertions) {
                         #[allow(clippy::unwrap_used)] // want to crash in dev
-                        Some((descr, list_array.unwrap()))
+                        Some((descr, dict_array.unwrap()))
                     } else {
                         // NOTE: Technically cannot ever happen, but I'd rather that than an uwnrap.
-                        list_array.map(|list_array| (descr, list_array))
+                        dict_array.map(|dict_array| (descr, dict_array))
                     }
                 })
                 .collect()
@@ -324,14 +339,14 @@ impl RangeQueryHandle<'_> {
                         )
                     }
 
-                    ColumnDescriptor::Component(descr) => list_arrays.get(descr).map_or_else(
+                    ColumnDescriptor::Component(descr) => dict_arrays.get(descr).map_or_else(
                         || {
                             arrow2::array::new_null_array(
                                 descr.datatype.clone(),
                                 pov_time_column.num_rows(),
                             )
                         },
-                        |list_array| list_array.to_boxed(),
+                        |dict_array| dict_array.to_boxed(),
                     ),
                 })
                 .collect_vec()


### PR DESCRIPTION
And also clean up the `datatype` situation: I didn't know what should be in charge of specifying all the wrappers in the final datatype. Now I do.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7361?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7361?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7361)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.