### PR TITLE
Don't show video load error if a blob has unrecognized or non-video media type

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -441,7 +441,8 @@ fn preview_if_blob_ui(
     let blob = blob.component_mono::<components::Blob>()?.ok()?;
     let media_type = component_map
         .get(&components::MediaType::name())
-        .and_then(|unit| unit.component_mono::<components::MediaType>()?.ok());
+        .and_then(|unit| unit.component_mono::<components::MediaType>()?.ok())
+        .or_else(|| components::MediaType::guess_from_data(&blob));
 
     let video_timestamp = component_map
         .get(&components::VideoTimestamp::name())


### PR DESCRIPTION
### What

Before:
![image](https://github.com/user-attachments/assets/acb4868a-b440-4a10-8019-8913246fa9a1)

After:
![image](https://github.com/user-attachments/assets/00385097-4420-4b47-bc15-759afac3876f)

... luckily I tried an obj file whose media type can't be recognized from bytes (because obj is a wild text format), which made me run into the corner case of video module not recognizing the format _and_ us not recognizing the media type from the blob.

Counter example, trying to load a wmv:
![image](https://github.com/user-attachments/assets/846c20d9-ad46-42d6-94d9-ec6e175c2517)
(btw. I did so by renaming the file to mp4 and dragging it in, otherwise we reject it earlier. Same could be achieved with direct log calls ofc)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7528?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7528?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7528)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.