### PR TITLE
Correctly display null timestamps in the dataframe view

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
@@ -247,11 +247,7 @@ impl DisplayColumn {
                     return;
                 }
 
-                let is_static = !time_data.is_valid(row_index);
-
-                if is_static {
-                    ui.label("static");
-                } else {
+                if time_data.is_valid(row_index) {
                     let timestamp = TimeInt::try_from(time_data.value(row_index));
                     match timestamp {
                         Ok(timestamp) => {
@@ -261,6 +257,8 @@ impl DisplayColumn {
                             ui.error_label(&format!("{err}"));
                         }
                     }
+                } else {
+                    ui.label("-");
                 }
             }
             Self::Component {

--- a/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
@@ -247,13 +247,19 @@ impl DisplayColumn {
                     return;
                 }
 
-                let timestamp = TimeInt::try_from(time_data.value(row_index));
-                match timestamp {
-                    Ok(timestamp) => {
-                        ui.label(timeline.typ().format(timestamp, ctx.app_options.time_zone));
-                    }
-                    Err(err) => {
-                        ui.error_label(&format!("{err}"));
+                let is_static = !time_data.is_valid(row_index);
+
+                if is_static {
+                    ui.label("static");
+                } else {
+                    let timestamp = TimeInt::try_from(time_data.value(row_index));
+                    match timestamp {
+                        Ok(timestamp) => {
+                            ui.label(timeline.typ().format(timestamp, ctx.app_options.time_zone));
+                        }
+                        Err(err) => {
+                            ui.error_label(&format!("{err}"));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### What

The dataframe view was previously ignoring the validity of data in time columns. This PR fixes this and properly displays `null`.

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/526c1fa6-a4e4-46a1-a56b-24a54ae1f08f">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7659?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7659?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7659)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.