### PR TITLE
ChunkStore: Protect specific time ranges during GC

### DIFF
--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -8,7 +8,7 @@ use nohash_hasher::IntMap;
 use web_time::Instant;
 
 use re_chunk::{Chunk, ChunkId};
-use re_log_types::{EntityPath, TimeInt, Timeline};
+use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_types_core::{ComponentName, SizeBytes};
 
 use crate::{
@@ -51,6 +51,9 @@ pub struct GarbageCollectionOptions {
 
     /// How many component revisions to preserve on each timeline.
     pub protect_latest: usize,
+
+    /// Do not remove any data within these time ranges.
+    pub protected_time_ranges: HashMap<Timeline, ResolvedTimeRange>,
 }
 
 impl GarbageCollectionOptions {
@@ -59,7 +62,20 @@ impl GarbageCollectionOptions {
             target: GarbageCollectionTarget::Everything,
             time_budget: std::time::Duration::MAX,
             protect_latest: 0,
+            protected_time_ranges: Default::default(),
         }
+    }
+
+    /// If true, we cannot remove this chunk.
+    pub fn is_chunk_protected(&self, chunk: &Chunk) -> bool {
+        for (timeline, protected_time_range) in &self.protected_time_ranges {
+            if let Some(time_column) = chunk.timelines().get(timeline) {
+                if time_column.time_range().intersects(*protected_time_range) {
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 
@@ -269,6 +285,10 @@ impl ChunkStore {
                 .filter(|chunk_id| !protected_chunk_ids.contains(chunk_id))
             {
                 if let Some(chunk) = self.chunks_per_chunk_id.get(chunk_id) {
+                    if options.is_chunk_protected(chunk) {
+                        continue;
+                    }
+
                     // NOTE: Do _NOT_ use `chunk.total_size_bytes` as it is sitting behind an Arc
                     // and would count as amortized (i.e. 0 bytes).
                     num_bytes_to_drop -= <Chunk as SizeBytes>::total_size_bytes(chunk) as f64;

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -394,8 +394,9 @@ impl EntityDb {
 
         self.gc(&GarbageCollectionOptions {
             target: GarbageCollectionTarget::Everything,
-            protect_latest: 1, // TODO(jleibs): Bump this after we have an undo buffer
+            protect_latest: 1,
             time_budget: DEFAULT_GC_TIME_BUDGET,
+            protected_time_ranges: Default::default(), // TODO(#3135): Use this for undo buffer
         })
     }
 
@@ -409,6 +410,13 @@ impl EntityDb {
             target: GarbageCollectionTarget::DropAtLeastFraction(fraction_to_purge as _),
             protect_latest: 1,
             time_budget: DEFAULT_GC_TIME_BUDGET,
+
+            // TODO(emilk): we could protect the data that is currently being viewed
+            // (e.g. when paused in the live camera example).
+            // To be perfect it would need margins (because of latest-at), i.e. we would need to know
+            // exactly how far back the latest-at is of each component at the current time…
+            // …but maybe it doesn't have to be perfect.
+            protected_time_ranges: Default::default(),
         });
 
         if store_events.is_empty() {


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/3135

This lets us protect a specific time range from being garbage-collected.

This will be used to implement undo, in order to protect the latest N undo points (e.g. the latest 100, if we have max-undo=100).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7603?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7603?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7603)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.