### PR TITLE
Text fields in the selection panel now span the available width

### DIFF
--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -974,6 +974,11 @@ fn container_top_level_properties(
     };
 
     ui.list_item_flat_noninteractive(PropertyContent::new("Name").value_fn(|ui, _| {
+        ui.spacing_mut().text_edit_width = ui
+            .spacing_mut()
+            .text_edit_width
+            .at_least(ui.available_width());
+
         let mut name = container.display_name.clone().unwrap_or_default();
         ui.add(egui::TextEdit::singleline(&mut name));
         container.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -1,3 +1,4 @@
+use egui::NumExt as _;
 use egui_tiles::ContainerKind;
 
 use re_context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
@@ -542,8 +543,11 @@ fn entity_path_filter_ui(
             .clone()
     });
 
-    let response =
-        ui.add(egui::TextEdit::multiline(&mut filter_string).layouter(&mut text_layouter));
+    let response = ui.add(
+        egui::TextEdit::multiline(&mut filter_string)
+            .desired_width(ui.spacing().text_edit_width.at_least(ui.available_width()))
+            .layouter(&mut text_layouter),
+    );
 
     if response.has_focus() {
         ui.data_mut(|data| data.insert_temp::<String>(filter_text_id, filter_string.clone()));
@@ -928,12 +932,22 @@ fn view_top_level_properties(
     view: &re_viewport_blueprint::SpaceViewBlueprint,
 ) {
     ui.list_item_flat_noninteractive(PropertyContent::new("Name").value_fn(|ui, _| {
+        ui.spacing_mut().text_edit_width = ui
+            .spacing_mut()
+            .text_edit_width
+            .at_least(ui.available_width());
+
         let mut name = view.display_name.clone().unwrap_or_default();
         ui.add(egui::TextEdit::singleline(&mut name).hint_text("(default)"));
         view.set_display_name(ctx, if name.is_empty() { None } else { Some(name) });
     }));
 
     ui.list_item_flat_noninteractive(PropertyContent::new("Space origin").value_fn(|ui, _| {
+        ui.spacing_mut().text_edit_width = ui
+            .spacing_mut()
+            .text_edit_width
+            .at_least(ui.available_width());
+
         super::space_view_space_origin_ui::space_view_space_origin_widget_ui(ui, ctx, view);
     }))
     .on_hover_text(


### PR DESCRIPTION
### What

The Name, Space origin, and Entity path filter text fields in the view (and container, for Name) selection panel now span the full available width. This avoids situations such as this where an ugly wrap happens because the field doesn't expand:
![image](https://github.com/user-attachments/assets/b0aeaafe-0dda-435c-963e-a18307f54bdb)

<br/><br/>


<img width="525" alt="image" src="https://github.com/user-attachments/assets/759ee99e-7b29-4d9a-a929-b2e1b2f3412c">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7487?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7487?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7487)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.