### PR TITLE
Use GPU based transfer to do chroma conversions of native decoder output

### DIFF
--- a/crates/store/re_video/examples/frames.rs
+++ b/crates/store/re_video/examples/frames.rs
@@ -36,15 +36,16 @@ fn main() {
         video.config.coded_height
     );
 
-    let mut decoder = create_decoder(&video);
+    let mut decoder = create_decoder(video_path, &video);
 
     write_video_frames(&video, decoder.as_mut(), &output_dir);
 }
 
-fn create_decoder(video: &VideoData) -> Box<dyn SyncDecoder> {
+fn create_decoder(debug_name: &str, video: &VideoData) -> Box<dyn SyncDecoder> {
     if video.config.is_av1() {
         Box::new(
-            re_video::decode::av1::SyncDav1dDecoder::new().expect("Failed to start AV1 decoder"),
+            re_video::decode::av1::SyncDav1dDecoder::new(debug_name.to_owned())
+                .expect("Failed to start AV1 decoder"),
         )
     } else {
         panic!("Unsupported codec: {}", video.human_readable_codec_string());

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -254,6 +254,9 @@ fn color_primaries(debug_name: &str, picture: &dav1d::Picture) -> ColorPrimaries
                 //     ColorPrimaries::Bt601
                 // }
                 //
+                // This is also what the mpv player does (and probably others):
+                // https://wiki.x266.mov/docs/colorimetry/primaries#2-unspecified
+                //
                 // …then again, eyeballing VLC it looks like it just always assumes BT.709.
                 // The handwavy test case employed here was the same video in low & high resolution
                 // without specified primaries. Both looked the same.

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -176,7 +176,7 @@ fn output_picture(
                     let mut data = Vec::with_capacity(num_packed_bytes_y + num_packed_bytes_uv * 2);
                     {
                         let plane = picture.plane(PlanarImageComponent::Y);
-                        if packed_stride_y != actual_stride_y {
+                        if packed_stride_y == actual_stride_y {
                             data.extend_from_slice(&plane[0..num_packed_bytes_y]);
                         } else {
                             re_tracing::profile_scope!("slow path, y-plane");

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -161,6 +161,8 @@ fn output_picture(picture: &dav1d::Picture, on_output: &(dyn Fn(Result<Frame>) +
                 {
                     let plane = picture.plane(PlanarImageComponent::Y);
                     if actual_stride_y != packed_stride_y {
+                        re_tracing::profile_scope!("slow path copy y-plane");
+
                         for y in 0..height_y {
                             let offset = y * actual_stride_y;
                             data.extend_from_slice(&plane[offset..(offset + packed_stride_y)]);
@@ -172,6 +174,8 @@ fn output_picture(picture: &dav1d::Picture, on_output: &(dyn Fn(Result<Frame>) +
                 for comp in [PlanarImageComponent::U, PlanarImageComponent::V] {
                     let plane = picture.plane(comp);
                     if actual_stride_uv != packed_stride_uv {
+                        re_tracing::profile_scope!("slow path copy u/v-plane");
+
                         for y in 0..height_uv {
                             let offset = y * actual_stride_uv;
                             data.extend_from_slice(&plane[offset..(offset + packed_stride_uv)]);

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -249,7 +249,7 @@ fn color_primaries(picture: &dav1d::Picture) -> ColorPrimaries {
                 //     ColorPrimaries::Bt601
                 // }
                 //
-                // ... then again, eyeballing VLC it looks like it just always assumes BT.709.
+                // …then again, eyeballing VLC it looks like it just always assumes BT.709.
                 // The handwavy test case employed here was the same video in low & high resolution
                 // without specified primaries. Both looked the same.
                 ColorPrimaries::Bt709

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -60,6 +60,7 @@ pub struct Frame {
 }
 
 /// Pixel format/layout used by [`Frame::data`].
+#[derive(Debug)]
 pub enum PixelFormat {
     Rgb8Unorm,
     Rgba8Unorm,
@@ -77,6 +78,7 @@ pub enum PixelFormat {
 ///
 /// For details see `re_renderer`'s `YuvPixelLayout` type.
 #[allow(non_camel_case_types)]
+#[derive(Debug)]
 pub enum YuvPixelLayout {
     Y_U_V444,
     Y_U_V422,
@@ -87,6 +89,7 @@ pub enum YuvPixelLayout {
 /// Yuv value range used by [`PixelFormat::Yuv`].
 ///
 /// For details see `re_renderer`'s `YuvRange` type.
+#[derive(Debug)]
 pub enum YuvRange {
     Limited,
     Full,
@@ -95,6 +98,7 @@ pub enum YuvRange {
 /// Color primaries used by [`PixelFormat::Yuv`].
 ///
 /// For details see `re_renderer`'s `ColorPrimaries` type.
+#[derive(Debug)]
 pub enum ColorPrimaries {
     Bt601,
     Bt709,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -59,7 +59,43 @@ pub struct Frame {
     pub duration: Time,
 }
 
+/// Pixel format/layout used by [`Frame::data`].
 pub enum PixelFormat {
     Rgb8Unorm,
     Rgba8Unorm,
+
+    Yuv {
+        layout: YuvPixelLayout,
+        range: YuvRange,
+        // TODO(andreas): color primaries should also apply to RGB data,
+        // but for now we just always assume RGB to be BT.709 ~= sRGB.
+        primaries: ColorPrimaries,
+    },
+}
+
+/// Pixel layout used by [`PixelFormat::Yuv`].
+///
+/// For details see `re_renderer`'s `YuvPixelLayout` type.
+#[allow(non_camel_case_types)]
+pub enum YuvPixelLayout {
+    Y_U_V444,
+    Y_U_V422,
+    Y_U_V420,
+    Y400,
+}
+
+/// Yuv value range used by [`PixelFormat::Yuv`].
+///
+/// For details see `re_renderer`'s `YuvRange` type.
+pub enum YuvRange {
+    Limited,
+    Full,
+}
+
+/// Color primaries used by [`PixelFormat::Yuv`].
+///
+/// For details see `re_renderer`'s `ColorPrimaries` type.
+pub enum ColorPrimaries {
+    Bt601,
+    Bt709,
 }

--- a/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/cpu_write_gpu_read_belt.rs
@@ -5,7 +5,7 @@ use crate::{
     wgpu_resources::{BufferDesc, GpuBuffer, GpuBufferPool, GpuTexture},
 };
 
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum CpuWriteGpuReadError {
     #[error("Attempting to allocate an empty buffer.")]
     ZeroSizeBufferAllocation,

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -50,7 +50,7 @@ pub trait DrawData {
     type Renderer: Renderer<RendererDrawData = Self> + Send + Sync;
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum DrawError {
     #[error(transparent)]
     Pool(#[from] PoolError),

--- a/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
@@ -258,7 +258,7 @@ impl<'a> ImageDataDesc<'a> {
                 label: self.label.clone(),
                 size: wgpu::Extent3d {
                     width: self.width_height[0],
-                    height: self.width_height[0],
+                    height: self.width_height[1],
                     depth_or_array_layers: 1,
                 },
                 mip_level_count: 1, // No mipmapping support yet.

--- a/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/image_data_to_texture.rs
@@ -111,6 +111,20 @@ pub enum ImageDataToTextureError {
     #[error("Gpu-based conversion for texture {label:?} did not succeed: {err}")]
     GpuBasedConversionError { label: DebugLabel, err: DrawError },
 
+    #[error("Texture {label:?} has invalid texture usage flags: {actual_usage:?}, expected at least {required_usage:?}")]
+    InvalidTargetTextureUsageFlags {
+        label: DebugLabel,
+        actual_usage: wgpu::TextureUsages,
+        required_usage: wgpu::TextureUsages,
+    },
+
+    #[error("Texture {label:?} has invalid texture format: {actual_format:?}, expected at least {required_format:?}")]
+    InvalidTargetTextureFormat {
+        label: DebugLabel,
+        actual_format: wgpu::TextureFormat,
+        required_format: wgpu::TextureFormat,
+    },
+
     // TODO(andreas): As we stop using `wgpu::TextureFormat` for input, this should become obsolete.
     #[error("Unsupported texture format {0:?}")]
     UnsupportedTextureFormat(wgpu::TextureFormat),
@@ -120,6 +134,8 @@ pub enum ImageDataToTextureError {
 ///
 /// Arbitrary (potentially gpu based) conversions may be performed to upload the data to the GPU.
 pub struct ImageDataDesc<'a> {
+    /// If this desc is not used for a texture update, this label is used for the target texture.
+    /// Otherwise, it may still used for any intermediate resources that may be required during the conversion process.
     pub label: DebugLabel,
 
     /// Data for the highest mipmap level.
@@ -141,13 +157,35 @@ pub struct ImageDataDesc<'a> {
 }
 
 impl<'a> ImageDataDesc<'a> {
-    fn validate(&self, limits: &wgpu::Limits) -> Result<(), ImageDataToTextureError> {
+    fn validate(
+        &self,
+        limits: &wgpu::Limits,
+        target_texture_desc: &TextureDesc,
+    ) -> Result<(), ImageDataToTextureError> {
         let Self {
             label,
             data,
             format,
             width_height,
         } = self;
+
+        if !target_texture_desc
+            .usage
+            .contains(self.target_texture_usage_requirements())
+        {
+            return Err(ImageDataToTextureError::InvalidTargetTextureUsageFlags {
+                label: target_texture_desc.label.clone(),
+                actual_usage: target_texture_desc.usage,
+                required_usage: self.target_texture_usage_requirements(),
+            });
+        }
+        if target_texture_desc.format != self.target_texture_format() {
+            return Err(ImageDataToTextureError::InvalidTargetTextureFormat {
+                label: target_texture_desc.label.clone(),
+                actual_format: target_texture_desc.format,
+                required_format: self.target_texture_format(),
+            });
+        }
 
         if width_height[0] == 0 || width_height[1] == 0 {
             return Err(ImageDataToTextureError::ZeroSize(label.clone()));
@@ -189,6 +227,48 @@ impl<'a> ImageDataDesc<'a> {
 
         Ok(())
     }
+
+    /// The texture usages required in order to store this image data.
+    pub fn target_texture_usage_requirements(&self) -> wgpu::TextureUsages {
+        match self.format {
+            SourceImageDataFormat::WgpuCompatible(_) => wgpu::TextureUsages::COPY_DST, // Data arrives via raw data copy.
+            SourceImageDataFormat::Yuv { .. } => {
+                YuvFormatConversionTask::REQUIRED_TARGET_TEXTURE_USAGE_FLAGS
+            }
+        }
+    }
+
+    /// The texture format required in order to store this image data.
+    pub fn target_texture_format(&self) -> wgpu::TextureFormat {
+        match self.format {
+            SourceImageDataFormat::WgpuCompatible(format) => format,
+            SourceImageDataFormat::Yuv { .. } => YuvFormatConversionTask::OUTPUT_FORMAT,
+        }
+    }
+
+    /// Creates a texture that can hold the image data.
+    pub fn create_target_texture(
+        &self,
+        ctx: &RenderContext,
+        texture_usages: wgpu::TextureUsages,
+    ) -> GpuTexture {
+        ctx.gpu_resources.textures.alloc(
+            &ctx.device,
+            &TextureDesc {
+                label: self.label.clone(),
+                size: wgpu::Extent3d {
+                    width: self.width_height[0],
+                    height: self.width_height[0],
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1, // No mipmapping support yet.
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: self.target_texture_format(),
+                usage: self.target_texture_usage_requirements() | texture_usages,
+            },
+        )
+    }
 }
 
 /// Takes raw image data and transfers & converts it to a GPU texture.
@@ -206,10 +286,11 @@ impl<'a> ImageDataDesc<'a> {
 pub fn transfer_image_data_to_texture(
     ctx: &RenderContext,
     image_data: ImageDataDesc<'_>,
-) -> Result<GpuTexture, ImageDataToTextureError> {
+    target_texture: &GpuTexture,
+) -> Result<(), ImageDataToTextureError> {
     re_tracing::profile_function!();
 
-    image_data.validate(&ctx.device.limits())?;
+    image_data.validate(&ctx.device.limits(), &target_texture.creation_desc)?;
 
     let ImageDataDesc {
         label,
@@ -236,29 +317,37 @@ pub fn transfer_image_data_to_texture(
         SourceImageDataFormat::WgpuCompatible(_) => label.clone(),
         SourceImageDataFormat::Yuv { .. } => format!("{label}_source_data").into(),
     };
-    let data_texture = ctx.gpu_resources.textures.alloc(
-        &ctx.device,
-        &TextureDesc {
-            label: data_texture_label,
-            size: wgpu::Extent3d {
-                width: data_texture_width,
-                height: data_texture_height,
-                depth_or_array_layers: 1,
+
+    let data_texture = match source_format {
+        // Needs intermediate data texture.
+        SourceImageDataFormat::Yuv { .. } => ctx.gpu_resources.textures.alloc(
+            &ctx.device,
+            &TextureDesc {
+                label: data_texture_label,
+                size: wgpu::Extent3d {
+                    width: data_texture_width,
+                    height: data_texture_height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1, // We don't have mipmap level generation yet!
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: data_texture_format,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             },
-            mip_level_count: 1, // We don't have mipmap level generation yet!
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: data_texture_format,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
-        },
-    );
+        ),
+
+        // Target is directly written to.
+        SourceImageDataFormat::WgpuCompatible(_) => target_texture.clone(),
+    };
+
     copy_data_to_texture(ctx, &data_texture, data.as_ref())?;
 
     // Build a converter task, feeding in the raw data.
     let converter_task = match source_format {
         SourceImageDataFormat::WgpuCompatible(_) => {
             // No further conversion needed, we're done here!
-            return Ok(data_texture);
+            return Ok(());
         }
         SourceImageDataFormat::Yuv {
             format,
@@ -270,19 +359,16 @@ pub fn transfer_image_data_to_texture(
             range,
             primaries,
             &data_texture,
-            &label,
-            output_width_height,
+            target_texture,
         ),
     };
 
     // Once there's different gpu based conversions, we should probably trait-ify this so we can keep the basic steps.
     // Note that we execute the task right away, but the way things are set up (by means of using the `Renderer` framework)
     // it would be fairly easy to schedule this differently!
-    let output_texture = converter_task
+    converter_task
         .convert_input_data_to_texture(ctx)
-        .map_err(|err| ImageDataToTextureError::GpuBasedConversionError { label, err })?;
-
-    Ok(output_texture)
+        .map_err(|err| ImageDataToTextureError::GpuBasedConversionError { label, err })
 }
 
 fn copy_data_to_texture(

--- a/crates/viewer/re_renderer/src/resource_managers/mod.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/mod.rs
@@ -11,7 +11,8 @@ mod texture_manager;
 mod yuv_converter;
 
 pub use image_data_to_texture::{
-    ColorPrimaries, ImageDataDesc, ImageDataToTextureError, SourceImageDataFormat,
+    transfer_image_data_to_texture, ColorPrimaries, ImageDataDesc, ImageDataToTextureError,
+    SourceImageDataFormat,
 };
 pub use texture_manager::{GpuTexture2D, TextureManager2D, TextureManager2DError};
 pub use yuv_converter::{YuvPixelLayout, YuvRange};

--- a/crates/viewer/re_renderer/src/resource_managers/texture_manager.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/texture_manager.rs
@@ -229,10 +229,10 @@ impl TextureManager2D {
         // Currently we don't store any data in the texture manager.
         // In the future we might handle (lazy?) mipmap generation in here or keep track of lazy upload processing.
 
-        Ok(GpuTexture2D(transfer_image_data_to_texture(
-            render_ctx,
-            creation_desc,
-        )?))
+        let texture =
+            creation_desc.create_target_texture(render_ctx, wgpu::TextureUsages::TEXTURE_BINDING);
+        transfer_image_data_to_texture(render_ctx, creation_desc, &texture)?;
+        Ok(GpuTexture2D(texture))
     }
 
     /// Creates a new 2D texture resource and schedules data upload to the GPU if a texture
@@ -277,11 +277,11 @@ impl TextureManager2D {
                 // Run potentially expensive texture creation code:
                 let tex_creation_desc = try_create_texture_desc()
                     .map_err(|err| TextureManager2DError::DataCreation(err))?;
-                let texture = GpuTexture2D(transfer_image_data_to_texture(
-                    render_ctx,
-                    tex_creation_desc,
-                )?);
-                entry.insert(texture).clone()
+
+                let texture = tex_creation_desc
+                    .create_target_texture(render_ctx, wgpu::TextureUsages::TEXTURE_BINDING);
+                transfer_image_data_to_texture(render_ctx, tex_creation_desc, &texture)?;
+                entry.insert(GpuTexture2D(texture)).clone()
             }
         };
 

--- a/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
+++ b/crates/viewer/re_renderer/src/resource_managers/yuv_converter.rs
@@ -300,26 +300,6 @@ impl YuvFormatConversionTask {
         input_data: &GpuTexture,
         target_texture: &GpuTexture,
     ) -> Self {
-        // TODO:
-        // let target_texture = ctx.gpu_resources.textures.alloc(
-        //     &ctx.device,
-        //     &TextureDesc {
-        //         label: output_label.clone(),
-        //         size: wgpu::Extent3d {
-        //             width: output_width_height[0],
-        //             height: output_width_height[1],
-        //             depth_or_array_layers: 1,
-        //         },
-        //         mip_level_count: 1, // We don't have mipmap level generation yet!
-        //         sample_count: 1,
-        //         dimension: wgpu::TextureDimension::D2,
-        //         format: Self::OUTPUT_FORMAT,
-        //         usage: output_usage_flags | wgpu::TextureUsages::RENDER_ATTACHMENT,
-        //     },
-        // );
-
-        // TODO: validate target_texture
-
         let target_label = target_texture.creation_desc.label.clone();
         let renderer = ctx.renderer::<YuvFormatConverter>();
 

--- a/crates/viewer/re_renderer/src/video/decoder/mod.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/mod.rs
@@ -139,7 +139,7 @@ impl VideoDecoder {
                 if cfg!(debug_assertions) {
                     return Err(DecodingError::NoNativeDebug); // because debug builds of rav1d are EXTREMELY slow
                 } else {
-                    let av1_decoder = re_video::decode::av1::SyncDav1dDecoder::new()
+                    let av1_decoder = re_video::decode::av1::SyncDav1dDecoder::new(debug_name.clone())
                         .map_err(|err| DecodingError::StartDecoder(err.to_string()))?;
 
                     let decoder = native_decoder::NativeDecoder::new(debug_name, Box::new(av1_decoder))?;

--- a/crates/viewer/re_renderer/src/video/decoder/native_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/native_decoder.rs
@@ -158,9 +158,14 @@ fn copy_video_frame_to_texture(
     re_tracing::profile_function!();
 
     let format = match &frame.format {
-        re_video::PixelFormat::Rgb8Unorm | re_video::PixelFormat::Rgba8Unorm => {
+        re_video::PixelFormat::Rgb8Unorm => {
+            unreachable!("Handled explicitly earlier in this function");
+        }
+
+        re_video::PixelFormat::Rgba8Unorm => {
             SourceImageDataFormat::WgpuCompatible(wgpu::TextureFormat::Rgba8Unorm)
         }
+
         re_video::PixelFormat::Yuv {
             layout,
             range,

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -60,6 +60,9 @@ pub enum DecodingError {
     #[cfg(not(target_arch = "wasm32"))]
     #[error("Native video decoding not supported in native debug builds.")]
     NoNativeDebug,
+
+    #[error("Failed to create gpu texture from decoded video data: {0}")]
+    ImageDataToTextureError(#[from] crate::resource_managers::ImageDataToTextureError),
 }
 
 pub type FrameDecodingResult = Result<VideoFrameTexture, DecodingError>;

--- a/crates/viewer/re_renderer/src/wgpu_resources/resource.rs
+++ b/crates/viewer/re_renderer/src/wgpu_resources/resource.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::AtomicU64;
 
-#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum PoolError {
     #[error("Requested resource isn't available because the handle is no longer valid")]
     ResourceNotAvailable,

--- a/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
+++ b/crates/viewer/re_viewer_context/src/gpu_bridge/image_to_gpu.rs
@@ -267,7 +267,7 @@ pub fn texture_creation_desc_from_color_image<'a>(
             //
             PixelFormat::Y_U_V24_FullRange | PixelFormat::Y_U_V24_LimitedRange => {
                 SourceImageDataFormat::Yuv {
-                    format: YuvPixelLayout::Y_U_V444,
+                    layout: YuvPixelLayout::Y_U_V444,
                     range,
                     primaries,
                 }
@@ -275,7 +275,7 @@ pub fn texture_creation_desc_from_color_image<'a>(
 
             PixelFormat::Y_U_V16_FullRange | PixelFormat::Y_U_V16_LimitedRange => {
                 SourceImageDataFormat::Yuv {
-                    format: YuvPixelLayout::Y_U_V422,
+                    layout: YuvPixelLayout::Y_U_V422,
                     range,
                     primaries,
                 }
@@ -283,7 +283,7 @@ pub fn texture_creation_desc_from_color_image<'a>(
 
             PixelFormat::Y_U_V12_FullRange | PixelFormat::Y_U_V12_LimitedRange => {
                 SourceImageDataFormat::Yuv {
-                    format: YuvPixelLayout::Y_U_V420,
+                    layout: YuvPixelLayout::Y_U_V420,
                     range,
                     primaries,
                 }
@@ -291,20 +291,20 @@ pub fn texture_creation_desc_from_color_image<'a>(
 
             PixelFormat::Y8_FullRange | PixelFormat::Y8_LimitedRange => {
                 SourceImageDataFormat::Yuv {
-                    format: YuvPixelLayout::Y400,
+                    layout: YuvPixelLayout::Y400,
                     range,
                     primaries,
                 }
             }
 
             PixelFormat::NV12 => SourceImageDataFormat::Yuv {
-                format: YuvPixelLayout::Y_UV420,
+                layout: YuvPixelLayout::Y_UV420,
                 range,
                 primaries,
             },
 
             PixelFormat::YUY2 => SourceImageDataFormat::Yuv {
-                format: YuvPixelLayout::YUYV422,
+                layout: YuvPixelLayout::YUYV422,
                 range,
                 primaries,
             },


### PR DESCRIPTION
### What

* Important chunk of https://github.com/rerun-io/rerun/issues/7605
* Related to https://github.com/rerun-io/rerun/issues/7608
   * todo: create a new ticket for bgr shenanigans and close this one

---

Fixes performance issues with our previous inefficient cpu based chroma conversion:

![image](https://github.com/user-attachments/assets/fed67eb9-902b-43d8-bbd6-8574a5f3b18d)

... and fixes color space issues:

Top left: now
Top right: before
Bottom: VLC
![image](https://github.com/user-attachments/assets/f5b797bd-e12d-46b0-96dd-32176d43e78c)

---

There was an oversight in the conversion pipeline that if fixed now: It only allowed for creating new textures.
Now it can also update existing textures! This means that it takes a target texture from the outside. Naturally, there's some constraints on what the target texture looks like and as a consequence I added some validation for that. Could be more, but I think this is solid enough for our purposes :)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7682?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7682?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7682)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.