### PR TITLE
Dataframe v2: new and improved chunk tools

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -707,6 +707,8 @@ impl Chunk {
 
     /// Unconditionally inserts an [`ArrowListArray`] as a component column.
     ///
+    /// Removes and replaces the column if it already exists.
+    ///
     /// This will fail if the end result is malformed in any way -- see [`Self::sanity_check`].
     #[inline]
     pub fn add_component(
@@ -719,6 +721,8 @@ impl Chunk {
     }
 
     /// Unconditionally inserts a [`TimeColumn`].
+    ///
+    /// Removes and replaces the column if it already exists.
     ///
     /// This will fail if the end result is malformed in any way -- see [`Self::sanity_check`].
     #[inline]

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -705,6 +705,22 @@ impl Chunk {
         }
     }
 
+    /// Unconditionally inserts an [`ArrowListArray`] as a component column.
+    ///
+    /// This will fail if the end result is malformed in any way -- see [`Self::sanity_check`].
+    #[inline]
+    pub fn add_component(
+        &mut self,
+        component_name: ComponentName,
+        list_array: ArrowListArray<i32>,
+    ) -> ChunkResult<()> {
+        self.components.insert(component_name, list_array);
+        self.sanity_check()
+    }
+
+    /// Unconditionally inserts a [`TimeColumn`].
+    ///
+    /// This will fail if the end result is malformed in any way -- see [`Self::sanity_check`].
     #[inline]
     pub fn add_timeline(&mut self, chunk_timeline: TimeColumn) -> ChunkResult<()> {
         self.timelines


### PR DESCRIPTION
Bunch of improvements and/or additions to the Chunk toolbox that happened as part of the implementation of the dataframe v2 API.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7649?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7649?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7649)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.