### PR TITLE
Add a hook for views to add additional UI in the tab title bar

### DIFF
--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -181,7 +181,7 @@ pub trait SpaceViewClass: Send + Sync {
         Ok(())
     }
 
-    /// Addition UI displayed in the tab title bar, between the "maximize" and "help" buttons.
+    /// Additional UI displayed in the tab title bar, between the "maximize" and "help" buttons.
     ///
     /// Note: this is a right-to-left layout.
     fn extra_title_bar_ui(

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -1,4 +1,5 @@
 use nohash_hasher::IntSet;
+
 use re_entity_db::EntityDb;
 use re_log_types::EntityPath;
 use re_types::{ComponentName, SpaceViewClassIdentifier};
@@ -170,6 +171,20 @@ pub trait SpaceViewClass: Send + Sync {
 
     /// Ui shown when the user selects a space view of this class.
     fn selection_ui(
+        &self,
+        _ctx: &ViewerContext<'_>,
+        _ui: &mut egui::Ui,
+        _state: &mut dyn SpaceViewState,
+        _space_origin: &EntityPath,
+        _space_view_id: SpaceViewId,
+    ) -> Result<(), SpaceViewSystemExecutionError> {
+        Ok(())
+    }
+
+    /// Addition UI displayed in the tab title bar, between the "maximize" and "help" buttons.
+    ///
+    /// Note: this is a right-to-left layout.
+    fn extra_title_bar_ui(
         &self,
         _ctx: &ViewerContext<'_>,
         _ui: &mut egui::Ui,

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -670,7 +670,8 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
         };
         let space_view_id = *space_view_id;
 
-        let Some(space_view) = self.viewport_blueprint.space_views.get(&space_view_id) else {
+        let Some(space_view_blueprint) = self.viewport_blueprint.space_views.get(&space_view_id)
+        else {
             return;
         };
         let num_space_views = tiles.tiles().filter(|tile| tile.is_pane()).count();
@@ -698,9 +699,29 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
             }
         }
 
-        let help_markdown = space_view
-            .class(self.ctx.space_view_class_registry)
-            .help_markdown(self.ctx.egui_ctx);
+        let space_view_class = space_view_blueprint.class(self.ctx.space_view_class_registry);
+
+        // give the view a chance to display some extra UI in the top bar.
+        let view_state = self
+            .view_states
+            .get_mut_or_create(space_view_id, space_view_class);
+        space_view_class
+            .extra_title_bar_ui(
+                self.ctx,
+                ui,
+                view_state,
+                &space_view_blueprint.space_origin,
+                space_view_id,
+            )
+            .unwrap_or_else(|err| {
+                re_log::error!(
+                    "Error in space view UI (class: {}, display name: {}): {err}",
+                    space_view_blueprint.class_identifier(),
+                    space_view_class.display_name(),
+                );
+            });
+
+        let help_markdown = space_view_class.help_markdown(self.ctx.egui_ctx);
         ui.help_hover_button().on_hover_ui(|ui| {
             ui.markdown_ui(&help_markdown);
         });

--- a/crates/viewer/re_viewport/src/viewport.rs
+++ b/crates/viewer/re_viewport/src/viewport.rs
@@ -715,7 +715,7 @@ impl<'a, 'b> egui_tiles::Behavior<SpaceViewId> for TabViewer<'a, 'b> {
             )
             .unwrap_or_else(|err| {
                 re_log::error!(
-                    "Error in space view UI (class: {}, display name: {}): {err}",
+                    "Error in view title bar UI (class: {}, display name: {}): {err}",
                     space_view_blueprint.class_identifier(),
                     space_view_class.display_name(),
                 );


### PR DESCRIPTION
### What

Add a hook so views can have additional buttons in the title bar. Unblocks #4466.

Background: will be used for column show/hide UI of the dataframe UI. We had ample discussion on doing so, how different it is from other views, and on how we accept that (and eventually embrace that in other views). See eg this comment: https://github.com/rerun-io/rerun/issues/7067#issuecomment-2343699532


<img width="770" alt="image" src="https://github.com/user-attachments/assets/05a533ae-62cb-40ba-bfad-f5fb4fc94188">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7438?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7438?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7438)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.