### PR TITLE
Fix `main` CI

### DIFF
--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -151,11 +151,15 @@ jobs:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
 
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.25.0
+
       - name: Delete existing /target/doc
         run: rm -rf ./target/doc
 
       - name: cargo doc --document-private-items
-        run: cargo doc --document-private-items --no-deps --all-features --workspace --exclude rerun-cli
+        run: pixi run cargo doc --document-private-items --no-deps --all-features --workspace --exclude rerun-cli
 
       - name: Set up git author
         run: |

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -47,9 +47,13 @@ thiserror.workspace = true
 
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
 # See https://github.com/rerun-io/rav1d/pull/1
-dav1d = { git = "https://github.com/rerun-io/rav1d", branch = "emilk/dav1d-interface", package = "rav1d", optional = true } # TODO(#7588): publish this fork
+# TODO(#7588): publish this fork of rav1d
+dav1d = { git = "https://github.com/rerun-io/rav1d", branch = "emilk/dav1d-interface", package = "rav1d", optional = true, default-features = false, features = [
+  # We opt-out of wasm features so we don't need  `nasm` installed. It's still pretty fast.
+  "bitdepth_8",
+] }
 
-# dav1d = { version = "0.10.3",  optional = true } # Requires more things to build, but is fast in debug builds. Useful for development.
+# dav1d = { version = "0.10.3",  optional = true } # Requires separate install of `dav1d` library. Fast in debug builds. Useful for development.
 
 [dev-dependencies]
 indicatif.workspace = true


### PR DESCRIPTION
### What
This disables the `asm` feature of `rav1d`, which means:
* No need to install `nasm` (fixing the build)
* Slower video decoding (but still limited mainly by https://github.com/rerun-io/rerun/issues/7608)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7613?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7613?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7613)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.