### PR TITLE
Fix running python doc tests twice on CI

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -43,34 +43,6 @@ permissions:
   id-token: "write"
 
 jobs:
-  py-test-docs:
-    name: Test Python Docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-          cache: "pip"
-          cache-dependency-path: "rerun_py/requirements-doc.txt"
-
-      - name: Install Python dependencies
-        shell: bash
-        run: |
-          pip install --upgrade pip
-          pip install -r rerun_py/requirements-doc.txt
-
-      - name: Build via mkdocs
-        shell: bash
-        run: |
-          mkdocs build --strict -f rerun_py/mkdocs.yml
-
-  # ---------------------------------------------------------------------------
-
   no-codegen-changes:
     name: Check if running codegen would produce any changes
     runs-on: ubuntu-latest-16-cores


### PR DESCRIPTION
### What

There's an identical job here https://github.com/rerun-io/rerun/blob/1923ba56314cb47a8b18e13fa13565914830ee81/.github/workflows/reusable_checks_python.yml#L48
which is executed whenever anything python changes. This should be sufficient!

### Checklist
* [x] tick!