### PR TITLE
Dataframe v2: never mention indicator components

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -767,6 +767,10 @@ impl ChunkStore {
 
         let components = static_components
             .chain(temporal_components)
+            .filter(|col| match col {
+                ColumnDescriptor::Time(_) => true,
+                ColumnDescriptor::Component(descr) => !descr.component_name.contains("Indicator"),
+            })
             .collect::<BTreeSet<_>>();
 
         timelines.chain(components).collect()

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -769,7 +769,9 @@ impl ChunkStore {
             .chain(temporal_components)
             .filter(|col| match col {
                 ColumnDescriptor::Time(_) => true,
-                ColumnDescriptor::Component(descr) => !descr.component_name.contains("Indicator"),
+                ColumnDescriptor::Component(descr) => {
+                    !descr.component_name.is_indicator_component()
+                }
             })
             .collect::<BTreeSet<_>>();
 

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -27,8 +27,8 @@ def test_load_recording() -> None:
         batches = view.select()
         table = pa.Table.from_batches(batches, batches.schema)
 
-        # my_index, log_time, log_tick, indicator, text
-        assert table.num_columns == 5
+        # my_index, log_time, log_tick, text
+        assert table.num_columns == 4
         assert table.num_rows == 1
 
         recording = rr.dataframe.load_recording(pathlib.Path(tmpdir) / "tmp.rrd")
@@ -38,8 +38,8 @@ def test_load_recording() -> None:
         batches = view.select()
         table = pa.Table.from_batches(batches, batches.schema)
 
-        # my_index, log_time, log_tick, indicator, text
-        assert table.num_columns == 5
+        # my_index, log_time, log_tick, text
+        assert table.num_columns == 4
         assert table.num_rows == 1
 
 
@@ -69,8 +69,8 @@ class TestDataframe:
         batches = view.select()
         table = pa.Table.from_batches(batches, batches.schema)
 
-        # my_index, log_time, log_tick, indicator, points, colors
-        assert table.num_columns == 6
+        # my_index, log_time, log_tick, points, colors
+        assert table.num_columns == 5
         assert table.num_rows == 2
 
     def test_select_columns(self) -> None:


### PR DESCRIPTION
* Fixes #7614 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7656?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7656?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7656)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.