### PR TITLE
Fix encoded image being suggested for non image blobs (like video)

### DIFF
--- a/crates/store/re_types/src/components/media_type_ext.rs
+++ b/crates/store/re_types/src/components/media_type_ext.rs
@@ -217,6 +217,11 @@ impl MediaType {
             }
         }
     }
+
+    /// Returns `true` if this is an image media type.
+    pub fn is_image(&self) -> bool {
+        self.as_str().starts_with("image/")
+    }
 }
 
 impl std::fmt::Display for MediaType {


### PR DESCRIPTION
### What

Before:
<img width="312" alt="image" src="https://github.com/user-attachments/assets/22dd1170-d81c-477e-9350-07957577a2a7">


After, the button is greyed out.

Made sure images still work fine by dragging in an image.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7428?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7428?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7428)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.