### PR TITLE
Fix  Rust's  `TimeColumn::new_seconds/new_nanos` creating sequence timelines

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -804,7 +804,7 @@ impl TimeColumn {
 
         Self::new(
             None,
-            Timeline::new_sequence(name.into()),
+            Timeline::new_temporal(name.into()),
             ArrowPrimitiveArray::<i64>::from_vec(time_vec),
         )
     }
@@ -834,7 +834,7 @@ impl TimeColumn {
 
         Self::new(
             None,
-            Timeline::new_sequence(name.into()),
+            Timeline::new_temporal(name.into()),
             ArrowPrimitiveArray::<i64>::from_vec(time_vec),
         )
     }


### PR DESCRIPTION
### What

Ran into this bug in the comparison test of an new upcoming snippet.

Considered added dedicated unit testing, but not entirely clear to me how to go about it without putting in too much effort 🤔  Luckily this will be in part covered by aforementioned snippet.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7402?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7402?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7402)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.