### PR TITLE
Add a `attr.rust.no_placeholder` attribute to codegen 

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/reflection.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/reflection.rs
@@ -6,7 +6,7 @@ use quote::{format_ident, quote};
 
 use crate::{
     codegen::{autogen_warning, Target},
-    ObjectKind, Objects, Reporter, ATTR_RERUN_COMPONENT_REQUIRED,
+    ObjectKind, Objects, Reporter, ATTR_RERUN_COMPONENT_REQUIRED, ATTR_RUST_NO_PLACEHOLDER,
 };
 
 use super::util::{append_tokens, doc_as_lines};
@@ -111,11 +111,22 @@ fn generate_component_reflection(
             obj.is_experimental(),
         )
         .join("\n");
+
+        let placeholder = if obj.attrs.has(ATTR_RUST_NO_PLACEHOLDER) {
+            quote! {
+                None
+            }
+        } else {
+            quote! {
+                Some(#type_name::default().to_arrow()?)
+            }
+        };
+
         let quoted_reflection = quote! {
             ComponentReflection {
                 docstring_md: #docstring_md,
 
-                placeholder: Some(#type_name::default().to_arrow()?),
+                placeholder: #placeholder,
             }
         };
         quoted_pairs.push(quote! { (#quoted_name, #quoted_reflection) });

--- a/crates/build/re_types_builder/src/lib.rs
+++ b/crates/build/re_types_builder/src/lib.rs
@@ -199,6 +199,7 @@ pub const ATTR_RUST_NEW_PUB_CRATE: &str = "attr.rust.new_pub_crate";
 pub const ATTR_RUST_OVERRIDE_CRATE: &str = "attr.rust.override_crate";
 pub const ATTR_RUST_REPR: &str = "attr.rust.repr";
 pub const ATTR_RUST_TUPLE_STRUCT: &str = "attr.rust.tuple_struct";
+pub const ATTR_RUST_NO_PLACEHOLDER: &str = "attr.rust.no_placeholder";
 pub const ATTR_CPP_NO_FIELD_CTORS: &str = "attr.cpp.no_field_ctors";
 pub const ATTR_CPP_RENAME_FIELD: &str = "attr.cpp.rename_field";
 

--- a/crates/store/re_types/definitions/attributes/rust.fbs
+++ b/crates/store/re_types/definitions/attributes/rust.fbs
@@ -41,3 +41,9 @@ attribute "attr.rust.new_pub_crate";
 /// an object of kind `Blueprint` with `attr.rust.override_crate=re_viewport`, the final
 /// object will be generated in `re_viewport/src/blueprint`.
 attribute "attr.rust.override_crate";
+
+/// No reflection placeholder value will be generated for this component.
+///
+/// This enables the component to not `impl Default`. The drawback is that this may result in a
+/// `ComponentFallbackError::MissingPlaceholderValue` error when using this component with the fallback system.
+attribute "attr.rust.no_placeholder";


### PR DESCRIPTION
### What

This attribute sets the `placeholder` field of the component's reflection to `None` instead of `Some(C::default())`. This makes it possible for the component not to implement `Default`, but make it incompatible with the fallback system (this would trigger the exisiting `ComponentFallbackError::MissingPlaceholderValue` error).


### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7440?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7440?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7440)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.