### PR TITLE
Always-on AV1 in `--release`; opt-in to nasm-optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6234,6 +6234,7 @@ dependencies = [
  "re_smart_channel",
  "re_tracing",
  "re_types",
+ "re_video",
  "re_viewer",
  "re_web_viewer_server",
  "re_ws_comms",

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -24,11 +24,14 @@ no-default-features = true
 features = ["all"]
 
 [features]
-default = []
+default = ["av1"]
 
-## Opt-in to native AV1 decoding.
-## You need to install [nasm](https://nasm.us/) to compile with this feature.
+## Native AV1 decoding.
 av1 = ["dep:dav1d"]
+
+## Enable faster native video decoding with assembly.
+## You need to install [nasm](https://nasm.us/) to compile with this feature.
+nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
 
 [dependencies]
 re_log.workspace = true

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -17,7 +17,11 @@ impl SyncDav1dDecoder {
         re_tracing::profile_function!();
 
         if !cfg!(feature = "nasm") {
-            re_log::warn_once!("NOTE: native AV1 video decoder is running extra slow. Speed up by compiling Rerun with the `nasm` feature enabled");
+            re_log::warn_once!(
+                "NOTE: native AV1 video decoder is running extra slowly. \
+                Speed it up by compiling Rerun with the `nasm` feature enabled. \
+                You'll need to also install nasm: https://nasm.us/"
+            );
         }
 
         // See https://videolan.videolan.me/dav1d/structDav1dSettings.html for settings docs

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -16,6 +16,10 @@ impl SyncDav1dDecoder {
     pub fn new() -> Result<Self> {
         re_tracing::profile_function!();
 
+        if !cfg!(feature = "nasm") {
+            re_log::warn_once!("NOTE: native AV1 video decoder is running extra slow. Speed up by compiling Rerun with the `nasm` feature enabled");
+        }
+
         // See https://videolan.videolan.me/dav1d/structDav1dSettings.html for settings docs
         let mut settings = dav1d::Settings::new();
 

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -39,13 +39,13 @@ doc = false
 # so wer have all the bells and wistles here
 default = ["native_viewer", "web_viewer"]
 
+## Enable faster native video decoding with assembly.
+## You need to install [nasm](https://nasm.us/) to compile with this feature.
+nasm = ["rerun/nasm"]
+
 ## Support spawning a native viewer.
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!
 native_viewer = ["rerun/native_viewer"]
-
-## Support for native AV1 video decoding.
-## You need to install [nasm](https://nasm.us/) to compile with this feature.
-video_av1 = ["rerun/video_av1"]
 
 ## Support serving a web viewer over HTTP.
 ##

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -20,6 +20,8 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+default-run = "rerun" # If someone types `cargo run` in this workspace, this is what we staert
+
 [lints]
 workspace = true
 

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -71,6 +71,10 @@ ecolor = ["re_types?/ecolor"]
 ## Integration with the [`log`](https://crates.io/crates/log/) crate.
 log = ["dep:env_logger", "dep:log"]
 
+## Enable faster native video decoding with assembly.
+## You need to install [nasm](https://nasm.us/) to compile with this feature.
+nasm = ["re_video/nasm"]
+
 ## Support spawning a native viewer.
 ## This adds a lot of extra dependencies, so only enable this feature if you need it!
 native_viewer = ["dep:re_viewer"]
@@ -94,10 +98,6 @@ server = ["re_sdk_comms?/server"]
 ## Embed the Rerun SDK & built-in types and re-export all of their public symbols.
 sdk = ["dep:re_sdk", "dep:re_types"]
 
-## Support for native AV1 video decoding.
-## You need to install [nasm](https://nasm.us/) to compile with this feature.
-video_av1 = ["re_viewer?/video_av1"]
-
 ## Support serving a web viewer over HTTP.
 ##
 ## Enabling this inflates the binary size quite a bit, since it embeds the viewer wasm.
@@ -117,10 +117,12 @@ re_entity_db.workspace = true
 re_error.workspace = true
 re_format.workspace = true
 re_log_types.workspace = true
+re_video.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 re_smart_channel.workspace = true
 re_tracing.workspace = true
+
 anyhow.workspace = true
 document-features.workspace = true
 itertools.workspace = true

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -157,3 +157,7 @@ unindent = { workspace = true, optional = true }
 
 [build-dependencies]
 re_build_tools.workspace = true
+
+[package.metadata.cargo-machete]
+# We only depend on re_video so we can enable extra features for it
+ignored = ["re_video"]

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -35,10 +35,6 @@ default = ["import-obj", "import-gltf", "import-stl"]
 ## Support for Arrow datatypes for end-to-end zero-copy.
 arrow = ["dep:arrow2"]
 
-## Support for native AV1 video decoding.
-## You need to install [nasm](https://nasm.us/) to compile with this feature.
-video_av1 = ["re_video/av1"]
-
 ## Support importing .obj files
 import-obj = ["dep:tobj"]
 
@@ -56,7 +52,7 @@ re_error.workspace = true
 re_log.workspace = true
 re_math.workspace = true
 re_tracing.workspace = true
-re_video.workspace = true
+re_video = { workspace = true, default-features = true }
 
 ahash.workspace = true
 anyhow.workspace = true

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -54,17 +54,11 @@ pub enum DecodingError {
     BadData,
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[error("No native video support. Try compiling rerun with the `video_av1` feature flag")]
-    NoNativeSupport,
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(feature = "video_av1")]
     #[error("Unsupported codec: {codec:?}. Only AV1 is currently supported on native.")]
     UnsupportedCodec { codec: String },
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[cfg(feature = "video_av1")]
-    #[error("Video decoding not supported in native debug builds.")]
+    #[error("Native video decoding not supported in native debug builds.")]
     NoNativeDebug,
 }
 

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -36,10 +36,6 @@ default = ["analytics"]
 ## Enable telemetry using our analytics SDK.
 analytics = ["dep:re_analytics"]
 
-## Support for native AV1 video decoding.
-## You need to install [nasm](https://nasm.us/) to compile with this feature.
-video_av1 = ["re_renderer/video_av1"]
-
 
 [dependencies]
 # Internal:

--- a/pixi.toml
+++ b/pixi.toml
@@ -122,18 +122,18 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer,video_av1 --"
+rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer,video_av1"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer,nasm"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer,video_av1"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer,nasm"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,video_av1 --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --release --"
 
 # Compile and run the web-viewer via rerun-cli.
 #

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -19,7 +19,7 @@ default = ["extension-module"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
-pypi = ["extension-module", "web_viewer"]
+pypi = ["extension-module", "nasm", "web_viewer"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -27,6 +27,10 @@ pypi = ["extension-module", "web_viewer"]
 ## * <https://pyo3.rs/latest/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror>
 ## * <https://pyo3.rs/main/building-and-distribution#building-python-extension-modules>
 extension-module = ["pyo3/extension-module"]
+
+## Enable faster native video decoding with assembly.
+## You need to install [nasm](https://nasm.us/) to compile with this feature.
+nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.
 ##


### PR DESCRIPTION
### What
Even without `nasm`, it is pretty fast.

I also added a warning to the user that they can get more performance by enabling the `nasm` feature.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7661?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7661?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7661)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.