### PR TITLE
Dataframe queries: address first wave of bug reports

### DIFF
--- a/crates/store/re_dataframe/src/latest_at.rs
+++ b/crates/store/re_dataframe/src/latest_at.rs
@@ -300,7 +300,7 @@ mod tests {
         // The output should be an empty recordbatch with the right schema and empty arrays.
         assert_eq!(0, batch.num_rows());
         assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-            .all(|(descr, field)| descr.to_arrow_field() == *field));
+            .all(|(descr, field)| descr.to_arrow_field(None) == *field));
         assert!(itertools::izip!(columns.iter(), batch.data.iter())
             .all(|(descr, array)| descr.datatype() == array.data_type()));
     }
@@ -371,6 +371,6 @@ mod tests {
                 .unwrap()
         );
         assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-            .all(|(descr, field)| descr.to_arrow_field() == *field));
+            .all(|(descr, field)| descr.to_arrow_field(None) == *field));
     }
 }

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -162,10 +162,7 @@ impl RangeQueryHandle<'_> {
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return Some(RecordBatch {
                 schema: ArrowSchema {
-                    fields: columns
-                        .iter()
-                        .map(ColumnDescriptor::to_arrow_field)
-                        .collect(),
+                    fields: columns.iter().map(|col| col.to_arrow_field(None)).collect(),
                     metadata: Default::default(),
                 },
                 data: ArrowChunk::new(
@@ -214,10 +211,7 @@ impl RangeQueryHandle<'_> {
             let columns = self.schema();
             return vec![RecordBatch {
                 schema: ArrowSchema {
-                    fields: columns
-                        .iter()
-                        .map(ColumnDescriptor::to_arrow_field)
-                        .collect(),
+                    fields: columns.iter().map(|col| col.to_arrow_field(None)).collect(),
                     metadata: Default::default(),
                 },
                 data: ArrowChunk::new(
@@ -495,7 +489,7 @@ mod tests {
             // The output should be an empty recordbatch with the right schema and empty arrays.
             assert_eq!(0, batch.num_rows());
             assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-                .all(|(descr, field)| descr.to_arrow_field() == *field));
+                .all(|(descr, field)| descr.to_arrow_field(None) == *field));
             assert!(itertools::izip!(columns.iter(), batch.data.iter())
                 .all(|(descr, array)| descr.datatype() == array.data_type()));
 
@@ -509,7 +503,7 @@ mod tests {
             // The output should be an empty recordbatch with the right schema and empty arrays.
             assert_eq!(0, batch.num_rows());
             assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-                .all(|(descr, field)| descr.to_arrow_field() == *field));
+                .all(|(descr, field)| descr.to_arrow_field(None) == *field));
             assert!(itertools::izip!(columns.iter(), batch.data.iter())
                 .all(|(descr, array)| descr.datatype() == array.data_type()));
 
@@ -589,7 +583,7 @@ mod tests {
                     .unwrap()
             );
             assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-                .all(|(descr, field)| descr.to_arrow_field() == *field));
+                .all(|(descr, field)| descr.to_arrow_field(None) == *field));
 
             let batch = handle.next_page();
             assert!(batch.is_none());
@@ -610,7 +604,7 @@ mod tests {
                     .unwrap()
             );
             assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-                .all(|(descr, field)| descr.to_arrow_field() == *field));
+                .all(|(descr, field)| descr.to_arrow_field(None) == *field));
 
             let _batch = handle.get(1, 1).pop().unwrap();
 


### PR DESCRIPTION
Fix and test all reported bugs (I think?).

Also introduces the first test suites.

* Fixes https://github.com/rerun-io/rerun/issues/7356

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
