### PR TITLE
Empty column tracker and new dataframe APIs on top

### DIFF
--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -340,6 +340,7 @@ impl ChunkStore {
                 info: _,
                 config: _,
                 type_registry: _,
+                per_column_metadata: _, // column metadata is additive only
                 chunks_per_chunk_id,
                 chunk_ids_per_min_row_id,
                 temporal_chunk_ids_per_entity_per_component,

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -32,8 +32,10 @@ pub use self::dataframe::{
 pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::stats::{ChunkStoreChunkStats, ChunkStoreStats};
-pub use self::store::{ChunkStore, ChunkStoreConfig, ChunkStoreGeneration};
+pub use self::store::{ChunkStore, ChunkStoreConfig, ChunkStoreGeneration, ColumnMetadata};
 pub use self::subscribers::{ChunkStoreSubscriber, ChunkStoreSubscriberHandle};
+
+pub(crate) use self::store::ColumnMetadataState;
 
 // Re-exports
 #[doc(no_inline)]

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -276,6 +276,36 @@ pub type ChunkIdSetPerTimePerTimelinePerEntity = BTreeMap<EntityPath, ChunkIdSet
 
 // ---
 
+#[derive(Debug, Clone)]
+pub struct ColumnMetadata {
+    /// Whether this column represents static data.
+    pub is_static: bool,
+
+    /// Whether this column represents an indicator component.
+    pub is_indicator: bool,
+
+    /// Whether this column represents a `Clear`-related component.
+    ///
+    /// `Clear`: [`re_types_core::archetypes::Clear`]
+    pub is_tombstone: bool,
+
+    /// Whether this column contains either no data or only contains null and/or empty values (`[]`).
+    pub is_semantically_empty: bool,
+}
+
+/// Internal state that needs to be maintained in order to compute [`ColumnMetadata`].
+#[derive(Debug, Clone)]
+pub struct ColumnMetadataState {
+    /// Whether non-semantically empty data was ever written to this column at any point.
+    ///
+    /// Semantically empty data is data that is either physically empty or only contains null
+    /// and/or empty values (`[]`).
+    ///
+    /// This is purely additive: once false, it will always be false. Even in case of garbage
+    /// collection.
+    pub is_semantically_non_empty: bool,
+}
+
 /// Incremented on each edit.
 #[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct ChunkStoreGeneration {
@@ -305,6 +335,8 @@ pub struct ChunkStore {
     // TODO(cmc): this would become fairly problematic in a world where each chunk can use a
     // different datatype for a given component.
     pub(crate) type_registry: IntMap<ComponentName, ArrowDataType>,
+
+    pub(crate) per_column_metadata: IntMap<EntityPath, IntMap<ComponentName, ColumnMetadataState>>,
 
     pub(crate) chunks_per_chunk_id: BTreeMap<ChunkId, Arc<Chunk>>,
 
@@ -370,6 +402,7 @@ impl Clone for ChunkStore {
             info: self.info.clone(),
             config: self.config.clone(),
             type_registry: self.type_registry.clone(),
+            per_column_metadata: self.per_column_metadata.clone(),
             chunks_per_chunk_id: self.chunks_per_chunk_id.clone(),
             chunk_ids_per_min_row_id: self.chunk_ids_per_min_row_id.clone(),
             temporal_chunk_ids_per_entity_per_component: self
@@ -394,6 +427,7 @@ impl std::fmt::Display for ChunkStore {
             info: _,
             config,
             type_registry: _,
+            per_column_metadata: _,
             chunks_per_chunk_id,
             chunk_ids_per_min_row_id: chunk_id_per_min_row_id,
             temporal_chunk_ids_per_entity_per_component: _,
@@ -449,6 +483,7 @@ impl ChunkStore {
             info: None,
             config,
             type_registry: Default::default(),
+            per_column_metadata: Default::default(),
             chunk_ids_per_min_row_id: Default::default(),
             chunks_per_chunk_id: Default::default(),
             temporal_chunk_ids_per_entity_per_component: Default::default(),
@@ -516,6 +551,40 @@ impl ChunkStore {
     #[inline]
     pub fn lookup_datatype(&self, component_name: &ComponentName) -> Option<&ArrowDataType> {
         self.type_registry.get(component_name)
+    }
+
+    /// Lookup the [`ColumnMetadata`] for a specific [`EntityPath`] and [`re_types_core::Component`].
+    pub fn lookup_column_metadata(
+        &self,
+        entity_path: &EntityPath,
+        component_name: &ComponentName,
+    ) -> Option<ColumnMetadata> {
+        let ColumnMetadataState {
+            is_semantically_non_empty,
+        } = self
+            .per_column_metadata
+            .get(entity_path)
+            .and_then(|per_component| per_component.get(component_name))?;
+
+        let is_static = self
+            .static_chunk_ids_per_entity
+            .get(entity_path)
+            .map_or(false, |per_component| {
+                per_component.get(component_name).is_some()
+            });
+
+        let is_indicator = component_name.is_indicator_component();
+
+        use re_types_core::Archetype as _;
+        let is_tombstone =
+            re_types_core::archetypes::Clear::all_components().contains(component_name);
+
+        Some(ColumnMetadata {
+            is_static,
+            is_indicator,
+            is_tombstone,
+            is_semantically_empty: !*is_semantically_non_empty,
+        })
     }
 }
 

--- a/crates/store/re_chunk_store/src/store.rs
+++ b/crates/store/re_chunk_store/src/store.rs
@@ -296,14 +296,11 @@ pub struct ColumnMetadata {
 /// Internal state that needs to be maintained in order to compute [`ColumnMetadata`].
 #[derive(Debug, Clone)]
 pub struct ColumnMetadataState {
-    /// Whether non-semantically empty data was ever written to this column at any point.
-    ///
-    /// Semantically empty data is data that is either physically empty or only contains null
-    /// and/or empty values (`[]`).
+    /// Whether this column contains either no data or only contains null and/or empty values (`[]`).
     ///
     /// This is purely additive: once false, it will always be false. Even in case of garbage
     /// collection.
-    pub is_semantically_non_empty: bool,
+    pub is_semantically_empty: bool,
 }
 
 /// Incremented on each edit.
@@ -560,7 +557,7 @@ impl ChunkStore {
         component_name: &ComponentName,
     ) -> Option<ColumnMetadata> {
         let ColumnMetadataState {
-            is_semantically_non_empty,
+            is_semantically_empty,
         } = self
             .per_column_metadata
             .get(entity_path)
@@ -583,7 +580,7 @@ impl ChunkStore {
             is_static,
             is_indicator,
             is_tombstone,
-            is_semantically_empty: !*is_semantically_non_empty,
+            is_semantically_empty: *is_semantically_empty,
         })
     }
 }

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -9,7 +9,7 @@ use re_types_core::SizeBytes;
 
 use crate::{
     store::ChunkIdSetPerTime, ChunkStore, ChunkStoreChunkStats, ChunkStoreConfig, ChunkStoreDiff,
-    ChunkStoreError, ChunkStoreEvent, ChunkStoreResult,
+    ChunkStoreError, ChunkStoreEvent, ChunkStoreResult, ColumnMetadataState,
 };
 
 // Used all over in docstrings.
@@ -321,6 +321,21 @@ impl ChunkStore {
                 component_name,
                 ArrowListArray::<i32>::get_child_type(list_array.data_type()).clone(),
             );
+
+            let column_metadata_state = self
+                .per_column_metadata
+                .entry(chunk.entity_path().clone())
+                .or_default()
+                .entry(component_name)
+                .or_insert(ColumnMetadataState {
+                    is_semantically_non_empty: false,
+                });
+            {
+                let is_semantically_empty =
+                    re_chunk::util::is_list_array_semantically_empty(list_array);
+
+                column_metadata_state.is_semantically_non_empty |= !is_semantically_empty;
+            }
         }
 
         let events = if self.config.enable_changelog {
@@ -485,6 +500,7 @@ impl ChunkStore {
             info: _,
             config: _,
             type_registry: _,
+            per_column_metadata,
             chunks_per_chunk_id,
             chunk_ids_per_min_row_id,
             temporal_chunk_ids_per_entity_per_component,
@@ -497,6 +513,8 @@ impl ChunkStore {
             gc_id: _,
             event_id,
         } = self;
+
+        per_column_metadata.remove(entity_path);
 
         let dropped_static_chunks = {
             let dropped_static_chunk_ids: BTreeSet<_> = static_chunk_ids_per_entity

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -328,13 +328,13 @@ impl ChunkStore {
                 .or_default()
                 .entry(component_name)
                 .or_insert(ColumnMetadataState {
-                    is_semantically_non_empty: false,
+                    is_semantically_empty: true,
                 });
             {
                 let is_semantically_empty =
                     re_chunk::util::is_list_array_semantically_empty(list_array);
 
-                column_metadata_state.is_semantically_non_empty |= !is_semantically_empty;
+                column_metadata_state.is_semantically_empty &= is_semantically_empty;
             }
         }
 

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -1,5 +1,5 @@
 use re_chunk::{EntityPath, TransportChunk};
-use re_chunk_store::{ChunkStore, ColumnDescriptor, QueryExpression, ViewContentsSelector};
+use re_chunk_store::{ChunkStore, ColumnDescriptor, QueryExpression};
 use re_log_types::EntityPathFilter;
 use re_query::Caches;
 
@@ -41,26 +41,21 @@ impl QueryEngine<'_> {
     /// entity that has been written to the store so far.
     ///
     /// The order of the columns to guaranteed to be in a specific order:
-    /// * first, the control columns in lexical order (`RowId`);
-    /// * second, the time columns in lexical order (`frame_nr`, `log_time`, ...);
-    /// * third, the component columns in lexical order (`Color`, `Radius, ...`).
+    /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
+    /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
     pub fn schema(&self) -> Vec<ColumnDescriptor> {
         self.store.schema()
     }
 
-    /// Returns the filtered schema for the given `view_contents`.
+    /// Returns the filtered schema for the given [`QueryExpression`].
     ///
     /// The order of the columns is guaranteed to be in a specific order:
-    /// * first, the control columns in lexical order (`RowId`);
-    /// * second, the time columns in lexical order (`frame_nr`, `log_time`, ...);
-    /// * third, the component columns in lexical order (`Color`, `Radius, ...`).
+    /// * first, the time columns in lexical order (`frame_nr`, `log_time`, ...);
+    /// * second, the component columns in lexical order (`Color`, `Radius, ...`).
     #[inline]
-    pub fn schema_for_view_contents(
-        &self,
-        view_contents: &ViewContentsSelector,
-    ) -> Vec<ColumnDescriptor> {
-        self.store.schema_for_view_contents(view_contents)
+    pub fn schema_for_query(&self, query: &QueryExpression) -> Vec<ColumnDescriptor> {
+        self.store.schema_for_query(query)
     }
 
     /// Starts a new query by instantiating a [`QueryHandle`].

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -163,12 +163,8 @@ impl QueryHandle<'_> {
     fn init_(&self) -> QueryHandleState {
         re_tracing::profile_scope!("init");
 
-        // 1. Compute the schema of the view contents.
-        let view_contents = if let Some(view_contents) = self.query.view_contents.as_ref() {
-            self.engine.store.schema_for_view_contents(view_contents)
-        } else {
-            self.engine.store.schema()
-        };
+        // 1. Compute the schema for the query.
+        let view_contents = self.engine.store.schema_for_query(&self.query);
 
         // 2. Compute the schema of the selected contents.
         //
@@ -405,6 +401,9 @@ impl QueryHandle<'_> {
                                             store_datatype: arrow2::datatypes::DataType::Null,
                                             join_encoding: JoinEncoding::default(),
                                             is_static: false,
+                                            is_indicator: false,
+                                            is_tombstone: false,
+                                            is_semantically_empty: false,
                                         }),
                                     )
                                 },

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -143,22 +143,25 @@ mode sets the default time range to _everything_. You can override this in the s
             SparseFillStrategy::None
         };
 
-        let view_columns = query_engine.schema_for_view_contents(&view_contents);
-        let selected_columns =
-            view_query.apply_column_visibility_to_view_columns(ctx, &view_columns)?;
-
-        let dataframe_query = re_chunk_store::QueryExpression {
+        let mut dataframe_query = re_chunk_store::QueryExpression {
             view_contents: Some(view_contents),
             filtered_index: view_query.timeline(ctx)?,
             filtered_index_range: Some(view_query.filter_by_range()?),
             filtered_point_of_view: view_query.filter_by_event()?,
             sparse_fill_strategy,
-            selection: selected_columns,
+            selection: None,
 
             // not yet unsupported by the dataframe view
             filtered_index_values: None,
             using_index_values: None,
+            include_semantically_empty_columns: false,
+            include_indicator_columns: false,
+            include_tombstone_columns: false,
         };
+
+        let view_columns = query_engine.schema_for_query(&dataframe_query);
+        dataframe_query.selection =
+            view_query.apply_column_visibility_to_view_columns(ctx, &view_columns)?;
 
         let query_handle = query_engine.query(dataframe_query);
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -670,6 +670,9 @@ impl PyRecording {
 
         let query = QueryExpression {
             view_contents: Some(contents),
+            include_semantically_empty_columns: false,
+            include_indicator_columns: false,
+            include_tombstone_columns: false,
             filtered_index: timeline.timeline,
             filtered_index_range: None,
             filtered_index_values: None,


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1acdb4e6-1b48-4932-89a6-cd00814726eb)

After:
![image](https://github.com/user-attachments/assets/d6b13b60-9d61-4aab-b577-381d22791e26)

Of course with static data this still looks pretty weird in many cases, such as shown in this screenshot,
But that's a job for the upcoming https://github.com/rerun-io/rerun/issues/7668.

---

* Fixes #7615 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7677?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7677?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7677)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.