### PR TITLE
Codegen a nullptr check when forwarding from component to datatype

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -1505,7 +1505,13 @@ fn to_arrow_method(
         (
             true,
             quote! {
-                return Loggable<#forwarded_type>::to_arrow(&instances->#field_name, num_instances);
+                if (num_instances == 0) {
+                    return Loggable<#forwarded_type>::to_arrow(nullptr, 0);
+                } else if (instances == nullptr) {
+                    return rerun::Error(ErrorCode::UnexpectedNullArgument, "Passed array instances is null when num_elements > 0.");
+                } else {
+                    return Loggable<#forwarded_type>::to_arrow(&instances->#field_name, num_instances);
+                }
             },
         )
     } else {

--- a/rerun_cpp/src/rerun/blueprint/components/active_tab.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/active_tab.hpp
@@ -60,7 +60,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::ActiveTab* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::EntityPath>::to_arrow(&instances->tab, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(
+                    &instances->tab,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_layout.hpp
@@ -55,10 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::AutoLayout* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->auto_layout,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->auto_layout,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/auto_space_views.hpp
@@ -56,10 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::AutoSpaceViews* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->auto_space_views,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->auto_space_views,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/column_share.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/column_share.hpp
@@ -56,7 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::ColumnShare* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->share, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->share,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/grid_columns.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/grid_columns.hpp
@@ -56,7 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::GridColumns* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::UInt32>::to_arrow(&instances->columns, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::UInt32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::UInt32>::to_arrow(
+                    &instances->columns,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/included_content.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/included_content.hpp
@@ -63,10 +63,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::IncludedContent* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::EntityPath>::to_arrow(
-                &instances->contents,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(
+                    &instances->contents,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/included_space_view.hpp
@@ -58,10 +58,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::IncludedSpaceView* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Uuid>::to_arrow(
-                &instances->space_view_id,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(
+                    &instances->space_view_id,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/interactive.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/interactive.hpp
@@ -57,10 +57,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::Interactive* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->interactive,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->interactive,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/lock_range_during_zoom.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/lock_range_during_zoom.hpp
@@ -59,10 +59,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::LockRangeDuringZoom* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->lock_range,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->lock_range,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/query_expression.hpp
@@ -66,7 +66,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::QueryExpression* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->filter, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(
+                    &instances->filter,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/root_container.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/root_container.hpp
@@ -57,7 +57,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::RootContainer* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Uuid>::to_arrow(&instances->id, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(&instances->id, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/row_share.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/row_share.hpp
@@ -56,7 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::RowShare* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->share, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->share,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/space_view_class.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/space_view_class.hpp
@@ -57,7 +57,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::SpaceViewClass* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/space_view_maximized.hpp
@@ -58,10 +58,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::SpaceViewMaximized* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Uuid>::to_arrow(
-                &instances->space_view_id,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Uuid>::to_arrow(
+                    &instances->space_view_id,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/space_view_origin.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/space_view_origin.hpp
@@ -59,10 +59,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::SpaceViewOrigin* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::EntityPath>::to_arrow(
-                &instances->value,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/tensor_dimension_index_slider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/tensor_dimension_index_slider.hpp
@@ -65,10 +65,22 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::TensorDimensionIndexSlider* instances, size_t num_instances
         ) {
-            return Loggable<rerun::blueprint::datatypes::TensorDimensionIndexSlider>::to_arrow(
-                &instances->selection,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::blueprint::datatypes::TensorDimensionIndexSlider>::to_arrow(
+                    nullptr,
+                    0
+                );
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::blueprint::datatypes::TensorDimensionIndexSlider>::to_arrow(
+                    &instances->selection,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/timeline_name.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/timeline_name.hpp
@@ -57,7 +57,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::TimelineName* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/viewer_recommendation_hash.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/viewer_recommendation_hash.hpp
@@ -59,7 +59,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::ViewerRecommendationHash* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::UInt64>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::UInt64>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::UInt64>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/visible.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visible.hpp
@@ -55,7 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::Visible* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(&instances->visible, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->visible,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visible_time_range.hpp
@@ -54,10 +54,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::VisibleTimeRange* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::VisibleTimeRange>::to_arrow(
-                &instances->value,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::VisibleTimeRange>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::VisibleTimeRange>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/visual_bounds2d.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visual_bounds2d.hpp
@@ -51,10 +51,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::VisualBounds2D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Range2D>::to_arrow(
-                &instances->range2d,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Range2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Range2D>::to_arrow(
+                    &instances->range2d,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/blueprint/components/visualizer_overrides.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/visualizer_overrides.hpp
@@ -96,10 +96,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const blueprint::components::VisualizerOverrides* instances, size_t num_instances
         ) {
-            return Loggable<rerun::blueprint::datatypes::Utf8List>::to_arrow(
-                &instances->visualizers,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::blueprint::datatypes::Utf8List>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::blueprint::datatypes::Utf8List>::to_arrow(
+                    &instances->visualizers,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/albedo_factor.hpp
+++ b/rerun_cpp/src/rerun/components/albedo_factor.hpp
@@ -55,10 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AlbedoFactor* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Rgba32>::to_arrow(
-                &instances->albedo_factor,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Rgba32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Rgba32>::to_arrow(
+                    &instances->albedo_factor,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/axis_length.hpp
+++ b/rerun_cpp/src/rerun/components/axis_length.hpp
@@ -55,7 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AxisLength* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->length, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->length,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/blob.hpp
+++ b/rerun_cpp/src/rerun/components/blob.hpp
@@ -57,7 +57,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Blob* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Blob>::to_arrow(&instances->data, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Blob>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Blob>::to_arrow(&instances->data, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/class_id.hpp
+++ b/rerun_cpp/src/rerun/components/class_id.hpp
@@ -55,7 +55,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ClassId* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::ClassId>::to_arrow(&instances->id, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::ClassId>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::ClassId>::to_arrow(&instances->id, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
+++ b/rerun_cpp/src/rerun/components/clear_is_recursive.hpp
@@ -56,7 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ClearIsRecursive* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(&instances->recursive, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->recursive,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/color.hpp
+++ b/rerun_cpp/src/rerun/components/color.hpp
@@ -80,7 +80,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Color* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Rgba32>::to_arrow(&instances->rgba, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Rgba32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Rgba32>::to_arrow(
+                    &instances->rgba,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/depth_meter.hpp
+++ b/rerun_cpp/src/rerun/components/depth_meter.hpp
@@ -62,7 +62,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::DepthMeter* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/disconnected_space.hpp
+++ b/rerun_cpp/src/rerun/components/disconnected_space.hpp
@@ -66,10 +66,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::DisconnectedSpace* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->is_disconnected,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->is_disconnected,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/draw_order.hpp
+++ b/rerun_cpp/src/rerun/components/draw_order.hpp
@@ -60,7 +60,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::DrawOrder* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/entity_path.hpp
+++ b/rerun_cpp/src/rerun/components/entity_path.hpp
@@ -57,10 +57,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::EntityPath* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::EntityPath>::to_arrow(
-                &instances->value,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::EntityPath>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/fill_ratio.hpp
+++ b/rerun_cpp/src/rerun/components/fill_ratio.hpp
@@ -60,7 +60,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::FillRatio* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/gamma_correction.hpp
+++ b/rerun_cpp/src/rerun/components/gamma_correction.hpp
@@ -61,7 +61,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::GammaCorrection* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->gamma, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->gamma,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_size2d.hpp
+++ b/rerun_cpp/src/rerun/components/half_size2d.hpp
@@ -75,7 +75,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::HalfSize2D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->xy, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->xy, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/half_size3d.hpp
+++ b/rerun_cpp/src/rerun/components/half_size3d.hpp
@@ -79,7 +79,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::HalfSize3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->xyz, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->xyz, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/image_buffer.hpp
+++ b/rerun_cpp/src/rerun/components/image_buffer.hpp
@@ -67,7 +67,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ImageBuffer* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Blob>::to_arrow(&instances->buffer, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Blob>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Blob>::to_arrow(
+                    &instances->buffer,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/image_format.hpp
+++ b/rerun_cpp/src/rerun/components/image_format.hpp
@@ -65,10 +65,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ImageFormat* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::ImageFormat>::to_arrow(
-                &instances->image_format,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::ImageFormat>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::ImageFormat>::to_arrow(
+                    &instances->image_format,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/image_plane_distance.hpp
+++ b/rerun_cpp/src/rerun/components/image_plane_distance.hpp
@@ -58,10 +58,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ImagePlaneDistance* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(
-                &instances->image_from_camera,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->image_from_camera,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/keypoint_id.hpp
+++ b/rerun_cpp/src/rerun/components/keypoint_id.hpp
@@ -55,7 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::KeypointId* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::KeypointId>::to_arrow(&instances->id, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::KeypointId>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::KeypointId>::to_arrow(
+                    &instances->id,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/marker_size.hpp
+++ b/rerun_cpp/src/rerun/components/marker_size.hpp
@@ -55,7 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::MarkerSize* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/media_type.hpp
+++ b/rerun_cpp/src/rerun/components/media_type.hpp
@@ -138,7 +138,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::MediaType* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/name.hpp
+++ b/rerun_cpp/src/rerun/components/name.hpp
@@ -67,7 +67,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Name* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/opacity.hpp
+++ b/rerun_cpp/src/rerun/components/opacity.hpp
@@ -58,10 +58,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Opacity* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(
-                &instances->opacity,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->opacity,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pinhole_projection.hpp
+++ b/rerun_cpp/src/rerun/components/pinhole_projection.hpp
@@ -75,10 +75,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PinholeProjection* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Mat3x3>::to_arrow(
-                &instances->image_from_camera,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(
+                    &instances->image_from_camera,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/pose_rotation_axis_angle.hpp
@@ -51,10 +51,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PoseRotationAxisAngle* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(
-                &instances->rotation,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(
+                    &instances->rotation,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pose_rotation_quat.hpp
+++ b/rerun_cpp/src/rerun/components/pose_rotation_quat.hpp
@@ -51,10 +51,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PoseRotationQuat* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Quaternion>::to_arrow(
-                &instances->quaternion,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Quaternion>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Quaternion>::to_arrow(
+                    &instances->quaternion,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pose_scale3d.hpp
+++ b/rerun_cpp/src/rerun/components/pose_scale3d.hpp
@@ -83,7 +83,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PoseScale3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->scale, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(
+                    &instances->scale,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pose_transform_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/components/pose_transform_mat3x3.hpp
@@ -68,7 +68,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PoseTransformMat3x3* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Mat3x3>::to_arrow(&instances->matrix, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(
+                    &instances->matrix,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/pose_translation3d.hpp
+++ b/rerun_cpp/src/rerun/components/pose_translation3d.hpp
@@ -77,7 +77,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::PoseTranslation3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->vector, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(
+                    &instances->vector,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/position2d.hpp
+++ b/rerun_cpp/src/rerun/components/position2d.hpp
@@ -70,7 +70,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Position2D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->xy, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->xy, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/position3d.hpp
+++ b/rerun_cpp/src/rerun/components/position3d.hpp
@@ -74,7 +74,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Position3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->xyz, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->xyz, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/radius.hpp
+++ b/rerun_cpp/src/rerun/components/radius.hpp
@@ -79,7 +79,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Radius* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/range1d.hpp
+++ b/rerun_cpp/src/rerun/components/range1d.hpp
@@ -56,7 +56,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Range1D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Range1D>::to_arrow(&instances->range, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Range1D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Range1D>::to_arrow(
+                    &instances->range,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/resolution.hpp
+++ b/rerun_cpp/src/rerun/components/resolution.hpp
@@ -71,10 +71,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Resolution* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec2D>::to_arrow(
-                &instances->resolution,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(
+                    &instances->resolution,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
+++ b/rerun_cpp/src/rerun/components/rotation_axis_angle.hpp
@@ -50,10 +50,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::RotationAxisAngle* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(
-                &instances->rotation,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::RotationAxisAngle>::to_arrow(
+                    &instances->rotation,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/rotation_quat.hpp
+++ b/rerun_cpp/src/rerun/components/rotation_quat.hpp
@@ -51,10 +51,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::RotationQuat* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Quaternion>::to_arrow(
-                &instances->quaternion,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Quaternion>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Quaternion>::to_arrow(
+                    &instances->quaternion,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/scalar.hpp
+++ b/rerun_cpp/src/rerun/components/scalar.hpp
@@ -57,7 +57,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Scalar* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float64>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float64>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float64>::to_arrow(
+                    &instances->value,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/scale3d.hpp
+++ b/rerun_cpp/src/rerun/components/scale3d.hpp
@@ -83,7 +83,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Scale3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->scale, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(
+                    &instances->scale,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/show_labels.hpp
+++ b/rerun_cpp/src/rerun/components/show_labels.hpp
@@ -60,10 +60,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ShowLabels* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Bool>::to_arrow(
-                &instances->show_labels,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Bool>::to_arrow(
+                    &instances->show_labels,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/stroke_width.hpp
+++ b/rerun_cpp/src/rerun/components/stroke_width.hpp
@@ -55,7 +55,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::StrokeWidth* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Float32>::to_arrow(&instances->width, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                    &instances->width,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_data.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_data.hpp
@@ -78,10 +78,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TensorData* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::TensorData>::to_arrow(
-                &instances->data,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::TensorData>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::TensorData>::to_arrow(
+                    &instances->data,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_dimension_index_selection.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_dimension_index_selection.hpp
@@ -54,10 +54,22 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TensorDimensionIndexSelection* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::TensorDimensionIndexSelection>::to_arrow(
-                &instances->selection,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::TensorDimensionIndexSelection>::to_arrow(
+                    nullptr,
+                    0
+                );
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::TensorDimensionIndexSelection>::to_arrow(
+                    &instances->selection,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_height_dimension.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_height_dimension.hpp
@@ -52,10 +52,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TensorHeightDimension* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(
-                &instances->dimension,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(
+                    &instances->dimension,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/tensor_width_dimension.hpp
+++ b/rerun_cpp/src/rerun/components/tensor_width_dimension.hpp
@@ -52,10 +52,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TensorWidthDimension* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(
-                &instances->dimension,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::TensorDimensionSelection>::to_arrow(
+                    &instances->dimension,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/texcoord2d.hpp
+++ b/rerun_cpp/src/rerun/components/texcoord2d.hpp
@@ -85,7 +85,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Texcoord2D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->uv, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->uv, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/text.hpp
+++ b/rerun_cpp/src/rerun/components/text.hpp
@@ -67,7 +67,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Text* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/text_log_level.hpp
+++ b/rerun_cpp/src/rerun/components/text_log_level.hpp
@@ -94,7 +94,16 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TextLogLevel* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Utf8>::to_arrow(&instances->value, num_instances);
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/transform_mat3x3.hpp
+++ b/rerun_cpp/src/rerun/components/transform_mat3x3.hpp
@@ -68,7 +68,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TransformMat3x3* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Mat3x3>::to_arrow(&instances->matrix, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Mat3x3>::to_arrow(
+                    &instances->matrix,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/translation3d.hpp
+++ b/rerun_cpp/src/rerun/components/translation3d.hpp
@@ -77,7 +77,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Translation3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->vector, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(
+                    &instances->vector,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/triangle_indices.hpp
+++ b/rerun_cpp/src/rerun/components/triangle_indices.hpp
@@ -66,7 +66,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::TriangleIndices* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::UVec3D>::to_arrow(&instances->indices, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::UVec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::UVec3D>::to_arrow(
+                    &instances->indices,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector2d.hpp
+++ b/rerun_cpp/src/rerun/components/vector2d.hpp
@@ -73,7 +73,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Vector2D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec2D>::to_arrow(&instances->vector, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec2D>::to_arrow(
+                    &instances->vector,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/vector3d.hpp
+++ b/rerun_cpp/src/rerun/components/vector3d.hpp
@@ -77,7 +77,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::Vector3D* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::Vec3D>::to_arrow(&instances->vector, num_instances);
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::Vec3D>::to_arrow(
+                    &instances->vector,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/video_timestamp.hpp
+++ b/rerun_cpp/src/rerun/components/video_timestamp.hpp
@@ -85,10 +85,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::VideoTimestamp* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::VideoTimestamp>::to_arrow(
-                &instances->timestamp,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::VideoTimestamp>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::VideoTimestamp>::to_arrow(
+                    &instances->timestamp,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/src/rerun/components/view_coordinates.hpp
+++ b/rerun_cpp/src/rerun/components/view_coordinates.hpp
@@ -262,10 +262,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::ViewCoordinates* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::ViewCoordinates>::to_arrow(
-                &instances->coordinates,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::ViewCoordinates>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::ViewCoordinates>::to_arrow(
+                    &instances->coordinates,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer1.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer1* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
-                &instances->single_required,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
+                    &instances->single_required,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer14.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer14* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer3>::to_arrow(
-                &instances->single_required_union,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer3>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer3>::to_arrow(
+                    &instances->single_required_union,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer19.hpp
@@ -61,10 +61,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer19* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer5>::to_arrow(
-                &instances->just_a_table_nothing_shady,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer5>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer5>::to_arrow(
+                    &instances->just_a_table_nothing_shady,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer2.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer2* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
-                &instances->single_required,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
+                    &instances->single_required,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer20.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer20* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer20>::to_arrow(
-                &instances->nested_transparent,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer20>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer20>::to_arrow(
+                    &instances->nested_transparent,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer21.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer21* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer21>::to_arrow(
-                &instances->nested_halves,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer21>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer21>::to_arrow(
+                    &instances->nested_halves,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun

--- a/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/components/affix_fuzzer3.hpp
@@ -49,10 +49,19 @@ namespace rerun {
         static Result<std::shared_ptr<arrow::Array>> to_arrow(
             const components::AffixFuzzer3* instances, size_t num_instances
         ) {
-            return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
-                &instances->single_required,
-                num_instances
-            );
+            if (num_instances == 0) {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(nullptr, 0);
+            } else if (instances == nullptr) {
+                return rerun::Error(
+                    ErrorCode::UnexpectedNullArgument,
+                    "Passed array instances is null when num_elements> 0."
+                );
+            } else {
+                return Loggable<rerun::datatypes::AffixFuzzer1>::to_arrow(
+                    &instances->single_required,
+                    num_instances
+                );
+            }
         }
     };
 } // namespace rerun


### PR DESCRIPTION
### What
We already have a similar check in our builders, but when a component forwards to the datatype builder, we need a similar check.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7430?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7430?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7430)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.