### PR TITLE
Fix error spam after decode error & make video error icon take a fixed amount of space

### DIFF
--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -101,13 +101,14 @@ getrandom = { workspace = true, features = [
 js-sys = { workspace = true }
 wasm-bindgen-futures.workspace = true
 web-sys = { workspace = true, features = [
+  "DomException",
   "EncodedVideoChunk",
   "EncodedVideoChunkInit",
   "EncodedVideoChunkType",
-  "VideoFrame",
   "VideoDecoder",
   "VideoDecoderConfig",
   "VideoDecoderInit",
+  "VideoFrame",
 ] }
 wasm-bindgen = { workspace = true }
 

--- a/crates/viewer/re_space_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_2d.rs
@@ -116,6 +116,8 @@ fn ui_from_scene(
     } else if bounds != updated_bounds {
         bounds_property.save_blueprint_component(ctx, &updated_bounds);
     }
+    // Update stored bounds on the state, so visualizers see an up-to-date value.
+    view_state.visual_bounds_2d = Some(bounds);
 
     RectTransform::from_to(letterboxed_bounds, response.rect)
 }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -302,7 +302,7 @@ impl VideoFrameReferenceVisualizer {
             video_error_texture.height() as _,
         );
         let center = glam::Vec3::from(world_from_entity.translation).truncate() + video_size * 0.5;
-        let top_left_corner_position = center - video_error_rect_size;
+        let top_left_corner_position = center - video_error_rect_size * 0.5;
 
         // Add a label that annotates a rectangle that is a bit bigger than the error icon.
         // This makes the label track the icon better than putting it at a point.


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7465

.. sort of. It's still rather strange that Firefox doesn't decode this. It runs into an error during decode which sounds like it incorrectly advertised support. I considered recognizing this error and handling it as a decoding not supported, but I don't want to hide the underlying js error too much to allow for further investigation down the line. What's shown now is decent enough:

<img width="2246" alt="image" src="https://github.com/user-attachments/assets/55195a2c-9a14-41e3-bbfe-0bfb960ee6f8">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7503?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7503?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7503)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.