### PR TITLE
Fix warning popping up when selecting a video asset

### DIFF
--- a/crates/store/re_types/src/image.rs
+++ b/crates/store/re_types/src/image.rs
@@ -55,6 +55,10 @@ pub enum ImageLoadError {
     /// Failure to convert the loaded image to a [`crate::archetypes::Image`].
     #[error(transparent)]
     ImageConversionError(#[from] ImageConversionError),
+
+    /// The encountered MIME type is not supported for decoding images.
+    #[error("MIME type '{0}' is not supported for images")]
+    UnsupportedMimeType(String),
 }
 
 #[cfg(feature = "image")]

--- a/crates/viewer/re_viewer_context/src/tensor/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/tensor/image_decode_cache.rs
@@ -72,7 +72,7 @@ fn decode_image(
         if let Some(format) = image::ImageFormat::from_mime_type(media_type) {
             reader.set_format(format);
         } else {
-            re_log::warn!("Unsupported image MediaType/MIME: {media_type:?}");
+            return Err(ImageLoadError::UnsupportedMimeType(media_type.to_owned()));
         }
     }
 


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7410?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7410?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7410)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.