### PR TITLE
Fix handling of the filter-by-event blueprint data

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -4,7 +4,7 @@ use crate::{
     dataframe_ui::dataframe_ui, expanded_rows::ExpandedRowsCache, view_query,
     visualizer_system::EmptySystem,
 };
-use re_chunk_store::{ColumnDescriptor, ComponentColumnSelector, SparseFillStrategy};
+use re_chunk_store::{ColumnDescriptor, SparseFillStrategy};
 use re_log_types::EntityPath;
 use re_types_core::SpaceViewClassIdentifier;
 use re_viewer_context::{
@@ -137,13 +137,6 @@ mode sets the default time range to _everything_. You can override this in the s
             .map(|entity| (entity.clone(), None))
             .collect();
 
-        let filtered_point_of_view = view_query.filter_by_event()?.map(|filter| {
-            ComponentColumnSelector::new_for_component_name(
-                filter.entity_path(),
-                filter.component_name(),
-            )
-        });
-
         let sparse_fill_strategy = if view_query.latest_at_enabled()? {
             SparseFillStrategy::LatestAtGlobal
         } else {
@@ -158,7 +151,7 @@ mode sets the default time range to _everything_. You can override this in the s
             view_contents: Some(view_contents),
             filtered_index: view_query.timeline(ctx)?,
             filtered_index_range: Some(view_query.filter_by_range()?),
-            filtered_point_of_view,
+            filtered_point_of_view: view_query.filter_by_event()?,
             sparse_fill_strategy,
             selection: selected_columns,
 

--- a/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
@@ -137,7 +137,7 @@ impl Query {
         // Read stuff
         //
 
-        let original_filter_by_event = self.filter_by_event()?;
+        let original_filter_by_event = self.filter_by_event_raw()?;
 
         let (mut active, event_entity, event_component) = original_filter_by_event
             .as_ref()


### PR DESCRIPTION
### What

Small API fix for the filter-by-event blueprint data handling in the dataframe view. Fixes some perma-write-blueprint issue and a minor UX bug introduced in #7621

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
