### PR TITLE
Fix codegen to silence a lint that appeared with Rust 1.79

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -975,6 +975,7 @@ fn quote_trait_impls_for_datatype_or_component(
                 // re_tracing::profile_function!();
 
                 #![allow(clippy::wildcard_imports)]
+                #![allow(clippy::manual_is_variant_and)]
                 use arrow2::{datatypes::*, array::*};
                 use ::re_types_core::{Loggable as _, ResultExt as _};
 

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -103,6 +103,7 @@ impl ::re_types_core::Loggable for BackgroundKind {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -105,6 +105,7 @@ impl ::re_types_core::Loggable for Corner2D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/latest_at_queries.rs
+++ b/crates/store/re_types/src/blueprint/components/latest_at_queries.rs
@@ -73,6 +73,7 @@ impl ::re_types_core::Loggable for LatestAtQueries {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -95,6 +95,7 @@ impl ::re_types_core::Loggable for PanelState {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/query_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/query_kind.rs
@@ -90,6 +90,7 @@ impl ::re_types_core::Loggable for QueryKind {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/time_range_queries.rs
+++ b/crates/store/re_types/src/blueprint/components/time_range_queries.rs
@@ -73,6 +73,7 @@ impl ::re_types_core::Loggable for TimeRangeQueries {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -101,6 +101,7 @@ impl ::re_types_core::Loggable for ViewFit {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
@@ -75,6 +75,7 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/filter_by_event.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_by_event.rs
@@ -72,6 +72,7 @@ impl ::re_types_core::Loggable for FilterByEvent {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
@@ -71,6 +71,7 @@ impl ::re_types_core::Loggable for FilterByRange {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/latest_at_query.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/latest_at_query.rs
@@ -71,6 +71,7 @@ impl ::re_types_core::Loggable for LatestAtQuery {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -84,6 +84,7 @@ impl ::re_types_core::Loggable for SelectedColumns {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/blueprint/datatypes/time_range_query.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/time_range_query.rs
@@ -109,6 +109,7 @@ impl ::re_types_core::Loggable for TimeRangeQuery {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -127,6 +127,7 @@ impl ::re_types_core::Loggable for AggregationPolicy {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for AnnotationContext {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -164,6 +164,7 @@ impl ::re_types_core::Loggable for Colormap {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -113,6 +113,7 @@ impl ::re_types_core::Loggable for FillMode {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for LineStrip2D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for LineStrip3D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -99,6 +99,7 @@ impl ::re_types_core::Loggable for MagnificationFilter {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -141,6 +141,7 @@ impl ::re_types_core::Loggable for MarkerShape {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -102,6 +102,7 @@ impl ::re_types_core::Loggable for TransformRelation {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/angle.rs
+++ b/crates/store/re_types/src/datatypes/angle.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Angle {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/annotation_info.rs
+++ b/crates/store/re_types/src/datatypes/annotation_info.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for AnnotationInfo {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for Blob {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/channel_datatype.rs
+++ b/crates/store/re_types/src/datatypes/channel_datatype.rs
@@ -149,6 +149,7 @@ impl ::re_types_core::Loggable for ChannelDatatype {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/class_description.rs
+++ b/crates/store/re_types/src/datatypes/class_description.rs
@@ -108,6 +108,7 @@ impl ::re_types_core::Loggable for ClassDescription {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/store/re_types/src/datatypes/class_description_map_elem.rs
@@ -77,6 +77,7 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/class_id.rs
+++ b/crates/store/re_types/src/datatypes/class_id.rs
@@ -88,6 +88,7 @@ impl ::re_types_core::Loggable for ClassId {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/color_model.rs
+++ b/crates/store/re_types/src/datatypes/color_model.rs
@@ -111,6 +111,7 @@ impl ::re_types_core::Loggable for ColorModel {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/image_format.rs
+++ b/crates/store/re_types/src/datatypes/image_format.rs
@@ -105,6 +105,7 @@ impl ::re_types_core::Loggable for ImageFormat {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_id.rs
@@ -90,6 +90,7 @@ impl ::re_types_core::Loggable for KeypointId {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_pair.rs
@@ -75,6 +75,7 @@ impl ::re_types_core::Loggable for KeypointPair {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/mat3x3.rs
+++ b/crates/store/re_types/src/datatypes/mat3x3.rs
@@ -88,6 +88,7 @@ impl ::re_types_core::Loggable for Mat3x3 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/mat4x4.rs
+++ b/crates/store/re_types/src/datatypes/mat4x4.rs
@@ -88,6 +88,7 @@ impl ::re_types_core::Loggable for Mat4x4 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/pixel_format.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format.rs
@@ -111,6 +111,7 @@ impl ::re_types_core::Loggable for PixelFormat {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/quaternion.rs
+++ b/crates/store/re_types/src/datatypes/quaternion.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for Quaternion {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/range1d.rs
+++ b/crates/store/re_types/src/datatypes/range1d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Range1D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/range2d.rs
+++ b/crates/store/re_types/src/datatypes/range2d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Range2D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/rgba32.rs
+++ b/crates/store/re_types/src/datatypes/rgba32.rs
@@ -78,6 +78,7 @@ impl ::re_types_core::Loggable for Rgba32 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
@@ -71,6 +71,7 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -223,6 +223,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/tensor_data.rs
+++ b/crates/store/re_types/src/datatypes/tensor_data.rs
@@ -87,6 +87,7 @@ impl ::re_types_core::Loggable for TensorData {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension.rs
@@ -67,6 +67,7 @@ impl ::re_types_core::Loggable for TensorDimension {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
@@ -69,6 +69,7 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
@@ -67,6 +67,7 @@ impl ::re_types_core::Loggable for TensorDimensionSelection {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/uuid.rs
+++ b/crates/store/re_types/src/datatypes/uuid.rs
@@ -79,6 +79,7 @@ impl ::re_types_core::Loggable for Uuid {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/uvec2d.rs
+++ b/crates/store/re_types/src/datatypes/uvec2d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for UVec2D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/uvec3d.rs
+++ b/crates/store/re_types/src/datatypes/uvec3d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for UVec3D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/uvec4d.rs
+++ b/crates/store/re_types/src/datatypes/uvec4d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for UVec4D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/vec2d.rs
+++ b/crates/store/re_types/src/datatypes/vec2d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Vec2D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/vec3d.rs
+++ b/crates/store/re_types/src/datatypes/vec3d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Vec3D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/vec4d.rs
+++ b/crates/store/re_types/src/datatypes/vec4d.rs
@@ -76,6 +76,7 @@ impl ::re_types_core::Loggable for Vec4D {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/video_timestamp.rs
+++ b/crates/store/re_types/src/datatypes/video_timestamp.rs
@@ -80,6 +80,7 @@ impl ::re_types_core::Loggable for VideoTimestamp {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/datatypes/view_coordinates.rs
+++ b/crates/store/re_types/src/datatypes/view_coordinates.rs
@@ -94,6 +94,7 @@ impl ::re_types_core::Loggable for ViewCoordinates {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -87,6 +87,7 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -91,6 +91,7 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -91,6 +91,7 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -91,6 +91,7 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
@@ -111,6 +111,7 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -69,6 +69,7 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -69,6 +69,7 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -69,6 +69,7 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
@@ -93,6 +93,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
@@ -97,6 +97,7 @@ impl ::re_types_core::Loggable for AffixFuzzer23 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
@@ -124,6 +124,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
@@ -124,6 +124,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
@@ -124,6 +124,7 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -69,6 +69,7 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
@@ -87,6 +87,7 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -87,6 +87,7 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -121,6 +121,7 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -71,6 +71,7 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -72,6 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -72,6 +72,7 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -80,6 +80,7 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -95,6 +95,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -85,6 +85,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -94,6 +94,7 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/enum_test.rs
+++ b/crates/store/re_types/src/testing/datatypes/enum_test.rs
@@ -117,6 +117,7 @@ impl ::re_types_core::Loggable for EnumTest {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -77,6 +77,7 @@ impl ::re_types_core::Loggable for FlattenedScalar {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/multi_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/multi_enum.rs
@@ -75,6 +75,7 @@ impl ::re_types_core::Loggable for MultiEnum {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/primitive_component.rs
@@ -72,6 +72,7 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/string_component.rs
@@ -72,6 +72,7 @@ impl ::re_types_core::Loggable for StringComponent {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types/src/testing/datatypes/valued_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/valued_enum.rs
@@ -99,6 +99,7 @@ impl ::re_types_core::Loggable for ValuedEnum {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
@@ -100,6 +100,7 @@ impl ::re_types_core::Loggable for ContainerKind {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -77,6 +77,7 @@ impl ::re_types_core::Loggable for Utf8List {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use ::re_types_core::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/bool.rs
+++ b/crates/store/re_types_core/src/datatypes/bool.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for Bool {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/store/re_types_core/src/datatypes/entity_path.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for EntityPath {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/float32.rs
+++ b/crates/store/re_types_core/src/datatypes/float32.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for Float32 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/float64.rs
+++ b/crates/store/re_types_core/src/datatypes/float64.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for Float64 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/time_int.rs
+++ b/crates/store/re_types_core/src/datatypes/time_int.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for TimeInt {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range.rs
@@ -76,6 +76,7 @@ impl crate::Loggable for TimeRange {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -89,6 +89,7 @@ impl crate::Loggable for TimeRangeBoundary {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/uint16.rs
+++ b/crates/store/re_types_core/src/datatypes/uint16.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for UInt16 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/uint32.rs
+++ b/crates/store/re_types_core/src/datatypes/uint32.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for UInt32 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/uint64.rs
+++ b/crates/store/re_types_core/src/datatypes/uint64.rs
@@ -72,6 +72,7 @@ impl crate::Loggable for UInt64 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/utf8.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8.rs
@@ -73,6 +73,7 @@ impl crate::Loggable for Utf8 {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({

--- a/crates/store/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/visible_time_range.rs
@@ -75,6 +75,7 @@ impl crate::Loggable for VisibleTimeRange {
         Self: Clone + 'a,
     {
         #![allow(clippy::wildcard_imports)]
+        #![allow(clippy::manual_is_variant_and)]
         use crate::{Loggable as _, ResultExt as _};
         use arrow2::{array::*, datatypes::*};
         Ok({


### PR DESCRIPTION
### What

#7563 introduced a lint that clippy chokes on with the codegen'd rust. This PR switches off that lint in the offending places.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7578?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7578?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7578)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.