### PR TITLE
Fix missing s in --break-system-packages

### DIFF
--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'
         run: |
-          pip install --break-system-package google-cloud-storage==2.9.0
+          pip install --break-system-packages google-cloud-storage==2.9.0
           scripts/ci/render_bench.py crates \
             --after $(date -d"30 days ago" +%Y-%m-%d) \
             --output "gs://rerun-builds/graphs"

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'
         run: |
-          python3 -m pip install --break-system-package google-cloud-storage==2.9.0
+          python3 -m pip install --break-system-packages google-cloud-storage==2.9.0
           scripts/ci/render_bench.py sizes \
             --after $(date -d"180 days ago" +%Y-%m-%d) \
             --output "gs://rerun-builds/graphs"


### PR DESCRIPTION
### What

I managed to wrongly spell the `--break-system-packages` argument in my previous fix 🤦🏻 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7550?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7550?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7550)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.