### PR TITLE
Add UI for precisely picking an exact sequence time

### DIFF
--- a/crates/store/re_log_types/src/time_point/time_int.rs
+++ b/crates/store/re_log_types/src/time_point/time_int.rs
@@ -60,8 +60,8 @@ impl TimeInt {
     pub const ONE: Self = Self(Some(NonMinI64::ONE));
 
     #[inline]
-    pub fn is_static(&self) -> bool {
-        *self == Self::STATIC
+    pub fn is_static(self) -> bool {
+        self == Self::STATIC
     }
 
     /// Creates a new temporal [`TimeInt`].
@@ -100,7 +100,7 @@ impl TimeInt {
 
     /// Returns `i64::MIN` for [`Self::STATIC`].
     #[inline]
-    pub const fn as_i64(&self) -> i64 {
+    pub const fn as_i64(self) -> i64 {
         match self.0 {
             Some(t) => t.get(),
             None => i64::MIN,
@@ -109,7 +109,7 @@ impl TimeInt {
 
     /// Returns `f64::MIN` for [`Self::STATIC`].
     #[inline]
-    pub const fn as_f64(&self) -> f64 {
+    pub const fn as_f64(self) -> f64 {
         match self.0 {
             Some(t) => t.get() as _,
             None => f64::MIN,
@@ -119,20 +119,20 @@ impl TimeInt {
     /// Always returns [`Self::STATIC`] for [`Self::STATIC`].
     #[inline]
     #[must_use]
-    pub fn inc(&self) -> Self {
+    pub fn inc(self) -> Self {
         match self.0 {
             Some(t) => Self::new_temporal(t.get().saturating_add(1)),
-            None => *self,
+            None => self,
         }
     }
 
     /// Always returns [`Self::STATIC`] for [`Self::STATIC`].
     #[inline]
     #[must_use]
-    pub fn dec(&self) -> Self {
+    pub fn dec(self) -> Self {
         match self.0 {
             Some(t) => Self::new_temporal(t.get().saturating_sub(1)),
-            None => *self,
+            None => self,
         }
     }
 }

--- a/crates/utils/re_format/src/lib.rs
+++ b/crates/utils/re_format/src/lib.rs
@@ -408,6 +408,20 @@ pub fn parse_f64(text: &str) -> Option<f64> {
     text.parse().ok()
 }
 
+/// Parses a number, ignoring whitespace (e.g. thousand separators),
+/// and treating the special minus character `MINUS` (−) as a minus sign.
+pub fn parse_i64(text: &str) -> Option<i64> {
+    let text: String = text
+        .chars()
+        // Ignore whitespace (trailing, leading, and thousands separators):
+        .filter(|c| !c.is_whitespace())
+        // Replace special minus character with normal minus (hyphen):
+        .map(|c| if c == '−' { '-' } else { c })
+        .collect();
+
+    text.parse().ok()
+}
+
 /// Pretty format a large number by using SI notation (base 10), e.g.
 ///
 /// ```


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/7653

I only implemented it for sequence timelines for now, since I didn't want to parse timestamps in different formats this early in the morning. Hopefully this can still help @teh-cmc.

It also shows how to do it for temporal timelines if someone wants to follow my lead.

![precise-time-control](https://github.com/user-attachments/assets/2577a551-5ce2-4f18-a396-37c4488998a9)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
