### PR TITLE
implement proper fallback for Entitypath on video frame reference vis…

### DIFF
--- a/crates/utils/re_format/src/lib.rs
+++ b/crates/utils/re_format/src/lib.rs
@@ -6,7 +6,7 @@ mod time;
 
 use std::{cmp::PartialOrd, fmt::Display};
 
-pub use time::next_grid_tick_magnitude_ns;
+pub use time::{format_timestamp_seconds, next_grid_tick_magnitude_ns, parse_timestamp_seconds};
 
 // --- Numbers ---
 

--- a/crates/utils/re_format/src/time.rs
+++ b/crates/utils/re_format/src/time.rs
@@ -28,12 +28,12 @@ pub fn format_timestamp_seconds(timestamp_seconds: f64) -> String {
     let hours = n / (60 * 60);
     let mins = (n / 60) % 60;
     let secs_int = n % 60;
-    let milliseconds = (timestamp_seconds.fract() * 1000.0) as u32;
+    let secs_hundredth = (timestamp_seconds.fract() * 100.0) as u32;
 
     if hours > 0 {
-        format!("{hours:02}:{mins:02}:{secs_int:02}.{milliseconds:03}")
+        format!("{hours:02}:{mins:02}:{secs_int:02}.{secs_hundredth:02}")
     } else {
-        format!("{mins:02}:{secs_int:02}.{milliseconds:03}")
+        format!("{mins:02}:{secs_int:02}.{secs_hundredth:02}")
     }
     // Not showing the minutes at all makes it too unclear what format this timestamp is in.
     // So let's not further strip this down.

--- a/crates/utils/re_format/src/time.rs
+++ b/crates/utils/re_format/src/time.rs
@@ -18,3 +18,48 @@ pub fn next_grid_tick_magnitude_ns(spacing_ns: i64) -> i64 {
         spacing_ns.checked_mul(10).unwrap_or(spacing_ns) // multiple of ten days
     }
 }
+
+/// Formats a timestamp in seconds to a string.
+///
+/// This is meant for a relatively stable display of timestamps that are typically in minutes
+/// where we still care about fractional seconds.
+pub fn format_timestamp_seconds(timestamp_seconds: f64) -> String {
+    let n = timestamp_seconds as i32;
+    let hours = n / (60 * 60);
+    let mins = (n / 60) % 60;
+    let secs_int = n % 60;
+    let milliseconds = (timestamp_seconds.fract() * 1000.0) as u32;
+
+    if hours > 0 {
+        format!("{hours:02}:{mins:02}:{secs_int:02}.{milliseconds:03}")
+    } else {
+        format!("{mins:02}:{secs_int:02}.{milliseconds:03}")
+    }
+    // Not showing the minutes at all makes it too unclear what format this timestamp is in.
+    // So let's not further strip this down.
+}
+
+/// Parses seconds from a string.
+///
+/// Supports:
+/// * fractional seconds
+/// * minutes:[fractional seconds]
+/// * hours:minutes:[fractional seconds]
+pub fn parse_timestamp_seconds(s: &str) -> Option<f64> {
+    let parts: Vec<&str> = s.split(':').collect();
+    match parts.len() {
+        1 => parts[0].parse::<f64>().ok(),
+        2 => {
+            let minutes = parts[0].parse::<i32>().ok()?;
+            let seconds = parts[1].parse::<f64>().ok()?;
+            Some((minutes * 60) as f64 + seconds)
+        }
+        3 => {
+            let hours = parts[0].parse::<i32>().ok()?;
+            let minutes = parts[0].parse::<i32>().ok()?;
+            let seconds = parts[1].parse::<f64>().ok()?;
+            Some(((hours * 60 + minutes) * 60) as f64 + seconds)
+        }
+        _ => None,
+    }
+}

--- a/crates/viewer/re_component_ui/src/entity_path.rs
+++ b/crates/viewer/re_component_ui/src/entity_path.rs
@@ -1,0 +1,27 @@
+use re_types::components::EntityPath;
+use re_viewer_context::{MaybeMutRef, ViewerContext};
+
+pub(crate) fn edit_or_view_entity_path(
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    path: &mut MaybeMutRef<'_, EntityPath>,
+) -> egui::Response {
+    if let Some(path) = path.as_mut() {
+        // A suggestion mechanism similar to the one in `space_view_space_origin_widget_ui` would be nice.
+        let mut string = path.to_string();
+        let response = ui.text_edit_singleline(&mut string);
+        *path = string.into();
+
+        response
+    } else {
+        // Assume the current query for information shown in hover cards etc.
+        let query = ctx.current_query();
+
+        // Entity paths right now always refer to the current recording.
+        // This might change in the future at which point we need more context here.
+        let db = ctx.recording();
+
+        let entity_path = path.as_ref().as_str().into();
+        re_data_ui::item_ui::entity_path_button(ctx, &query, db, ui, None, &entity_path)
+    }
+}

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod color;
 mod datatype_uis;
