### PR TITLE
Remove the feature flag for plot query clamping

### DIFF
--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -188,13 +188,8 @@ impl SeriesLineSystem {
             .view_state
             .downcast_ref::<TimeSeriesSpaceViewState>()
             .map_or(0, |state| state.time_offset);
-        let time_range = determine_time_range(
-            view_query.latest_at,
-            time_offset,
-            data_result,
-            plot_mem,
-            ctx.viewer_ctx.app_options.plot_query_clamping,
-        );
+        let time_range =
+            determine_time_range(view_query.latest_at, time_offset, data_result, plot_mem);
         {
             use re_space_view::RangeResultsExt as _;
 

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -202,13 +202,8 @@ impl SeriesPointSystem {
             .view_state
             .downcast_ref::<TimeSeriesSpaceViewState>()
             .map_or(0, |state| state.time_offset);
-        let time_range = determine_time_range(
-            view_query.latest_at,
-            time_offset,
-            data_result,
-            plot_mem,
-            ctx.viewer_ctx.app_options.plot_query_clamping,
-        );
+        let time_range =
+            determine_time_range(view_query.latest_at, time_offset, data_result, plot_mem);
 
         {
             use re_space_view::RangeResultsExt as _;

--- a/crates/viewer/re_space_view_time_series/src/util.rs
+++ b/crates/viewer/re_space_view_time_series/src/util.rs
@@ -32,7 +32,6 @@ pub fn determine_time_range(
     time_offset: i64,
     data_result: &re_viewer_context::DataResult,
     plot_mem: Option<&egui_plot::PlotMemory>,
-    enable_query_clamping: bool,
 ) -> ResolvedTimeRange {
     let query_range = data_result.query_range();
 
@@ -68,7 +67,7 @@ pub fn determine_time_range(
 
     // If we're not in auto mode, which is the mode where the query drives the bounds of the plot,
     // then we want the bounds of the plots to drive the query!
-    if !is_auto_bounds && enable_query_clamping {
+    if !is_auto_bounds {
         if let Some((x_min, x_max)) = plot_bounds {
             time_range.set_min(i64::max(time_range.min().as_i64(), x_min));
             time_range.set_max(i64::min(time_range.max().as_i64(), x_max));

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -379,14 +379,13 @@ fn options_menu_ui(
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", allow(clippy::needless_pass_by_ref_mut))]
-fn experimental_feature_ui(_ui: &mut egui::Ui, _app_options: &mut re_viewer_context::AppOptions) {
-    // IMPORTANT: if/when adding wasm-compatible experimental features, remove the conditional
-    // compilation directive just above the call size of this function!!
-
-    #[cfg(not(target_arch = "wasm32"))]
-    _ui
-        .re_checkbox(&mut _app_options.experimental_space_view_screenshots, "Space view screenshots")
+// IMPORTANT: if/when adding wasm-compatible experimental features, move this conditional
+// compilation directive to `space_view_screenshot` and remove the one above the call size of this
+// function!!
+#[cfg(not(target_arch = "wasm32"))]
+fn experimental_feature_ui(ui: &mut egui::Ui, app_options: &mut re_viewer_context::AppOptions) {
+    ui
+        .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
         .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
 }
 

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -379,13 +379,14 @@ fn options_menu_ui(
     }
 }
 
-fn experimental_feature_ui(ui: &mut egui::Ui, app_options: &mut re_viewer_context::AppOptions) {
+#[cfg_attr(target_arch = "wasm32", allow(clippy::needless_pass_by_ref_mut))]
+fn experimental_feature_ui(_ui: &mut egui::Ui, _app_options: &mut re_viewer_context::AppOptions) {
     // IMPORTANT: if/when adding wasm-compatible experimental features, remove the conditional
     // compilation directive just above the call size of this function!!
 
     #[cfg(not(target_arch = "wasm32"))]
-    ui
-        .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
+    _ui
+        .re_checkbox(&mut _app_options.experimental_space_view_screenshots, "Space view screenshots")
         .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
 }
 

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -352,6 +352,9 @@ fn options_menu_ui(
         });
     }
 
+    // Currently, the wasm target does not have any experimental features. Remove this conditional
+    // compilation directive if/when this changes.
+    #[cfg(not(target_arch = "wasm32"))]
     {
         ui.add_space(SPACING);
         ui.label("Experimental features:");
@@ -377,6 +380,9 @@ fn options_menu_ui(
 }
 
 fn experimental_feature_ui(ui: &mut egui::Ui, app_options: &mut re_viewer_context::AppOptions) {
+    // IMPORTANT: if/when adding wasm-compatible experimental features, remove the conditional
+    // compilation directive just above the call size of this function!!
+
     #[cfg(not(target_arch = "wasm32"))]
     ui
         .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -381,12 +381,6 @@ fn experimental_feature_ui(ui: &mut egui::Ui, app_options: &mut re_viewer_contex
     ui
         .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
         .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
-
-    ui.re_checkbox(
-        &mut app_options.plot_query_clamping,
-        "Plots: query clamping",
-    )
-    .on_hover_text("Toggle query clamping for the plot visualizers. This is enabled by default and is only made toggable to facilitate potential bug hunts and performance comparisons.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewer_context/src/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/app_options.rs
@@ -17,9 +17,6 @@ pub struct AppOptions {
     #[cfg(not(target_arch = "wasm32"))]
     pub experimental_space_view_screenshots: bool,
 
-    /// Toggle query clamping for the plot visualizers.
-    pub plot_query_clamping: bool,
-
     /// Displays an overlay for debugging picking.
     pub show_picking_debug_overlay: bool,
 
@@ -49,8 +46,6 @@ impl Default for AppOptions {
 
             #[cfg(not(target_arch = "wasm32"))]
             experimental_space_view_screenshots: false,
-
-            plot_query_clamping: true,
 
             show_picking_debug_overlay: false,
 


### PR DESCRIPTION
### What

It has been defaulting to active for a few release without issues.

DNM: depends on #7663


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7664?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7664?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7664)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.