### PR TITLE
Enable `glam` asserts in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,7 @@ flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }
 getrandom = "0.2"
-glam = "0.28"
+glam = { version = "0.28", features = ["debug-glam-assert"] }
 glob = "0.3"
 gltf = "1.1"
 half = "2.3.1"


### PR DESCRIPTION
### What
From <https://docs.rs/glam/latest/glam/#glam-assertions>:

> glam does not enforce validity checks on method parameters at runtime. For example methods that require normalized vectors as input such as `Quat::from_axis_angle(axis, angle)` will not check that axis is a valid normalized vector. To help catch unintended misuse of glam the debug-glam-assert or glam-assert features can be enabled to add checks ensure that inputs to are valid.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7618?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7618?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7618)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.