### PR TITLE
Fix Linux build: Make the `nasm` feature a no-op

### DIFF
--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -31,8 +31,9 @@ av1 = ["dep:dav1d"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with linux
-nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
+# TODO(#7671): this feature flag currently does nothing
+# nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
+nasm = [] ## TODO(#7671): fix Linux build
 
 [dependencies]
 re_log.workspace = true

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -31,7 +31,7 @@ av1 = ["dep:dav1d"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with arch linux
+## TODO(#7671): there is a bug that makes this incompatible with linux
 nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
 
 [dependencies]

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -31,6 +31,7 @@ av1 = ["dep:dav1d"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
+## TODO(#7671): there is a bug that makes this incompatible with arch linux
 nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
 
 [dependencies]

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -16,7 +16,8 @@ impl SyncDav1dDecoder {
     pub fn new() -> Result<Self> {
         re_tracing::profile_function!();
 
-        // TODO(#7671): enable this check again when the `nasm` feature actually does something
+        // TODO(#7671): enable this warning again when the `nasm` feature actually does something
+        #[allow(clippy::overly_complex_bool_expr)]
         if false && !cfg!(feature = "nasm") {
             re_log::warn_once!(
                 "NOTE: native AV1 video decoder is running extra slowly. \

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -16,6 +16,15 @@ impl SyncDav1dDecoder {
     pub fn new() -> Result<Self> {
         re_tracing::profile_function!();
 
+        // TODO(#7671): enable this check again when the `nasm` feature actually does something
+        if false && !cfg!(feature = "nasm") {
+            re_log::warn_once!(
+                "NOTE: native AV1 video decoder is running extra slowly. \
+                Speed it up by compiling Rerun with the `nasm` feature enabled. \
+                You'll need to also install nasm: https://nasm.us/"
+            );
+        }
+
         // See https://videolan.videolan.me/dav1d/structDav1dSettings.html for settings docs
         let mut settings = dav1d::Settings::new();
 

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -16,14 +16,6 @@ impl SyncDav1dDecoder {
     pub fn new() -> Result<Self> {
         re_tracing::profile_function!();
 
-        if !cfg!(feature = "nasm") {
-            re_log::warn_once!(
-                "NOTE: native AV1 video decoder is running extra slowly. \
-                Speed it up by compiling Rerun with the `nasm` feature enabled. \
-                You'll need to also install nasm: https://nasm.us/"
-            );
-        }
-
         // See https://videolan.videolan.me/dav1d/structDav1dSettings.html for settings docs
         let mut settings = dav1d::Settings::new();
 

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -43,6 +43,7 @@ default = ["native_viewer", "web_viewer"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
+## TODO(#7671): there is a bug that makes this incompatible with arch linux
 nasm = ["rerun/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -43,7 +43,7 @@ default = ["native_viewer", "web_viewer"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with arch linux
+## TODO(#7671): there is a bug that makes this incompatible with linux
 nasm = ["rerun/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -43,7 +43,7 @@ default = ["native_viewer", "web_viewer"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with linux
+# TODO(#7671): this feature flag currently does nothing
 nasm = ["rerun/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -73,7 +73,7 @@ log = ["dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with arch linux
+## TODO(#7671): there is a bug that makes this incompatible with linux
 nasm = ["re_video/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -73,6 +73,7 @@ log = ["dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
+## TODO(#7671): there is a bug that makes this incompatible with arch linux
 nasm = ["re_video/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -73,7 +73,7 @@ log = ["dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with linux
+# TODO(#7671): this feature flag currently does nothing
 nasm = ["re_video/nasm"]
 
 ## Support spawning a native viewer.

--- a/pixi.toml
+++ b/pixi.toml
@@ -122,18 +122,18 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer --"
+rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer,nasm"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer,nasm"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --release --"
 
 # Compile and run the web-viewer via rerun-cli.
 #

--- a/pixi.toml
+++ b/pixi.toml
@@ -122,18 +122,18 @@ man = "cargo --quiet run --package rerun-cli --all-features -- man > docs/conten
 # Compile and run the rerun viewer.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --"
+rerun = "cargo run --package rerun-cli --no-default-features --features native_viewer --"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer,nasm"
+rerun-build = "cargo build --package rerun-cli --no-default-features --features native_viewer"
 
 # Compile `rerun-cli` without the web-viewer.
-rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer,nasm"
+rerun-build-release = "cargo build --package rerun-cli --release --no-default-features --features native_viewer"
 
 # Compile and run the rerun viewer with --release.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
-rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --release --"
+rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer --release --"
 
 # Compile and run the web-viewer via rerun-cli.
 #

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -30,7 +30,7 @@ extension-module = ["pyo3/extension-module"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with arch linux
+## TODO(#7671): there is a bug that makes this incompatible with linux
 nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -19,7 +19,7 @@ default = ["extension-module"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
-pypi = ["extension-module", "web_viewer"]
+pypi = ["extension-module", "nasm", "web_viewer"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -30,7 +30,7 @@ extension-module = ["pyo3/extension-module"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-## TODO(#7671): there is a bug that makes this incompatible with linux
+# TODO(#7671): this feature flag currently does nothing
 nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -19,7 +19,7 @@ default = ["extension-module"]
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
-pypi = ["extension-module", "nasm", "web_viewer"]
+pypi = ["extension-module", "web_viewer"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we
@@ -30,6 +30,7 @@ extension-module = ["pyo3/extension-module"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
+## TODO(#7671): there is a bug that makes this incompatible with arch linux
 nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.


### PR DESCRIPTION
### What
* Circumvent https://github.com/rerun-io/rerun/issues/7671

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7675?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7675?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7675)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.