### PR TITLE
Dataframe v2: support for `filtered_point_of_view`

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -829,8 +829,6 @@ pub struct QueryExpression2 {
     /// Example: `ResolvedTimeRange(10, 20)`.
     pub filtered_index_range: Option<IndexRange>,
 
-    /// TODO(cmc): NOT IMPLEMENTED.
-    ///
     /// The specific index values used to filter out _rows_ from the view contents.
     ///
     /// Only rows where at least 1 column contains non-null data at these specific values will be kept
@@ -858,8 +856,6 @@ pub struct QueryExpression2 {
     // TODO(jleibs): We need an alternative name for sampled.
     pub sampled_index_values: Option<Vec<IndexValue>>,
 
-    /// TODO(cmc): NOT IMPLEMENTED.
-    ///
     /// The component column used to filter out _rows_ from the view contents.
     ///
     /// Only rows where this column contains non-null data be kept in the final dataset.

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -27,13 +27,13 @@ use crate::{QueryEngine, RecordBatch};
 // * [x] custom selection
 // * [x] support for overlaps (slow)
 // * [x] pagination (any solution, even a slow one)
+// * [x] pov support
+// * [ ] latestat sparse-filling
+// * [ ] sampling support
 // * [ ] overlaps (less dumb)
 // * [ ] selector-based `filtered_index`
 // * [ ] clears
-// * [ ] latestat sparse-filling
 // * [ ] pagination (fast)
-// * [ ] pov support
-// * [ ] sampling support
 // * [ ] configurable cache bypass
 // * [ ] allocate null arrays once
 // * [ ] take kernel duplicates all memory

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -820,6 +820,10 @@ mod tests {
     // * [x] filtered_point_of_view
     // * [ ] sampled_index_values
     // * [ ] sparse_fill_strategy
+    //
+    // In addition to those, some much needed extras:
+    // * [ ] timelines returned with selection=none
+    // * [ ] clears
 
     // TODO(cmc): At some point I'd like to stress multi-entity queries too, but that feels less
     // urgent considering how things are implemented (each entity lives in its own index, so it's


### PR DESCRIPTION
Title.

* DNM: requires #7589

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7589)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.