### PR TITLE
Dataframe v2: support for `using_index_values`

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -748,12 +748,12 @@ pub struct QueryExpression2 {
     /// Example: `[TimeInt(12), TimeInt(14)]`.
     pub filtered_index_values: Option<BTreeSet<IndexValue>>,
 
-    /// TODO(cmc): NOT IMPLEMENTED.
-    ///
     /// The specific index values used to sample _rows_ from the view contents.
     ///
     /// The final dataset will contain one row per sampled index value, regardless of whether data
     /// existed for that index value in the view contents.
+    /// The semantics of the query are consistent with all other settings: the results will be
+    /// sorted on the `filtered_index`, and only contain unique index values.
     ///
     /// The order of the samples will be respected in the final result.
     ///
@@ -761,7 +761,7 @@ pub struct QueryExpression2 {
     /// and [`QueryExpression2::filtered_index_values`].
     ///
     /// Example: `[TimeInt(12), TimeInt(14)]`.
-    pub using_index_values: Option<Vec<IndexValue>>,
+    pub using_index_values: Option<BTreeSet<IndexValue>>,
 
     /// The component column used to filter out _rows_ from the view contents.
     ///

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -733,7 +733,7 @@ pub struct QueryExpression2 {
     /// Only rows where at least 1 of the view-contents contains non-null data within that range will be kept in
     /// the final dataset.
     ///
-    /// This is ignored if [`QueryExpression2::sampled_index_values`] is set.
+    /// This is ignored if [`QueryExpression2::using_index_values`] is set.
     ///
     /// Example: `ResolvedTimeRange(10, 20)`.
     pub filtered_index_range: Option<IndexRange>,
@@ -743,7 +743,7 @@ pub struct QueryExpression2 {
     /// Only rows where at least 1 column contains non-null data at these specific values will be kept
     /// in the final dataset.
     ///
-    /// This is ignored if [`QueryExpression2::sampled_index_values`] is set.
+    /// This is ignored if [`QueryExpression2::using_index_values`] is set.
     ///
     /// Example: `[TimeInt(12), TimeInt(14)]`.
     pub filtered_index_values: Option<BTreeSet<IndexValue>>,
@@ -757,13 +757,11 @@ pub struct QueryExpression2 {
     ///
     /// The order of the samples will be respected in the final result.
     ///
-    /// If [`QueryExpression2::sampled_index_values`] is set, it overrides both [`QueryExpression2::filtered_index_range`]
+    /// If [`QueryExpression2::using_index_values`] is set, it overrides both [`QueryExpression2::filtered_index_range`]
     /// and [`QueryExpression2::filtered_index_values`].
     ///
     /// Example: `[TimeInt(12), TimeInt(14)]`.
-    //
-    // TODO(jleibs): We need an alternative name for sampled.
-    pub sampled_index_values: Option<Vec<IndexValue>>,
+    pub using_index_values: Option<Vec<IndexValue>>,
 
     /// The component column used to filter out _rows_ from the view contents.
     ///
@@ -774,8 +772,6 @@ pub struct QueryExpression2 {
     // TODO(cmc): multi-pov support
     pub filtered_point_of_view: Option<ComponentColumnSelector>,
 
-    /// TODO(cmc): NOT IMPLEMENTED.
-    ///
     /// Specifies how null values should be filled in the returned dataframe.
     ///
     /// Defaults to [`SparseFillStrategy::None`].
@@ -803,7 +799,7 @@ impl QueryExpression2 {
             filtered_index: index,
             filtered_index_range: None,
             filtered_index_values: None,
-            sampled_index_values: None,
+            using_index_values: None,
             filtered_point_of_view: None,
             sparse_fill_strategy: SparseFillStrategy::None,
             selection: None,

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -881,7 +881,7 @@ mod tests {
     // * [x] selection
     // * [x] filtered_point_of_view
     // * [x] sparse_fill_strategy
-    // * [ ] sampled_index_values
+    // * [ ] using_index_values
     //
     // In addition to those, some much needed extras:
     // * [ ] timelines returned with selection=none

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -923,8 +923,8 @@ mod tests {
         let expected = unindent::unindent(
             "\
             [
-                Int64[None, 1, 2, 3, 4, 5, 6, 7],
-                Timestamp(Nanosecond, None)[None, 1970-01-01 00:00:00.000000001, None, None, None, 1970-01-01 00:00:00.000000005, None, 1970-01-01 00:00:00.000000007],
+                Int64[None, 10, 20, 30, 40, 50, 60, 70],
+                Timestamp(Nanosecond, None)[None, 1970-01-01 00:00:00.000000010, None, None, None, 1970-01-01 00:00:00.000000050, None, 1970-01-01 00:00:00.000000070],
                 ListArray[None, None, None, [2], [3], [4], None, [6]],
                 ListArray[[c], None, None, None, None, None, None, None],
                 ListArray[None, [{x: 0, y: 0}], [{x: 1, y: 1}], [{x: 2, y: 2}], [{x: 3, y: 3}], [{x: 4, y: 4}], [{x: 5, y: 5}], [{x: 8, y: 8}]],
@@ -969,8 +969,8 @@ mod tests {
         let expected = unindent::unindent(
             "\
             [
-                Int64[None, 1, 2, 3, 4, 5, 6, 7],
-                Timestamp(Nanosecond, None)[None, 1970-01-01 00:00:00.000000001, None, None, None, 1970-01-01 00:00:00.000000005, None, 1970-01-01 00:00:00.000000007],
+                Int64[None, 10, 20, 30, 40, 50, 60, 70],
+                Timestamp(Nanosecond, None)[None, 1970-01-01 00:00:00.000000010, None, None, None, 1970-01-01 00:00:00.000000050, None, 1970-01-01 00:00:00.000000070],
                 ListArray[None, None, None, [2], [3], [4], [4], [6]],
                 ListArray[[c], [c], [c], [c], [c], [c], [c], [c]],
                 ListArray[None, [{x: 0, y: 0}], [{x: 1, y: 1}], [{x: 2, y: 2}], [{x: 3, y: 3}], [{x: 4, y: 4}], [{x: 5, y: 5}], [{x: 8, y: 8}]],
@@ -997,7 +997,7 @@ mod tests {
 
         let timeline = Timeline::new_sequence("frame_nr");
         let mut query = QueryExpression2::new(timeline);
-        query.filtered_index_range = Some(ResolvedTimeRange::new(3, 6));
+        query.filtered_index_range = Some(ResolvedTimeRange::new(30, 60));
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());
@@ -1015,8 +1015,8 @@ mod tests {
         let expected = unindent::unindent(
             "\
             [
-                Int64[None, 3, 4, 5, 6],
-                Timestamp(Nanosecond, None)[None, None, None, 1970-01-01 00:00:00.000000005, None],
+                Int64[None, 30, 40, 50, 60],
+                Timestamp(Nanosecond, None)[None, None, None, 1970-01-01 00:00:00.000000050, None],
                 ListArray[None, [2], [3], [4], None],
                 ListArray[[c], None, None, None, None],
                 ListArray[None, [{x: 2, y: 2}], [{x: 3, y: 3}], [{x: 4, y: 4}], [{x: 5, y: 5}]],
@@ -1044,7 +1044,7 @@ mod tests {
         let timeline = Timeline::new_sequence("frame_nr");
         let mut query = QueryExpression2::new(timeline);
         query.filtered_index_values = Some(
-            [0, 3, 6, 9]
+            [0, 30, 60, 90]
                 .into_iter()
                 .map(TimeInt::new_temporal)
                 .chain(std::iter::once(TimeInt::STATIC))
@@ -1067,7 +1067,7 @@ mod tests {
         let expected = unindent::unindent(
             "\
             [
-                Int64[None, 3, 6],
+                Int64[None, 30, 60],
                 Timestamp(Nanosecond, None)[None, None, None],
                 ListArray[None, [2], None],
                 ListArray[[c], None, None],
@@ -1175,8 +1175,8 @@ mod tests {
             let expected = unindent::unindent(
                 "\
                 [
-                    Int64[1, 2, 3, 4, 5, 6, 7],
-                    Timestamp(Nanosecond, None)[1970-01-01 00:00:00.000000001, None, None, None, 1970-01-01 00:00:00.000000005, None, 1970-01-01 00:00:00.000000007],
+                    Int64[10, 20, 30, 40, 50, 60, 70],
+                    Timestamp(Nanosecond, None)[1970-01-01 00:00:00.000000010, None, None, None, 1970-01-01 00:00:00.000000050, None, 1970-01-01 00:00:00.000000070],
                     ListArray[None, None, [2], [3], [4], None, [6]],
                     ListArray[None, None, None, None, None, None, None],
                     ListArray[[{x: 0, y: 0}], [{x: 1, y: 1}], [{x: 2, y: 2}], [{x: 3, y: 3}], [{x: 4, y: 4}], [{x: 5, y: 5}], [{x: 8, y: 8}]],
@@ -1212,7 +1212,7 @@ mod tests {
             let expected = unindent::unindent(
                 "\
                 [
-                    Int64[3, 4, 5, 7],
+                    Int64[30, 40, 50, 70],
                     Timestamp(Nanosecond, None)[None, None, None, None],
                     ListArray[[2], [3], [4], [6]],
                     ListArray[None, None, None, None],
@@ -1304,7 +1304,7 @@ mod tests {
             let expected = unindent::unindent(
                 "\
                 [
-                    Int64[None, 3, 4, 5, 7],
+                    Int64[None, 30, 40, 50, 70],
                     Timestamp(Nanosecond, None)[None, None, None, None, None],
                     ListArray[None, [2], [3], [4], [6]],
                     ListArray[[c], None, None, None, None],
@@ -1387,8 +1387,8 @@ mod tests {
             let expected = unindent::unindent(
                 "\
                 [
-                    Int64[None, 1, 2, 3, 4, 5, 6, 7],
-                    Int64[None, 1, 2, 3, 4, 5, 6, 7],
+                    Int64[None, 10, 20, 30, 40, 50, 60, 70],
+                    Int64[None, 10, 20, 30, 40, 50, 60, 70],
                     NullArray(8),
                 ]\
                 ",
@@ -1523,7 +1523,7 @@ mod tests {
             let expected = unindent::unindent(
                 "\
                 [
-                    Int64[None, 3, 4, 5, 7],
+                    Int64[None, 30, 40, 50, 70],
                     Timestamp(Nanosecond, None)[None, None, None, None, None],
                     NullArray(5),
                     NullArray(5),
@@ -1549,13 +1549,13 @@ mod tests {
 
         let entity_path = EntityPath::from("this/that");
 
-        let frame1 = TimeInt::new_temporal(1);
-        let frame2 = TimeInt::new_temporal(2);
-        let frame3 = TimeInt::new_temporal(3);
-        let frame4 = TimeInt::new_temporal(4);
-        let frame5 = TimeInt::new_temporal(5);
-        let frame6 = TimeInt::new_temporal(6);
-        let frame7 = TimeInt::new_temporal(7);
+        let frame1 = TimeInt::new_temporal(10);
+        let frame2 = TimeInt::new_temporal(20);
+        let frame3 = TimeInt::new_temporal(30);
+        let frame4 = TimeInt::new_temporal(40);
+        let frame5 = TimeInt::new_temporal(50);
+        let frame6 = TimeInt::new_temporal(60);
+        let frame7 = TimeInt::new_temporal(70);
 
         let points1 = MyPoint::from_iter(0..1);
         let points2 = MyPoint::from_iter(1..2);

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -591,7 +591,7 @@ impl QueryHandle<'_> {
 
         // What's the next sample we're interested in, if any?
         //
-        // `None` iif the query isn't sampled. Short-circuits if the query is sampled but has run out of samples.
+        // `None` iff the query isn't sampled. Short-circuits if the query is sampled but has run out of samples.
         let sampled_index_value =
             if let Some(using_index_values) = state.using_index_values_stack.lock().as_mut() {
                 // NOTE: Look closely -- this short-circuits is there are no more samples in the vec.

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -164,7 +164,7 @@ mode sets the default time range to _everything_. You can override this in the s
 
             // not yet unsupported by the dataframe view
             filtered_index_values: None,
-            sampled_index_values: None,
+            using_index_values: None,
         };
 
         let query_handle = query_engine.query(dataframe_query);

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -556,7 +556,7 @@ impl PyRecording {
             filtered_index: timeline.timeline,
             filtered_index_range: None,
             filtered_index_values: None,
-            sampled_index_values: None,
+            using_index_values: None,
             filtered_point_of_view: None,
             sparse_fill_strategy: SparseFillStrategy::None,
             selection: None,


### PR DESCRIPTION
Implements support for `using_index_values`.

I've changed the definition to a `BTreeSet` instead of a `Vec`, so that this is consistent with the rest of the API: i.e. the results are sorted, and unique. Otherwise things get real ugly, real fast.

* DNM: requires #7612

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7589?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7589)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.