### PR TITLE
Dataframe API: remove control columns from public surface

### DIFF
--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -25,10 +25,10 @@ mod subscribers;
 mod writes;
 
 pub use self::dataframe::{
-    ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor, ComponentColumnSelector,
-    ControlColumnDescriptor, ControlColumnSelector, Index, IndexRange, IndexValue, JoinEncoding,
-    LatestAtQueryExpression, QueryExpression, QueryExpression2, RangeQueryExpression,
-    SparseFillStrategy, TimeColumnDescriptor, TimeColumnSelector, ViewContentsSelector,
+    ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor, ComponentColumnSelector, Index,
+    IndexRange, IndexValue, JoinEncoding, LatestAtQueryExpression, QueryExpression,
+    QueryExpression2, RangeQueryExpression, SparseFillStrategy, TimeColumnDescriptor,
+    TimeColumnSelector, ViewContentsSelector,
 };
 pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};

--- a/crates/store/re_dataframe/src/range.rs
+++ b/crates/store/re_dataframe/src/range.rs
@@ -350,7 +350,7 @@ impl RangeQueryHandle<'_> {
                         JoinEncoding::OverlappingSlice => None,
                         JoinEncoding::DictionaryEncode => Some(descr),
                     },
-                    _ => None,
+                    ColumnDescriptor::Time(_) => None,
                 })
                 .filter_map(|descr| {
                     let arrays = pov_time_column
@@ -426,7 +426,7 @@ impl RangeQueryHandle<'_> {
                         }
                         JoinEncoding::DictionaryEncode => None,
                     },
