### PR TITLE
Use `EntityPathFilter` in `re_dataframe`'s queries

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -10,8 +10,8 @@ use arrow2::{
 use itertools::Itertools as _;
 
 use re_chunk::LatestAtQuery;
-use re_log_types::ResolvedTimeRange;
 use re_log_types::{EntityPath, TimeInt, Timeline};
+use re_log_types::{EntityPathFilter, ResolvedTimeRange};
 use re_types_core::{ArchetypeName, ComponentName, Loggable as _};
 
 use crate::ChunkStore;
@@ -338,10 +338,10 @@ impl From<RangeQueryExpression> for QueryExpression {
 
 impl QueryExpression {
     #[inline]
-    pub fn entity_path_expr(&self) -> &EntityPathExpression {
+    pub fn entity_path_filter(&self) -> &EntityPathFilter {
         match self {
-            Self::LatestAt(query) => &query.entity_path_expr,
-            Self::Range(query) => &query.entity_path_expr,
+            Self::LatestAt(query) => &query.entity_path_filter,
+            Self::Range(query) => &query.entity_path_filter,
         }
     }
 }
@@ -361,7 +361,7 @@ pub struct LatestAtQueryExpression {
     /// The entity path expression to query.
     ///
     /// Example: `world/camera/**`
-    pub entity_path_expr: EntityPathExpression,
+    pub entity_path_filter: EntityPathFilter,
 
     /// The timeline to query.
     ///
@@ -378,13 +378,14 @@ impl std::fmt::Display for LatestAtQueryExpression {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
-            entity_path_expr,
+            entity_path_filter,
             timeline,
             at,
         } = self;
 
         f.write_fmt(format_args!(
-            "latest state for '{entity_path_expr}' at {} on {:?}",
+            "latest state for '{}' at {} on {:?}",
+            entity_path_filter.iter_expressions().join(", "),
             timeline.typ().format_utc(*at),
             timeline.name(),
         ))
@@ -396,7 +397,7 @@ pub struct RangeQueryExpression {
     /// The entity path expression to query.
     ///
     /// Example: `world/camera/**`
-    pub entity_path_expr: EntityPathExpression,
+    pub entity_path_filter: EntityPathFilter,
 
     /// The timeline to query.
     ///
@@ -425,79 +426,19 @@ impl std::fmt::Display for RangeQueryExpression {
     #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
-            entity_path_expr,
+            entity_path_filter,
             timeline,
             time_range,
             pov,
         } = self;
 
         f.write_fmt(format_args!(
-            "{entity_path_expr} ranging {}..={} on {:?} as seen from {pov}",
+            "{} ranging {}..={} on {:?} as seen from {pov}",
+            entity_path_filter.iter_expressions().join(", "),
             timeline.typ().format_utc(time_range.min()),
             timeline.typ().format_utc(time_range.max()),
             timeline.name(),
         ))
-    }
-}
-
-/// An expression to select one or more entities to query.
-///
-/// Example: `world/camera/**`
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct EntityPathExpression {
-    pub path: EntityPath,
-
-    /// If true, ALSO include children and grandchildren of this path (recursive rule).
-    pub include_subtree: bool,
-}
-
-impl std::fmt::Display for EntityPathExpression {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            path,
-            include_subtree,
-        } = self;
-
-        f.write_fmt(format_args!(
-            "{path}{}{}",
-            if path.is_root() { "" } else { "/" },
-            if *include_subtree { "**" } else { "" }
-        ))
-    }
-}
-
-impl EntityPathExpression {
-    #[inline]
-    pub fn matches(&self, path: &EntityPath) -> bool {
-        if self.include_subtree {
-            path.starts_with(&self.path)
-        } else {
-            path == &self.path
-        }
-    }
-}
-
-impl<S: AsRef<str>> From<S> for EntityPathExpression {
-    #[inline]
-    fn from(s: S) -> Self {
-        let s = s.as_ref();
-        if s == "/**" {
-            Self {
-                path: EntityPath::root(),
-                include_subtree: true,
-            }
-        } else if let Some(path) = s.strip_suffix("/**") {
-            Self {
-                path: EntityPath::parse_forgiving(path),
-                include_subtree: true,
-            }
-        } else {
-            Self {
-                path: EntityPath::parse_forgiving(s),
-                include_subtree: false,
-            }
-        }
     }
 }
 
@@ -612,7 +553,7 @@ impl ChunkStore {
             .into_iter()
             .filter(|descr| {
                 descr.entity_path().map_or(true, |entity_path| {
-                    query.entity_path_expr().matches(entity_path)
+                    query.entity_path_filter().matches(entity_path)
                 })
             })
             .collect_vec();

--- a/crates/store/re_dataframe/examples/latest_at.rs
+++ b/crates/store/re_dataframe/examples/latest_at.rs
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let path_to_rrd = get_arg(1);
-    let entity_path_expr = args.get(2).map_or("/**", |s| s.as_str());
+    let entity_path_filter = args.get(2).map_or("/**", |s| s.as_str());
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::DEFAULT,
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_expr: entity_path_expr.into(),
+            entity_path_filter: entity_path_filter.into(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };

--- a/crates/store/re_dataframe/examples/latest_at.rs
+++ b/crates/store/re_dataframe/examples/latest_at.rs
@@ -3,7 +3,7 @@ use itertools::Itertools as _;
 use re_chunk::{TimeInt, Timeline};
 use re_chunk_store::{ChunkStore, ChunkStoreConfig, LatestAtQueryExpression, VersionPolicy};
 use re_dataframe::QueryEngine;
-use re_log_types::StoreKind;
+use re_log_types::{EntityPathFilter, StoreKind};
 
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect_vec();
@@ -20,7 +20,7 @@ fn main() -> anyhow::Result<()> {
     };
 
     let path_to_rrd = get_arg(1);
-    let entity_path_filter = args.get(2).map_or("/**", |s| s.as_str());
+    let entity_path_filter = EntityPathFilter::try_from(args.get(2).map_or("/**", |s| s.as_str()))?;
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::DEFAULT,
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_filter: entity_path_filter.into(),
+            entity_path_filter: entity_path_filter.clone(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };

--- a/crates/store/re_dataframe/examples/range.rs
+++ b/crates/store/re_dataframe/examples/range.rs
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
 
     let path_to_rrd = get_arg(1);
     let entity_path_pov = get_arg(2).as_str();
-    let entity_path_expr = args.get(3).map_or("/**", |s| s.as_str());
+    let entity_path_filter = args.get(3).map_or("/**", |s| s.as_str());
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::DEFAULT,
@@ -43,7 +43,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = RangeQueryExpression {
-            entity_path_expr: entity_path_expr.into(),
+            entity_path_filter: entity_path_filter.into(),
             timeline: Timeline::log_tick(),
             time_range: ResolvedTimeRange::new(0, 30),
             pov: ComponentColumnDescriptor::new::<re_types::components::Position3D>(

--- a/crates/store/re_dataframe/examples/range.rs
+++ b/crates/store/re_dataframe/examples/range.rs
@@ -5,7 +5,7 @@ use re_chunk_store::{
     VersionPolicy,
 };
 use re_dataframe::QueryEngine;
-use re_log_types::{ResolvedTimeRange, StoreKind};
+use re_log_types::{EntityPathFilter, ResolvedTimeRange, StoreKind};
 
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect_vec();
@@ -23,7 +23,7 @@ fn main() -> anyhow::Result<()> {
 
     let path_to_rrd = get_arg(1);
     let entity_path_pov = get_arg(2).as_str();
-    let entity_path_filter = args.get(3).map_or("/**", |s| s.as_str());
+    let entity_path_filter = EntityPathFilter::try_from(args.get(3).map_or("/**", |s| s.as_str()))?;
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::DEFAULT,
@@ -43,7 +43,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = RangeQueryExpression {
-            entity_path_filter: entity_path_filter.into(),
+            entity_path_filter: entity_path_filter.clone(),
             timeline: Timeline::log_tick(),
             time_range: ResolvedTimeRange::new(0, 30),
             pov: ComponentColumnDescriptor::new::<re_types::components::Position3D>(

--- a/crates/store/re_dataframe/examples/range_paginated.rs
+++ b/crates/store/re_dataframe/examples/range_paginated.rs
@@ -7,7 +7,7 @@ use re_chunk_store::{
     VersionPolicy,
 };
 use re_dataframe::{QueryEngine, RecordBatch};
-use re_log_types::{ResolvedTimeRange, StoreKind};
+use re_log_types::{EntityPathFilter, ResolvedTimeRange, StoreKind};
 
 fn main() -> anyhow::Result<()> {
     let args = std::env::args().collect_vec();
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
 
     let path_to_rrd = get_arg(1);
     let entity_path_pov = get_arg(2).as_str();
-    let entity_path_filter = args.get(3).map_or("/**", |s| s.as_str());
+    let entity_path_filter = EntityPathFilter::try_from(args.get(3).map_or("/**", |s| s.as_str()))?;
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::ALL_DISABLED,
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = RangeQueryExpression {
-            entity_path_filter: entity_path_filter.into(),
+            entity_path_filter: entity_path_filter.clone(),
             timeline: Timeline::log_tick(),
             time_range: ResolvedTimeRange::new(0, 30),
             pov: ComponentColumnDescriptor::new::<re_types::components::Position3D>(

--- a/crates/store/re_dataframe/examples/range_paginated.rs
+++ b/crates/store/re_dataframe/examples/range_paginated.rs
@@ -25,7 +25,7 @@ fn main() -> anyhow::Result<()> {
 
     let path_to_rrd = get_arg(1);
     let entity_path_pov = get_arg(2).as_str();
-    let entity_path_expr = args.get(3).map_or("/**", |s| s.as_str());
+    let entity_path_filter = args.get(3).map_or("/**", |s| s.as_str());
 
     let stores = ChunkStore::from_rrd_filepath(
         &ChunkStoreConfig::ALL_DISABLED,
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
         };
 
         let query = RangeQueryExpression {
-            entity_path_expr: entity_path_expr.into(),
+            entity_path_filter: entity_path_filter.into(),
             timeline: Timeline::log_tick(),
             time_range: ResolvedTimeRange::new(0, 30),
             pov: ComponentColumnDescriptor::new::<re_types::components::Position3D>(

--- a/crates/store/re_dataframe/src/latest_at.rs
+++ b/crates/store/re_dataframe/src/latest_at.rs
@@ -247,7 +247,7 @@ mod tests {
         ChunkStore, ChunkStoreConfig, ColumnDescriptor, ComponentColumnDescriptor,
         LatestAtQueryExpression, TimeColumnDescriptor,
     };
-    use re_log_types::{example_components::MyPoint, StoreId, StoreKind};
+    use re_log_types::{example_components::MyPoint, EntityPathFilter, StoreId, StoreKind};
     use re_query::Caches;
     use re_types::{
         components::{Color, Position3D, Radius},
@@ -269,7 +269,7 @@ mod tests {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_filter: "/**".into(),
+            entity_path_filter: EntityPathFilter::all(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };
@@ -335,7 +335,7 @@ mod tests {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_filter: "/**".into(),
+            entity_path_filter: EntityPathFilter::all(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };

--- a/crates/store/re_dataframe/src/latest_at.rs
+++ b/crates/store/re_dataframe/src/latest_at.rs
@@ -269,7 +269,7 @@ mod tests {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_expr: "/**".into(),
+            entity_path_filter: "/**".into(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };
@@ -335,7 +335,7 @@ mod tests {
         };
 
         let query = LatestAtQueryExpression {
-            entity_path_expr: "/**".into(),
+            entity_path_filter: "/**".into(),
             timeline: Timeline::log_time(),
             at: TimeInt::MAX,
         };

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -482,7 +482,7 @@ mod tests {
         let entity_path: EntityPath = "/points".into();
 
         let query = RangeQueryExpression {
-            entity_path_expr: "/**".into(),
+            entity_path_filter: "/**".into(),
             timeline: Timeline::log_time(),
             time_range: ResolvedTimeRange::EVERYTHING,
             pov: ComponentColumnDescriptor::new::<Position3D>(entity_path.clone()),
@@ -572,7 +572,7 @@ mod tests {
         };
 
         let query = RangeQueryExpression {
-            entity_path_expr: "/**".into(),
+            entity_path_filter: "/**".into(),
             timeline: Timeline::log_time(),
             time_range: ResolvedTimeRange::EVERYTHING,
             pov: ComponentColumnDescriptor::new::<MyPoint>(entity_path.clone()),

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -458,7 +458,9 @@ mod tests {
         ChunkStore, ChunkStoreConfig, ColumnDescriptor, ComponentColumnDescriptor,
         RangeQueryExpression, TimeColumnDescriptor,
     };
-    use re_log_types::{example_components::MyPoint, ResolvedTimeRange, StoreId, StoreKind};
+    use re_log_types::{
+        example_components::MyPoint, EntityPathFilter, ResolvedTimeRange, StoreId, StoreKind,
+    };
     use re_query::Caches;
     use re_types::{
         components::{Color, Position3D, Radius},
@@ -482,7 +484,7 @@ mod tests {
         let entity_path: EntityPath = "/points".into();
 
         let query = RangeQueryExpression {
-            entity_path_filter: "/**".into(),
+            entity_path_filter: EntityPathFilter::all(),
             timeline: Timeline::log_time(),
             time_range: ResolvedTimeRange::EVERYTHING,
             pov: ComponentColumnDescriptor::new::<Position3D>(entity_path.clone()),
@@ -572,7 +574,7 @@ mod tests {
         };
 
         let query = RangeQueryExpression {
-            entity_path_filter: "/**".into(),
+            entity_path_filter: EntityPathFilter::all(),
             timeline: Timeline::log_time(),
             time_range: ResolvedTimeRange::EVERYTHING,
             pov: ComponentColumnDescriptor::new::<MyPoint>(entity_path.clone()),

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -128,6 +128,12 @@ impl std::iter::Sum for EntityPathFilter {
     }
 }
 
+impl<S: AsRef<str>> From<S> for EntityPathFilter {
+    fn from(rules: S) -> Self {
+        Self::parse_forgiving(rules.as_ref(), &EntityPathSubs::default())
+    }
+}
+
 impl EntityPathFilter {
     /// Example of rules:
     ///
@@ -229,7 +235,8 @@ impl EntityPathFilter {
         None
     }
 
-    pub fn is_included(&self, path: &EntityPath) -> bool {
+    /// Does this filter include the given entity path?
+    pub fn matches(&self, path: &EntityPath) -> bool {
         let effect = self
             .most_specific_match(path)
             .unwrap_or(RuleEffect::Exclude);
@@ -240,7 +247,7 @@ impl EntityPathFilter {
     }
 
     /// Is there a rule for this exact entity path (ignoring subtree)?
-    pub fn is_exact_included(&self, entity_path: &EntityPath) -> bool {
+    pub fn matches_exactly(&self, entity_path: &EntityPath) -> bool {
         self.rules.iter().any(|(rule, effect)| {
             effect == &RuleEffect::Include && !rule.include_subtree && rule.path == *entity_path
         })
@@ -340,7 +347,7 @@ impl EntityPathFilter {
 
     /// Checks whether this results of this filter "fully contain" the results of another filter.
     ///
-    /// If this returns `true` there should not exist any [`EntityPath`] for which [`Self::is_included`]
+    /// If this returns `true` there should not exist any [`EntityPath`] for which [`Self::matches`]
     /// would return `true` and the other filter would return `false` for this filter.
     ///
     /// This check operates purely on the rule expressions and not the actual entity tree,

--- a/crates/viewer/re_selection_panel/src/space_view_entity_picker.rs
+++ b/crates/viewer/re_selection_panel/src/space_view_entity_picker.rs
@@ -161,7 +161,7 @@ fn add_entities_line_ui(
 
         let is_explicitly_excluded = entity_path_filter.is_explicitly_excluded(entity_path);
         let is_explicitly_included = entity_path_filter.is_explicitly_included(entity_path);
-        let is_included = entity_path_filter.is_included(entity_path);
+        let is_included = entity_path_filter.matches(entity_path);
 
         ui.add_enabled_ui(add_info.can_add_self_or_descendant.is_compatible(), |ui| {
             let widget_text = if is_explicitly_excluded {

--- a/crates/viewer/re_viewer_context/src/space_view/spawn_heuristics.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/spawn_heuristics.rs
@@ -54,7 +54,10 @@ impl RecommendedSpaceView {
         let space_env = EntityPathSubs::new_with_origin(&origin);
         Self {
             origin,
-            query_filter: EntityPathFilter::from_query_expressions(expressions, &space_env),
+            query_filter: EntityPathFilter::from_query_expressions_forgiving(
+                expressions,
+                &space_env,
+            ),
         }
     }
 

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -301,7 +301,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
 
         let entity_path = &tree.path;
 
-        let matches_filter = self.entity_path_filter.is_included(entity_path);
+        let matches_filter = self.entity_path_filter.matches(entity_path);
         *num_matching_entities += matches_filter as usize;
 
         // This list will be updated below during `update_overrides_recursive` by calling `choose_default_visualizers`
@@ -332,7 +332,7 @@ impl<'a> QueryExpressionEvaluator<'a> {
         // Ignore empty nodes.
         // Since we recurse downwards, this prunes any branches that don't have anything to contribute to the scene
         // and aren't directly included.
-        let exact_included = self.entity_path_filter.is_exact_included(entity_path);
+        let exact_included = self.entity_path_filter.matches_exactly(entity_path);
         if exact_included || !children.is_empty() || !visualizers.is_empty() {
             Some(data_results.insert(DataResultNode {
                 data_result: DataResult {

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -118,7 +118,8 @@ impl SpaceViewContents {
         };
         let query = expressions.iter().map(|qe| qe.0.as_str());
 
-        let entity_path_filter = EntityPathFilter::from_query_expressions(query, space_env);
+        let entity_path_filter =
+            EntityPathFilter::from_query_expressions_forgiving(query, space_env);
 
         Self {
             blueprint_entity_path: property.blueprint_store_path,

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -285,7 +285,7 @@ impl ViewportBlueprint {
                         || space_view
                             .contents
                             .entity_path_filter
-                            .is_included(&instance_path.entity_path)
+                            .matches(&instance_path.entity_path)
                 })
             }
 


### PR DESCRIPTION
### What

This PR change `re_dataframe` to use the existing `EntityPathFilter` instead of the `EntityPathExpression` introduced last week (which lacks many features).

Also renames some methods of `EntityPathFilter`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7377?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7377?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7377)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.