### PR TITLE
Update egui with less wgpu lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,7 +1777,7 @@ checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
 [[package]]
 name = "ecolor"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "bytemuck",
  "emath",
@@ -1787,7 +1787,7 @@ dependencies = [
 [[package]]
 name = "eframe"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1841,7 +1841,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1860,7 +1860,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -1900,7 +1900,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "ahash",
  "egui",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1989,7 +1989,7 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "emath"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2090,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2109,7 +2109,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.28.1"
-source = "git+https://github.com/emilk/egui.git?rev=e0f0b7f47f4094967530214aec060b9f1ce5954e#e0f0b7f47f4094967530214aec060b9f1ce5954e"
+source = "git+https://github.com/emilk/egui.git?rev=f97f85089df5e936999d5b7280e2e93e2958fac8#f97f85089df5e936999d5b7280e2e93e2958fac8"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "egui_table"
 version = "0.28.1"
-source = "git+https://github.com/rerun-io/egui_table.git?rev=c76473b244f03a7c67fbbbff9def6fc86c1ca4ea#c76473b244f03a7c67fbbbff9def6fc86c1ca4ea"
+source = "git+https://github.com/rerun-io/egui_table.git?rev=15be049a4eac3b9f87aa758505ebe46fd76dcef6#15be049a4eac3b9f87aa758505ebe46fd76dcef6"
 dependencies = [
  "egui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,12 +514,12 @@ missing_errors_doc = "allow"
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }      # egui master 2024-09-19
-eframe = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }      # egui master 2024-09-19
-egui = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }        # egui master 2024-09-19
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" } # egui master 2024-09-19
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }   # egui master 2024-09-19
-emath = { git = "https://github.com/emilk/egui.git", rev = "e0f0b7f47f4094967530214aec060b9f1ce5954e" }       # egui master 2024-09-19
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" }      # egui master 2024-09-25
+eframe = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" }      # egui master 2024-09-25
+egui = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" }        # egui master 2024-09-25
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" } # egui master 2024-09-25
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" }   # egui master 2024-09-25
+emath = { git = "https://github.com/emilk/egui.git", rev = "f97f85089df5e936999d5b7280e2e93e2958fac8" }       # egui master 2024-09-25
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -13,7 +13,7 @@ use crate::{
     global_bindings::GlobalBindings,
     renderer::Renderer,
     resource_managers::{MeshManager, TextureManager2D},
-    wgpu_resources::{GpuRenderPipelinePoolMoveAccessor, WgpuResourcePools},
+    wgpu_resources::WgpuResourcePools,
     FileServer, RecommendedFileResolver,
 };
 
