### PR TITLE
Fix `cargo t --all`

### DIFF
--- a/crates/viewer/re_ui/src/modal.rs
+++ b/crates/viewer/re_ui/src/modal.rs
@@ -9,9 +9,10 @@ use egui::NumExt;
 /// Usage:
 /// ```
 /// # use re_ui::modal::{Modal, ModalHandler};
-/// let mut modal_handler = ModalHandler::default();
 ///
 /// # egui::__run_test_ui(|ui| {
+/// let mut modal_handler = ModalHandler::default();
+///
 /// if ui.button("Open").clicked() {
 ///     modal_handler.open();
 /// }


### PR DESCRIPTION
Tests are broken on `main` due to a failing doctest in re_ui, this fixes that.

```
test crates/viewer/re_ui/src/modal.rs - modal::ModalHandler (line 10) ... FAILED

failures:

---- crates/viewer/re_ui/src/modal.rs - modal::ModalHandler (line 10) stdout ----
error[E0596]: cannot borrow `modal_handler` as mutable, as it is a captured variable in a `Fn` closure
  --> crates/viewer/re_ui/src/modal.rs:17:5
   |
10 |     modal_handler.open();
   |     ^^^^^^^^^^^^^ cannot borrow as mutable

error[E0596]: cannot borrow `modal_handler` as mutable, as it is a captured variable in a `Fn` closure
  --> crates/viewer/re_ui/src/modal.rs:20:1
   |
13 | modal_handler.ui(ui.ctx(), || Modal::new("Modal Window"), |ui, _| {
   | ^^^^^^^^^^^^^ cannot borrow as mutable

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0596`.
Couldn't compile the test.

failures:
    crates/viewer/re_ui/src/modal.rs - modal::ModalHandler (line 10)

test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.20s

error: doctest failed, to rerun pass `-p re_ui --doc`
```


* [x] yes