### PR TITLE
Fix BGR(A) rendering on WebGL

### DIFF
--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -101,6 +101,15 @@ impl DeviceCaps {
         }
     }
 
+    pub fn support_bgra_textures(&self) -> bool {
+        match self.tier {
+            // TODO(wgpu#3583): Incorrectly reported by wgpu right now.
+            // GLES2 does not support BGRA textures!
+            DeviceTier::Gles => false,
+            DeviceTier::FullWebGpuSupport => true,
+        }
+    }
+
     /// Picks the highest possible tier for a given adapter.
     ///
     /// Note that it is always possible to pick a lower tier!

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -480,6 +480,11 @@ This means, either a call to RenderContext::before_submit was omitted, or the pr
     pub fn active_frame_idx(&self) -> u64 {
         self.active_frame.frame_index
     }
+
+    /// Returns the device's capabilities.
+    pub fn device_caps(&self) -> &DeviceCaps {
+        &self.config.device_caps
+    }
 }
 
 pub struct FrameGlobalCommandEncoder(Option<wgpu::CommandEncoder>);

--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -226,7 +226,12 @@ fn try_get_or_create_albedo_texture(
         colormap: None,
     };
 
-    if re_viewer_context::gpu_bridge::required_shader_decode(albedo_texture_format).is_some() {
+    if re_viewer_context::gpu_bridge::required_shader_decode(
+        render_ctx.device_caps(),
+        albedo_texture_format,
+    )
+    .is_some()
+    {
         re_log::warn_once!("Mesh can't yet handle encoded image formats like NV12 & YUY2 or BGR(A) formats without a channel type other than U8. Ignoring the texture at {name:?}.");
         return None;
     }
@@ -234,7 +239,11 @@ fn try_get_or_create_albedo_texture(
     let texture =
         re_viewer_context::gpu_bridge::get_or_create_texture(render_ctx, texture_key, || {
             let debug_name = "mesh albedo texture";
-            texture_creation_desc_from_color_image(&image_info, debug_name)
+            texture_creation_desc_from_color_image(
+                render_ctx.device_caps(),
+                &image_info,
+                debug_name,
+            )
         });
 
     match texture {


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7454

This fixes it the "proper" way by still using BGR(A) textures when possible since this enables use thereof on Meshes. To do so, we now check for the device capabilities in the relevant places - this is pretty straight forward since there's already a central place to check for shader decode requirements and one for determining the texture format.

<img width="2326" alt="image" src="https://github.com/user-attachments/assets/01d361c7-38fd-4ca6-b11a-96737834df55">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7504?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7504?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7504)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

## Tested on
* [x] Native
* [x] WebGL
* [x] WebGPU