### PR TITLE
Add missing `show_labels` and `draw_order` arguments in Python API.

### DIFF
--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows2d_ext.py
@@ -17,6 +17,8 @@ class Arrows2DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
+        draw_order: datatypes.Float32Like | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ) -> None:
         """
@@ -39,6 +41,12 @@ class Arrows2DExt:
             Optional colors for the points.
         labels:
             Optional text labels for the arrows.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
+        draw_order:
+            An optional floating point value that specifies the 2D drawing order of the arrows.
+
+            Objects with higher values are drawn on top of those with lower values.
         class_ids:
             Optional class Ids for the points.
 
@@ -55,6 +63,8 @@ class Arrows2DExt:
                 radii=radii,
                 colors=colors,
                 labels=labels,
+                show_labels=show_labels,
+                draw_order=draw_order,
                 class_ids=class_ids,
             )
             return

--- a/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/arrows3d_ext.py
@@ -17,6 +17,7 @@ class Arrows3DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ) -> None:
         """
@@ -39,6 +40,8 @@ class Arrows3DExt:
             Optional colors for the points.
         labels:
             Optional text labels for the arrows.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         class_ids:
             Optional class Ids for the points.
 
@@ -55,6 +58,7 @@ class Arrows3DExt:
                 radii=radii,
                 colors=colors,
                 labels=labels,
+                show_labels=show_labels,
                 class_ids=class_ids,
             )
             return

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes2d_ext.py
@@ -47,6 +47,7 @@ class Boxes2DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         draw_order: datatypes.Float32ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ) -> None:
@@ -79,6 +80,8 @@ class Boxes2DExt:
             Optional radii for the lines that make up the boxes.
         labels:
             Optional text labels for the boxes.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         draw_order:
             An optional floating point value that specifies the 2D drawing order.
             Objects with higher values are drawn on top of those with lower values.
@@ -164,6 +167,7 @@ class Boxes2DExt:
                 radii=radii,
                 colors=colors,
                 labels=labels,
+                show_labels=show_labels,
                 draw_order=draw_order,
                 class_ids=class_ids,
             )

--- a/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/boxes3d_ext.py
@@ -25,6 +25,7 @@ class Boxes3DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         fill_mode: components.FillMode | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ) -> None:
         """
@@ -65,6 +66,8 @@ class Boxes3DExt:
             Optionally choose whether the boxes are drawn with lines or solid.
         labels:
             Optional text labels for the boxes.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         class_ids:
             Optional `ClassId`s for the boxes.
 
@@ -131,6 +134,7 @@ class Boxes3DExt:
                 radii=radii,
                 fill_mode=fill_mode,
                 labels=labels,
+                show_labels=show_labels,
                 class_ids=class_ids,
             )
             return

--- a/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/ellipsoids3d_ext.py
@@ -23,6 +23,7 @@ class Ellipsoids3DExt:
         line_radii: datatypes.Float32ArrayLike | None = None,
         fill_mode: components.FillMode | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
     ) -> None:
         """
@@ -56,6 +57,8 @@ class Ellipsoids3DExt:
             Optionally choose whether the ellipsoids are drawn with lines or solid.
         labels:
             Optional text labels for the ellipsoids.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         class_ids:
             Optional `ClassId`s for the ellipsoids.
 
@@ -81,6 +84,7 @@ class Ellipsoids3DExt:
                 line_radii=line_radii,
                 fill_mode=fill_mode,
                 labels=labels,
+                show_labels=show_labels,
                 class_ids=class_ids,
             )
             return

--- a/rerun_py/rerun_sdk/rerun/archetypes/points2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points2d_ext.py
@@ -16,6 +16,7 @@ class Points2DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         draw_order: datatypes.Float32ArrayLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
         keypoint_ids: datatypes.KeypointIdArrayLike | None = None,
@@ -36,6 +37,8 @@ class Points2DExt:
              As either 0-1 floats or 0-255 integers, with separate alpha.
         labels:
              Optional text labels for the points.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         draw_order:
              An optional floating point value that specifies the 2D drawing order.
              Objects with higher values are drawn on top of those with lower values.
@@ -64,6 +67,7 @@ class Points2DExt:
                 radii=radii,
                 colors=colors,
                 labels=labels,
+                show_labels=show_labels,
                 draw_order=draw_order,
                 class_ids=class_ids,
                 keypoint_ids=keypoint_ids,

--- a/rerun_py/rerun_sdk/rerun/archetypes/points3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/points3d_ext.py
@@ -16,6 +16,7 @@ class Points3DExt:
         radii: datatypes.Float32ArrayLike | None = None,
         colors: datatypes.Rgba32ArrayLike | None = None,
         labels: datatypes.Utf8ArrayLike | None = None,
+        show_labels: datatypes.BoolLike | None = None,
         class_ids: datatypes.ClassIdArrayLike | None = None,
         keypoint_ids: datatypes.KeypointIdArrayLike | None = None,
     ):
@@ -35,6 +36,8 @@ class Points3DExt:
              As either 0-1 floats or 0-255 integers, with separate alpha.
         labels:
              Optional text labels for the points.
+        show_labels:
+            Optional choice of whether the text labels should be shown by default.
         class_ids:
              Optional class Ids for the points.
 
@@ -60,6 +63,7 @@ class Points3DExt:
                 radii=radii,
                 colors=colors,
                 labels=labels,
+                show_labels=show_labels,
                 class_ids=class_ids,
                 keypoint_ids=keypoint_ids,
             )


### PR DESCRIPTION
### What

Some `*_ext.py` constructor functions were missing the `show_labels` or `draw_order` component parameters.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] I've included a screenshot or gif (if applicable)
* [X] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7363?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7363?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [X] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [X] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7363)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.