### PR TITLE
Dataframe v2: support for `filtered_index_values`

### DIFF
--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -527,6 +527,13 @@ impl QueryHandle<'_> {
             .min_by_key(|streaming_state| streaming_state.index_value)
             .map(|streaming_state| streaming_state.index_value)?;
 
+        if let Some(filtered_index_values) = self.query.filtered_index_values.as_ref() {
+            if !filtered_index_values.contains(&cur_index_value) {
+                self.increment_cursors_at_index_value(cur_index_value);
+                return self.next_row();
+            }
+        }
+
         for streaming_state in &mut view_streaming_state {
             if streaming_state.as_ref().map(|s| s.index_value) != Some(cur_index_value) {
                 *streaming_state = None;


### PR DESCRIPTION
Title.

* DNM: requires #7587

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7589)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.