### PR TITLE
Add test for mp4 chunked up into parts

### DIFF
--- a/tests/python/chunked_video/chunked_video.py
+++ b/tests/python/chunked_video/chunked_video.py
@@ -1,0 +1,64 @@
+"""Logs all videos in a folder to a single entity in order."""
+
+# Order is either alphabetical or - if present - by last filename digits parsed as integer.
+#
+# Any folder of .mp4 files can be used.
+# For Rerun internal users, there are examples assets available at
+# https://github.com/rerun-io/internal-test-assets/tree/main/video
+#
+# Things to look out for:
+# * are all chunks arriving, are things crashing
+# * is the video playing smooth on video asset transitions
+# * does seeking across and within video assets work
+# * TODO(#7481): does memory usage induced by mp4 parsing stay low and doesn't accumluate (see also )
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import rerun as rr
+
+
+# Try sorting by last filename digits parsed as integer.
+def get_trailing_number(filename: Path) -> int:
+    match = re.search(r"\d+$", filename.stem)
+    return int(match.group()) if match else 0
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <path_to_folder>")
+        sys.exit(1)
+
+    rr.init("rerun_example_chunked_video", spawn=True)
+
+    video_folder = Path(sys.argv[1])
+    video_files = [file for file in video_folder.iterdir() if file.suffix == ".mp4"]
+
+    video_files.sort(key=get_trailing_number)
+
+    last_time_ns = 0
+    for file in video_files:
+        print(f"Logging video {file}, start time {last_time_ns}ns")
+
+        rr.set_time_nanos("video_time", last_time_ns)
+
+        video_asset = rr.AssetVideo(path=file)
+        rr.log("video", video_asset)
+
+        frame_timestamps_ns = video_asset.read_frame_timestamps_ns()
+        rr.send_columns(
+            "video",
+            # Note timeline values don't have to be the same as the video timestamps.
+            times=[rr.TimeNanosColumn("video_time", frame_timestamps_ns + last_time_ns)],
+            components=[
+                rr.VideoFrameReference.indicator(),
+                rr.components.VideoTimestamp.nanoseconds(frame_timestamps_ns),
+            ],
+        )
+        last_time_ns += frame_timestamps_ns[-1]
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/python/chunked_video/chunked_video.py
+++ b/tests/python/chunked_video/chunked_video.py
@@ -10,7 +10,7 @@
 # * are all chunks arriving, are things crashing
 # * is the video playing smooth on video asset transitions
 # * does seeking across and within video assets work
-# * TODO(#7481): does memory usage induced by mp4 parsing stay low and doesn't accumluate (see also )
+# * does memory usage induced by mp4 parsing stay low over time and doesn't accumluate (TODO(#7481): it should be smaller to begin with)
 from __future__ import annotations
 
 import re


### PR DESCRIPTION
### What

Add a (manual) python test to check whether we behave correctly if the video asset changes over time.

For testing I took a 1.4gb video which fails to process in a single block due to out-of-memory issues and split it up into 1min segments. These then get loaded by this new script.
The resulting video works fine in Chrome. Having some Firefox sided crashes, likely since this is a 4k 60fps video
(unlike it says at the beginning, the video is _not_ an hdr video)

https://rerun.io/viewer/pr/7569?url=https://static.rerun.io/rrd/0.19.0/rerun_example_chunked_video_b1924f46b121adc34b51bee497a00b1d389a8bbd.rrd

There are unfortunately some hickups between the video segments, but it works decently well overall I'd say.

https://github.com/user-attachments/assets/39ad4a65-ec3e-4440-8501-458bdeaebce6


I think with this (and other 8k tests I did) we're done with
* Fixes #7480

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7580?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7580?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7580)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.