### PR TITLE
Retry reading .rrd files until end-of-stream message header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4958,6 +4958,7 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "re_types",
+ "tempfile",
  "thiserror",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4944,6 +4944,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "image",
+ "notify",
  "once_cell",
  "parking_lot",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ ndarray = "0.16"
 ndarray-rand = "0.15"
 never = "0.1"
 nohash-hasher = "0.2"
-notify = "6.0"
+notify = {version = "6.1.1", features = ["macos_kqueue"]}
 num-derive = "0.4"
 num-traits = "0.2"
 once_cell = "1.17" # No lazy_static - use `std::sync::OnceLock` or `once_cell` instead

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 [dependencies]
 re_build_info.workspace = true
 re_chunk.workspace = true
-re_log_encoding = { workspace = true, features = ["decoder"] }
+re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
 re_log_types.workspace = true
 re_log.workspace = true
 re_smart_channel.workspace = true
@@ -37,10 +37,11 @@ ahash.workspace = true
 anyhow.workspace = true
 arrow2.workspace = true
 image.workspace = true
-once_cell.workspace = true
 notify.workspace = true
+once_cell.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 walkdir.workspace = true
 

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -26,7 +26,7 @@ default = []
 [dependencies]
 re_build_info.workspace = true
 re_chunk.workspace = true
-re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
+re_log_encoding = { workspace = true, features = ["decoder"] }
 re_log_types.workspace = true
 re_log.workspace = true
 re_smart_channel.workspace = true
@@ -41,9 +41,12 @@ notify.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
-tempfile.workspace = true
 thiserror.workspace = true
 walkdir.workspace = true
+
+[dev-dependencies]
+re_log_encoding = { workspace = true, features = ["decoder", "encoder"] }
+tempfile.workspace = true
 
 [build-dependencies]
 re_build_tools.workspace = true

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -38,6 +38,7 @@ anyhow.workspace = true
 arrow2.workspace = true
 image.workspace = true
 once_cell.workspace = true
