### PR TITLE
Improve performance for scenes with many entities & transforms

### DIFF
--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -430,7 +430,8 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) -> Vec<Arc<Chunk>> {
-        self.query_id.fetch_add(1, Ordering::Relaxed);
+        // Don't do a profile scope here, this can have a lot of overhead when executing many small queries.
+        //re_tracing::profile_function!(format!("{query:?}"));
 
         // Reminder: if a chunk has been indexed for a given component, then it must contain at
         // least one non-null value for that column.
@@ -508,6 +509,9 @@ impl ChunkStore {
         query: &LatestAtQuery,
         temporal_chunk_ids_per_time: &ChunkIdSetPerTime,
     ) -> Option<Vec<Arc<Chunk>>> {
+        // Don't do a profile scope here, this can have a lot of overhead when executing many small queries.
+        //re_tracing::profile_function!();
+
         let upper_bound = temporal_chunk_ids_per_time
             .per_start_time
             .range(..=query.at())

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -430,8 +430,6 @@ impl ChunkStore {
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) -> Vec<Arc<Chunk>> {
-        re_tracing::profile_function!(format!("{query:?}"));
-
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
         // Reminder: if a chunk has been indexed for a given component, then it must contain at
@@ -510,8 +508,6 @@ impl ChunkStore {
         query: &LatestAtQuery,
         temporal_chunk_ids_per_time: &ChunkIdSetPerTime,
     ) -> Option<Vec<Arc<Chunk>>> {
-        re_tracing::profile_function!();
-
         let upper_bound = temporal_chunk_ids_per_time
             .per_start_time
             .range(..=query.at())

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -649,8 +649,6 @@ impl LatestAtCache {
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) -> Option<UnitChunkShared> {
-        re_tracing::profile_scope!("latest_at", format!("{component_name} @ {query:?}"));
-
         debug_assert_eq!(query.timeline(), self.cache_key.timeline);
 
         let Self {

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -649,6 +649,9 @@ impl LatestAtCache {
         entity_path: &EntityPath,
         component_name: ComponentName,
     ) -> Option<UnitChunkShared> {
+        // Don't do a profile scope here, this can have a lot of overhead when executing many small queries.
+        //re_tracing::profile_scope!("latest_at", format!("{component_name} @ {query:?}"));
+
         debug_assert_eq!(query.timeline(), self.cache_key.timeline);
 
         let Self {

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -529,16 +529,8 @@ fn query_and_resolve_tree_transform_at_entity(
     entity_path: &EntityPath,
     entity_db: &EntityDb,
     query: &LatestAtQuery,
+    transform3d_components: impl Iterator<Item = re_types::ComponentName>,
 ) -> Option<glam::Affine3A> {
-    let Some(transform3d_components) =
-        TransformComponentTracker::access(entity_db.store_id(), |tracker| {
-            tracker.transform3d_components(entity_path).cloned()
-        })
-        .flatten()
-    else {
-        return None;
-    };
-
     // TODO(#6743): Doesn't take into account overrides.
     let result = entity_db.latest_at(query, entity_path, transform3d_components);
     if result.components.is_empty() {
@@ -575,16 +567,8 @@ fn query_and_resolve_instance_poses_at_entity(
     entity_path: &EntityPath,
     entity_db: &EntityDb,
     query: &LatestAtQuery,
+    pose3d_components: impl Iterator<Item = re_types::ComponentName>,
 ) -> Vec<glam::Affine3A> {
-    let Some(pose3d_components) =
-        TransformComponentTracker::access(entity_db.store_id(), |tracker| {
-            tracker.pose3d_components(entity_path).cloned()
-        })
-        .flatten()
-    else {
-        return Vec::new();
-    };
-
     // TODO(#6743): Doesn't take into account overrides.
     let result = entity_db.latest_at(query, entity_path, pose3d_components);
 
@@ -726,6 +710,7 @@ fn query_and_resolve_obj_from_pinhole_image_plane(
 }
 
 /// Resolved transforms at an entity.
+#[derive(Default)]
 struct TransformsAtEntity {
     parent_from_entity_tree_transform: Option<glam::Affine3A>,
     entity_from_instance_poses: Vec<glam::Affine3A>,
@@ -741,23 +726,49 @@ fn transforms_at(
 ) -> Result<TransformsAtEntity, UnreachableTransformReason> {
     re_tracing::profile_function!();
 
-    let transforms_at_entity = TransformsAtEntity {
-        parent_from_entity_tree_transform: query_and_resolve_tree_transform_at_entity(
+    let potential_transform_components =
+        TransformComponentTracker::access(entity_db.store_id(), |tracker| {
+            tracker.potential_transform_components(entity_path).cloned()
+        })
+        .flatten()
+        .unwrap_or_default();
+
+    let parent_from_entity_tree_transform = if potential_transform_components.transform3d.is_empty()
+    {
+        None
+    } else {
+        query_and_resolve_tree_transform_at_entity(
             entity_path,
             entity_db,
             query,
-        ),
-        entity_from_instance_poses: query_and_resolve_instance_poses_at_entity(
+            potential_transform_components.transform3d.iter().copied(),
+        )
+    };
+    let entity_from_instance_poses = if potential_transform_components.pose3d.is_empty() {
+        Vec::new()
+    } else {
+        query_and_resolve_instance_poses_at_entity(
             entity_path,
             entity_db,
             query,
-        ),
-        instance_from_pinhole_image_plane: query_and_resolve_obj_from_pinhole_image_plane(
+            potential_transform_components.pose3d.iter().copied(),
+        )
+    };
+    let instance_from_pinhole_image_plane = if potential_transform_components.pinhole {
+        query_and_resolve_obj_from_pinhole_image_plane(
             entity_path,
             entity_db,
             query,
             pinhole_image_plane_distance,
-        ),
+        )
+    } else {
+        None
+    };
+
+    let transforms_at_entity = TransformsAtEntity {
+        parent_from_entity_tree_transform,
+        entity_from_instance_poses,
+        instance_from_pinhole_image_plane,
     };
 
     // Handle pinhole encounters.
@@ -773,13 +784,16 @@ fn transforms_at(
     }
 
     // If there is any other transform, we ignore `DisconnectedSpace`.
-    if transforms_at_entity
+    let no_other_transforms = transforms_at_entity
         .parent_from_entity_tree_transform
         .is_none()
         && transforms_at_entity.entity_from_instance_poses.is_empty()
         && transforms_at_entity
             .instance_from_pinhole_image_plane
-            .is_none()
+            .is_none();
+
+    if no_other_transforms
+        && potential_transform_components.disconnected_space
         && entity_db
             .latest_at_component::<DisconnectedSpace>(entity_path, query)
             .map_or(false, |(_index, res)| **res)


### PR DESCRIPTION
### What

Not super significant unfortunately, in one badly affected scene I went from ~130ms to ~110ms. It's probably better in those that aren't using any transforms at all.
We need to do some more general overhaul there and imho at that point we might as well start thinking more seriously about range queries for transforms. See among others:
* https://github.com/rerun-io/rerun/issues/7025
* https://github.com/rerun-io/rerun/issues/723

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7456?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7456?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide
* [x] run checklists & samples to check if transforms still work fine

- [PR Build Summary](https://build.rerun.io/pr/7456)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.