### PR TITLE
Add a command palette action to reset egui's memory (debug build only)

### DIFF
--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -78,6 +78,9 @@ pub enum UICommand {
     #[cfg(not(target_arch = "wasm32"))]
     PrintPrimaryCache,
 
+    #[cfg(debug_assertions)]
+    ResetEguiMemory,
+
     #[cfg(target_arch = "wasm32")]
     CopyDirectLink,
 
@@ -232,6 +235,11 @@ impl UICommand {
                 "Prints the state of the entire primary cache to the console and clipboard. WARNING: this may be A LOT of text.",
             ),
 
+            #[cfg(debug_assertions)]
+            UICommand::ResetEguiMemory => (
+                "Reset egui memory",
+                "Reset egui memory, useful for debugging UI code.",
+            ),
 
             #[cfg(target_arch = "wasm32")]
             Self::CopyDirectLink => (
@@ -339,6 +347,9 @@ impl UICommand {
             Self::ClearPrimaryCache => None,
             #[cfg(not(target_arch = "wasm32"))]
             Self::PrintPrimaryCache => None,
+
+            #[cfg(debug_assertions)]
+            Self::ResetEguiMemory => None,
 
             #[cfg(target_arch = "wasm32")]
             Self::CopyDirectLink => None,

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -766,6 +766,14 @@ impl App {
                 }
             }
 
+            #[cfg(debug_assertions)]
+            UICommand::ResetEguiMemory => {
+                egui_ctx.memory_mut(|mem| *mem = Default::default());
+
+                // re-apply style, which is lost when resetting memory
+                re_ui::apply_style_and_install_loaders(egui_ctx);
+            }
+
             #[cfg(target_arch = "wasm32")]
             UICommand::CopyDirectLink => {
                 self.run_copy_direct_link_command(store_context);


### PR DESCRIPTION
### What

This command resets egui memory (and restore `re_ui` styling). Accessible from the command palette in debug build only.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
