### PR TITLE
In debug builds, spawn the binary at `target/debug/rerun`, if it exists

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -50,6 +50,9 @@ All Rust examples are set up as separate executables, so they can be run by spec
 cargo run -p dna
 ```
 
+They will either connect to an already running rerun viewer, or spawn a new one.
+In debug builds, it will spawn `target/debug/rerun` if it exists, otherwise look for `rerun` on `PATH`.
+
 
 ## Building and installing the Rerun Python SDK
 

--- a/crates/top/re_sdk/src/spawn.rs
+++ b/crates/top/re_sdk/src/spawn.rs
@@ -87,6 +87,15 @@ impl SpawnOptions {
             return path.to_owned();
         }
 
+        #[cfg(debug_assertions)]
+        {
+            let local_build_path = format!("target/debug/{RERUN_BINARY}");
+            if std::fs::metadata(&local_build_path).is_ok() {
+                re_log::info!("Spawning the locally built rerun at {local_build_path}");
+                return local_build_path;
+            }
+        }
+
         self.executable_name.clone()
     }
 }

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -7,6 +7,7 @@ These are examples of how to use the [`rerun`](https://github.com/rerun-io/rerun
 To try out any example in the list that follows, simply run `cargo run -p <example_name>`; e.g. `cargo run -p minimal`.
 
 By default, the examples spawn a Rerun Viewer and stream log data to it.
+In debug builds, they will spawn `target/debug/rerun` if it exists, otherwise look for `rerun` on `PATH`.
 
 You can instead save the log data to an `.rrd` file using `cargo run -p objectron -- --save data.rrd`. You can then open that `.rrd` file with `rerun data.rrd` or `cargo run -- data.rrd`.
 


### PR DESCRIPTION
### What
This makes it easier to test examples with the latest built viewer, without setting up a pixi environment or modifying `PATH`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7437?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7437?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7437)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.