### PR TITLE
Add Pathlib support to load_recording

### DIFF
--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Sequence
 
 import pyarrow as pa
@@ -70,7 +71,7 @@ class RRDArchive:
     def num_recordings(self) -> int: ...
     def all_recordings(self) -> list[Recording]: ...
 
-def load_recording(filename: str) -> Recording:
+def load_recording(filename: str | os.PathLike) -> Recording:
     """
     Load a single recording from an RRD.
 
@@ -84,7 +85,7 @@ def load_recording(filename: str) -> Recording:
     """
     ...
 
-def load_archive(filename: str) -> RRDArchive:
+def load_archive(filename: str | os.PathLike) -> RRDArchive:
     """
     Load a rerun archive file from disk.
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -603,7 +603,7 @@ impl PyRRDArchive {
 }
 
 #[pyfunction]
-pub fn load_recording(path_to_rrd: String) -> PyResult<PyRecording> {
+pub fn load_recording(path_to_rrd: std::path::PathBuf) -> PyResult<PyRecording> {
     let archive = load_archive(path_to_rrd)?;
 
     let num_recordings = archive.num_recordings();
@@ -624,7 +624,7 @@ pub fn load_recording(path_to_rrd: String) -> PyResult<PyRecording> {
 }
 
 #[pyfunction]
-pub fn load_archive(path_to_rrd: String) -> PyResult<PyRRDArchive> {
+pub fn load_archive(path_to_rrd: std::path::PathBuf) -> PyResult<PyRRDArchive> {
     let stores =
         ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd, VersionPolicy::Warn)
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7627

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7637?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7637?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7637)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.