+notify.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
 thiserror.workspace = true

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -48,6 +48,10 @@ impl crate::DataLoader for RrdLoader {
 
         match extension.as_str() {
             "rbl" => {
+                // We assume .rbl is not streamed and no retrying after seeing EOF is needed.
+                // Otherwise we'd risk retrying to read .rbl file that has no end-of-stream header and
+                // blocking the UI update thread indefinitely and making the viewer unresponsive (as .rbl
+                // files are sometimes read on UI update).
                 let file = std::fs::File::open(&filepath)
                     .with_context(|| format!("Failed to open file {filepath:?}"))?;
                 let file = std::io::BufReader::new(file);
@@ -182,23 +186,7 @@ impl Read for RetryableFileReader {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         loop {
             match self.reader.read(buf) {
-                Ok(0) => match self.rx.recv() {
-                    Ok(Ok(event)) => match event.kind {
-                        EventKind::Remove(_) => {
-                            return Err(std::io::Error::new(
-                                std::io::ErrorKind::NotFound,
-                                "file removed",
-                            ))
-                        }
-                        _ => continue,
-                    },
-                    Ok(Err(e)) => {
-                        return Err(std::io::Error::new(std::io::ErrorKind::Other, e));
-                    }
-                    Err(e) => {
-                        return Err(std::io::Error::new(std::io::ErrorKind::Other, e));
-                    }
-                },
+                Ok(0) => self.block_until_file_changes()?,
                 Ok(n) => {
                     return Ok(n);
                 }
@@ -206,7 +194,110 @@ impl Read for RetryableFileReader {
                     std::io::ErrorKind::Interrupted => continue,
                     _ => return Err(err),
                 },
-            }
+            };
         }
+    }
+}
+
+impl RetryableFileReader {
+    fn block_until_file_changes(&self) -> std::io::Result<usize> {
+        match self.rx.recv() {
+            Ok(Ok(event)) => match event.kind {
+                EventKind::Remove(_) => Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "file removed",
+                )),
+                _ => Ok(0),
+            },
+            Ok(Err(e)) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+            Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use re_build_info::CrateVersion;
+    use re_chunk::RowId;
+    use re_log_encoding::{decoder, encoder::Encoder};
+    use re_log_types::{
+        ApplicationId, LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource, Time,
+    };
+    use tempfile::NamedTempFile;
+
+    use super::*;
+
+    #[test]
+    fn test_loading_with_retryable_reader() {
+        let rrd_file = NamedTempFile::new().unwrap();
+        let rrd_file_path = rrd_file.path().to_owned();
+
+        let mut encoder = Encoder::new(
+            re_build_info::CrateVersion::LOCAL,
+            re_log_encoding::EncodingOptions::UNCOMPRESSED,
+            rrd_file,
+        )
+        .unwrap();
+
+        fn new_message() -> LogMsg {
+            LogMsg::SetStoreInfo(SetStoreInfo {
+                row_id: *RowId::new(),
+                info: StoreInfo {
+                    application_id: ApplicationId("test".to_owned()),
+                    store_id: StoreId::random(StoreKind::Recording),
+                    cloned_from: None,
+                    is_official_example: true,
+                    started: Time::now(),
+                    store_source: StoreSource::RustSdk {
+                        rustc_version: String::new(),
+                        llvm_version: String::new(),
+                    },
+                    store_version: Some(CrateVersion::LOCAL),
+                },
+            })
+        }
+
+        let messages = (0..5).map(|_| new_message()).collect::<Vec<_>>();
+
+        for m in &messages {
+            encoder.append(m).expect("failed to append message");
+        }
+
+        let reader = RetryableFileReader::new(&rrd_file_path).unwrap();
+        let mut decoder = Decoder::new(decoder::VersionPolicy::Warn, reader).unwrap();
+
+        // we should be able to read 5 messages that we wrote
+        let decoded_messages = (0..5)
+            .map(|_| {
+                let msg = decoder.next().unwrap().unwrap();
+                msg
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(messages, decoded_messages);
+
+        // as we're using retryable reader, we should be able to read more messages that we're now going to append
+        let decoder_handle = thread::spawn(move || {
+            let mut remaining = Vec::new();
+            for msg in decoder {
+                let msg = msg.unwrap();
+                remaining.push(msg);
+            }
+
+            remaining
+        });
+
+        // append more messages to the file
+        let more_messages = (0..100).map(|_| new_message()).collect::<Vec<_>>();
+        for m in &more_messages {
+            encoder.append(m).unwrap();
+        }
+        // close the stream to stop the decoder reading, otherwise with retryable reader we'd be waiting indefinitely
+        encoder.finish().unwrap();
+
+        let remaining_messages = decoder_handle.join().unwrap();
+
+        assert_eq!(more_messages, remaining_messages);
     }
 }

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -66,9 +66,8 @@ impl crate::DataLoader for RrdLoader {
                     .with_context(|| format!("Failed to open spawn IO thread for {filepath:?}"))?;
             }
             "rrd" => {
-                // for .rrd files we retry reading despite reaching EOF to support live (writer) streaming
-                // TODO (#4056) instead of indefinitely retrying and keeping the file open we should introduce
-                //  a new "eof marker" message header in the encoding and handle it accordingly in the Decoder.
+                // For .rrd files we retry reading despite reaching EOF to support live (writer) streaming.
+                // Decoder will give up when it sees end of file marker (i.e. end-of-stream message header)
                 let retryable_reader = RetryableFileReader::new(&filepath).with_context(|| {
                     format!("failed to create retryable file reader for {filepath:?}")
                 })?;

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -308,9 +308,15 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
                 uncompressed_len,
             } => (uncompressed_len as usize, compressed_len as usize),
             MessageHeader::EndOfStream => {
-                re_log::info!("Reached end of stream");
+                // we might have a concatenated stream, so we peek beyond end of file marker to see
+                if self.peek_file_header() {
+                    re_log::debug!("Reached end of stream, but it seems we have a concatenated file, continuing");
+                    return self.next();
+                }
+
+                re_log::debug!("Reached end of stream, iterator complete");
                 return None;
-            },
+            }
         };
 
         self.uncompressed
@@ -368,52 +374,115 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 // ----------------------------------------------------------------------------
 
 #[cfg(all(feature = "decoder", feature = "encoder"))]
-#[test]
-fn test_encode_decode() {
+mod tests {
+    use std::io::Cursor;
+
+    use crate::decoder::{DecodeError, VersionPolicy};
+    use crate::decoder::{Decoder, LogMsg};
+    use crate::encoder::Encoder;
+    use crate::{Compression, EncodingOptions, Serializer};
+    use re_build_info::CrateVersion;
     use re_chunk::RowId;
     use re_log_types::{
-        ApplicationId, LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource, Time,
+        ApplicationId, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource, Time,
     };
 
-    let rrd_version = CrateVersion::LOCAL;
-
-    let messages = vec![LogMsg::SetStoreInfo(SetStoreInfo {
-        row_id: *RowId::new(),
-        info: StoreInfo {
-            application_id: ApplicationId("test".to_owned()),
-            store_id: StoreId::random(StoreKind::Recording),
-            cloned_from: None,
-            is_official_example: true,
-            started: Time::now(),
-            store_source: StoreSource::RustSdk {
-                rustc_version: String::new(),
-                llvm_version: String::new(),
+    fn fake_log_message() -> LogMsg {
+        LogMsg::SetStoreInfo(SetStoreInfo {
+            row_id: *RowId::new(),
+            info: StoreInfo {
+                application_id: ApplicationId("test".to_owned()),
+                store_id: StoreId::random(StoreKind::Recording),
+                cloned_from: None,
+                is_official_example: true,
+                started: Time::now(),
+                store_source: StoreSource::RustSdk {
+                    rustc_version: String::new(),
+                    llvm_version: String::new(),
+                },
+                store_version: Some(CrateVersion::LOCAL),
             },
-            store_version: Some(rrd_version),
-        },
-    })];
+        })
+    }
 
-    let options = [
-        EncodingOptions {
-            compression: Compression::Off,
-            serializer: Serializer::MsgPack,
-        },
-        EncodingOptions {
-            compression: Compression::LZ4,
-            serializer: Serializer::MsgPack,
-        },
-    ];
+    #[test]
+    fn test_encode_decode() {
+        let rrd_version = CrateVersion::LOCAL;
 
-    for options in options {
-        let mut file = vec![];
-        crate::encoder::encode_ref(rrd_version, options, messages.iter().map(Ok), &mut file)
+        let messages = vec![fake_log_message()];
+
+        let options = [
+            EncodingOptions {
+                compression: Compression::Off,
+                serializer: Serializer::MsgPack,
+            },
+            EncodingOptions {
+                compression: Compression::LZ4,
+                serializer: Serializer::MsgPack,
+            },
+        ];
+
+        for options in options {
+            let mut file = vec![];
+            crate::encoder::encode_ref(rrd_version, options, messages.iter().map(Ok), &mut file)
+                .unwrap();
+
+            let decoded_messages = Decoder::new(VersionPolicy::Error, &mut file.as_slice())
+                .unwrap()
+                .collect::<Result<Vec<LogMsg>, DecodeError>>()
+                .unwrap();
+
+            assert_eq!(messages, decoded_messages);
+        }
+    }
+
+    #[test]
+    fn test_concatenated_streams() {
+        let options = [
+            EncodingOptions {
+                compression: Compression::Off,
+                serializer: Serializer::MsgPack,
+            },
+            EncodingOptions {
+                compression: Compression::LZ4,
+                serializer: Serializer::MsgPack,
+            },
+        ];
+
+        for options in options {
+            let mut data = vec![];
+
+            // write "2 files" i.e. 2 streams that end with end-of-stream marker
+            let messages = vec![fake_log_message(), fake_log_message(), fake_log_message(), fake_log_message()];
+
+            // (2 encoders as each encoder writes a file header)
+            let writer = Cursor::new(&mut data);
+            let mut encoder1 = Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+            encoder1.append(&messages[0]).unwrap();
+            encoder1.append(&messages[1]).unwrap();
+            encoder1.finish().unwrap();
+
+            let written = data.len() as u64;
+            let mut writer = Cursor::new(&mut data);
+            writer.set_position(written);
+            let mut encoder2 = Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+
+            encoder2.append(&messages[2]).unwrap();
+            encoder2.append(&messages[3]).unwrap();
+            encoder2.finish().unwrap();
+
+            let mut decoder = Decoder::new_concatenated(
+                VersionPolicy::Error,
+                std::io::BufReader::new(data.as_slice()),
+            )
             .unwrap();
 
-        let decoded_messages = Decoder::new(VersionPolicy::Error, &mut file.as_slice())
-            .unwrap()
-            .collect::<Result<Vec<LogMsg>, DecodeError>>()
-            .unwrap();
+            let mut decoded_messages = vec![];
+            while let Some(msg) = decoder.next() {
+                decoded_messages.push(msg.unwrap());
+            }
 
-        assert_eq!(messages, decoded_messages);
+            assert_eq!(messages, decoded_messages);
+        }
     }
 }

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -375,12 +375,7 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 
 #[cfg(all(feature = "decoder", feature = "encoder"))]
 mod tests {
-    use std::io::Cursor;
-
-    use crate::decoder::{DecodeError, VersionPolicy};
-    use crate::decoder::{Decoder, LogMsg};
-    use crate::encoder::Encoder;
-    use crate::{Compression, EncodingOptions, Serializer};
+    use super::*;
     use re_build_info::CrateVersion;
     use re_chunk::RowId;
     use re_log_types::{
@@ -405,7 +400,7 @@ mod tests {
         })
     }
 
-    #[test]
+#[test]
     fn test_encode_decode() {
         let rrd_version = CrateVersion::LOCAL;
 
@@ -453,19 +448,24 @@ mod tests {
             let mut data = vec![];
 
             // write "2 files" i.e. 2 streams that end with end-of-stream marker
-            let messages = vec![fake_log_message(), fake_log_message(), fake_log_message(), fake_log_message()];
+            let messages = vec![
+                fake_log_message(),
+                fake_log_message(),
+                fake_log_message(),
+                fake_log_message(),
+            ];
 
             // (2 encoders as each encoder writes a file header)
-            let writer = Cursor::new(&mut data);
-            let mut encoder1 = Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+            let writer = std::io::Cursor::new(&mut data);
+            let mut encoder1 = crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
             encoder1.append(&messages[0]).unwrap();
             encoder1.append(&messages[1]).unwrap();
             encoder1.finish().unwrap();
 
             let written = data.len() as u64;
-            let mut writer = Cursor::new(&mut data);
+            let mut writer = std::io::Cursor::new(&mut data);
             writer.set_position(written);
-            let mut encoder2 = Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+            let mut encoder2 = crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
 
             encoder2.append(&messages[2]).unwrap();
             encoder2.append(&messages[3]).unwrap();

--- a/crates/store/re_log_encoding/src/decoder/mod.rs
+++ b/crates/store/re_log_encoding/src/decoder/mod.rs
@@ -373,7 +373,7 @@ impl<R: std::io::Read> Iterator for Decoder<R> {
 
 // ----------------------------------------------------------------------------
 
-#[cfg(all(feature = "decoder", feature = "encoder"))]
+#[cfg(all(test, feature = "decoder", feature = "encoder"))]
 mod tests {
     use super::*;
     use re_build_info::CrateVersion;
@@ -400,7 +400,7 @@ mod tests {
         })
     }
 
-#[test]
+    #[test]
     fn test_encode_decode() {
         let rrd_version = CrateVersion::LOCAL;
 
@@ -457,7 +457,8 @@ mod tests {
 
             // (2 encoders as each encoder writes a file header)
             let writer = std::io::Cursor::new(&mut data);
-            let mut encoder1 = crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+            let mut encoder1 =
+                crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
             encoder1.append(&messages[0]).unwrap();
             encoder1.append(&messages[1]).unwrap();
             encoder1.finish().unwrap();
@@ -465,7 +466,8 @@ mod tests {
             let written = data.len() as u64;
             let mut writer = std::io::Cursor::new(&mut data);
             writer.set_position(written);
-            let mut encoder2 = crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
+            let mut encoder2 =
+                crate::encoder::Encoder::new(CrateVersion::LOCAL, options, writer).unwrap();
 
             encoder2.append(&messages[2]).unwrap();
             encoder2.append(&messages[3]).unwrap();

--- a/crates/store/re_log_encoding/src/file_sink.rs
+++ b/crates/store/re_log_encoding/src/file_sink.rs
@@ -157,6 +157,10 @@ fn spawn_and_stream<W: std::io::Write + Send + 'static>(
                         }
                     }
                 }
+                if let Err(err) = encoder.finish() {
+                    re_log::error!("Failed to end log stream for {target}: {err}");
+                    return;
+                }
                 re_log::debug!("Log stream written to {target}");
             }
         })

--- a/tests/rust/test_ui_wakeup/src/main.rs
+++ b/tests/rust/test_ui_wakeup/src/main.rs
@@ -13,6 +13,8 @@
 //!   * The viewer wakes up when browser is alt-tabbed away
 //!   * Switch to a different browser tab, send a few messages, switch back. The messages should be there
 //!     (this is not a conclusive test, as the messages might have been received on tab select)
+//! * Run `cargo r -p test_ui_wakeup -- --save stream.rrd` and in another terminal start the viewer with `pixi run rerun stream.rrd` and test:
+//!  * The viewer is updated on every new message (every ENTER press)
 
 use std::io::Read as _;
 


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

* Fix for #4056

We introduce a retryable file reader that is used when reading `.rrd` files that are still being written and it simply ignored the EoF condition. We also introduce an *end-of-stream* message header that ensures we stop decoding (and endlessly trying to read the file) message stream once we see this header.

`.rrd` files generated with using a prior sdk version should work just fine, the only downside is that while the viewer is running there will be an open file handle for that file since no end-of-stream message will exist.

### Testing done
* viewer loading a file that's still being written 
* viewer loading a file with already written content
* streaming file from an http endpoint
* tests
```
cargo test --all-targets --all-features
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7475?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7475?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7475)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.