### PR TITLE
Update to latest egui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "ahash",
  "egui",
@@ -1916,13 +1916,13 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "ahash",
  "bytemuck",
  "egui",
  "egui-winit",
- "glow",
+ "glow 0.14.0",
  "log",
  "memoffset 0.9.0",
  "puffin",
@@ -1989,7 +1989,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=6b7f4312373a301a4cdf7d99a0d546acd34bcd66#6b7f4312373a301a4cdf7d99a0d546acd34bcd66"
+source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
 
 [[package]]
 name = "equivalent"
@@ -2541,6 +2541,18 @@ name = "glow"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glow"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f865cbd94bd355b89611211e49508da98a1fce0ad755c1e8448fb96711b24528"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -7979,7 +7991,7 @@ dependencies = [
  "block",
  "cfg_aliases 0.1.1",
  "core-graphics-types",
- "glow",
+ "glow 0.13.1",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1879,7 +1879,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark"
 version = "0.17.0"
-source = "git+https://github.com/rerun-io/egui_commonmark?rev=5997e897df5b2aceab9df833ee4bb293d05d9b07#5997e897df5b2aceab9df833ee4bb293d05d9b07"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=7a9dc755bfa351a3796274cb8ca87129b051c084#7a9dc755bfa351a3796274cb8ca87129b051c084"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "egui_commonmark_backend"
 version = "0.17.0"
-source = "git+https://github.com/rerun-io/egui_commonmark?rev=5997e897df5b2aceab9df833ee4bb293d05d9b07#5997e897df5b2aceab9df833ee4bb293d05d9b07"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=7a9dc755bfa351a3796274cb8ca87129b051c084#7a9dc755bfa351a3796274cb8ca87129b051c084"
 dependencies = [
  "egui",
  "egui_extras",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "ahash",
  "egui",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "egui_table"
 version = "0.28.1"
-source = "git+https://github.com/rerun-io/egui_table.git?rev=0f594701d528c4a9553521cb941de1886549dc70#0f594701d528c4a9553521cb941de1886549dc70"
+source = "git+https://github.com/rerun-io/egui_table.git?rev=c76473b244f03a7c67fbbbff9def6fc86c1ca4ea#c76473b244f03a7c67fbbbff9def6fc86c1ca4ea"
 dependencies = [
  "egui",
  "serde",
@@ -1989,7 +1989,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed#b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed"
+source = "git+https://github.com/emilk/egui.git?rev=66076101e12eee01dec374285521b0bed4ecc40a#66076101e12eee01dec374285521b0bed4ecc40a"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,24 +1879,22 @@ dependencies = [
 [[package]]
 name = "egui_commonmark"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe88871b75bd43c52a2b44ce5b53160506e7976e239112c56728496d019cc60d"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=5997e897df5b2aceab9df833ee4bb293d05d9b07#5997e897df5b2aceab9df833ee4bb293d05d9b07"
 dependencies = [
  "egui",
  "egui_commonmark_backend",
  "egui_extras",
- "pulldown-cmark 0.11.0",
+ "pulldown-cmark 0.12.1",
 ]
 
 [[package]]
 name = "egui_commonmark_backend"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148edd9546feba319b16d5a5e551cda46095031ec1e6665e5871eef9ee692967"
+source = "git+https://github.com/rerun-io/egui_commonmark?rev=5997e897df5b2aceab9df833ee4bb293d05d9b07#5997e897df5b2aceab9df833ee4bb293d05d9b07"
 dependencies = [
  "egui",
  "egui_extras",
- "pulldown-cmark 0.11.0",
+ "pulldown-cmark 0.12.1",
 ]
 
 [[package]]
@@ -4515,9 +4513,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
+checksum = "666f0f59e259aea2d72e6012290c09877a780935cc3c18b1ceded41f3890d59c"
 dependencies = [
  "bitflags 2.6.0",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,12 +514,12 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" }      # egui master 2024-09-06
-eframe = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" }      # egui master 2024-09-06
-egui = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" }        # egui master 2024-09-06
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" } # egui master 2024-09-06
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" }   # egui master 2024-09-06
-emath = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf7d99a0d546acd34bcd66" }       # egui master 2024-09-06
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }      # egui master 2024-09-06
+eframe = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }      # egui master 2024-09-06
+egui = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }        # egui master 2024-09-06
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" } # egui master 2024-09-06
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }   # egui master 2024-09-06
+emath = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }       # egui master 2024-09-06
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,12 +514,12 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }      # egui master 2024-09-06
-eframe = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }      # egui master 2024-09-06
-egui = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }        # egui master 2024-09-06
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" } # egui master 2024-09-06
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }   # egui master 2024-09-06
-emath = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31e0c26c40ac8249d8b2ed" }       # egui master 2024-09-06
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" }      # egui master 2024-09-06
+eframe = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" }      # egui master 2024-09-06
+egui = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" }        # egui master 2024-09-06
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" } # egui master 2024-09-06
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" }   # egui master 2024-09-06
+emath = { git = "https://github.com/emilk/egui.git", rev = "66076101e12eee01dec374285521b0bed4ecc40a" }       # egui master 2024-09-06
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }
@@ -535,7 +535,7 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "b01a7b1ee82181fb8c31
 egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "b2f5e232524deed983bcad01c05f27d0e8b89d98" } # https://github.com/rerun-io/egui_tiles/pull/78 2024-08-28
 # egui_tiles = { path = "../egui_tiles" }
 
-egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "5997e897df5b2aceab9df833ee4bb293d05d9b07" } # https://github.com/lampsitter/egui_commonmark/pull/65
+egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "7a9dc755bfa351a3796274cb8ca87129b051c084" } # https://github.com/lampsitter/egui_commonmark/pull/65
 
 # commit on `rerun-io/mp4` `main` branch
 # https://github.com/rerun-io/mp4/commit/ef529032547d7f97161e95c58bd76856cb116349

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -535,7 +535,7 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "6b7f4312373a301a4cdf
 egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "b2f5e232524deed983bcad01c05f27d0e8b89d98" } # https://github.com/rerun-io/egui_tiles/pull/78 2024-08-28
 # egui_tiles = { path = "../egui_tiles" }
 
-# egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "63d5c8933445b9ea9088c4a50b71f4ede1f3c247" } # https://github.com/lampsitter/egui_commonmark/pull/51
+egui_commonmark = { git = "https://github.com/rerun-io/egui_commonmark", rev = "5997e897df5b2aceab9df833ee4bb293d05d9b07" } # https://github.com/lampsitter/egui_commonmark/pull/65
 
 # commit on `rerun-io/mp4` `main` branch
 # https://github.com/rerun-io/mp4/commit/ef529032547d7f97161e95c58bd76856cb116349

--- a/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
@@ -40,10 +40,7 @@ fn edit_view_enum_impl<EnumT: re_types_core::reflection::Enum>(
             });
 
         combobox_response.response = combobox_response.response.on_hover_ui(|ui| {
-            ui.markdown_ui(
-                ui.id().with(prev_selected_value),
-                prev_selected_value.docstring_md(),
-            );
+            ui.markdown_ui(prev_selected_value.docstring_md());
         });
 
         response_with_changes_of_inner(combobox_response)
@@ -59,6 +56,6 @@ fn variant_ui<EnumT: re_types_core::reflection::Enum>(
 ) -> egui::Response {
     ui.selectable_value(current_value, variant, variant.to_string())
         .on_hover_ui(|ui| {
-            ui.markdown_ui(ui.id().with(variant), variant.docstring_md());
+            ui.markdown_ui(variant.docstring_md());
         })
 }

