### PR TITLE
Disable the `map_unwrap_or` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,6 @@ manual_ok_or = "warn"
 manual_string_new = "warn"
 map_err_ignore = "warn"
 map_flatten = "warn"
-map_unwrap_or = "warn"
 match_on_vec_items = "warn"
 match_same_arms = "warn"
 match_wild_err_arm = "warn"
@@ -499,6 +498,7 @@ zero_sized_map_values = "warn"
 #self_named_module_files = "warn"
 
 manual_range_contains = "allow" # this one is just worse imho
+map_unwrap_or = "allow"         # so is this one
 ref_patterns = "allow"          # It's nice to avoid ref pattern, but there are some situations that are hard (impossible?) to express without.
 
 # TODO(emilk): enable more of these lints:


### PR DESCRIPTION
### What

`map_or(default_value, |val| f(val))` is imo strictly worse than `map(|val| f(val)).unwrap_or(default_value)`, especially in a context of chained calls where having each on a different line is better. So this PR disables this lint.

Relevant slack thread: https://rerunio.slack.com/archives/C0440MD5UAV/p1724749276769059

Arguably, the self-admitted known limitations are much worse than the supposed problem this lint is supposed to fix: https://rust-lang.github.io/rust-clippy/stable/index.html#/map_unwrap_or

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7524?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7524?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7524)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.