### PR TITLE
Switch ArrowDict to signed and fix static datatype

### DIFF
--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -84,7 +84,7 @@ pub fn arrays_to_list_array(
 pub fn arrays_to_dictionary<Idx: Copy + Eq>(
     array_datatype: ArrowDatatype,
     arrays: &[Option<(Idx, &dyn ArrowArray)>],
-) -> Option<ArrowDictionaryArray<u32>> {
+) -> Option<ArrowDictionaryArray<i32>> {
     // Dedupe the input arrays based on the given primary key.
     let arrays_dense_deduped = arrays
         .iter()
@@ -96,7 +96,7 @@ pub fn arrays_to_dictionary<Idx: Copy + Eq>(
 
     // Compute the keys for the final dictionary, using that same primary key.
     let keys = {
-        let mut cur_key = 0u32;
+        let mut cur_key = 0i32;
         arrays
             .iter()
             .dedup_by_with_count(|lhs, rhs| {
@@ -140,7 +140,7 @@ pub fn arrays_to_dictionary<Idx: Copy + Eq>(
     };
 
     let datatype = ArrowDatatype::Dictionary(
-        arrow2::datatypes::IntegerType::UInt32,
+        arrow2::datatypes::IntegerType::Int32,
         std::sync::Arc::new(data.data_type().clone()),
         true, // is_sorted
     );
@@ -149,7 +149,7 @@ pub fn arrays_to_dictionary<Idx: Copy + Eq>(
     // unique values.
     ArrowDictionaryArray::try_new(
         datatype,
-        ArrowPrimitiveArray::<u32>::from(keys),
+        ArrowPrimitiveArray::<i32>::from(keys),
         data.to_boxed(),
     )
     .ok()

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -482,7 +482,7 @@ impl ChunkStore {
                                 archetype_name: None,
                                 archetype_field_name: None,
                                 component_name: *component_name,
-                                datatype: datatype.clone(),
+                                datatype: ArrowListArray::<i32>::default_datatype(datatype.clone()),
                                 is_static: true,
                             })
                         })

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -91,7 +91,7 @@ impl RangeQueryHandle<'_> {
                         .map(|col| match col {
                             ColumnDescriptor::Component(mut descr) => {
                                 descr.datatype = ArrowDatatype::Dictionary(
-                                    arrow2::datatypes::IntegerType::UInt32,
+                                    arrow2::datatypes::IntegerType::Int32,
                                     descr.datatype.into(),
                                     true,
                                 );
@@ -311,7 +311,7 @@ impl RangeQueryHandle<'_> {
         // see if this ever becomes an issue before going down this road.
         //
         // TODO(cmc): Opportunities for parallelization, if it proves to be a net positive in practice.
-        let dict_arrays: HashMap<&ComponentColumnDescriptor, ArrowDictionaryArray<u32>> = {
+        let dict_arrays: HashMap<&ComponentColumnDescriptor, ArrowDictionaryArray<i32>> = {
             re_tracing::profile_scope!("queries");
 
             columns
@@ -612,7 +612,7 @@ mod tests {
                     })
                     .unwrap()
                     .as_any()
-                    .downcast_ref::<ArrowDictionaryArray<u32>>()
+                    .downcast_ref::<ArrowDictionaryArray<i32>>()
                     .unwrap()
                     .values()
                     .clone()
@@ -639,7 +639,7 @@ mod tests {
                     })
                     .unwrap()
                     .as_any()
-                    .downcast_ref::<ArrowDictionaryArray<u32>>()
+                    .downcast_ref::<ArrowDictionaryArray<i32>>()
                     .unwrap()
                     .values()
                     .clone()


### PR DESCRIPTION
### What
Certain arrow implementations required that dictionary keys be signed.

Also the type returned by static data columns was missing the arraylist.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7383?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7383?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7383)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.