### PR TITLE
Split out (ultra-)slow cargo doc jobs and run them only on nightly

### DIFF
--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -104,7 +104,7 @@ jobs:
           pixi-version: v0.25.0
 
       - name: Rust checks & tests
-        run: pixi run rs-check --skip individual_crates
+        run: pixi run rs-check --skip individual_crates docs_slow
 
   misc-rerun-lints:
     name: Rerun lints

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -67,11 +67,11 @@ jobs:
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'pr' }}
-        run: pixi run rs-check --skip individual_crates tests
+        run: pixi run rs-check --skip individual_crates tests docs_slow
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'main' }}
-        run: pixi run rs-check --skip individual_crates
+        run: pixi run rs-check --skip individual_crates docs_slow
 
       - name: Rust all checks & tests
         if: ${{ inputs.CHANNEL == 'nightly' }}

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -1,7 +1,6 @@
 use re_chunk_store::RowId;
 use re_log_types::{hash::Hash64, Instance, TimeInt};
-use re_renderer::renderer::MeshInstance;
-use re_renderer::RenderContext;
+use re_renderer::{renderer::MeshInstance, RenderContext};
 use re_types::{
     archetypes::Mesh3D,
     components::{


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7387
    * well, sort of ;)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7399?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7399?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7399)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.