### PR TITLE
Fix image & video cache creating new entries when selecting data without explicit media type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,6 +6209,7 @@ name = "rerun_c"
 version = "0.19.0-alpha.1+dev"
 dependencies = [
  "ahash",
+ "infer",
  "once_cell",
  "parking_lot",
  "re_arrow2",
@@ -6224,6 +6225,7 @@ dependencies = [
  "arrow",
  "crossbeam",
  "document-features",
+ "infer",
  "itertools 0.13.0",
  "mimalloc",
  "once_cell",

--- a/crates/store/re_types/src/archetypes/asset_video_ext.rs
+++ b/crates/store/re_types/src/archetypes/asset_video_ext.rs
@@ -44,11 +44,18 @@ impl AssetVideo {
     /// Returned timestamps are in nanoseconds since start and are guaranteed to be monotonically increasing.
     #[cfg(feature = "video")]
     pub fn read_frame_timestamps_ns(&self) -> Result<Vec<i64>, re_video::VideoLoadError> {
-        Ok(re_video::VideoData::load_from_bytes(
-            self.blob.as_slice(),
-            self.media_type.as_ref().map(|m| m.as_str()),
-        )?
-        .frame_timestamps_ns()
-        .collect())
+        let Some(media_type) = self
+            .media_type
+            .clone()
+            .or_else(|| MediaType::guess_from_data(&self.blob))
+        else {
+            return Err(re_video::VideoLoadError::UnrecognizedMimeType);
+        };
+
+        Ok(
+            re_video::VideoData::load_from_bytes(self.blob.as_slice(), media_type.as_str())?
+                .frame_timestamps_ns()
+                .collect(),
+        )
     }
 }

--- a/crates/store/re_types/src/image.rs
+++ b/crates/store/re_types/src/image.rs
@@ -59,6 +59,10 @@ pub enum ImageLoadError {
     /// The encountered MIME type is not supported for decoding images.
     #[error("MIME type '{0}' is not supported for images")]
     UnsupportedMimeType(String),
+
+    /// Failed to read the MIME type from inspecting the image data blob.
+    #[error("Could not detect MIME type from the image contents")]
+    UnrecognizedMimeType,
 }
 
 #[cfg(feature = "image")]

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -48,28 +48,16 @@ impl VideoData {
     ///
     /// TODO(andreas, jan): This should not copy the data, but instead store slices into a shared buffer.
     /// at the very least the should be a way to extract only metadata.
-    pub fn load_from_bytes(data: &[u8], media_type: Option<&str>) -> Result<Self, VideoLoadError> {
-        // Media type guessing here should be identical to `re_types::MediaType::guess_from_data`,
-        // but we don't want to depend on `re_types` here.
-        let media_type = if let Some(media_type) = media_type {
-            media_type.to_owned()
-        } else if mp4::is_mp4(data) {
-            "video/mp4".to_owned()
-        } else {
-            return Err(VideoLoadError::UnrecognizedVideoFormat {
-                provided_media_type: media_type.map(|m| m.to_owned()),
-            });
-        };
-
-        match media_type.as_str() {
+    pub fn load_from_bytes(data: &[u8], media_type: &str) -> Result<Self, VideoLoadError> {
+        match media_type {
             "video/mp4" => mp4::load_mp4(data),
             media_type => {
                 if media_type.starts_with("video/") {
-                    Err(VideoLoadError::UnsupportedMediaType {
+                    Err(VideoLoadError::UnsupportedMimeType {
                         provided_or_detected_media_type: media_type.to_owned(),
                     })
                 } else {
-                    Err(VideoLoadError::MediaTypeIsNotAVideo {
+                    Err(VideoLoadError::MimeTypeIsNotAVideo {
                         provided_or_detected_media_type: media_type.to_owned(),
                     })
                 }
@@ -270,18 +258,18 @@ pub enum VideoLoadError {
     InvalidSamples,
 
     #[error("The media type of the blob is not a video: {provided_or_detected_media_type}")]
-    MediaTypeIsNotAVideo {
+    MimeTypeIsNotAVideo {
         provided_or_detected_media_type: String,
     },
 
-    #[error("Video file has unsupported media type {provided_or_detected_media_type}")]
-    UnsupportedMediaType {
+    #[error("MIME type '{provided_or_detected_media_type}' is not supported for videos")]
+    UnsupportedMimeType {
         provided_or_detected_media_type: String,
     },
 
-    // Technically this is a "failed to detect" case, but the only formats we detect as of writing are the ones we support.
-    #[error("Video file has unsupported format")]
-    UnrecognizedVideoFormat { provided_media_type: Option<String> },
+    /// Not used in `re_video` itself, but useful for media type detection ahead of calling [`VideoData::load_from_bytes`].
+    #[error("Could not detect MIME type from the video contents")]
+    UnrecognizedMimeType,
 
     // `FourCC`'s debug impl doesn't quote the result
     #[error("Video track uses unsupported codec \"{0}\"")] // NOLINT

--- a/crates/store/re_video/src/mp4.rs
+++ b/crates/store/re_video/src/mp4.rs
@@ -91,39 +91,3 @@ fn unknown_codec_fourcc(mp4: &re_mp4::Mp4, track: &re_mp4::Track) -> re_mp4::Fou
         _ => Default::default(),
     }
 }
-
-/// Returns whether a buffer is MP4 video data.
-///
-/// From `infer` crate.
-pub fn is_mp4(buf: &[u8]) -> bool {
-    buf.len() > 11
-        && (buf[4] == b'f' && buf[5] == b't' && buf[6] == b'y' && buf[7] == b'p')
-        && ((buf[8] == b'a' && buf[9] == b'v' && buf[10] == b'c' && buf[11] == b'1')
-            || (buf[8] == b'd' && buf[9] == b'a' && buf[10] == b's' && buf[11] == b'h')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'2')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'3')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'4')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'5')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'6')
-            || (buf[8] == b'i' && buf[9] == b's' && buf[10] == b'o' && buf[11] == b'm')
-            || (buf[8] == b'm' && buf[9] == b'm' && buf[10] == b'p' && buf[11] == b'4')
-            || (buf[8] == b'm' && buf[9] == b'p' && buf[10] == b'4' && buf[11] == b'1')
-            || (buf[8] == b'm' && buf[9] == b'p' && buf[10] == b'4' && buf[11] == b'2')
-            || (buf[8] == b'm' && buf[9] == b'p' && buf[10] == b'4' && buf[11] == b'v')
-            || (buf[8] == b'm' && buf[9] == b'p' && buf[10] == b'7' && buf[11] == b'1')
-            || (buf[8] == b'M' && buf[9] == b'S' && buf[10] == b'N' && buf[11] == b'V')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'A' && buf[11] == b'S')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'S' && buf[11] == b'C')
-            || (buf[8] == b'N' && buf[9] == b'S' && buf[10] == b'D' && buf[11] == b'C')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'S' && buf[11] == b'H')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'S' && buf[11] == b'M')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'S' && buf[11] == b'P')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'S' && buf[11] == b'S')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'X' && buf[11] == b'C')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'X' && buf[11] == b'H')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'X' && buf[11] == b'M')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'X' && buf[11] == b'P')
-            || (buf[8] == b'N' && buf[9] == b'D' && buf[10] == b'X' && buf[11] == b'S')
-            || (buf[8] == b'F' && buf[9] == b'4' && buf[10] == b'V' && buf[11] == b' ')
-            || (buf[8] == b'F' && buf[9] == b'4' && buf[10] == b'P' && buf[11] == b' '))
-}

