### PR TITLE
Use `Range<u64>` as argument for the `RangeQueryHandle::get()`

### DIFF
--- a/crates/store/re_dataframe/examples/range_paginated.rs
+++ b/crates/store/re_dataframe/examples/range_paginated.rs
@@ -61,21 +61,21 @@ fn main() -> anyhow::Result<()> {
             query_handle.num_rows()
         );
 
-        let (offset, len) = (0, 4);
-        println!("offset:{offset} len:{len}");
-        concat_and_print(query_handle.get(offset, len));
+        let row_range = 0..4;
+        println!("range: {row_range:?}");
+        concat_and_print(query_handle.get(row_range));
 
-        let (offset, len) = (2, 4);
-        println!("offset:{offset} len:{len}");
-        concat_and_print(query_handle.get(offset, len));
+        let row_range = 2..6;
+        println!("range: {row_range:?}");
+        concat_and_print(query_handle.get(row_range));
 
-        let (offset, len) = (10, 5);
-        println!("offset:{offset} len:{len}");
-        concat_and_print(query_handle.get(offset, len));
+        let row_range = 10..15;
+        println!("range: {row_range:?}");
+        concat_and_print(query_handle.get(row_range));
 
-        let (offset, len) = (0, 15);
-        println!("offset:{offset} len:{len}");
-        concat_and_print(query_handle.get(offset, len));
+        let row_range = 0..15;
+        println!("range: {row_range:?}");
+        concat_and_print(query_handle.get(row_range));
     }
 
     Ok(())

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -44,15 +44,15 @@ impl QueryHandle<'_> {
         }
     }
 
-    fn get(&self, start: u64, num_rows: u64) -> Vec<RecordBatch> {
+    fn get(&self, row_range: Range<u64>) -> Vec<RecordBatch> {
         match self {
             QueryHandle::LatestAt(query_handle) => {
                 // latest-at queries only have one row
-                debug_assert_eq!((start, num_rows), (0, 1));
+                debug_assert_eq!(row_range, 0..1);
 
                 vec![query_handle.get()]
             }
-            QueryHandle::Range(query_handle) => query_handle.get(start, num_rows),
+            QueryHandle::Range(query_handle) => query_handle.get(row_range),
         }
     }
 
@@ -178,10 +178,7 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
 
         let data = RowsDisplayData::try_new(
             &info.visible_rows,
-            self.query_handle.get(
-                info.visible_rows.start,
-                info.visible_rows.end - info.visible_rows.start,
-            ),
+            self.query_handle.get(info.visible_rows.clone()),
             self.schema,
             &self.query_handle.timeline(),
         );


### PR DESCRIPTION
### What

Minor change of API [suggested](https://github.com/rerun-io/rerun/pull/7380#discussion_r1751462590) by @emilk: use `Range<u64>` for the `RangeQueryHandle::get(row_range)` API.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7395?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7395?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7395)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.