### PR TITLE
Silence RUSTSEC-2023-0086

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,6 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
-  "RUSTSEC-2023-0081", # TODO(#5998): unmaintained crate "safemem" pulled in by "cargo-run-wasm"
   "RUSTSEC-2023-0086", # TODO(emilk): Waiting for https://github.com/apache/arrow-rs/pull/6401
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ all-features = true
 version = 2
 ignore = [
   "RUSTSEC-2023-0081", # TODO(#5998): unmaintained crate "safemem" pulled in by "cargo-run-wasm"
+  "RUSTSEC-2023-0086", # TODO(emilk): Waiting for https://github.com/apache/arrow-rs/pull/6401
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,7 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
-  "RUSTSEC-2023-0086", # TODO(emilk): Waiting for https://github.com/apache/arrow-rs/pull/6401
+  "RUSTSEC-2023-0086", # TODO(#3741): Waiting for https://github.com/apache/arrow-rs/pull/6401
 ]
 
 


### PR DESCRIPTION
### What
* Waiting for a proper fix in https://github.com/apache/arrow-rs/pull/6401
* Should be fixed before https://github.com/rerun-io/rerun/issues/3741 is considered finished

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7426?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7426?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7426)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.