### PR TITLE
Fix failing dataframe tests (no more row id column)

### DIFF
--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -26,8 +26,8 @@ class TestDataframe:
         batches = view.select()
         table = pa.Table.from_batches(batches, batches.schema)
 
-        # row, log_time, log_tick, indicator, points, colors
-        assert table.num_columns == 6
+        # log_time, log_tick, indicator, points, colors
+        assert table.num_columns == 5
         assert table.num_rows == 2
 
     def test_select_column(self) -> None:
@@ -72,8 +72,8 @@ class TestDataframe:
             batches = view.select()
             table = pa.Table.from_batches(batches, batches.schema)
 
-            # row, log_time, log_tick, points
-            assert table.num_columns == 4
+            # log_time, log_tick, points
+            assert table.num_columns == 3
             assert table.num_rows == 2
 
         bad_content_expressions = [
@@ -85,7 +85,7 @@ class TestDataframe:
             view = self.recording.view(index="log_time", contents=expr)
             batches = view.select()
 
-            # row, log_time, log_tick
+            # log_time, log_tick
             table = pa.Table.from_batches(batches, batches.schema)
-            assert table.num_columns == 3
+            assert table.num_columns == 2
             assert table.num_rows == 0


### PR DESCRIPTION
### What

☝🏻 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7624?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7624?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7624)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.