-                    _ => None,
+                    ColumnDescriptor::Time(_) => None,
                 })
                 .map(|descr| {
                     let arrays = pov_time_column
@@ -472,8 +472,6 @@ impl RangeQueryHandle<'_> {
                 columns
                     .iter()
                     .map(|descr| match descr {
-                        ColumnDescriptor::Control(_descr) => pov_chunk.row_ids_array().to_boxed(),
-
                         ColumnDescriptor::Time(descr) => {
                             let time_column = pov_chunk.timelines().get(&descr.timeline).cloned();
                             time_column.map_or_else(
@@ -530,10 +528,6 @@ impl RangeQueryHandle<'_> {
                     let packed_arrays = columns
                         .iter()
                         .map(|descr| match descr {
-                            ColumnDescriptor::Control(_descr) => {
-                                pov_chunk.row_ids_array().sliced(row, 1).to_boxed()
-                            }
-
                             ColumnDescriptor::Time(descr) => {
                                 let time_column = pov_chunk.timelines().get(&descr.timeline);
                                 time_column.map_or_else(

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -6,7 +6,7 @@ use egui::NumExt as _;
 use itertools::Itertools;
 
 use re_chunk_store::external::re_chunk::ArrowArray;
-use re_chunk_store::{ColumnDescriptor, LatestAtQuery, RowId};
+use re_chunk_store::{ColumnDescriptor, LatestAtQuery};
 use re_dataframe2::QueryHandle;
 use re_log_types::{EntityPath, TimeInt, Timeline, TimelineName};
 use re_types_core::ComponentName;
@@ -371,7 +371,6 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                     column.data_ui(
                         self.ctx,
                         ui,
-                        RowId::ZERO,
                         &latest_at_query,
                         batch_row_idx,
                         instance_index,

--- a/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
@@ -11,7 +11,7 @@ use re_chunk_store::external::arrow2::{
     datatypes::DataType,
     datatypes::DataType as ArrowDataType,
 };
-use re_chunk_store::{ColumnDescriptor, ComponentColumnDescriptor, LatestAtQuery, RowId};
+use re_chunk_store::{ColumnDescriptor, ComponentColumnDescriptor, LatestAtQuery};
 use re_log_types::{EntityPath, TimeInt, Timeline};
 use re_types::external::arrow2::datatypes::IntegerType;
 use re_types_core::ComponentName;
@@ -114,7 +114,6 @@ impl ComponentData {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        row_id: RowId,
         latest_at_query: &LatestAtQuery,
         entity_path: &EntityPath,
         component_name: ComponentName,
@@ -154,7 +153,7 @@ impl ComponentData {
                 ctx.recording(),
                 entity_path,
                 component_name,
-                Some(row_id),
+                None,
                 &*data_to_display,
             );
         } else {
@@ -227,7 +226,6 @@ impl DisplayColumn {
         &self,
         ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
-        row_id: RowId,
         latest_at_query: &LatestAtQuery,
         row_index: usize,
         instance_index: Option<u64>,
@@ -267,7 +265,6 @@ impl DisplayColumn {
                 component_data.data_ui(
                     ctx,
                     ui,
-                    row_id,
                     latest_at_query,
                     entity_path,
                     *component_name,

--- a/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
@@ -111,12 +111,12 @@ impl Query {
         let mut selected_columns = datatypes::SelectedColumns::default();
         for column in columns {
             match column {
-                ColumnSelector::Control(_) => {}
                 ColumnSelector::Time(desc) => {
                     selected_columns
                         .time_columns
                         .push(desc.timeline.as_str().into());
                 }
+
                 ColumnSelector::Component(desc) => {
                     let blueprint_component_descriptor =
                         datatypes::ComponentColumnSelector::new(&desc.entity_path, desc.component);
@@ -186,12 +186,12 @@ impl Query {
         let result = view_columns
             .iter()
             .filter(|column| match column {
-                ColumnDescriptor::Control(_) => true,
                 ColumnDescriptor::Time(desc) => {
                     // we always include the query timeline column because we need it for the dataframe ui
                     desc.timeline.name() == &query_timeline_name
                         || selected_time_columns.contains(desc.timeline.name())
                 }
+
                 ColumnDescriptor::Component(desc) => {
                     // Check against both the full name and short name, as the user might have used
                     // the latter in the blueprint API.
@@ -232,7 +232,7 @@ impl Query {
                 HideColumnAction::HideTimeColumn { timeline_name } => {
                     selected_columns.retain(|column| match column {
                         ColumnSelector::Time(desc) => desc.timeline != timeline_name,
-                        _ => true,
+                        ColumnSelector::Component(_) => true,
                     });
                 }
 
@@ -244,7 +244,7 @@ impl Query {
                         ColumnSelector::Component(desc) => {
                             desc.entity_path != entity_path || desc.component != component_name
                         }
-                        _ => true,
+                        ColumnSelector::Time(_) => true,
                     });
                 }
             }

--- a/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
@@ -294,36 +294,6 @@ impl Query {
             ui.add_space(12.0);
 
             //
-            // Control columns (always selected)
-            //
-
-            let mut first = true;
-            for column in view_columns {
-                let ColumnDescriptor::Control(_) = column else {
-                    continue;
-                };
-
-                if first {
-                    ui.label("Control");
-                    first = false;
-                }
-
-                // Control columns are always shown because:
-                // - now it's just `RowId`
-                // - the dataframe UI requires the `RowId` column to be present (for tooltips)
-                let is_enabled = false;
-                let mut is_visible = true;
-
-                ui.add_enabled_ui(is_enabled, |ui| {
-                    if ui
-                        .re_checkbox(&mut is_visible, column.short_name())
-                        .on_disabled_hover_text("The query timeline must always be visible")
-                        .changed()
-                    { /* cannot happen for now */ }
-                });
-            }
-
-            //
             // Time columns
             //
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -13,13 +13,12 @@ use pyo3::{
 
 use re_chunk_store::{
     ChunkStore, ChunkStoreConfig, ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor,
-    ComponentColumnSelector, ControlColumnDescriptor, ControlColumnSelector, QueryExpression2,
-    SparseFillStrategy, TimeColumnDescriptor, TimeColumnSelector, VersionPolicy,
-    ViewContentsSelector,
+    ComponentColumnSelector, QueryExpression2, SparseFillStrategy, TimeColumnDescriptor,
+    TimeColumnSelector, VersionPolicy, ViewContentsSelector,
 };
 use re_dataframe2::QueryEngine;
 use re_log_types::{EntityPathFilter, ResolvedTimeRange, TimeType};
-use re_sdk::{ComponentName, EntityPath, Loggable as _, StoreId, StoreKind};
+use re_sdk::{ComponentName, EntityPath, StoreId, StoreKind};
 
 /// Register the `rerun.dataframe` module.
 pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -27,8 +26,6 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<PyRRDArchive>()?;
     m.add_class::<PyRecording>()?;
-    m.add_class::<PyControlColumnDescriptor>()?;
-    m.add_class::<PyControlColumnSelector>()?;
     m.add_class::<PyIndexColumnDescriptor>()?;
     m.add_class::<PyIndexColumnSelector>()?;
     m.add_class::<PyComponentColumnDescriptor>()?;
@@ -39,43 +36,6 @@ pub(crate) fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(crate::dataframe::load_recording, m)?)?;
 
     Ok(())
-}
-
-/// Python binding for [`ControlColumnDescriptor`]
-#[pyclass(frozen, name = "ControlColumnDescriptor")]
-#[derive(Clone)]
-struct PyControlColumnDescriptor(ControlColumnDescriptor);
-
-#[pymethods]
-impl PyControlColumnDescriptor {
-    fn __repr__(&self) -> String {
-        format!("Ctrl({})", self.0.component_name.short_name())
-    }
-}
-
-impl From<ControlColumnDescriptor> for PyControlColumnDescriptor {
-    fn from(desc: ControlColumnDescriptor) -> Self {
-        Self(desc)
-    }
-}
-
-/// Python binding for [`ControlColumnSelector`]
-#[pyclass(frozen, name = "ControlColumnSelector")]
-#[derive(Clone)]
-struct PyControlColumnSelector(ControlColumnSelector);
-
-#[pymethods]
-impl PyControlColumnSelector {
-    #[staticmethod]
-    fn row_id() -> Self {
-        Self(ControlColumnSelector {
-            component: re_chunk::RowId::name(),
-        })
-    }
-
-    fn __repr__(&self) -> String {
-        format!("Ctrl({})", self.0.component.short_name())
-    }
 }
 
 /// Python binding for [`TimeColumnDescriptor`]
@@ -192,10 +152,6 @@ impl PyComponentColumnSelector {
 /// Python binding for [`AnyColumn`] type-alias.
 #[derive(FromPyObject)]
 enum AnyColumn {
-    #[pyo3(transparent, annotation = "control_descriptor")]
-    ControlDescriptor(PyControlColumnDescriptor),
-    #[pyo3(transparent, annotation = "control_selector")]
-    ControlSelector(PyControlColumnSelector),
     #[pyo3(transparent, annotation = "time_descriptor")]
     TimeDescriptor(PyIndexColumnDescriptor),
     #[pyo3(transparent, annotation = "time_selector")]
@@ -209,8 +165,6 @@ enum AnyColumn {
 impl AnyColumn {
     fn into_selector(self) -> ColumnSelector {
         match self {
-            Self::ControlDescriptor(desc) => ColumnDescriptor::Control(desc.0).into(),
-            Self::ControlSelector(selector) => selector.0.into(),
             Self::TimeDescriptor(desc) => ColumnDescriptor::Time(desc.0).into(),
             Self::TimeSelector(selector) => selector.0.into(),
             Self::ComponentDescriptor(desc) => ColumnDescriptor::Component(desc.0).into(),
@@ -266,19 +220,6 @@ pub struct PySchema {
 
 #[pymethods]
 impl PySchema {
-    fn control_columns(&self) -> Vec<PyControlColumnDescriptor> {
-        self.schema
-            .iter()
-            .filter_map(|column| {
-                if let ColumnDescriptor::Control(col) = column {
-                    Some(col.clone().into())
-                } else {
-                    None
-                }
-            })
-            .collect()
-    }
-
     fn index_columns(&self) -> Vec<PyIndexColumnDescriptor> {
         self.schema
             .iter()


### PR DESCRIPTION
* Prevents ~hard~annoying-to-solve cross-feature interactions in the new API implementation.
* Fixes #7599

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7612?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7612?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7612)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.