### PR TITLE
Dataframe queries: simplified schema wrapping management

### DIFF
--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -6,6 +6,10 @@ use re_query::Caches;
 
 use crate::{LatestAtQueryHandle, RangeQueryHandle};
 
+// Used all over in docstrings.
+#[allow(unused_imports)]
+use re_chunk_store::ComponentColumnDescriptor;
+
 // ---
 
 // TODO(#3741): `arrow2` has no concept of a `RecordBatch`, so for now we just use our trustworthy
@@ -107,7 +111,7 @@ impl QueryEngine<'_> {
     /// Creating a handle is very cheap as it doesn't perform any kind of querying.
     ///
     /// If `columns` is specified, the schema of the result will strictly follow this specification.
-    /// [`componentcolumndescriptor::datatype`] and [`componentcolumndescriptor::is_static`] are ignored.
+    /// [`ComponentColumnDescriptor::datatype`] and [`ComponentColumnDescriptor::is_static`] are ignored.
     ///
     /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
     /// data will be null for the entire column.
@@ -140,7 +144,7 @@ impl QueryEngine<'_> {
     /// Creating a handle is very cheap as it doesn't perform any kind of querying.
     ///
     /// If `columns` is specified, the schema of the result will strictly follow this specification.
-    /// [`componentcolumndescriptor::datatype`] and [`componentcolumndescriptor::is_static`] are ignored.
+    /// [`ComponentColumnDescriptor::datatype`] and [`ComponentColumnDescriptor::is_static`] are ignored.
     ///
     /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
     /// data will be null for the entire column.

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -107,6 +107,8 @@ impl QueryEngine<'_> {
     /// Creating a handle is very cheap as it doesn't perform any kind of querying.
     ///
     /// If `columns` is specified, the schema of the result will strictly follow this specification.
+    /// [`componentcolumndescriptor::datatype`] and [`componentcolumndescriptor::is_static`] are ignored.
+    ///
     /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
     /// data will be null for the entire column.
     /// If `columns` is left unspecified, the schema of the returned result will correspond to what's returned by
@@ -117,6 +119,13 @@ impl QueryEngine<'_> {
     /// are still valid data-columns to include in the result. So a user could, for example, query
     /// for a range of data on the `frame` timeline, but still include the `log_time` timeline in
     /// the result.
+    //
+    // TODO(#7365): We need to stop using `ComponentColumnDescriptor` as input to the dataframe APIs.
+    // It's fundamentally flawed: there is no way to guarantee that passed-in schema will match the
+    // returned schema.
+    // E.g. what are we supposed to do if the user pass in a non-nullable datatype, and the
+    // column does not exist? Or its state only starts halfway through the time range? Then we
+    // need to insert null values but the datatype is non-nullable…
     #[inline]
     pub fn latest_at(
         &self,
@@ -131,6 +140,8 @@ impl QueryEngine<'_> {
     /// Creating a handle is very cheap as it doesn't perform any kind of querying.
     ///
     /// If `columns` is specified, the schema of the result will strictly follow this specification.
+    /// [`componentcolumndescriptor::datatype`] and [`componentcolumndescriptor::is_static`] are ignored.
+    ///
     /// Any provided [`ColumnDescriptor`]s that don't match a column in the result will still be included, but the
     /// data will be null for the entire column.
     /// If `columns` is left unspecified, the schema of the returned result will correspond to what's returned by
@@ -141,6 +152,13 @@ impl QueryEngine<'_> {
     /// are still valid data-columns to include in the result. So a user could, for example, query
     /// for a range of data on the `frame` timeline, but still include the `log_time` timeline in
     /// the result.
+    //
+    // TODO(#7365): We need to stop using `ComponentColumnDescriptor` as input to the dataframe APIs.
+    // It's fundamentally flawed: there is no way to guarantee that passed-in schema will match the
+    // returned schema.
+    // E.g. what are we supposed to do if the user pass in a non-nullable datatype, and the
+    // column does not exist? Or its state only starts halfway through the time range? Then we
+    // need to insert null values but the datatype is non-nullable…
     #[inline]
     pub fn range(
         &self,

--- a/crates/store/re_dataframe/src/latest_at.rs
+++ b/crates/store/re_dataframe/src/latest_at.rs
@@ -212,9 +212,8 @@ impl LatestAtQueryHandle<'_> {
             schema: ArrowSchema {
                 fields: columns
                     .iter()
-                    .zip(packed_arrays.iter())
-                    .map(|(descr, arr)| descr.to_arrow_field(Some(arr.data_type().clone())))
-                    .collect(),
+                    .map(|descr| descr.to_arrow_field())
+                    .collect_vec(),
                 metadata: Default::default(),
             },
             data: ArrowChunk::new(packed_arrays),
@@ -299,9 +298,11 @@ mod tests {
 
         // The output should be an empty recordbatch with the right schema and empty arrays.
         assert_eq!(0, batch.num_rows());
-        assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-            .all(|(descr, field)| descr.to_arrow_field(None) == *field));
-        assert!(itertools::izip!(columns.iter(), batch.data.iter())
+        assert!(
+            itertools::izip!(handle.schema(), batch.schema.fields.iter())
+                .all(|(descr, field)| descr.to_arrow_field() == *field)
+        );
+        assert!(itertools::izip!(handle.schema(), batch.data.iter())
             .all(|(descr, array)| descr.datatype() == array.data_type()));
     }
 
@@ -370,7 +371,9 @@ mod tests {
                 )
                 .unwrap()
         );
-        assert!(itertools::izip!(columns.iter(), batch.schema.fields.iter())
-            .all(|(descr, field)| descr.to_arrow_field(None) == *field));
+        assert!(
+            itertools::izip!(handle.schema(), batch.schema.fields.iter())
+                .all(|(descr, field)| descr.to_arrow_field() == *field)
+        );
     }
 }


### PR DESCRIPTION
Hotfix for the pending schema mismatch woes in the dataframe APIs.

It greatly simplifies all the schema wrapping management logic, and test it.
It's still a bandaid, there is a fundamental design issue here (#7365), but it is a much saner foundation to start iterating on.


* Always advertise every datatype as _at least_ a `List`.
* Always add an extra dict wrapper in the range case.
* Always guarantee `handle.schema() == recordbatch.schema`.
* Complain a lot about #7365 which is a massive PITA.
* Fix CI.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7366?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7366?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7366)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.