### PR TITLE
Dataframe v2: support for clear semantics

### DIFF
--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -265,11 +265,6 @@ impl QueryHandle<'_> {
                 }
             }
         }
-            };
-
-                        }
-
-            }
 
         QueryHandleState {
             view_contents,

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -254,10 +254,12 @@ impl QueryHandle<'_> {
 
                     // The chunks were sorted that way before, and it needs to stay that way after.
                     chunks.sort_by_key(|(_cursor, chunk)| {
+                        // NOTE: The chunk has been densified already: its global time range is the same as
+                        // the time range for the specific component of interest.
                         chunk
-                            .time_range_per_component()
+                            .timelines()
                             .get(&self.query.filtered_index)
-                            .and_then(|per_component| per_component.get(&descr.component_name))
+                            .map(|time_column| time_column.time_range())
                             .map_or(TimeInt::STATIC, |time_range| time_range.min())
                     });
                 }


### PR DESCRIPTION
Support clear semantics in the dataframe API.
Tombstones are never visible to end-users, only their effect.

Like every other Dataframe v2 feature PR, and following recommendations from @jleibs, this prioritizes convenience of implementation over everything else, for now.
All clear chunks are fetched, post-processed, and re-injected into the view contents during init(), and then the streaming join runs as usual after that.

Static clear semantics can get pretty unhinged, but that's A) not specific to the dataframe API and B) so extremely niche that our time is better spent on real-world problems right now:
- #7650 
- #7631 

---

- Fixes https://github.com/rerun-io/rerun/issues/7495
- Fixes https://github.com/rerun-io/rerun/issues/7414
- Fixes https://github.com/rerun-io/rerun/issues/7468
- Fixes https://github.com/rerun-io/rerun/issues/7493
- DNM: requires #7649 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7652?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7652?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7652)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.