+mod entity_path;
 mod fallback_ui;
 mod image_format;
 mod line_strip;
@@ -132,6 +133,8 @@ pub fn create_component_ui_registry() -> re_viewer_context::ComponentUiRegistry 
     registry.add_multiline_edit_or_view(pinhole::multiline_view_pinhole);
 
     line_strip::register_linestrip_component_ui(&mut registry);
+
+    registry.add_singleline_edit_or_view(entity_path::edit_or_view_entity_path);
 
     registry
 }

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -137,7 +137,7 @@ pub fn create_component_ui_registry() -> re_viewer_context::ComponentUiRegistry 
 
     registry.add_singleline_edit_or_view(entity_path::edit_or_view_entity_path);
 
-    registry.add_singleline_edit_or_view(video_timestamp::edit_or_view_entity_path);
+    registry.add_singleline_edit_or_view(video_timestamp::edit_or_view_timestamp);
 
     registry
 }

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -17,6 +17,7 @@ mod resolution;
 mod response_utils;
 mod timeline;
 mod transforms;
+mod video_timestamp;
 mod view_coordinates;
 mod visual_bounds2d;
 
@@ -135,6 +136,8 @@ pub fn create_component_ui_registry() -> re_viewer_context::ComponentUiRegistry 
     line_strip::register_linestrip_component_ui(&mut registry);
 
     registry.add_singleline_edit_or_view(entity_path::edit_or_view_entity_path);
+
+    registry.add_singleline_edit_or_view(video_timestamp::edit_or_view_entity_path);
 
     registry
 }

--- a/crates/viewer/re_component_ui/src/video_timestamp.rs
+++ b/crates/viewer/re_component_ui/src/video_timestamp.rs
@@ -26,6 +26,8 @@ pub(crate) fn edit_or_view_entity_path(
     } else {
         ui.label(format_timestamp_seconds(timestamp_seconds))
     }