--- a/crates/top/rerun_c/Cargo.toml
+++ b/crates/top/rerun_c/Cargo.toml
@@ -40,5 +40,6 @@ re_video.workspace = true
 
 ahash.workspace = true
 arrow2.workspace = true
+infer.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -103,9 +103,7 @@ pub fn blob_preview_and_save_ui(
     // Try to treat it as an image:
     let image = blob_row_id.and_then(|row_id| {
         ctx.cache
-            .entry(|c: &mut re_viewer_context::ImageDecodeCache| {
-                c.entry(row_id, blob, media_type.as_ref().map(|mt| mt.as_str()))
-            })
+            .entry(|c: &mut re_viewer_context::ImageDecodeCache| c.entry(row_id, blob, media_type))
             .ok()
     });
     if let Some(image) = &image {
@@ -118,7 +116,7 @@ pub fn blob_preview_and_save_ui(
             c.entry(
                 blob_row_id,
                 blob,
-                media_type.as_ref().map(|mt| mt.as_str()),
+                media_type,
                 ctx.app_options.video_decoder_hw_acceleration,
             )
         });
@@ -286,15 +284,13 @@ fn show_video_blob_info(
                 }
             });
         }
-        Err(VideoLoadError::MediaTypeIsNotAVideo { .. }) => {
+        Err(VideoLoadError::MimeTypeIsNotAVideo { .. }) => {
             // Don't show an error if this wasn't a video in the first place.
             // Unfortunately we can't easily detect here if the Blob was _supposed_ to be a video, for that we'd need tagged components!
             // (User may have confidently logged a non-video format as Video, we should tell them that!)
         }
-        Err(VideoLoadError::UnrecognizedVideoFormat {
-            provided_media_type: None,
-        }) => {
-            // If we couldn't detect the media type and the loader didn't know the format,
+        Err(VideoLoadError::UnrecognizedMimeType) => {
+            // If we couldn't detect the media type,
             // we can't show an error for unrecognized formats since maybe this wasn't a video to begin with.
             // See also `MediaTypeIsNotAVideo` case above.
         }

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -135,7 +135,7 @@ impl Video {
     /// - `video/mp4`
     pub fn load(
         data: &[u8],
-        media_type: Option<&str>,
+        media_type: &str,
         decode_hw_acceleration: DecodeHardwareAcceleration,
     ) -> Result<Self, VideoLoadError> {
         let data = Arc::new(re_video::VideoData::load_from_bytes(data, media_type)?);

--- a/crates/viewer/re_space_view_spatial/src/lib.rs
+++ b/crates/viewer/re_space_view_spatial/src/lib.rs
@@ -83,9 +83,9 @@ fn resolution_of_image_at(
             .latest_at_component::<MediaType>(entity_path, query)
             .map(|(_, c)| c);
 
-        let image = ctx.cache.entry(|c: &mut ImageDecodeCache| {
-            c.entry(row_id, &blob, media_type.as_ref().map(|mt| mt.as_str()))
-        });
+        let image = ctx
+            .cache
+            .entry(|c: &mut ImageDecodeCache| c.entry(row_id, &blob, media_type.as_ref()));
 
         if let Ok(image) = image {
             return Some(Resolution::from([

--- a/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
@@ -155,14 +155,12 @@ impl EncodedImageVisualizer {
             let Some(blob) = blobs.first() else {
                 continue;
             };
-            let media_type = media_types.and_then(|media_types| media_types.first().cloned());
+            let media_type = media_types
+                .and_then(|media_types| media_types.first().cloned())
+                .map(|media_type| MediaType(media_type.into()));
 
             let image = ctx.viewer_ctx.cache.entry(|c: &mut ImageDecodeCache| {
-                c.entry(
-                    tensor_data_row_id,
-                    blob,
-                    media_type.as_ref().map(|mt| mt.as_str()),
-                )
+                c.entry(tensor_data_row_id, blob, media_type.as_ref())
             });
 
             let image = match image {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -409,7 +409,7 @@ fn latest_at_query_video_from_datastore(
         c.entry(
             blob_row_id,
             &blob,
-            media_type.as_ref().map(|m| m.as_str()),
+            media_type.as_ref(),
             ctx.app_options.video_decoder_hw_acceleration,
         )
     }))

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -6,6 +6,7 @@ use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_types::{
     archetypes::Image,
+    components::MediaType,
     image::{ImageKind, ImageLoadError},
     Loggable as _,
 };
@@ -42,11 +43,21 @@ impl ImageDecodeCache {
         &mut self,
         blob_row_id: RowId,
         image_bytes: &[u8],
-        media_type: Option<&str>,
+        media_type: Option<&MediaType>,
     ) -> Result<ImageInfo, ImageLoadError> {
         re_tracing::profile_function!();
 
-        let inner_key = Hash64::hash(media_type);
+        // In order to avoid loading the same video multiple times with
+        // known and unknown media type, we have to resolve the media type before
+        // loading & building the cache key.
+        let Some(media_type) = media_type
+            .cloned()
+            .or_else(|| MediaType::guess_from_data(image_bytes))
+        else {
+            return Err(ImageLoadError::UnrecognizedMimeType);
+        };
+
+        let inner_key = Hash64::hash(&media_type);
 
         let lookup = self
             .cache
@@ -54,7 +65,7 @@ impl ImageDecodeCache {
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| {
-                let result = decode_image(blob_row_id, image_bytes, media_type);
+                let result = decode_image(blob_row_id, image_bytes, media_type.as_str());
                 let memory_used = result.as_ref().map_or(0, |image| image.buffer.len() as u64);
                 self.memory_used += memory_used;
                 DecodedImageResult {
@@ -71,25 +82,16 @@ impl ImageDecodeCache {
 fn decode_image(
     blob_row_id: RowId,
     image_bytes: &[u8],
-    media_type: Option<&str>,
+    media_type: &str,
 ) -> Result<ImageInfo, ImageLoadError> {
     re_tracing::profile_function!();
 
     let mut reader = image::io::Reader::new(std::io::Cursor::new(image_bytes));
 
-    if let Some(media_type) = media_type {
-        if let Some(format) = image::ImageFormat::from_mime_type(media_type) {
-            reader.set_format(format);
-        } else {
-            return Err(ImageLoadError::UnsupportedMimeType(media_type.to_owned()));
-        }
-    }
-
-    if reader.format().is_none() {
-        if let Ok(format) = image::guess_format(image_bytes) {
-            // Weirdly enough, `reader.decode` doesn't do this for us.
-            reader.set_format(format);
-        }
+    if let Some(format) = image::ImageFormat::from_mime_type(media_type) {
+        reader.set_format(format);
+    } else {
+        return Err(ImageLoadError::UnsupportedMimeType(media_type.to_owned()));
     }
 
     let dynamic_image = reader.decode()?;

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -55,6 +55,7 @@ arrow2 = { workspace = true, features = ["io_ipc", "io_print", "arrow"] }
 crossbeam.workspace = true
 document-features.workspace = true
 itertools = { workspace = true }
+infer.workspace = true
 # TODO(#5875): `mimalloc` starts leaking OS pages starting with `0.1.38`.
 # When the bug is fixed, change this back to `mimalloc = { workspace = true, …`.
 mimalloc = { version = "=0.1.37", features = ["local_dynamic_tls"] }

--- a/rerun_py/src/video.rs
+++ b/rerun_py/src/video.rs
@@ -1,6 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)] // False positive due to #[pyfunction] macro
 
 use pyo3::{exceptions::PyRuntimeError, pyfunction, Bound, PyAny, PyResult};
+use re_video::VideoLoadError;
 
 use crate::arrow::array_to_rust;
 
@@ -29,11 +30,20 @@ pub fn asset_video_read_frame_timestamps_ns(
             ))
         })?;
 
-    Ok(re_video::VideoData::load_from_bytes(
-        video_bytes_arrow_uint8_array.values().as_slice(),
-        media_type,
+    let video_bytes = video_bytes_arrow_uint8_array.values().as_slice();
+
+    let Some(media_type) =
+        media_type.or_else(|| infer::Infer::new().get(video_bytes).map(|v| v.mime_type()))
+    else {
+        return Err(PyRuntimeError::new_err(
+            VideoLoadError::UnrecognizedMimeType.to_string(),
+        ));
+    };
+
+    Ok(
+        re_video::VideoData::load_from_bytes(video_bytes, media_type)
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
+            .frame_timestamps_ns()
+            .collect(),
     )
-    .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
-    .frame_timestamps_ns()
-    .collect())
 }


### PR DESCRIPTION
### What

* Fixes  #7584
   * but also affects images, just not as noticeable there until you kept a blob selected for a long time

That lengthy title is best explained in steps:
* load a large video (or image!) by drag & droping it in
* select it
* observe how memory goes up again!

This happened because image & video both use the media type as part of their cache key entries, but we tend to sometimes resolve it ahead of time and sometimes not, so we get new cache entries.
We _do_ want the media type in the cache entries so we can memorize which (user selected / override affected) media types won't work, but we have to make sure we don't waste memory because of when we resolve the media type.


Before:

https://github.com/user-attachments/assets/c3544b3f-95df-4311-994e-864166f3e1d4

After:

https://github.com/user-attachments/assets/9e1a5be2-3fe6-4242-aa38-4f11e018dbcb


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7590?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7590?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7590)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.