### PR TITLE
Show video at VideoTimestamp when hovering/selecting entity

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -443,6 +443,10 @@ fn preview_if_blob_ui(
         .get(&components::MediaType::name())
         .and_then(|unit| unit.component_mono::<components::MediaType>()?.ok());
 
+    let video_timestamp = component_map
+        .get(&components::VideoTimestamp::name())
+        .and_then(|unit| unit.component_mono::<components::VideoTimestamp>()?.ok());
+
     blob_preview_and_save_ui(
         ctx,
         ui,
@@ -452,6 +456,7 @@ fn preview_if_blob_ui(
         blob_row_id,
         &blob,
         media_type.as_ref(),
+        video_timestamp,
     );
 
     Some(())


### PR DESCRIPTION
### What
![video-scrub-preview](https://github.com/user-attachments/assets/5338e719-847f-4b38-a8d1-39c717d18537)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7502?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7502?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7502)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.