### PR TITLE
Fix "no view state found" error

### DIFF
--- a/crates/viewer/re_viewer_context/src/space_view/view_states.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/view_states.rs
@@ -29,4 +29,10 @@ impl ViewStates {
             .or_insert_with(|| view_class.new_state())
             .as_mut()
     }
+
+    pub fn ensure_state_exists(&mut self, view_id: SpaceViewId, view_class: &dyn SpaceViewClass) {
+        self.states
+            .entry(view_id)
+            .or_insert_with(|| view_class.new_state());
+    }
 }

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -535,7 +535,8 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
                 });
             }
 
-            execute_systems_for_space_view(ctx, view, latest_at, self.view_states)
+            let class = space_view_blueprint.class(self.ctx.space_view_class_registry);
+            execute_systems_for_space_view(ctx, view, latest_at, self.view_states.get_mut_or_create(*view_id, class))
         });
 
         let class = space_view_blueprint.class(self.ctx.space_view_class_registry);


### PR DESCRIPTION
### What

Error log would often be observed on startup with existing blueprint.

Fairly sure this regressed due to
* https://github.com/rerun-io/rerun/pull/7409

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7432?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7432?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7432)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.