### PR TITLE
`Caches` per recording

### DIFF
--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1232,7 +1232,6 @@ impl App {
                 );
             }
             store_hub.purge_fraction_of_ram(fraction_to_purge);
-            self.state.cache.purge_memory();
 
             let mem_use_after = MemoryUse::capture();
 
@@ -1600,7 +1599,7 @@ impl eframe::App for App {
 
             // We haven't called `begin_frame` at this point, so pretend we did and add one to the active frame index.
             let renderer_active_frame_idx = render_ctx.active_frame_idx().wrapping_add(1);
-            self.state.cache.begin_frame(renderer_active_frame_idx);
+            store_hub.begin_frame(renderer_active_frame_idx);
         }
 
         self.show_text_logs_as_notifications();

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -8,10 +8,9 @@ use re_smart_channel::ReceiveSet;
 use re_types::blueprint::components::PanelState;
 use re_ui::ContextExt as _;
 use re_viewer_context::{
-    blueprint_timeline, AppOptions, ApplicationSelectionState, Caches, CommandSender,
-    ComponentUiRegistry, PlayState, RecordingConfig, SpaceViewClassExt as _,
-    SpaceViewClassRegistry, StoreContext, StoreHub, SystemCommandSender as _, ViewStates,
-    ViewerContext,
+    blueprint_timeline, AppOptions, ApplicationSelectionState, CommandSender, ComponentUiRegistry,
+    PlayState, RecordingConfig, SpaceViewClassExt as _, SpaceViewClassRegistry, StoreContext,
+    StoreHub, SystemCommandSender as _, ViewStates, ViewerContext,
 };
 use re_viewport::Viewport;
 use re_viewport_blueprint::ui::add_space_view_or_container_modal_ui;
@@ -27,10 +26,6 @@ const WATERMARK: bool = false; // Nice for recording media material
 pub struct AppState {
     /// Global options for the whole viewer.
     pub(crate) app_options: AppOptions,
-
-    /// Things that need caching.
-    #[serde(skip)]
-    pub(crate) cache: Caches,
 
     /// Configuration for the current recording (found in [`EntityDb`]).
     recording_configs: HashMap<StoreId, RecordingConfig>,
@@ -73,7 +68,6 @@ impl Default for AppState {
     fn default() -> Self {
         Self {
             app_options: Default::default(),
-            cache: Default::default(),
             recording_configs: Default::default(),
             blueprint_cfg: Default::default(),
             selection_panel: Default::default(),
@@ -149,7 +143,6 @@ impl AppState {
 
         let Self {
             app_options,
-            cache,
             recording_configs,
             blueprint_cfg,
             selection_panel,
@@ -254,7 +247,7 @@ impl AppState {
         let egui_ctx = ui.ctx().clone();
         let ctx = ViewerContext {
             app_options,
-            cache,
+            cache: store_context.caches,
             space_view_class_registry,
             reflection,
             component_ui_registry,
@@ -321,7 +314,7 @@ impl AppState {
         // but it's just a bunch of refs so not really that big of a deal in practice.
         let ctx = ViewerContext {
             app_options,
-            cache,
+            cache: store_context.caches,
             space_view_class_registry,
             reflection,
             component_ui_registry,

--- a/crates/viewer/re_viewer_context/src/store_context.rs
+++ b/crates/viewer/re_viewer_context/src/store_context.rs
@@ -1,7 +1,7 @@
 use re_entity_db::{EntityDb, StoreBundle};
 use re_log_types::{ApplicationId, StoreId};
 
-use crate::StoreHub;
+use crate::{Caches, StoreHub};
 
 /// The current Blueprint and Recording being displayed by the viewer
 pub struct StoreContext<'a> {
@@ -23,6 +23,9 @@ pub struct StoreContext<'a> {
     ///
     /// This is the same bundle as is in [`Self::hub`], but extracted for ease-of-access.
     pub bundle: &'a StoreBundle,
+
+    /// Things that need caching.
+    pub caches: &'a Caches,
 
     /// The store hub, which keeps track of all the default and active blueprints, among other things.
     pub hub: &'a StoreHub,

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -66,6 +66,7 @@ impl TestContext {
                     default_blueprint: None,
                     recording: &self.recording_store,
                     bundle: &Default::default(),
+                    caches: &Default::default(),
                     hub: &Default::default(),
                 };
 

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -770,6 +770,7 @@ mod tests {
             default_blueprint: None,
             recording: &test_ctx.recording_store,
             bundle: &Default::default(),
+            caches: &Default::default(),
             hub: &re_viewer_context::StoreHub::test_hub(),
         };
 

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -616,6 +616,7 @@ mod tests {
             default_blueprint: None,
             recording: &recording,
             bundle: &Default::default(),
+            caches: &Default::default(),
             hub: &StoreHub::test_hub(),
         };
 


### PR DESCRIPTION
Moves `Caches` from `AppState` to the `StoreHub`, and make them per-recording instead of viewer-wide in the process.

This is:
* a pre-requisite to fix the repeated static logging issues (#7404)
* a necessary step towards proper secondary caching
* a fix for a very old issue: cache memory is not reclaimed when closing a recording

I'm not a fan of the implementation: it's brittle, confusing, and I don't like it. Still, it's a net improvement over the status quo, and fixes a very annoying "leak" for end users.

Before:

https://github.com/user-attachments/assets/a54c1923-a939-4700-a485-eeb2a2dd4966



After:

https://github.com/user-attachments/assets/dd5adb65-d328-474c-bc31-e65a59332f03



---

* Part of #7404 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7513?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7513?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7513)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.