--- a/crates/viewer/re_data_ui/src/component_name.rs
+++ b/crates/viewer/re_data_ui/src/component_name.rs
@@ -31,9 +31,9 @@ impl DataUi for ComponentName {
                     .map(|info| info.docstring_md)
                 {
                     if ui_layout.is_selection_panel() {
-                        ui.markdown_ui(egui::Id::new((self, "full")), markdown);
+                        ui.markdown_ui(markdown);
                     } else if let Some(first_line) = markdown.lines().next() {
-                        ui.markdown_ui(egui::Id::new((self, "first_line")), first_line);
+                        ui.markdown_ui(first_line);
                     }
                 }
 

--- a/crates/viewer/re_space_view/src/view_property_ui.rs
+++ b/crates/viewer/re_space_view/src/view_property_ui.rs
@@ -72,7 +72,6 @@ fn view_property_ui_impl(
             ui,
             field.component_name,
             reflection.display_name,
-            name,
             field,
             &blueprint_path,
             component_results.component_row_id(&field.component_name),
@@ -90,7 +89,6 @@ fn view_property_ui_impl(
                     ui,
                     field.component_name,
                     display_name,
-                    name,
                     field,
                     &blueprint_path,
                     component_results.component_row_id(&field.component_name),
@@ -119,7 +117,6 @@ fn view_property_component_ui(
     ui: &mut egui::Ui,
     component_name: ComponentName,
     root_item_display_name: &str,
-    archetype_name: ArchetypeName,
     field: &ArchetypeFieldReflection,
     blueprint_path: &re_log_types::EntityPath,
     row_id: Option<RowId>,
@@ -173,8 +170,7 @@ fn view_property_component_ui(
     };
 
     list_item_response.on_hover_ui(|ui| {
-        let id = egui::Id::new((archetype_name, field.display_name));
-        ui.markdown_ui(id, field.docstring_md);
+        ui.markdown_ui(field.docstring_md);
     });
 }
 

--- a/crates/viewer/re_space_view_dataframe/Cargo.toml
+++ b/crates/viewer/re_space_view_dataframe/Cargo.toml
@@ -36,7 +36,7 @@ re_viewport_blueprint.workspace = true
 
 anyhow.workspace = true
 egui_extras.workspace = true
-egui_table = { git = "https://github.com/rerun-io/egui_table.git", rev = "0f594701d528c4a9553521cb941de1886549dc70" } # main as of 2024-09-09
+egui_table = { git = "https://github.com/rerun-io/egui_table.git", rev = "c76473b244f03a7c67fbbbff9def6fc86c1ca4ea" } # main as of 2024-09-13
 egui.workspace = true
 itertools.workspace = true
 thiserror.workspace = true

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -173,6 +173,10 @@ impl DataframeTableDelegate<'_> {
 }
 
 impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
+    fn default_row_height(&self) -> f32 {
+        re_ui::DesignTokens::table_line_height()
+    }
+
     fn prepare(&mut self, info: &egui_table::PrefetchInfo) {
         re_tracing::profile_function!();
 
@@ -337,7 +341,6 @@ fn dataframe_ui_impl(ctx: &ViewerContext<'_>, ui: &mut egui::Ui, query_handle: &
                 egui_table::HeaderRow::new(re_ui::DesignTokens::table_header_height()),
             ])
             .num_rows(num_rows)
-            .row_height(re_ui::DesignTokens::table_line_height())
             .show(ui, &mut table_delegate);
     });
 }

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -388,10 +388,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
                         "Scene up is unspecified".to_owned()
                     };
                 ui.label(up_description).on_hover_ui(|ui| {
-                    ui.markdown_ui(
-                        egui::Id::new("view_coordinates_tooltip"),
-                        "Set with `rerun.ViewCoordinates`.",
-                    );
+                    ui.markdown_ui("Set with `rerun.ViewCoordinates`.");
                 });
 
                 if let Some(eye) = &state.state_3d.view_eye {

--- a/crates/viewer/re_space_view_text_document/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_text_document/src/space_view_class.rs
@@ -157,7 +157,7 @@ Displays text from a text component, as raw text or markdown."
                                         .or_insert(egui::FontId::proportional(32.0))
                                         .size = 24.0;
 
-                                    egui_commonmark::CommonMarkViewer::new("markdown_viewer")
+                                    egui_commonmark::CommonMarkViewer::new()
                                         .max_image_width(Some(ui.available_width().floor() as _))
                                         .show(ui, &mut state.commonmark_cache, body);
                                     return;

--- a/crates/viewer/re_time_panel/benches/bench_density_graph.rs
+++ b/crates/viewer/re_time_panel/benches/bench_density_graph.rs
@@ -18,49 +18,51 @@ use re_time_panel::__bench::{
 };
 
 fn run(b: &mut Bencher<'_, WallTime>, config: DensityGraphBuilderConfig, entry: ChunkEntry) {
-    egui::__run_test_ui(|ui| {
-        let row_rect = ui.max_rect();
-        assert!(row_rect.width() > 100.0 && row_rect.height() > 100.0);
+    egui::__run_test_ctx(|ctx| {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            let row_rect = ui.max_rect();
+            assert!(row_rect.width() > 100.0 && row_rect.height() > 100.0);
 
-        let mut db = EntityDb::with_store_config(
-            StoreId::from_string(StoreKind::Recording, "test".into()),
-            ChunkStoreConfig::COMPACTION_DISABLED,
-        );
-        let entity_path = re_log_types::EntityPath::parse_strict("/data").unwrap();
-        let timeline = re_log_types::Timeline::log_time();
+            let mut db = EntityDb::with_store_config(
+                StoreId::from_string(StoreKind::Recording, "test".into()),
+                ChunkStoreConfig::COMPACTION_DISABLED,
+            );
+            let entity_path = re_log_types::EntityPath::parse_strict("/data").unwrap();
+            let timeline = re_log_types::Timeline::log_time();
 
-        add_data(
-            &mut db,
-            &entity_path,
-            entry.num_chunks,
-            entry.num_rows_per_chunk,
-            entry.sorted,
-            entry.time_start_ms,
-            timeline,
-        )
-        .unwrap();
-
-        let item = TimePanelItem {
-            entity_path,
-            component_name: None,
-        };
-
-        let time_range = db
-            .time_range_for(&timeline)
-            .unwrap_or(ResolvedTimeRange::EMPTY);
-        let time_ranges_ui =
-            TimeRangesUi::new(row_rect.x_range(), time_range.into(), &[time_range]);
-
-        b.iter(|| {
-            black_box(build_density_graph(
-                ui,
-                &time_ranges_ui,
-                row_rect,
-                &db,
-                &item,
+            add_data(
+                &mut db,
+                &entity_path,
+                entry.num_chunks,
+                entry.num_rows_per_chunk,
+                entry.sorted,
+                entry.time_start_ms,
                 timeline,
-                config,
-            ));
+            )
+            .unwrap();
+
+            let item = TimePanelItem {
+                entity_path,
+                component_name: None,
+            };
+
+            let time_range = db
+                .time_range_for(&timeline)
+                .unwrap_or(ResolvedTimeRange::EMPTY);
+            let time_ranges_ui =
+                TimeRangesUi::new(row_rect.x_range(), time_range.into(), &[time_range]);
+
+            b.iter(|| {
+                black_box(build_density_graph(
+                    ui,
+                    &time_ranges_ui,
+                    row_rect,
+                    &db,
+                    &item,
+                    timeline,
+                    config,
+                ));
+            });
         });
     });
 }

--- a/crates/viewer/re_time_panel/src/time_control_ui.rs
+++ b/crates/viewer/re_time_panel/src/time_control_ui.rs
@@ -44,7 +44,6 @@ impl TimeControlUi {
                 .on_hover_ui(|ui| {
                     list_item::list_item_scope(ui, "tooltip", |ui| {
                         ui.markdown_ui(
-                            egui::Id::new("timeline_selector_tooltip"),
                             r"
 Select timeline.
 

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -91,7 +91,7 @@ pub fn apply_style_and_install_loaders(egui_ctx: &egui::Context) {
     );
 
     egui_ctx.options_mut(|o| {
-        o.follow_system_theme = false;
+        o.theme_preference = egui::ThemePreference::Dark;
         o.fallback_theme = egui::Theme::Dark;
     });
 

--- a/crates/viewer/re_ui/src/section_collapsing_header.rs
+++ b/crates/viewer/re_ui/src/section_collapsing_header.rs
@@ -56,7 +56,7 @@ impl<'a> SectionCollapsingHeader<'a> {
     #[inline]
     pub fn help_markdown(mut self, help: &'a str) -> Self {
         self.help = Some(Box::new(move |ui| {
-            ui.markdown_ui(egui::Id::new(help), help);
+            ui.markdown_ui(help);
         }));
         self
     }

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -934,7 +934,7 @@ pub trait UiExt {
     }
 
     /// Show some markdown
-    fn markdown_ui(&mut self, id: egui::Id, markdown: &str) {
+    fn markdown_ui(&mut self, markdown: &str) {
         use parking_lot::Mutex;
         use std::sync::Arc;
 
@@ -946,7 +946,7 @@ pub trait UiExt {
             .clone()
         });
 
-        egui_commonmark::CommonMarkViewer::new(id).show(ui, &mut commonmark_cache.lock(), markdown);
+        egui_commonmark::CommonMarkViewer::new().show(ui, &mut commonmark_cache.lock(), markdown);
     }
 
     /// A drop-down menu with a list of options.

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -897,6 +897,14 @@ impl App {
             .frame(DesignTokens::top_panel_frame())
             .show_animated_inside(ui, self.egui_debug_panel_open, |ui| {
                 egui::ScrollArea::vertical().show(ui, |ui| {
+                    if ui
+                        .button("request_discard")
+                        .on_hover_text("Request a second layout pass. Just for testing.")
+                        .clicked()
+                    {
+                        ui.ctx().request_discard();
+                    }
+
                     egui::CollapsingHeader::new("egui settings")
                         .default_open(false)
                         .show(ui, |ui| {

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -54,10 +54,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
         _query: &ViewQuery<'_>,
         _system_output: SystemExecutionOutput,
     ) -> Result<(), SpaceViewSystemExecutionError> {
-        ui.markdown_ui(
-            egui::Id::new(self.display_name()),
-            &self.help_markdown(ctx.egui_ctx),
-        );
+        ui.markdown_ui(&self.help_markdown(ctx.egui_ctx));
 
         Ok(())
     }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -50,8 +50,8 @@ impl TestContext {
         self.selection_state.on_frame_start(|_| true, None);
     }
 
-    pub fn run(&self, mut func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui)) {
-        egui::__run_test_ui(|ui| {
+    pub fn run(&self, func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui) + Copy) {
+        egui::__run_test_ui(move |ui| {
             re_ui::apply_style_and_install_loaders(ui.ctx());
             let blueprint_query = LatestAtQuery::latest(self.active_timeline);
             let (command_sender, _) = command_channel();
@@ -92,6 +92,7 @@ impl TestContext {
                 focused_item: &None,
             };
 
+            let mut func = func;
             func(&ctx, ui);
         });
     }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -50,50 +50,51 @@ impl TestContext {
         self.selection_state.on_frame_start(|_| true, None);
     }
 
-    pub fn run(&self, func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui) + Copy) {
-        egui::__run_test_ui(move |ui| {
-            re_ui::apply_style_and_install_loaders(ui.ctx());
-            let blueprint_query = LatestAtQuery::latest(self.active_timeline);
-            let (command_sender, _) = command_channel();
-            let component_ui_registry = ComponentUiRegistry::new(Box::new(
-                |_ctx, _ui, _ui_layout, _query, _db, _entity_path, _row_id, _component| {},
-            ));
+    pub fn run(&self, mut func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui)) {
+        egui::__run_test_ctx(|ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                re_ui::apply_style_and_install_loaders(ui.ctx());
+                let blueprint_query = LatestAtQuery::latest(self.active_timeline);
+                let (command_sender, _) = command_channel();
+                let component_ui_registry = ComponentUiRegistry::new(Box::new(
+                    |_ctx, _ui, _ui_layout, _query, _db, _entity_path, _row_id, _component| {},
+                ));
 
-            let store_context = StoreContext {
-                app_id: "rerun_test".into(),
-                blueprint: &self.blueprint_store,
-                default_blueprint: None,
-                recording: &self.recording_store,
-                bundle: &Default::default(),
-                hub: &Default::default(),
-            };
+                let store_context = StoreContext {
+                    app_id: "rerun_test".into(),
+                    blueprint: &self.blueprint_store,
+                    default_blueprint: None,
+                    recording: &self.recording_store,
+                    bundle: &Default::default(),
+                    hub: &Default::default(),
+                };
 
-            let rec_cfg = RecordingConfig::default();
-            rec_cfg.time_ctrl.write().set_timeline(self.active_timeline);
+                let rec_cfg = RecordingConfig::default();
+                rec_cfg.time_ctrl.write().set_timeline(self.active_timeline);
 
-            let egui_context = ui.ctx().clone();
-            let ctx = ViewerContext {
-                app_options: &Default::default(),
-                cache: &Default::default(),
-                reflection: &Default::default(),
-                component_ui_registry: &component_ui_registry,
-                space_view_class_registry: &self.space_view_class_registry,
-                store_context: &store_context,
-                applicable_entities_per_visualizer: &Default::default(),
-                indicated_entities_per_visualizer: &Default::default(),
-                query_results: &Default::default(),
-                rec_cfg: &rec_cfg,
-                blueprint_cfg: &Default::default(),
-                selection_state: &self.selection_state,
-                blueprint_query: &blueprint_query,
-                egui_ctx: &egui_context,
-                render_ctx: None,
-                command_sender: &command_sender,
-                focused_item: &None,
-            };
+                let egui_context = ui.ctx().clone();
+                let ctx = ViewerContext {
+                    app_options: &Default::default(),
+                    cache: &Default::default(),
+                    reflection: &Default::default(),
+                    component_ui_registry: &component_ui_registry,
+                    space_view_class_registry: &self.space_view_class_registry,
+                    store_context: &store_context,
+                    applicable_entities_per_visualizer: &Default::default(),
+                    indicated_entities_per_visualizer: &Default::default(),
+                    query_results: &Default::default(),
+                    rec_cfg: &rec_cfg,
+                    blueprint_cfg: &Default::default(),
+                    selection_state: &self.selection_state,
+                    blueprint_query: &blueprint_query,
+                    egui_ctx: &egui_context,
+                    render_ctx: None,
+                    command_sender: &command_sender,
+                    focused_item: &None,
+                };
 
-            let mut func = func;
-            func(&ctx, ui);
+                func(&ctx, ui);
+            });
         });
     }
 }

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -100,7 +100,7 @@ impl<'a> Viewport<'a> {
         let Viewport { blueprint, .. } = self;
 
         let is_zero_sized_viewport = ui.available_size().min_elem() <= 0.0;
-        if is_zero_sized_viewport {
+        if is_zero_sized_viewport || !ui.is_visible() {
             return;
         }
 
@@ -488,7 +488,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         };
 
         let is_zero_sized_viewport = ui.available_size().min_elem() <= 0.0;
-        if is_zero_sized_viewport {
+        if is_zero_sized_viewport || !ui.is_visible() {
             return Default::default();
         }
 

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -659,7 +659,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         &mut self,
         tiles: &egui_tiles::Tiles<SpaceViewId>,
         ui: &mut egui::Ui,
-        tile_id: egui_tiles::TileId,
+        _tile_id: egui_tiles::TileId,
         tabs: &egui_tiles::Tabs,
         _scroll_offset: &mut f32,
     ) {
@@ -703,7 +703,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
             .class(self.ctx.space_view_class_registry)
             .help_markdown(self.ctx.egui_ctx);
         ui.help_hover_button().on_hover_ui(|ui| {
-            ui.markdown_ui(ui.id().with(tile_id), &help_markdown);
+            ui.markdown_ui(&help_markdown);
         });
     }
 


### PR DESCRIPTION
### What
Uses the latest egui containing this gem:
* https://github.com/emilk/egui/pull/5059

So far `request_discard` (running a second pass) is only used in these situations:
* For when a `Grid` first shows up
* When an egui_table first shows up
* When asked to auto-size an `egui_table` row

Of course, running a second pass has some costs. Luckily, we already execute our most expensive stuff (the viewport) last, and so we can easily early-out from things like point cloud upload/rendering, as shown in this puffin-capture of a frame with two passes in it:

![image](https://github.com/user-attachments/assets/8fecdc38-191e-4396-afaf-61abaa06437d)

NOTE: this flamegraph is of a DEBUG build - the point is not the relative times, but that `pass 0` becomes very cheap, if the `request_discard` is called from one of the non-viewport panels (e.g. the selection panel).

There might still be cases where we do expensive stuff twice, e.g. if something calls `request_discard` in a space view tooltip.

If we come to regret this, we can disable all second passes by setting `egui::Options::max_passes` to `1`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7418?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7418?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7418)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.