### PR TITLE
Remove unused `SpaceViewClass::on_frame_start`

### DIFF
--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -272,10 +272,8 @@ impl AppState {
             focused_item,
         };
 
-        // First update the viewport and thus all active space views.
-        // This may update their heuristics, so that all panels that are shown in this frame,
-        // have the latest information.
-        viewport.on_frame_start(&ctx, view_states);
+        // Update the viewport. May spawn new views and handle queued requests (like screenshots).
+        viewport.on_frame_start(&ctx);
 
         {
             re_tracing::profile_scope!("updated_query_results");

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -4,8 +4,8 @@ use re_log_types::EntityPath;
 use re_types::{ComponentName, SpaceViewClassIdentifier};
 
 use crate::{
-    ApplicableEntities, IndicatedEntities, PerSystemEntities, PerVisualizer, QueryRange,
-    SmallVisualizerSet, SpaceViewClassRegistryError, SpaceViewId, SpaceViewSpawnHeuristics,
+    ApplicableEntities, IndicatedEntities, PerVisualizer, QueryRange, SmallVisualizerSet,
+    SpaceViewClassRegistryError, SpaceViewId, SpaceViewSpawnHeuristics,
     SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery,
     ViewerContext, VisualizableEntities,
 };
@@ -167,19 +167,6 @@ pub trait SpaceViewClass: Send + Sync {
 
     /// Determines which space views should be spawned by default for this class.
     fn spawn_heuristics(&self, ctx: &ViewerContext<'_>) -> SpaceViewSpawnHeuristics;
-
-    /// Executed for all active space views on frame start (before any ui is drawn),
-    /// can be use for heuristic & state updates before populating the scene.
-    ///
-    /// Is only allowed to access archetypes defined by [`Self::blueprint_archetype`]
-    /// Passed entity properties are individual properties without propagated values.
-    fn on_frame_start(
-        &self,
-        _ctx: &ViewerContext<'_>,
-        _state: &mut dyn SpaceViewState,
-        _ent_paths: &PerSystemEntities,
-    ) {
-    }
 
     /// Ui shown when the user selects a space view of this class.
     fn selection_ui(

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -204,9 +204,10 @@ impl<'a> Viewport<'a> {
         self.blueprint.set_maximized(maximized, ctx);
     }
 
-    pub fn on_frame_start(&mut self, ctx: &ViewerContext<'_>, view_states: &mut ViewStates) {
+    pub fn on_frame_start(&mut self, ctx: &ViewerContext<'_>) {
         re_tracing::profile_function!();
 
+        // Handle pending view screenshots:
         if let Some(render_ctx) = ctx.render_ctx {
             for space_view in self.blueprint.space_views.values() {
                 #[allow(clippy::blocks_in_conditions)]
@@ -219,12 +220,10 @@ impl<'a> Viewport<'a> {
                 )
                 .is_some()
                 {}
-
-                space_view.on_frame_start(ctx, view_states);
             }
         }
 
-        self.blueprint.on_frame_start(ctx);
+        self.blueprint.spawn_heuristic_space_views(ctx);
     }
 
     /// Process any deferred `TreeActions` and then sync to blueprint

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -18,9 +18,9 @@ use re_types::{
 };
 use re_types_core::Archetype as _;
 use re_viewer_context::{
-    ContentsName, PerSystemEntities, QueryRange, RecommendedSpaceView, SpaceViewClass,
-    SpaceViewClassRegistry, SpaceViewId, SpaceViewState, StoreContext, SystemCommand,
-    SystemCommandSender as _, ViewContext, ViewStates, ViewerContext, VisualizerCollection,
+    ContentsName, QueryRange, RecommendedSpaceView, SpaceViewClass, SpaceViewClassRegistry,
+    SpaceViewId, SpaceViewState, StoreContext, SystemCommand, SystemCommandSender as _,
+    ViewContext, ViewStates, ViewerContext, VisualizerCollection,
 };
 
 use crate::{SpaceViewContents, ViewProperty};
@@ -355,29 +355,6 @@ impl SpaceViewBlueprint {
         space_view_class_registry: &'a re_viewer_context::SpaceViewClassRegistry,
     ) -> &'a dyn SpaceViewClass {
         space_view_class_registry.get_class_or_log_error(self.class_identifier)
-    }
-
-    pub fn on_frame_start(&self, ctx: &ViewerContext<'_>, view_states: &mut ViewStates) {
-        let query_result = ctx.lookup_query_result(self.id).clone();
-
-        let mut per_system_entities = PerSystemEntities::default();
-        {
-            re_tracing::profile_scope!("per_system_data_results");
-
-            query_result.tree.visit(&mut |node| {
-                for system in &node.data_result.visualizers {
-                    per_system_entities
-                        .entry(*system)
-                        .or_default()
-                        .insert(node.data_result.entity_path.clone());
-                }
-                true
-            });
-        }
-
-        let class = self.class(ctx.space_view_class_registry);
-        let view_state = view_states.get_mut_or_create(self.id, class);
-        class.on_frame_start(ctx, view_state, &per_system_entities);
     }
 
     #[inline]

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -308,13 +308,12 @@ impl ViewportBlueprint {
         self.set_auto_space_views(false, ctx);
     }
 
-    pub fn on_frame_start(&self, ctx: &ViewerContext<'_>) {
-        if self.auto_space_views() {
-            self.spawn_heuristic_space_views(ctx);
+    /// Spawns new space views if enabled.
+    pub fn spawn_heuristic_space_views(&self, ctx: &ViewerContext<'_>) {
+        if !self.auto_space_views() {
+            return;
         }
-    }
 
-    fn spawn_heuristic_space_views(&self, ctx: &ViewerContext<'_>) {
         re_tracing::profile_function!();
 
         for entry in ctx.space_view_class_registry.iter_registry() {


### PR DESCRIPTION

### What

A relic from a time where we needed this for property heuristics. No view class implemented this method at this point!

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7409?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7409?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7409)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.