+    // Show the exact timestamp always in the hover text.
+    .on_hover_text(format!("{}ns", re_format::format_int(timestamp.as_nanos())))
 }
 
 fn format_timestamp_seconds(timestamp_seconds: f64) -> String {

--- a/crates/viewer/re_component_ui/src/video_timestamp.rs
+++ b/crates/viewer/re_component_ui/src/video_timestamp.rs
@@ -1,0 +1,68 @@
+use re_types::components::VideoTimestamp;
+use re_viewer_context::{MaybeMutRef, ViewerContext};
+
+pub(crate) fn edit_or_view_entity_path(
+    _ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    timestamp: &mut MaybeMutRef<'_, VideoTimestamp>,
+) -> egui::Response {
+    let mut timestamp_seconds = timestamp.as_seconds();
+
+    if let Some(timestamp) = timestamp.as_mut() {
+        let response = ui.add(
+            egui::DragValue::new(&mut timestamp_seconds)
+                .clamp_existing_to_range(false)
+                .range(0.0..=f32::MAX)
+                .speed(0.01) // 0.01 seconds is the smallest step we show right now.
+                .custom_formatter(|n, _| format_timestamp_seconds(n))
+                .custom_parser(parse_timestamp_seconds),
+        );
+
+        if response.changed() {
+            *timestamp = VideoTimestamp::from_seconds(timestamp_seconds);
+        }
+
+        response
+    } else {
+        ui.label(format_timestamp_seconds(timestamp_seconds))
+    }
+}
+
+fn format_timestamp_seconds(timestamp_seconds: f64) -> String {
+    let n = timestamp_seconds as i32;
+    let hours = n / (60 * 60);
+    let mins = (n / 60) % 60;
+    let secs_int = n % 60;
+    let secs_frac = (timestamp_seconds.fract() * 100.0) as u32;
+
+    if hours > 0 {
+        format!("{hours:02}:{mins:02}:{secs_int:02}.{secs_frac:02}")
+    } else {
+        format!("{mins:02}:{secs_int:02}.{secs_frac:02}")
+    }
+    // Not showing the minutes at all makes it too unclear what format this timestamp is in.
+    // So let's not further strip this down.
+}
+
+fn parse_timestamp_seconds(s: &str) -> Option<f64> {
+    // For parsing we support:
+    // * raw seconds
+    // * minutes:seconds
+    // * hours:minutes:seconds
+    let parts: Vec<&str> = s.split(':').collect();
+    match parts.len() {
+        1 => parts[0].parse::<f64>().ok(),
+        2 => {
+            let minutes = parts[0].parse::<i32>().ok()?;
+            let seconds = parts[1].parse::<f64>().ok()?;
+            Some((minutes * 60) as f64 + seconds)
+        }
+        3 => {
+            let hours = parts[0].parse::<i32>().ok()?;
+            let minutes = parts[0].parse::<i32>().ok()?;
+            let seconds = parts[1].parse::<f64>().ok()?;
+            Some(((hours * 60 + minutes) * 60) as f64 + seconds)
+        }
+        _ => None,
+    }
+}

--- a/crates/viewer/re_component_ui/src/video_timestamp.rs
+++ b/crates/viewer/re_component_ui/src/video_timestamp.rs
@@ -1,7 +1,7 @@
 use re_types::components::VideoTimestamp;
 use re_viewer_context::{MaybeMutRef, ViewerContext};
 
-pub(crate) fn edit_or_view_entity_path(
+pub fn edit_or_view_timestamp(
     _ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     timestamp: &mut MaybeMutRef<'_, VideoTimestamp>,
@@ -14,8 +14,8 @@ pub(crate) fn edit_or_view_entity_path(
                 .clamp_existing_to_range(false)
                 .range(0.0..=f32::MAX)
                 .speed(0.01) // 0.01 seconds is the smallest step we show right now.
-                .custom_formatter(|n, _| format_timestamp_seconds(n))
-                .custom_parser(parse_timestamp_seconds),
+                .custom_formatter(|n, _| re_format::format_timestamp_seconds(n))
+                .custom_parser(re_format::parse_timestamp_seconds),
         );
 
         if response.changed() {
@@ -24,47 +24,8 @@ pub(crate) fn edit_or_view_entity_path(
 
         response
     } else {
-        ui.label(format_timestamp_seconds(timestamp_seconds))
+        ui.label(re_format::format_timestamp_seconds(timestamp_seconds))
     }
     // Show the exact timestamp always in the hover text.
     .on_hover_text(format!("{}ns", re_format::format_int(timestamp.as_nanos())))
-}
-
-fn format_timestamp_seconds(timestamp_seconds: f64) -> String {
-    let n = timestamp_seconds as i32;
-    let hours = n / (60 * 60);
-    let mins = (n / 60) % 60;
-    let secs_int = n % 60;
-    let secs_frac = (timestamp_seconds.fract() * 100.0) as u32;
-
-    if hours > 0 {
-        format!("{hours:02}:{mins:02}:{secs_int:02}.{secs_frac:02}")
-    } else {
-        format!("{mins:02}:{secs_int:02}.{secs_frac:02}")
-    }
-    // Not showing the minutes at all makes it too unclear what format this timestamp is in.
-    // So let's not further strip this down.
-}
-
-fn parse_timestamp_seconds(s: &str) -> Option<f64> {
-    // For parsing we support:
-    // * raw seconds
-    // * minutes:seconds
-    // * hours:minutes:seconds
-    let parts: Vec<&str> = s.split(':').collect();
-    match parts.len() {
-        1 => parts[0].parse::<f64>().ok(),
-        2 => {
-            let minutes = parts[0].parse::<i32>().ok()?;
-            let seconds = parts[1].parse::<f64>().ok()?;
-            Some((minutes * 60) as f64 + seconds)
-        }
-        3 => {
-            let hours = parts[0].parse::<i32>().ok()?;
-            let minutes = parts[0].parse::<i32>().ok()?;
-            let seconds = parts[1].parse::<f64>().ok()?;
-            Some(((hours * 60 + minutes) * 60) as f64 + seconds)
-        }
-        _ => None,
-    }
 }


### PR DESCRIPTION
### What

* Fixes #7423
* fallback provider for `EntityPath` on `VideoFrameReference` visualizer
* component display & edit ui for 
    * `EntityPath`
    * `VideoTimestamp`

Demo:

https://github.com/user-attachments/assets/e1702fb2-7a9d-4031-bc11-ee459e63206d



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7492?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7492?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7492)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.