@@ -224,7 +224,6 @@ impl RenderContext {
 
         let active_frame = ActiveFrameContext {
             before_view_builder_encoder: Mutex::new(FrameGlobalCommandEncoder::new(&device)),
-            pinned_render_pipelines: None,
             frame_index: STARTUP_FRAME_IDX,
             top_level_error_scope,
         };
@@ -341,13 +340,6 @@ This means, either a call to RenderContext::before_submit was omitted, or the pr
         // Map all read staging buffers.
         self.gpu_readback_belt.get_mut().after_queue_submit();
 
-        // Give back moved render pipelines to the pool if any were moved out.
-        if let Some(moved_render_pipelines) = self.active_frame.pinned_render_pipelines.take() {
-            self.gpu_resources
-                .render_pipelines
-                .return_resources(moved_render_pipelines);
-        }
-
         // Close previous' frame error scope.
         if let Some(top_level_error_scope) = self.active_frame.top_level_error_scope.take() {
             let frame_index_for_uncaptured_errors = self.frame_index_for_uncaptured_errors.clone();
@@ -373,7 +365,6 @@ This means, either a call to RenderContext::before_submit was omitted, or the pr
         // New active frame!
         self.active_frame = ActiveFrameContext {
             before_view_builder_encoder: Mutex::new(FrameGlobalCommandEncoder::new(&self.device)),
-            pinned_render_pipelines: None,
             frame_index: self.active_frame.frame_index.wrapping_add(1),
             top_level_error_scope: Some(WgpuErrorScope::start(&self.device)),
         };
@@ -523,13 +514,6 @@ pub struct ActiveFrameContext {
     /// This should be used for any gpu copy operation outside of a renderer or view builder.
     /// (i.e. typically in [`crate::renderer::DrawData`] creation!)
     pub before_view_builder_encoder: Mutex<FrameGlobalCommandEncoder>,
-
-    /// Render pipelines that were moved out of the resource pool.
-    ///
-    /// Will be moved back to the resource pool at the start of the frame.
-    /// This is needed for accessing the render pipelines without keeping a reference
-    /// to the resource pool lock during the lifetime of a render pass.
-    pub pinned_render_pipelines: Option<GpuRenderPipelinePoolMoveAccessor>,
 
     /// Index of this frame. Is incremented for every render frame.
     ///

--- a/crates/viewer/re_renderer/src/queueable_draw_data.rs
+++ b/crates/viewer/re_renderer/src/queueable_draw_data.rs
@@ -17,11 +17,11 @@ pub enum QueueableDrawDataError {
     UnexpectedDrawDataType(&'static str),
 }
 
-type DrawFn = dyn for<'a, 'b> Fn(
+type DrawFn = dyn for<'pipelines, 'encoder> Fn(
         &Renderers,
-        &GpuRenderPipelinePoolAccessor<'a>,
+        &GpuRenderPipelinePoolAccessor<'pipelines>,
         DrawPhase,
-        &mut wgpu::RenderPass<'b>,
+        &mut wgpu::RenderPass<'encoder>,
         &dyn std::any::Any,
     ) -> Result<(), QueueableDrawDataError>
     + Sync

--- a/crates/viewer/re_renderer/src/queueable_draw_data.rs
+++ b/crates/viewer/re_renderer/src/queueable_draw_data.rs
@@ -19,10 +19,10 @@ pub enum QueueableDrawDataError {
 
 type DrawFn = dyn for<'a, 'b> Fn(
         &Renderers,
-        &'b GpuRenderPipelinePoolAccessor<'b>,
+        &GpuRenderPipelinePoolAccessor<'a>,
         DrawPhase,
-        &'a mut wgpu::RenderPass<'b>,
-        &'b dyn std::any::Any,
+        &mut wgpu::RenderPass<'b>,
+        &dyn std::any::Any,
     ) -> Result<(), QueueableDrawDataError>
     + Sync
     + Send;

--- a/crates/viewer/re_renderer/src/renderer/compositor.rs
+++ b/crates/viewer/re_renderer/src/renderer/compositor.rs
@@ -186,12 +186,12 @@ impl Renderer for Compositor {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a CompositorDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &CompositorDrawData,
     ) -> Result<(), DrawError> {
         let pipeline_handle = match phase {
             DrawPhase::Compositing => self.render_pipeline_regular,

--- a/crates/viewer/re_renderer/src/renderer/debug_overlay.rs
+++ b/crates/viewer/re_renderer/src/renderer/debug_overlay.rs
@@ -223,12 +223,12 @@ impl Renderer for DebugOverlayRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         _phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a DebugOverlayDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &DebugOverlayDrawData,
     ) -> Result<(), DrawError> {
         let pipeline = render_pipelines.get(self.render_pipeline)?;
 

--- a/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/depth_cloud.rs
@@ -473,12 +473,12 @@ impl Renderer for DepthCloudRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
         if draw_data.instances.is_empty() {

--- a/crates/viewer/re_renderer/src/renderer/generic_skybox.rs
+++ b/crates/viewer/re_renderer/src/renderer/generic_skybox.rs
@@ -146,12 +146,12 @@ impl Renderer for GenericSkybox {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         _phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
 

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -744,12 +744,12 @@ impl Renderer for LineRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         let (pipeline_handle, bind_group_all_lines) = match phase {
             DrawPhase::OutlineMask => (

--- a/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
+++ b/crates/viewer/re_renderer/src/renderer/mesh_renderer.rs
@@ -395,12 +395,12 @@ impl Renderer for MeshRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
 

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -69,12 +69,12 @@ pub trait Renderer {
     // TODO(andreas): Some Renderers need to create their own passes, need something like this for that.
 
     /// Called once per phase given by [`Renderer::participated_phases`].
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError>;
 
     /// Combination of flags indicating in which phases [`Renderer::draw`] should be called.

--- a/crates/viewer/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/point_cloud.rs
@@ -571,12 +571,12 @@ impl Renderer for PointCloudRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         let (pipeline_handle, bind_group_all_points) = match phase {
             DrawPhase::OutlineMask => (

--- a/crates/viewer/re_renderer/src/renderer/rectangles.rs
+++ b/crates/viewer/re_renderer/src/renderer/rectangles.rs
@@ -653,12 +653,12 @@ impl Renderer for RectangleRenderer {
         }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
-        draw_data: &'a Self::RendererDrawData,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &Self::RendererDrawData,
     ) -> Result<(), DrawError> {
         re_tracing::profile_function!();
         if draw_data.instances.is_empty() {

--- a/crates/viewer/re_renderer/src/renderer/test_triangle.rs
+++ b/crates/viewer/re_renderer/src/renderer/test_triangle.rs
@@ -69,11 +69,11 @@ impl Renderer for TestTriangle {
         Self { render_pipeline }
     }
 
-    fn draw<'a>(
+    fn draw(
         &self,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         _phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
+        pass: &mut wgpu::RenderPass<'_>,
         _draw_data: &TestTriangleDrawData,
     ) -> Result<(), DrawError> {
         let pipeline = render_pipelines.get(self.render_pipeline)?;

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -481,12 +481,12 @@ impl ViewBuilder {
         self.setup.resolution_in_pixel
     }
 
-    fn draw_phase<'a>(
-        &'a self,
+    fn draw_phase(
+        &self,
         renderers: &Renderers,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
         phase: DrawPhase,
-        pass: &mut wgpu::RenderPass<'a>,
+        pass: &mut wgpu::RenderPass<'_>,
     ) {
         re_tracing::profile_function!();
 
@@ -764,18 +764,14 @@ impl ViewBuilder {
     ///
     /// The bound surface(s) on the `RenderPass` are expected to be the same format as specified on `Context` creation.
     /// `screen_position` specifies where on the output pass the view is placed.
-    pub fn composite<'a>(
-        &'a self,
-        ctx: &RenderContext,
-        render_pipelines: &'a GpuRenderPipelinePoolAccessor<'a>,
-        pass: &mut wgpu::RenderPass<'a>,
-    ) {
+    pub fn composite(&self, ctx: &RenderContext, pass: &mut wgpu::RenderPass<'_>) {
         re_tracing::profile_function!();
 
         pass.set_bind_group(0, &self.setup.bind_group_0, &[]);
+
         self.draw_phase(
             &ctx.read_lock_renderers(),
-            render_pipelines,
+            &ctx.gpu_resources.render_pipelines.resources(),
             DrawPhase::Compositing,
             pass,
         );

--- a/crates/viewer/re_renderer/src/wgpu_resources/bind_group_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/bind_group_pool.rs
@@ -9,7 +9,6 @@ use super::{
     buffer_pool::{GpuBuffer, GpuBufferHandle, GpuBufferPool},
     dynamic_resource_pool::{DynamicResource, DynamicResourcePool, DynamicResourcesDesc},
     sampler_pool::{GpuSamplerHandle, GpuSamplerPool},
-    static_resource_pool::StaticResourcePoolAccessor as _,
     texture_pool::{GpuTexture, GpuTextureHandle, GpuTexturePool},
     WgpuResourcePools,
 };

--- a/crates/viewer/re_renderer/src/wgpu_resources/mod.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/mod.rs
@@ -24,7 +24,7 @@ pub use pipeline_layout_pool::{GpuPipelineLayoutPool, PipelineLayoutDesc};
 mod render_pipeline_pool;
 pub use render_pipeline_pool::{
     GpuRenderPipelineHandle, GpuRenderPipelinePool, GpuRenderPipelinePoolAccessor,
-    GpuRenderPipelinePoolMoveAccessor, RenderPipelineDesc, VertexBufferLayout,
+    RenderPipelineDesc, VertexBufferLayout,
 };
 
 mod sampler_pool;

--- a/crates/viewer/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/pipeline_layout_pool.rs
@@ -2,9 +2,7 @@ use crate::{debug_label::DebugLabel, RenderContext};
 
 use super::{
     bind_group_layout_pool::GpuBindGroupLayoutHandle,
-    static_resource_pool::{
-        StaticResourcePool, StaticResourcePoolAccessor as _, StaticResourcePoolReadLockAccessor,
-    },
+    static_resource_pool::{StaticResourcePool, StaticResourcePoolReadLockAccessor},
 };
 
 slotmap::new_key_type! { pub struct GpuPipelineLayoutHandle; }

--- a/crates/viewer/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/render_pipeline_pool.rs
@@ -6,10 +6,7 @@ use super::{
     pipeline_layout_pool::{GpuPipelineLayoutHandle, GpuPipelineLayoutPool},
     resource::PoolError,
     shader_module_pool::{GpuShaderModuleHandle, GpuShaderModulePool},
-    static_resource_pool::{
-        StaticResourcePool, StaticResourcePoolAccessor, StaticResourcePoolMemMoveAccessor,
-        StaticResourcePoolReadLockAccessor,
-    },
+    static_resource_pool::{StaticResourcePool, StaticResourcePoolReadLockAccessor},
 };
 
 slotmap::new_key_type! { pub struct GpuRenderPipelineHandle; }
@@ -171,10 +168,7 @@ impl RenderPipelineDesc {
 }
 
 pub type GpuRenderPipelinePoolAccessor<'a> =
-    dyn StaticResourcePoolAccessor<GpuRenderPipelineHandle, wgpu::RenderPipeline> + 'a;
-
-pub type GpuRenderPipelinePoolMoveAccessor =
-    StaticResourcePoolMemMoveAccessor<GpuRenderPipelineHandle, wgpu::RenderPipeline>;
+    StaticResourcePoolReadLockAccessor<'a, GpuRenderPipelineHandle, wgpu::RenderPipeline>;
 
 #[derive(Default)]
 pub struct GpuRenderPipelinePool {
@@ -254,22 +248,6 @@ impl GpuRenderPipelinePool {
         &self,
     ) -> StaticResourcePoolReadLockAccessor<'_, GpuRenderPipelineHandle, wgpu::RenderPipeline> {
         self.pool.resources()
-    }
-
-    /// Takes out all resources from the pool.
-    ///
-    /// This is useful when the existing resources need to be accessed without
-    /// taking a lock on the pool.
-    /// Resource can be put with `return_resources`.
-    pub fn take_resources(&mut self) -> GpuRenderPipelinePoolMoveAccessor {
-        self.pool.take_resources()
-    }
-
-    /// Counterpart to `take_resources`.
-    ///
-    /// Logs an error if resources were added to the pool since `take_resources` was called.
-    pub fn return_resources(&mut self, resources: GpuRenderPipelinePoolMoveAccessor) {
-        self.pool.return_resources(resources);
     }
 
     pub fn num_resources(&self) -> usize {

--- a/crates/viewer/re_renderer/src/wgpu_resources/static_resource_pool.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/static_resource_pool.rs
@@ -92,31 +92,6 @@ where
         }
     }
 
-    /// Takes out all resources from the pool.
-    ///
-    /// This is useful when the existing resources need to be accessed without
-    /// taking a lock on the pool.
-    pub fn take_resources(&mut self) -> StaticResourcePoolMemMoveAccessor<Handle, Res> {
-        StaticResourcePoolMemMoveAccessor {
-            resources: std::mem::take(self.resources.get_mut()),
-            current_frame_index: self.current_frame_index,
-        }
-    }
-
-    /// Counter part to `take_resources`.
-    ///
-    /// Logs an error if resources were added to the pool since `take_resources` was called.
-    pub fn return_resources(&mut self, resources: StaticResourcePoolMemMoveAccessor<Handle, Res>) {
-        let resources_added_meanwhile =
-            std::mem::replace(self.resources.get_mut(), resources.resources);
-        if !resources_added_meanwhile.is_empty() {
-            re_log::error!(
-                "{} resources were discarded because they were added to the resource pool while the resources were taken out.",
-                resources_added_meanwhile.len()
-            );
-        }
-    }
-
     pub fn num_resources(&self) -> usize {
         self.resources.read().len()
     }
@@ -132,21 +107,14 @@ fn to_pool_error<T>(get_result: Option<T>, handle: impl Key) -> Result<T, PoolEr
     })
 }
 
-/// Accessor to the resource pool, either by taking a read lock or by moving out the resources.
-pub trait StaticResourcePoolAccessor<Handle: Key, Res> {
-    fn get(&self, handle: Handle) -> Result<&Res, PoolError>;
-}
-
 /// Accessor to the resource pool by taking a read lock.
 pub struct StaticResourcePoolReadLockAccessor<'a, Handle: Key, Res> {
     resources: RwLockReadGuard<'a, SlotMap<Handle, StoredResource<Res>>>,
     current_frame_index: u64,
 }
 
-impl<'a, Handle: Key, Res> StaticResourcePoolAccessor<Handle, Res>
-    for StaticResourcePoolReadLockAccessor<'a, Handle, Res>
-{
-    fn get(&self, handle: Handle) -> Result<&Res, PoolError> {
+impl<'a, Handle: Key, Res> StaticResourcePoolReadLockAccessor<'a, Handle, Res> {
+    pub fn get(&self, handle: Handle) -> Result<&Res, PoolError> {
         to_pool_error(
             self.resources.get(handle).map(|resource| {
                 resource.statistics.last_frame_used.store(
@@ -158,37 +126,12 @@ impl<'a, Handle: Key, Res> StaticResourcePoolAccessor<Handle, Res>
             handle,
         )
     }
-}
 
-impl<'a, Handle: Key, Res> StaticResourcePoolReadLockAccessor<'a, Handle, Res> {
     pub fn get_statistics(&self, handle: Handle) -> Result<&ResourceStatistics, PoolError> {
         to_pool_error(
             self.resources
                 .get(handle)
                 .map(|resource| &resource.statistics),
-            handle,
-        )
-    }
-}
-
-/// Accessor to the resource pool by moving out the resources.
-pub struct StaticResourcePoolMemMoveAccessor<Handle: Key, Res> {
-    resources: SlotMap<Handle, StoredResource<Res>>,
-    current_frame_index: u64,
-}
-
-impl<Handle: Key, Res> StaticResourcePoolAccessor<Handle, Res>
-    for StaticResourcePoolMemMoveAccessor<Handle, Res>
-{
-    fn get(&self, handle: Handle) -> Result<&Res, PoolError> {
-        to_pool_error(
-            self.resources.get(handle).map(|resource| {
-                resource.statistics.last_frame_used.store(
-                    self.current_frame_index,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-                &resource.resource
-            }),
             handle,
         )
     }
@@ -201,9 +144,7 @@ mod tests {
     use slotmap::Key;
 
     use super::StaticResourcePool;
-    use crate::wgpu_resources::{
-        resource::PoolError, static_resource_pool::StaticResourcePoolAccessor as _,
-    };
+    use crate::wgpu_resources::resource::PoolError;
 
     slotmap::new_key_type! { pub struct ConcreteHandle; }
 

--- a/crates/viewer/re_renderer_examples/framework.rs
+++ b/crates/viewer/re_renderer_examples/framework.rs
@@ -255,9 +255,6 @@ impl<E: Example + 'static> Application<E> {
                         });
 
                 {
-                    // Lock render pipelines for the lifetime of the composite pass.
-                    let render_pipelines = self.re_ctx.gpu_resources.render_pipelines.resources();
-
                     let mut composite_pass =
                         composite_cmd_encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                             label: None,
@@ -283,11 +280,9 @@ impl<E: Example + 'static> Application<E> {
                             0.0,
                             1.0,
                         );
-                        draw_result.view_builder.composite(
-                            &self.re_ctx,
-                            &render_pipelines,
-                            &mut composite_pass,
-                        );
+                        draw_result
+                            .view_builder
+                            .composite(&self.re_ctx, &mut composite_pass);
                     }
                 };
 

--- a/crates/viewer/re_space_view_dataframe/Cargo.toml
+++ b/crates/viewer/re_space_view_dataframe/Cargo.toml
@@ -37,7 +37,7 @@ re_viewport_blueprint.workspace = true
 
 anyhow.workspace = true
 egui_extras.workspace = true
-egui_table = { git = "https://github.com/rerun-io/egui_table.git", rev = "c76473b244f03a7c67fbbbff9def6fc86c1ca4ea" } # main as of 2024-09-13
+egui_table = { git = "https://github.com/rerun-io/egui_table.git", rev = "15be049a4eac3b9f87aa758505ebe46fd76dcef6" } # main as of 2024-09-25
 egui.workspace = true
 itertools.workspace = true
 thiserror.workspace = true

--- a/crates/viewer/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_tensor/src/space_view_class.rs
@@ -374,6 +374,7 @@ impl TensorSpaceView {
             },
             minification: egui::TextureFilter::Linear, // TODO(andreas): allow for mipmapping based filter
             wrap_mode: egui::TextureWrapMode::ClampToEdge,
+            mipmap_mode: None,
         };
 
         gpu_bridge::render_image(

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -910,7 +910,7 @@ impl App {
                         .on_hover_text("Request a second layout pass. Just for testing.")
                         .clicked()
                     {
-                        ui.ctx().request_discard();
+                        ui.ctx().request_discard("testing");
                     }
 
                     egui::CollapsingHeader::new("egui settings")

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -91,6 +91,10 @@ impl App {
                 debug_menu_options_ui(ui, &mut self.state.app_options, &self.command_sender);
 
                 ui.label("egui debug options:");
+                ui.weak(format!(
+                    "pixels_per_point: {:?}",
+                    ui.ctx().pixels_per_point()
+                ));
                 egui_debug_options_ui(ui);
             });
 


### PR DESCRIPTION
* Had this fix in it: https://github.com/emilk/egui/pull/5161
* https://github.com/rerun-io/rerun/issues/6801 is NOT fixed by this PR :(

@Wumpf you had a pretty solid repro of this yesterday - please test 🙏 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7509?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7509?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7509)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.