### PR TITLE
Dataframe v2: make `num_rows` aware of filters and such

### DIFF
--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -406,7 +406,15 @@ impl QueryHandle<'_> {
             all_unique_timestamps.retain(|time| filtered_index_values.contains(time));
         }
 
-        all_unique_timestamps.len() as _
+        let num_rows = all_unique_timestamps.len() as _;
+
+        if cfg!(debug_assertions) {
+            let expected_num_rows =
+                self.engine.query(self.query.clone()).into_iter().count() as u64;
+            assert_eq!(expected_num_rows, num_rows);
+        }
+
+        num_rows
     }
 
     /// Returns the next row's worth of data.

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -886,6 +886,10 @@ mod tests {
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());
+        assert_eq!(
+            query_engine.query(query.clone()).into_iter().count() as u64,
+            query_handle.num_rows()
+        );
         let dataframe = concatenate_record_batches(
             query_handle.schema().clone(),
             &query_handle.into_batch_iter().collect_vec(),
@@ -928,6 +932,10 @@ mod tests {
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());
+        assert_eq!(
+            query_engine.query(query.clone()).into_iter().count() as u64,
+            query_handle.num_rows()
+        );
         let dataframe = concatenate_record_batches(
             query_handle.schema().clone(),
             &query_handle.into_batch_iter().collect_vec(),
@@ -970,6 +978,10 @@ mod tests {
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());
+        assert_eq!(
+            query_engine.query(query.clone()).into_iter().count() as u64,
+            query_handle.num_rows()
+        );
         let dataframe = concatenate_record_batches(
             query_handle.schema().clone(),
             &query_handle.into_batch_iter().collect_vec(),
@@ -1018,6 +1030,10 @@ mod tests {
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());
+        assert_eq!(
+            query_engine.query(query.clone()).into_iter().count() as u64,
+            query_handle.num_rows()
+        );
         let dataframe = concatenate_record_batches(
             query_handle.schema().clone(),
             &query_handle.into_batch_iter().collect_vec(),
@@ -1068,6 +1084,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1091,6 +1111,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1114,6 +1138,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1147,6 +1175,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1198,6 +1230,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1231,6 +1267,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1277,6 +1317,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1306,6 +1350,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1354,6 +1402,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),
@@ -1434,6 +1486,10 @@ mod tests {
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());
+            assert_eq!(
+                query_engine.query(query.clone()).into_iter().count() as u64,
+                query_handle.num_rows()
+            );
             let dataframe = concatenate_record_batches(
                 query_handle.schema().clone(),
                 &query_handle.into_batch_iter().collect_vec(),

--- a/crates/store/re_dataframe2/src/query.rs
+++ b/crates/store/re_dataframe2/src/query.rs
@@ -386,7 +386,7 @@ impl QueryHandle<'_> {
             Either::Right(view_chunks)
         };
 
-        let all_unique_timestamps: HashSet<TimeInt> = view_chunks
+        let mut all_unique_timestamps: HashSet<TimeInt> = view_chunks
             .flat_map(|chunks| {
                 chunks.iter().filter_map(|(_cursor, chunk)| {
                     if chunk.is_static() {
@@ -401,6 +401,10 @@ impl QueryHandle<'_> {
             })
             .flatten()
             .collect();
+
+        if let Some(filtered_index_values) = self.query.filtered_index_values.as_ref() {
+            all_unique_timestamps.retain(|time| filtered_index_values.contains(time));
+        }
 
         all_unique_timestamps.len() as _
     }

--- a/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
@@ -79,7 +79,8 @@ impl Query {
     ) -> Result<Option<components::FilterByEvent>, SpaceViewSystemExecutionError> {
         Ok(self
             .query_property
-            .component_or_empty::<components::FilterByEvent>()?)
+            .component_or_empty::<components::FilterByEvent>()?
+            .filter(|filter_by_event| filter_by_event.active()))
     }
 
     pub(super) fn save_filter_by_event(

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -4,15 +4,6 @@ import pyarrow as pa
 
 from .types import AnyColumn, ComponentLike, ViewContentsLike
 
-class ControlColumnDescriptor:
-    """A control-level column such as `RowId`."""
-
-class ControlColumnSelector:
-    """A selector for a control column."""
-
-    @staticmethod
-    def row_id() -> ControlColumnSelector: ...
-
 class IndexColumnDescriptor:
     """A column containing the index values for when the component data was updated."""
 
@@ -35,7 +26,6 @@ class ComponentColumnSelector:
 class Schema:
     """The schema representing all columns in a [`Recording`][]."""
 
-    def control_columns(self) -> list[ControlColumnDescriptor]: ...
     def index_columns(self) -> list[IndexColumnDescriptor]: ...
     def component_columns(self) -> list[ComponentColumnDescriptor]: ...
     def column_for(self, entity_path: str, component: ComponentLike) -> Optional[ComponentColumnDescriptor]: ...

--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -8,20 +8,15 @@ if TYPE_CHECKING:
     from .rerun_bindings import (
         ComponentColumnDescriptor as ComponentColumnDescriptor,
         ComponentColumnSelector as ComponentColumnSelector,
-        ControlColumnDescriptor as ControlColumnDescriptor,
-        ControlColumnSelector as ControlColumnSelector,
         TimeColumnDescriptor as TimeColumnDescriptor,
         TimeColumnSelector as TimeColumnSelector,
     )
 
-
 ComponentLike: TypeAlias = Union[str, type["ComponentMixin"]]
 
 AnyColumn: TypeAlias = Union[
-    "ControlColumnDescriptor",
     "TimeColumnDescriptor",
     "ComponentColumnDescriptor",
-    "ControlColumnSelector",
     "TimeColumnSelector",
     "ComponentColumnSelector",
 ]

--- a/rerun_py/rerun_sdk/rerun/dataframe.py
+++ b/rerun_py/rerun_sdk/rerun/dataframe.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from rerun_bindings import (
     ComponentColumnDescriptor as ComponentColumnDescriptor,
     ComponentColumnSelector as ComponentColumnSelector,
-    ControlColumnDescriptor as ControlColumnDescriptor,
-    ControlColumnSelector as ControlColumnSelector,
     Recording as Recording,
     RRDArchive as RRDArchive,
     Schema as Schema,


### PR DESCRIPTION
Fix `num_rows()` returning wrong values when you set filters, PoVs, and such.

This fixes the `ERROR ERROR ERROR` we see on `main`... but now all I see is emptiness :thinking: 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7621?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7621?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7621)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.