### PR TITLE
Make `VideoDecoder` a `trait`

### DIFF
--- a/crates/viewer/re_renderer/src/video/decoder/native.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/native.rs
@@ -1,10 +1,12 @@
+// TODO(#7298): decode on native
+
 #![allow(dead_code, unused_variables, clippy::unnecessary_wraps)]
 
 use std::sync::Arc;
 
 use crate::{
     resource_managers::GpuTexture2D,
-    video::{DecodeHardwareAcceleration, DecodingError, FrameDecodingResult},
+    video::{DecodingError, FrameDecodingResult},
     RenderContext,
 };
 
@@ -12,18 +14,18 @@ use crate::{
 #[allow(unused_imports)]
 use super::latest_at_idx;
 
-use super::alloc_video_frame_texture;
+use super::{alloc_video_frame_texture, VideoDecoder};
 
-pub struct VideoDecoder {
+/// A [`VideoDecoder`] that always fails.
+pub struct NoNativeVideoDecoder {
     data: Arc<re_video::VideoData>,
     zeroed_texture: GpuTexture2D,
 }
 
-impl VideoDecoder {
+impl NoNativeVideoDecoder {
     pub fn new(
         render_context: &RenderContext,
         data: Arc<re_video::VideoData>,
-        _hw_acceleration: DecodeHardwareAcceleration,
     ) -> Result<Self, DecodingError> {
         let device = render_context.device.clone();
         let zeroed_texture = alloc_video_frame_texture(
@@ -37,9 +39,11 @@ impl VideoDecoder {
             zeroed_texture,
         })
     }
+}
 
+impl VideoDecoder for NoNativeVideoDecoder {
     #[allow(clippy::unused_self)]
-    pub fn frame_at(
+    fn frame_at(
         &mut self,
         _render_ctx: &RenderContext,
         _presentation_timestamp_s: f64,

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -67,7 +67,7 @@ pub enum VideoFrameTexture {
 pub struct VideoDecodingStreamId(pub u64);
 
 struct DecoderEntry {
-    decoder: decoder::VideoDecoder,
+    decoder: Box<dyn decoder::VideoDecoder>,
     frame_index: u64,
 }
 
@@ -192,7 +192,7 @@ impl Video {
         let decoder_entry = match decoders.entry(decoder_stream_id) {
             Entry::Occupied(occupied_entry) => occupied_entry.into_mut(),
             Entry::Vacant(vacant_entry) => {
-                let new_decoder = decoder::VideoDecoder::new(
+                let new_decoder = decoder::new_video_decoder(
                     render_context,
                     self.data.clone(),
                     self.decode_hw_acceleration,


### PR DESCRIPTION
### What
* Part of #7298 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7577?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7577?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7577)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.