### PR TITLE
Dataframe view now has zebra stripes on every line

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/expanded_rows.rs
+++ b/crates/viewer/re_space_view_dataframe/src/expanded_rows.rs
@@ -101,6 +101,21 @@ impl<'a> ExpandedRows<'a> {
             + row_nr as f32 * self.row_height
     }
 
+    /// Returns whether the first line of the specified row is odd.
+    ///
+    /// This depends on how many additional lines the rows before have.
+    pub(crate) fn is_row_odd(&self, row_nr: u64) -> bool {
+        let total_lines = self
+            .cache
+            .expanded_rows
+            .range(0..row_nr)
+            .map(|(_, additional_lines)| *additional_lines)
+            .sum::<u64>()
+            + row_nr;
+
+        total_lines % 2 == 1
+    }
+
     /// Return by how many additional lines this row is expended.
     pub(crate) fn additional_lines_for_row(&self, row_nr: u64) -> u64 {
         self.cache.expanded_rows.get(&row_nr).copied().unwrap_or(0)

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -130,6 +130,9 @@ impl DesignTokens {
         // let floating_color = get_aliased_color(&json, "{Alias.Color.Surface.Floating.value}");
         let floating_color = get_global_color(&self.json, "{Global.Color.Grey.250}");
 
+        // For table zebra stripes.
+        egui_style.visuals.faint_bg_color = get_global_color(&self.json, "{Global.Color.Grey.150}");
+
         // Used as the background of text edits, scroll bars and others things
         // that needs to look different from other interactive stuff.
         // We need this very dark, since the theme overall is very, very dark.


### PR DESCRIPTION
### What

This PR adds zebra stripes to all dataframe view lines. Before, when a row was extend to show instances (#7400), those additional lines weren't striped. Also, the alternating colour is now a bit more visible.

<img width="1789" alt="image" src="https://github.com/user-attachments/assets/95da89a8-d132-4b10-97fd-4f2ce20f40bc">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7434?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7434?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7434)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.