### PR TITLE
Fix debug assertion in `create_labels`

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/ui.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui.rs
@@ -169,7 +169,7 @@ pub fn create_labels(
     // Closest last (painters algorithm)
     labels.sort_by_key(|label| {
         if let UiLabelTarget::Position3D(pos) = label.target {
-            OrderedFloat::from(-ui_from_world_3d.transform_point3(pos).z)
+            OrderedFloat::from(-ui_from_world_3d.project_point3(pos).z)
         } else {
             OrderedFloat::from(0.0)
         }


### PR DESCRIPTION
### What

glam on debug now notices that what we have here is a perspective transform. We actually don't quite care about the perspective divide here, but this fixes the issue and still has the correct label ordering (just to be sure I checked with the spiral of labels generated by the old `test_api` script)

<img width="431" alt="image" src="https://github.com/user-attachments/assets/c634d4f6-a0cc-4d5e-aa17-4059942ec786">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7639?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7639?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7639)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.