### PR TITLE
Allow showing the same videos at several timestamps at the same time

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/asset_video.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/asset_video.fbs
@@ -9,8 +9,7 @@ namespace rerun.archetypes;
 /// In order to display a video, you need to log a [archetypes.VideoFrameReference] for each frame.
 ///
 /// \example archetypes/video_auto_frames title="Video with automatically determined frames" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
-/// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
-// TODO(#7420): update screenshot for manual frames example
+/// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png"
 table AssetVideo (
   "attr.docs.unreleased",
   "attr.rerun.experimental"

--- a/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
@@ -6,8 +6,7 @@ namespace rerun.archetypes;
 /// To show an entire video, a fideo frame reference for each frame of the video should be logged.
 ///
 /// \example archetypes/video_auto_frames title="Video with automatically determined frames" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
-/// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png"
-// TODO(#7420): update screenshot for manual frames example
+/// \example archetypes/video_manual_frames title="Demonstrates manual use of video frame references" image="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png"
 table VideoFrameReference (
     "attr.docs.unreleased",
     "attr.rerun.experimental"

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -102,12 +102,12 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // Create two entities, showing the same video frozen at different times.
 ///     rec.log(
-///         "frame_at_one_second",
+///         "frame_1s",
 ///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///     rec.log(
-///         "frame_at_two_second",
+///         "frame_2s",
 ///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -102,13 +102,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // Create two entities, showing the same video frozen at different times.
 ///     rec.log(
-///         "frame_at_start",
-///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(0.0))
+///         "frame_at_one_second",
+///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///     rec.log(
-///         "frame_at_one_second",
-///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
+///         "frame_at_two_second",
+///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///
@@ -118,11 +118,11 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ```
 /// <center>
 /// <picture>
-///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-///   <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png" width="640">
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+///   <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png" width="640">
 /// </picture>
 /// </center>
 #[derive(Clone, Debug)]

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -99,12 +99,12 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // Create two entities, showing the same video frozen at different times.
 ///     rec.log(
-///         "frame_at_one_second",
+///         "frame_1s",
 ///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///     rec.log(
-///         "frame_at_two_second",
+///         "frame_2s",
 ///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -99,13 +99,13 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 ///     // Create two entities, showing the same video frozen at different times.
 ///     rec.log(
-///         "frame_at_start",
-///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(0.0))
+///         "frame_at_one_second",
+///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///     rec.log(
-///         "frame_at_one_second",
-///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
+///         "frame_at_two_second",
+///         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
 ///             .with_video_reference("video_asset"),
 ///     )?;
 ///
@@ -115,11 +115,11 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// ```
 /// <center>
 /// <picture>
-///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-///   <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png" width="640">
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+///   <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png" width="640">
 /// </picture>
 /// </center>
 #[derive(Clone, Debug)]

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -1,3 +1,4 @@
+use re_renderer::external::re_video::VideoLoadError;
 use re_types::components::{Blob, MediaType};
 use re_ui::{list_item::PropertyContent, UiExt};
 use re_viewer_context::UiLayout;
@@ -104,15 +105,10 @@ pub fn blob_preview_and_save_ui(
         image_preview_ui(ctx, ui, ui_layout, query, entity_path, image);
     }
     // Try to treat it as a video if treating it as image didn't work:
-    else if let Some(render_ctx) = ctx.render_ctx {
+    else {
         let video_result = blob_row_id.map(|row_id| {
             ctx.cache.entry(|c: &mut re_viewer_context::VideoCache| {
-                c.entry(
-                    row_id,
-                    blob,
-                    media_type.as_ref().map(|mt| mt.as_str()),
-                    render_ctx,
-                )
+                c.entry(row_id, blob, media_type.as_ref().map(|mt| mt.as_str()))
             })
         });
         if let Some(video_result) = &video_result {
@@ -161,7 +157,7 @@ pub fn blob_preview_and_save_ui(
 fn show_video_blob_info(
     ui: &mut egui::Ui,
     ui_layout: UiLayout,
-    video_result: &Result<re_renderer::video::Video, re_renderer::video::VideoError>,
+    video_result: &Result<re_renderer::video::Video, VideoLoadError>,
 ) {
     match video_result {
         Ok(video) => {

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -527,7 +527,7 @@ pub struct ActiveFrameContext {
     /// This counter is part of the `content timeline` and may be arbitrarily
     /// behind both of the `device timeline` and `queue timeline`.
     /// See <https://www.w3.org/TR/webgpu/#programming-model-timelines>
-    frame_index: u64,
+    pub frame_index: u64,
 
     /// Top level device error scope, created at startup and closed & reopened on every frame.
     ///

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -475,6 +475,11 @@ This means, either a call to RenderContext::before_submit was omitted, or the pr
     pub(crate) fn read_lock_renderers(&self) -> RwLockReadGuard<'_, Renderers> {
         self.renderers.read()
     }
+
+    /// Returns the global frame index of the active frame.
+    pub fn active_frame_idx(&self) -> u64 {
+        self.active_frame.frame_index
+    }
 }
 
 pub struct FrameGlobalCommandEncoder(Option<wgpu::CommandEncoder>);

--- a/crates/viewer/re_renderer/src/lib.rs
+++ b/crates/viewer/re_renderer/src/lib.rs
@@ -88,6 +88,7 @@ pub use self::file_server::FileServer;
 pub use ecolor::{Color32, Hsva, Rgba};
 
 pub mod external {
+    pub use re_video;
     pub use wgpu;
 }
 

--- a/crates/viewer/re_renderer/src/video/decoder/native.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/native.rs
@@ -38,7 +38,11 @@ impl VideoDecoder {
     }
 
     #[allow(clippy::unused_self)]
-    pub fn frame_at(&mut self, timestamp_s: f64) -> FrameDecodingResult {
+    pub fn frame_at(
+        &mut self,
+        _render_ctx: &RenderContext,
+        _timestamp_s: f64,
+    ) -> FrameDecodingResult {
         FrameDecodingResult::Error(DecodingError::NoNativeSupport)
     }
 }

--- a/crates/viewer/re_renderer/src/video/decoder/web.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/web.rs
@@ -13,7 +13,7 @@ use super::latest_at_idx;
 use crate::{
     resource_managers::GpuTexture2D,
     video::{DecodingError, FrameDecodingResult},
-    RenderContext,
+    DebugLabel, RenderContext,
 };
 
 #[derive(Clone)]
@@ -55,6 +55,8 @@ pub struct VideoDecoder {
     last_used_frame_timestamp: Time,
     current_segment_idx: usize,
     current_sample_idx: usize,
+
+    error_on_last_frame_at: bool,
 }
 
 // SAFETY: There is no way to access the same JS object from different OS threads
@@ -132,10 +134,40 @@ impl VideoDecoder {
             last_used_frame_timestamp: Time::new(u64::MAX),
             current_segment_idx: usize::MAX,
             current_sample_idx: usize::MAX,
+
+            error_on_last_frame_at: false,
         })
     }
 
-    pub fn frame_at(&mut self, timestamp_s: f64) -> FrameDecodingResult {
+    pub fn frame_at(
+        &mut self,
+        render_ctx: &RenderContext,
+        timestamp_s: f64,
+    ) -> FrameDecodingResult {
+        let result = self.decode_frame_at(timestamp_s);
+        match &result {
+            FrameDecodingResult::Ready(_) => {
+                self.error_on_last_frame_at = false;
+            }
+            FrameDecodingResult::Pending(_) => {
+                if self.error_on_last_frame_at {
+                    // If we switched from error to pending, clear the texture.
+                    // This is important to avoid flickering, in particular when switching from
+                    // benign errors like DecodingError::NegativeTimestamp.
+                    // If we don't do this, we see the last valid texture which can look really weird.
+                    self.clear_video_texture(render_ctx);
+                }
+
+                self.error_on_last_frame_at = false;
+            }
+            FrameDecodingResult::Error(_) => {
+                self.error_on_last_frame_at = true;
+            }
+        }
+        result
+    }
+
+    fn decode_frame_at(&mut self, timestamp_s: f64) -> FrameDecodingResult {
         if timestamp_s < 0.0 {
             return FrameDecodingResult::Error(DecodingError::NegativeTimestamp);
         }
@@ -232,6 +264,30 @@ impl VideoDecoder {
         }
 
         FrameDecodingResult::Ready(self.texture.clone())
+    }
+
+    /// Clears the texture that is shown on pending to black.
+    fn clear_video_texture(&self, render_ctx: &RenderContext) {
+        // Clear texture is a native only feature, so let's not do that.
+        // before_view_builder_encoder.clear_texture(texture, subresource_range);
+
+        // But our target is also a render target, so just create a dummy renderpass with clear.
+        let mut before_view_builder_encoder =
+            render_ctx.active_frame.before_view_builder_encoder.lock();
+        let _ = before_view_builder_encoder
+            .get()
+            .begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: DebugLabel::from("clear_video_texture").get(),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &self.texture.default_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations::<wgpu::Color> {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                ..Default::default()
+            });
     }
 
     /// Enqueue all samples in the given segment.

--- a/crates/viewer/re_renderer/src/video/decoder/web.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/web.rs
@@ -145,7 +145,7 @@ impl VideoDecoder {
         render_ctx: &RenderContext,
         timestamp_s: f64,
     ) -> FrameDecodingResult {
-        let result = self.decode_frame_at(timestamp_s);
+        let result = self.frame_at_internal(timestamp_s);
         match &result {
             FrameDecodingResult::Ready(_) => {
                 self.error_on_last_frame_at = false;
@@ -168,7 +168,7 @@ impl VideoDecoder {
         result
     }
 
-    fn decode_frame_at(&mut self, timestamp_s: f64) -> FrameDecodingResult {
+    fn frame_at_internal(&mut self, timestamp_s: f64) -> FrameDecodingResult {
         if timestamp_s < 0.0 {
             return FrameDecodingResult::Error(DecodingError::NegativeTimestamp);
         }

--- a/crates/viewer/re_renderer/src/video/decoder/web.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/web.rs
@@ -81,6 +81,7 @@ unsafe impl Sync for VideoFrame {}
 
 impl Drop for VideoDecoder {
     fn drop(&mut self) {
+        re_log::debug!("Dropping VideoDecoder");
         if let Err(err) = self.decoder.close() {
             re_log::warn!(
                 "Error when closing video decoder: {}",

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -52,7 +52,9 @@ pub enum FrameDecodingResult {
 ///
 /// A single video may use several decoders at a time to simultaneously decode frames at different timestamps.
 /// The id does not need to be globally unique, just unique enough to distinguish streams of the same video.
-pub type VideoDecodingStreamId = u64;
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+
+pub struct VideoDecodingStreamId(pub u64);
 
 struct DecoderEntry {
     decoder: decoder::VideoDecoder,

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -150,7 +150,7 @@ impl Video {
 
     /// Removes all decoders that have been unused in the last frame.
     ///
-    /// Decoders are very memory intensive, so they should be cleaned up as soon they're no longer neede.
+    /// Decoders are very memory intensive, so they should be cleaned up as soon they're no longer needed.
     pub fn purge_unused_decoders(&self, active_frame_idx: u64) {
         if active_frame_idx == 0 {
             return;

--- a/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
@@ -71,8 +71,6 @@ impl MeshCache {
 }
 
 impl Cache for MeshCache {
-    fn begin_frame(&mut self) {}
-
     fn purge_memory(&mut self) {
         self.0.clear();
     }

--- a/crates/viewer/re_space_view_spatial/src/proc_mesh.rs
+++ b/crates/viewer/re_space_view_spatial/src/proc_mesh.rs
@@ -119,8 +119,6 @@ impl WireframeCache {
 }
 
 impl Cache for WireframeCache {
-    fn begin_frame(&mut self) {}
-
     fn purge_memory(&mut self) {
         self.0.clear();
     }
@@ -250,8 +248,6 @@ impl SolidCache {
 }
 
 impl Cache for SolidCache {
-    fn begin_frame(&mut self) {}
-
     fn purge_memory(&mut self) {
         self.0.clear();
     }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -157,8 +157,9 @@ impl VideoFrameReferenceVisualizer {
             return;
         };
 
-        let decode_stream_id: re_renderer::video::VideoDecodingStreamId =
-            Hash64::hash((entity_path.hash(), view_id)).hash64();
+        let decode_stream_id = re_renderer::video::VideoDecodingStreamId(
+            Hash64::hash((entity_path.hash(), view_id)).hash64(),
+        );
 
         // Follow the reference to the video asset.
         let video_reference = video_references

--- a/crates/viewer/re_viewer_context/src/cache/caches.rs
+++ b/crates/viewer/re_viewer_context/src/cache/caches.rs
@@ -9,6 +9,8 @@ pub struct Caches(Mutex<HashMap<TypeId, Box<dyn Cache>>>);
 
 impl Caches {
     /// Call once per frame to potentially flush the cache(s).
+    ///
+    /// `renderer_active_frame_idx`: The global frame index as reported by [`re_renderer::RenderContext::active_frame_idx`].
     pub fn begin_frame(&self, renderer_active_frame_idx: u64) {
         re_tracing::profile_function!();
         for cache in self.0.lock().values_mut() {
@@ -43,6 +45,8 @@ impl Caches {
 /// A cache for memoizing things in order to speed up immediate mode UI & other immediate mode style things.
 pub trait Cache: std::any::Any + Send + Sync {
     /// Called once per frame to potentially flush the cache.
+    ///
+    /// `_renderer_active_frame_idx`: The global frame index as reported by [`re_renderer::RenderContext::active_frame_idx`].
     fn begin_frame(&mut self, _renderer_active_frame_idx: u64) {}
 
     /// Attempt to free up memory.

--- a/crates/viewer/re_viewer_context/src/cache/caches.rs
+++ b/crates/viewer/re_viewer_context/src/cache/caches.rs
@@ -9,10 +9,10 @@ pub struct Caches(Mutex<HashMap<TypeId, Box<dyn Cache>>>);
 
 impl Caches {
     /// Call once per frame to potentially flush the cache(s).
-    pub fn begin_frame(&self) {
+    pub fn begin_frame(&self, renderer_active_frame_idx: u64) {
         re_tracing::profile_function!();
         for cache in self.0.lock().values_mut() {
-            cache.begin_frame();
+            cache.begin_frame(renderer_active_frame_idx);
         }
     }
 
@@ -43,7 +43,7 @@ impl Caches {
 /// A cache for memoizing things in order to speed up immediate mode UI & other immediate mode style things.
 pub trait Cache: std::any::Any + Send + Sync {
     /// Called once per frame to potentially flush the cache.
-    fn begin_frame(&mut self);
+    fn begin_frame(&mut self, _renderer_active_frame_idx: u64) {}
 
     /// Attempt to free up memory.
     fn purge_memory(&mut self);

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -98,7 +98,7 @@ fn decode_image(
 }
 
 impl Cache for ImageDecodeCache {
-    fn begin_frame(&mut self) {
+    fn begin_frame(&mut self, _renderer_active_frame_idx: u64) {
         #[cfg(not(target_arch = "wasm32"))]
         let max_decode_cache_use = 4_000_000_000;
 

--- a/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
@@ -17,8 +17,6 @@ impl ImageStatsCache {
 }
 
 impl Cache for ImageStatsCache {
-    fn begin_frame(&mut self) {}
-
     fn purge_memory(&mut self) {
         // Purging the image stats is not worth it - these are very small objects!
     }

--- a/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
@@ -22,8 +22,6 @@ impl TensorStatsCache {
 }
 
 impl Cache for TensorStatsCache {
-    fn begin_frame(&mut self) {}
-
     fn purge_memory(&mut self) {
         // Purging the tensor stats is not worth it - these are very small objects!
     }

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -1,10 +1,7 @@
 use crate::Cache;
 use re_chunk::RowId;
 use re_log_types::hash::Hash64;
-use re_renderer::{
-    video::{Video, VideoError},
-    RenderContext,
-};
+use re_renderer::{external::re_video::VideoLoadError, video::Video};
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -17,7 +14,7 @@ struct Entry {
     used_this_frame: AtomicBool,
 
     /// Keeps failed loads around, so we can don't try again and again.
-    video: Arc<Result<Video, VideoError>>,
+    video: Arc<Result<Video, VideoLoadError>>,
 }
 
 /// Caches meshes based on media type & row id.
@@ -35,14 +32,13 @@ impl VideoCache {
         row_id: RowId,
         video_data: &re_types::datatypes::Blob,
         media_type: Option<&str>,
-        render_ctx: &RenderContext,
-    ) -> Arc<Result<Video, VideoError>> {
+    ) -> Arc<Result<Video, VideoLoadError>> {
         re_tracing::profile_function!();
 
         let key = Hash64::hash((row_id, media_type));
 
         let entry = self.0.entry(key).or_insert_with(|| {
-            let video = Video::load(render_ctx, video_data, media_type);
+            let video = Video::load(video_data, media_type);
             Entry {
                 used_this_frame: AtomicBool::new(true),
                 video: Arc::new(video),

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -54,9 +54,12 @@ impl VideoCache {
 }
 
 impl Cache for VideoCache {
-    fn begin_frame(&mut self) {
+    fn begin_frame(&mut self, renderer_active_frame_idx: u64) {
         for v in self.0.values() {
             v.used_this_frame.store(false, Ordering::Release);
+            if let Ok(video) = v.video.as_ref() {
+                video.purge_unused_decoders(renderer_active_frame_idx);
+            }
         }
     }
 

--- a/docs/content/reference/types/archetypes/asset_video.md
+++ b/docs/content/reference/types/archetypes/asset_video.md
@@ -44,10 +44,10 @@ snippet: archetypes/video_auto_frames
 snippet: archetypes/video_manual_frames
 
 <picture data-inline-viewer="snippets/video_manual_frames">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-  <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+  <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png">
 </picture>
 

--- a/docs/content/reference/types/archetypes/video_frame_reference.md
+++ b/docs/content/reference/types/archetypes/video_frame_reference.md
@@ -41,10 +41,10 @@ snippet: archetypes/video_auto_frames
 snippet: archetypes/video_manual_frames
 
 <picture data-inline-viewer="snippets/video_manual_frames">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-  <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+  <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png">
 </picture>
 

--- a/docs/snippets/all/archetypes/video_manual_frames.cpp
+++ b/docs/snippets/all/archetypes/video_manual_frames.cpp
@@ -23,14 +23,8 @@ int main(int argc, char* argv[]) {
     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
 
     // Create two entities, showing the same video frozen at different times.
-    rec.log(
-        "frame_at_one_second",
-        rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
-    );
-    rec.log(
-        "frame_at_two_second",
-        rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
-    );
+    rec.log("frame_1s", rerun::VideoFrameReference(1.0s).with_video_reference("video_asset"));
+    rec.log("frame_2s", rerun::VideoFrameReference(2.0s).with_video_reference("video_asset"));
 
     // TODO(#5520): log blueprint once supported
 }

--- a/docs/snippets/all/archetypes/video_manual_frames.cpp
+++ b/docs/snippets/all/archetypes/video_manual_frames.cpp
@@ -1,6 +1,5 @@
 // Log a video asset using manually created frame references.
 // TODO(#7298): ⚠️ Video is currently only supported in the Rerun web viewer.
-// TODO(#7420): This sample doesn't render yet.
 
 #include <rerun.hpp>
 
@@ -24,10 +23,13 @@ int main(int argc, char* argv[]) {
     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
 
     // Create two entities, showing the same video frozen at different times.
-    rec.log("frame_at_start", rerun::VideoFrameReference(0.0s).with_video_reference("video_asset"));
     rec.log(
         "frame_at_one_second",
         rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
+    );
+    rec.log(
+        "frame_at_two_second",
+        rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
     );
 
     // TODO(#5520): log blueprint once supported

--- a/docs/snippets/all/archetypes/video_manual_frames.py
+++ b/docs/snippets/all/archetypes/video_manual_frames.py
@@ -18,14 +18,14 @@ rr.log("video_asset", rr.AssetVideo(path=sys.argv[1]), static=True)
 
 # Create two entities, showing the same video frozen at different times.
 rr.log(
-    "frame_at_one_second",
+    "frame_1s",
     rr.VideoFrameReference(
         timestamp=rr.components.VideoTimestamp(seconds=1.0),
         video_reference="video_asset",
     ),
 )
 rr.log(
-    "frame_at_two_second",
+    "frame_2s",
     rr.VideoFrameReference(
         timestamp=rr.components.VideoTimestamp(seconds=2.0),
         video_reference="video_asset",
@@ -33,6 +33,4 @@ rr.log(
 )
 
 # Send blueprint that shows two 2D views next to each other.
-rr.send_blueprint(
-    rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
-)
+rr.send_blueprint(rrb.Horizontal(rrb.Spatial2DView(origin="frame_1s"), rrb.Spatial2DView(origin="frame_2s")))

--- a/docs/snippets/all/archetypes/video_manual_frames.py
+++ b/docs/snippets/all/archetypes/video_manual_frames.py
@@ -1,6 +1,5 @@
 """Manual use of individual video frame references."""
 # TODO(#7298): ⚠️ Video is currently only supported in the Rerun web viewer.
-# TODO(#7420): This sample doesn't render yet.
 
 import sys
 
@@ -19,21 +18,21 @@ rr.log("video_asset", rr.AssetVideo(path=sys.argv[1]), static=True)
 
 # Create two entities, showing the same video frozen at different times.
 rr.log(
-    "frame_at_start",
-    rr.VideoFrameReference(
-        timestamp=rr.components.VideoTimestamp(seconds=0.0),
-        video_reference="video_asset",
-    ),
-)
-rr.log(
     "frame_at_one_second",
     rr.VideoFrameReference(
         timestamp=rr.components.VideoTimestamp(seconds=1.0),
         video_reference="video_asset",
     ),
 )
+rr.log(
+    "frame_at_two_second",
+    rr.VideoFrameReference(
+        timestamp=rr.components.VideoTimestamp(seconds=2.0),
+        video_reference="video_asset",
+    ),
+)
 
 # Send blueprint that shows two 2D views next to each other.
 rr.send_blueprint(
-    rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_start"), rrb.Spatial2DView(origin="frame_at_one_second"))
+    rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
 )

--- a/docs/snippets/all/archetypes/video_manual_frames.rs
+++ b/docs/snippets/all/archetypes/video_manual_frames.rs
@@ -1,6 +1,5 @@
 //! Log a video asset using manually created frame references.
 //! TODO(#7298): ⚠️ Video is currently only supported in the Rerun web viewer.
-//! TODO(#7420): This sample doesn't render yet.
 
 use rerun::external::anyhow;
 
@@ -19,13 +18,13 @@ fn main() -> anyhow::Result<()> {
 
     // Create two entities, showing the same video frozen at different times.
     rec.log(
-        "frame_at_start",
-        &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(0.0))
+        "frame_at_one_second",
+        &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
             .with_video_reference("video_asset"),
     )?;
     rec.log(
-        "frame_at_one_second",
-        &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
+        "frame_at_two_second",
+        &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
             .with_video_reference("video_asset"),
     )?;
 

--- a/docs/snippets/all/archetypes/video_manual_frames.rs
+++ b/docs/snippets/all/archetypes/video_manual_frames.rs
@@ -18,12 +18,12 @@ fn main() -> anyhow::Result<()> {
 
     // Create two entities, showing the same video frozen at different times.
     rec.log(
-        "frame_at_one_second",
+        "frame_1s",
         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(1.0))
             .with_video_reference("video_asset"),
     )?;
     rec.log(
-        "frame_at_two_second",
+        "frame_2s",
         &rerun::VideoFrameReference::new(rerun::components::VideoTimestamp::from_seconds(2.0))
             .with_video_reference("video_asset"),
     )?;

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -195,7 +195,6 @@ quick_start = [ # These examples don't have exactly the same implementation.
 "archetypes/video_auto_frames" = [
   "$config_dir/../../tests/assets/video/Big_Buck_Bunny_1080_10s_av1.mp4",
 ]
-# TODO(#7420): This sample doesn't render yet. Once it does it would be nice to have a video that looks significantly different after 1s.
 "archetypes/video_manual_frames" = [
-  "$config_dir/../../tests/assets/video/Big_Buck_Bunny_1080_10s_av1.mp4",
+  "$config_dir/../../tests/assets/video/Sintel_1080_10s_av1.mp4",
 ]

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -83,7 +83,7 @@ namespace rerun::archetypes {
     /// ```
     ///
     /// ### Demonstrates manual use of video frame references
-    /// ![image](https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png)
+    /// ![image](https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png)
     ///
     /// ```cpp
     /// #include <rerun.hpp>
@@ -108,10 +108,13 @@ namespace rerun::archetypes {
     ///     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
     ///
     ///     // Create two entities, showing the same video frozen at different times.
-    ///     rec.log("frame_at_start", rerun::VideoFrameReference(0.0s).with_video_reference("video_asset"));
     ///     rec.log(
     ///         "frame_at_one_second",
     ///         rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
+    ///     );
+    ///     rec.log(
+    ///         "frame_at_two_second",
+    ///         rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
     ///     );
     ///
     ///     // TODO(#5520): log blueprint once supported

--- a/rerun_cpp/src/rerun/archetypes/asset_video.hpp
+++ b/rerun_cpp/src/rerun/archetypes/asset_video.hpp
@@ -108,14 +108,8 @@ namespace rerun::archetypes {
     ///     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
     ///
     ///     // Create two entities, showing the same video frozen at different times.
-    ///     rec.log(
-    ///         "frame_at_one_second",
-    ///         rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
-    ///     );
-    ///     rec.log(
-    ///         "frame_at_two_second",
-    ///         rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
-    ///     );
+    ///     rec.log("frame_1s", rerun::VideoFrameReference(1.0s).with_video_reference("video_asset"));
+    ///     rec.log("frame_2s", rerun::VideoFrameReference(2.0s).with_video_reference("video_asset"));
     ///
     ///     // TODO(#5520): log blueprint once supported
     /// }

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -78,7 +78,7 @@ namespace rerun::archetypes {
     /// ```
     ///
     /// ### Demonstrates manual use of video frame references
-    /// ![image](https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png)
+    /// ![image](https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png)
     ///
     /// ```cpp
     /// #include <rerun.hpp>
@@ -103,10 +103,13 @@ namespace rerun::archetypes {
     ///     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
     ///
     ///     // Create two entities, showing the same video frozen at different times.
-    ///     rec.log("frame_at_start", rerun::VideoFrameReference(0.0s).with_video_reference("video_asset"));
     ///     rec.log(
     ///         "frame_at_one_second",
     ///         rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
+    ///     );
+    ///     rec.log(
+    ///         "frame_at_two_second",
+    ///         rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
     ///     );
     ///
     ///     // TODO(#5520): log blueprint once supported

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -103,14 +103,8 @@ namespace rerun::archetypes {
     ///     rec.log_static("video_asset", rerun::AssetVideo::from_file(path).value_or_throw());
     ///
     ///     // Create two entities, showing the same video frozen at different times.
-    ///     rec.log(
-    ///         "frame_at_one_second",
-    ///         rerun::VideoFrameReference(1.0s).with_video_reference("video_asset")
-    ///     );
-    ///     rec.log(
-    ///         "frame_at_two_second",
-    ///         rerun::VideoFrameReference(2.0s).with_video_reference("video_asset")
-    ///     );
+    ///     rec.log("frame_1s", rerun::VideoFrameReference(1.0s).with_video_reference("video_asset"));
+    ///     rec.log("frame_2s", rerun::VideoFrameReference(2.0s).with_video_reference("video_asset"));
     ///
     ///     // TODO(#5520): log blueprint once supported
     /// }

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -90,14 +90,14 @@ class AssetVideo(AssetVideoExt, Archetype):
 
     # Create two entities, showing the same video frozen at different times.
     rr.log(
-        "frame_at_one_second",
+        "frame_1s",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=1.0),
             video_reference="video_asset",
         ),
     )
     rr.log(
-        "frame_at_two_second",
+        "frame_2s",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=2.0),
             video_reference="video_asset",
@@ -105,9 +105,7 @@ class AssetVideo(AssetVideoExt, Archetype):
     )
 
     # Send blueprint that shows two 2D views next to each other.
-    rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
-    )
+    rr.send_blueprint(rrb.Horizontal(rrb.Spatial2DView(origin="frame_1s"), rrb.Spatial2DView(origin="frame_2s")))
     ```
     <center>
     <picture>

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video.py
@@ -72,7 +72,6 @@ class AssetVideo(AssetVideoExt, Archetype):
     ### Demonstrates manual use of video frame references:
     ```python
     # TODO(#7298): ⚠️ Video is currently only supported in the Rerun web viewer.
-    # TODO(#7420): This sample doesn't render yet.
 
     import sys
 
@@ -91,32 +90,32 @@ class AssetVideo(AssetVideoExt, Archetype):
 
     # Create two entities, showing the same video frozen at different times.
     rr.log(
-        "frame_at_start",
-        rr.VideoFrameReference(
-            timestamp=rr.components.VideoTimestamp(seconds=0.0),
-            video_reference="video_asset",
-        ),
-    )
-    rr.log(
         "frame_at_one_second",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=1.0),
             video_reference="video_asset",
         ),
     )
+    rr.log(
+        "frame_at_two_second",
+        rr.VideoFrameReference(
+            timestamp=rr.components.VideoTimestamp(seconds=2.0),
+            video_reference="video_asset",
+        ),
+    )
 
     # Send blueprint that shows two 2D views next to each other.
     rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_start"), rrb.Spatial2DView(origin="frame_at_one_second"))
+        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
     )
     ```
     <center>
     <picture>
-      <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-      <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-      <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png" width="640">
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+      <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png" width="640">
     </picture>
     </center>
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -71,7 +71,6 @@ class VideoFrameReference(Archetype):
     ### Demonstrates manual use of video frame references:
     ```python
     # TODO(#7298): ⚠️ Video is currently only supported in the Rerun web viewer.
-    # TODO(#7420): This sample doesn't render yet.
 
     import sys
 
@@ -90,32 +89,32 @@ class VideoFrameReference(Archetype):
 
     # Create two entities, showing the same video frozen at different times.
     rr.log(
-        "frame_at_start",
-        rr.VideoFrameReference(
-            timestamp=rr.components.VideoTimestamp(seconds=0.0),
-            video_reference="video_asset",
-        ),
-    )
-    rr.log(
         "frame_at_one_second",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=1.0),
             video_reference="video_asset",
         ),
     )
+    rr.log(
+        "frame_at_two_second",
+        rr.VideoFrameReference(
+            timestamp=rr.components.VideoTimestamp(seconds=2.0),
+            video_reference="video_asset",
+        ),
+    )
 
     # Send blueprint that shows two 2D views next to each other.
     rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_start"), rrb.Spatial2DView(origin="frame_at_one_second"))
+        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
     )
     ```
     <center>
     <picture>
-      <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/480w.png">
-      <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/768w.png">
-      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1024w.png">
-      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/1200w.png">
-      <img src="https://static.rerun.io/video_manual_frames/320a44e1e06b8b3a3161ecbbeae3e04d1ccb9589/full.png" width="640">
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png">
+      <img src="https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/full.png" width="640">
     </picture>
     </center>
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -89,14 +89,14 @@ class VideoFrameReference(Archetype):
 
     # Create two entities, showing the same video frozen at different times.
     rr.log(
-        "frame_at_one_second",
+        "frame_1s",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=1.0),
             video_reference="video_asset",
         ),
     )
     rr.log(
-        "frame_at_two_second",
+        "frame_2s",
         rr.VideoFrameReference(
             timestamp=rr.components.VideoTimestamp(seconds=2.0),
             video_reference="video_asset",
@@ -104,9 +104,7 @@ class VideoFrameReference(Archetype):
     )
 
     # Send blueprint that shows two 2D views next to each other.
-    rr.send_blueprint(
-        rrb.Horizontal(rrb.Spatial2DView(origin="frame_at_one_second"), rrb.Spatial2DView(origin="frame_at_two_second"))
-    )
+    rr.send_blueprint(rrb.Horizontal(rrb.Spatial2DView(origin="frame_1s"), rrb.Spatial2DView(origin="frame_2s")))
     ```
     <center>
     <picture>

--- a/tests/assets/download_test_assets.py
+++ b/tests/assets/download_test_assets.py
@@ -14,7 +14,9 @@ from typing import Final
 import requests
 import tqdm
 
-test_assets = ["video/Big_Buck_Bunny_1080_10s_av1.mp4"]
+test_assets = [
+    "video/Big_Buck_Bunny_1080_10s_av1.mp4" "video/Sintel_1080_10s_av1.mp4",
+]
 
 test_asset_base_url = "https://storage.googleapis.com/rerun-test-assets/"
 

--- a/tests/assets/download_test_assets.py
+++ b/tests/assets/download_test_assets.py
@@ -15,7 +15,8 @@ import requests
 import tqdm
 
 test_assets = [
-    "video/Big_Buck_Bunny_1080_10s_av1.mp4" "video/Sintel_1080_10s_av1.mp4",
+    "video/Big_Buck_Bunny_1080_10s_av1.mp4",
+    "video/Sintel_1080_10s_av1.mp4",
 ]
 
 test_asset_base_url = "https://storage.googleapis.com/rerun-test-assets/"


### PR DESCRIPTION
### What

* Fixes #7420

https://github.com/user-attachments/assets/5f0a1f76-fd56-4f80-87f9-c3e02cd6e8d2
Decoders are now lazily created. There can now be several per video, each identified by a user provided identifier.
If decoders are not used for a frame, they get automatically destroyed.

Also fixes flickering issue when switching from an video error state to pending - now whenever we enter the pending state after an error, we clear out the target texture first.

Commit-by-commit review enabled.

![example screenshot](https://static.rerun.io/video_manual_frames/9f41c00f84a98cc3f26875fba7c1d2fa2bad7151/1200w.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7473?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7473?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7473)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.