### PR TITLE
Add support for (some) `SystemCommand` to `TestContest`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5982,6 +5982,7 @@ dependencies = [
  "serde",
  "slotmap",
  "smallvec",
+ "strum_macros",
  "thiserror",
  "uuid",
  "wasm-bindgen-futures",

--- a/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
@@ -255,3 +255,28 @@ impl Query {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Query;
+    use re_viewer_context::test_context::TestContext;
+    use re_viewer_context::SpaceViewId;
+
+    /// Simple test to demo round-trip testing using [`TestContext::run_and_handle_system_commands`].
+    #[test]
+    fn test_latest_at_enabled() {
+        let mut test_context = TestContext::default();
+
+        let view_id = SpaceViewId::random();
+
+        test_context.run_and_handle_system_commands(|ctx, _| {
+            let query = Query::from_blueprint(ctx, view_id);
+            query.save_latest_at_enabled(ctx, true);
+        });
+
+        test_context.run(|ctx, _| {
+            let query = Query::from_blueprint(ctx, view_id);
+            assert!(query.latest_at_enabled().unwrap());
+        });
+    }
+}

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -60,6 +60,7 @@ rfd.workspace = true
 serde.workspace = true
 slotmap.workspace = true
 smallvec.workspace = true
+strum_macros.workspace = true
 thiserror.workspace = true
 uuid = { workspace = true, features = ["serde", "v4", "js"] }
 wgpu.workspace = true

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -87,13 +87,6 @@ pub enum SystemCommand {
     FileSaver(Box<dyn FnOnce() -> anyhow::Result<std::path::PathBuf> + Send + 'static>),
 }
 
-impl std::fmt::Debug for SystemCommand {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // just print the variant name as all content is not `Debug`
-        <Self as std::fmt::Display>::fmt(self, f)
-    }
-}
-
 /// Interface for sending [`SystemCommand`] messages.
 pub trait SystemCommandSender {
     fn send_system(&self, command: SystemCommand);

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -8,6 +8,7 @@ use re_ui::{UICommand, UICommandSender};
 
 /// Commands used by internal system components
 // TODO(jleibs): Is there a better crate for this?
+#[derive(strum_macros::Display)]
 pub enum SystemCommand {
     /// Make this the active application.
     ActivateApp(re_log_types::ApplicationId),
@@ -84,6 +85,13 @@ pub enum SystemCommand {
     /// Add a task, run on a background thread, that saves something to disk.
     #[cfg(not(target_arch = "wasm32"))]
     FileSaver(Box<dyn FnOnce() -> anyhow::Result<std::path::PathBuf> + Send + 'static>),
+}
+
+impl std::fmt::Debug for SystemCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // just print the variant name as all content is not `Debug`
+        <Self as std::fmt::Display>::fmt(self, f)
+    }
 }
 
 /// Interface for sending [`SystemCommand`] messages.

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -89,7 +89,7 @@ pub enum SystemCommand {
 
 impl std::fmt::Debug for SystemCommand {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // not call variant contents can be made `Debug`, so we only output the variant name
+        // not all variant contents can be made `Debug`, so we only output the variant name
         f.write_str(self.into())
     }
 }

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -8,7 +8,7 @@ use re_ui::{UICommand, UICommandSender};
 
 /// Commands used by internal system components
 // TODO(jleibs): Is there a better crate for this?
-#[derive(strum_macros::Display)]
+#[derive(strum_macros::IntoStaticStr)]
 pub enum SystemCommand {
     /// Make this the active application.
     ActivateApp(re_log_types::ApplicationId),
@@ -85,6 +85,13 @@ pub enum SystemCommand {
     /// Add a task, run on a background thread, that saves something to disk.
     #[cfg(not(target_arch = "wasm32"))]
     FileSaver(Box<dyn FnOnce() -> anyhow::Result<std::path::PathBuf> + Send + 'static>),
+}
+
+impl std::fmt::Debug for SystemCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // not call variant contents can be made `Debug`, so we only output the variant name
+        f.write_str(self.into())
+    }
 }
 
 /// Interface for sending [`SystemCommand`] messages.

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -126,8 +126,8 @@ impl TestContext {
     ///Best-effort attempt to meaningfully handle some of the system commands.
     pub fn handle_system_command(&mut self) {
         while let Some(command) = self.command_receiver.recv_system() {
-            eprintln!("Handling system command: {command:#?}");
-
+            let mut handled: bool = true;
+            let command_name = command.to_string();
             match command {
                 SystemCommand::UpdateBlueprint(store_id, chunks) => {
                     assert_eq!(&store_id, self.blueprint_store.store_id());
@@ -162,14 +162,19 @@ impl TestContext {
                 | SystemCommand::ActivateRecording(_)
                 | SystemCommand::CloseStore(_)
                 | SystemCommand::CloseAllRecordings
-                | SystemCommand::EnableExperimentalDataframeSpaceView(_) => {}
+                | SystemCommand::EnableExperimentalDataframeSpaceView(_) => handled = false,
 
                 #[cfg(debug_assertions)]
-                SystemCommand::EnableInspectBlueprintTimeline(_) => {}
+                SystemCommand::EnableInspectBlueprintTimeline(_) => handled = false,
 
                 #[cfg(not(target_arch = "wasm32"))]
-                SystemCommand::FileSaver(_) => {}
+                SystemCommand::FileSaver(_) => handled = false,
             }
+
+            eprintln!(
+                "{} system command: {command_name}",
+                if handled { "Handled" } else { "Ignored" }
+            );
         }
     }
 }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -114,7 +114,7 @@ impl TestContext {
     }
 
     /// Run the given function with a [`ViewerContext`] produced by the [`Self`] and handle any
-    /// system commands issued during execution (see [`handle_commands`]).
+    /// system commands issued during execution (see [`handle_system_command`]).
     pub fn run_and_handle_system_commands(
         &mut self,
         func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui),
@@ -127,7 +127,7 @@ impl TestContext {
     pub fn handle_system_command(&mut self) {
         while let Some(command) = self.command_receiver.recv_system() {
             let mut handled = true;
-            let command_name = command.to_string();
+            let command_name = format!("{command:?}");
             match command {
                 SystemCommand::UpdateBlueprint(store_id, chunks) => {
                     assert_eq!(&store_id, self.blueprint_store.store_id());
@@ -172,7 +172,7 @@ impl TestContext {
             }
 
             eprintln!(
-                "{} system command: {command_name}",
+                "{} system command: {command_name:?}",
                 if handled { "Handled" } else { "Ignored" }
             );
         }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -125,6 +125,8 @@ impl TestContext {
     ///Best-effort attempt to meaningfully handle some of the system commands.
     pub fn handle_system_command(&mut self) {
         while let Some(command) = self.command_receiver.recv_system() {
+            eprintln!("Handling system command: {command:#?}");
+
             match command {
                 SystemCommand::UpdateBlueprint(store_id, chunks) => {
                     assert_eq!(&store_id, self.blueprint_store.store_id());

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -123,7 +123,7 @@ impl TestContext {
         self.handle_system_command();
     }
 
-    ///Best-effort attempt to meaningfully handle some of the system commands.
+    /// Best-effort attempt to meaningfully handle some of the system commands.
     pub fn handle_system_command(&mut self) {
         while let Some(command) = self.command_receiver.recv_system() {
             let mut handled = true;

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -1,13 +1,14 @@
-use crate::{
-    blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
-    ComponentUiRegistry, RecordingConfig, SpaceViewClassRegistry, StoreContext, SystemCommand,
-    ViewerContext,
-};
 use std::sync::Arc;
 
 use re_chunk_store::LatestAtQuery;
 use re_entity_db::EntityDb;
 use re_log_types::{StoreId, StoreKind, Timeline};
+
+use crate::{
+    blueprint_timeline, command_channel, ApplicationSelectionState, CommandReceiver, CommandSender,
+    ComponentUiRegistry, RecordingConfig, SpaceViewClassRegistry, StoreContext, SystemCommand,
+    ViewerContext,
+};
 
 /// Harness to execute code that rely on [`crate::ViewerContext`].
 ///

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -126,7 +126,7 @@ impl TestContext {
     ///Best-effort attempt to meaningfully handle some of the system commands.
     pub fn handle_system_command(&mut self) {
         while let Some(command) = self.command_receiver.recv_system() {
-            let mut handled: bool = true;
+            let mut handled = true;
             let command_name = command.to_string();
             match command {
                 SystemCommand::UpdateBlueprint(store_id, chunks) => {

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -114,7 +114,7 @@ impl TestContext {
     }
 
     /// Run the given function with a [`ViewerContext`] produced by the [`Self`] and handle any
-    /// system commands issued during execution (see [`handle_system_command`]).
+    /// system commands issued during execution (see [`Self::handle_system_command`]).
     pub fn run_and_handle_system_commands(
         &mut self,
         func: impl FnMut(&ViewerContext<'_>, &mut egui::Ui),


### PR DESCRIPTION
### What

This PR adds best-effort support for some `SystemCommand`s in `TestContext`, the mocking test tool for `ViewerContext`. This primarily enable writes to the blueprint store, which enables testing e.g. wrapper over `ViewProperties`. This PR includes a simple example of that.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7611?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7611?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7611)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.