### PR TITLE
Show what video frame is shown when hovering video in selection panel

### DIFF
--- a/crates/utils/re_format/src/time.rs
+++ b/crates/utils/re_format/src/time.rs
@@ -27,13 +27,12 @@ pub fn format_timestamp_seconds(timestamp_seconds: f64) -> String {
     let n = timestamp_seconds as i32;
     let hours = n / (60 * 60);
     let mins = (n / 60) % 60;
-    let secs_int = n % 60;
-    let secs_hundredth = (timestamp_seconds.fract() * 100.0) as u32;
+    let secs = (n % 60) as f64 + timestamp_seconds.fract();
 
     if hours > 0 {
-        format!("{hours:02}:{mins:02}:{secs_int:02}.{secs_hundredth:02}")
+        format!("{hours:02}:{mins:02}:{secs:02.02}")
     } else {
-        format!("{mins:02}:{secs_int:02}.{secs_hundredth:02}")
+        format!("{mins:02}:{secs:02.02}")
     }
     // Not showing the minutes at all makes it too unclear what format this timestamp is in.
     // So let's not further strip this down.

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -251,6 +251,7 @@ fn show_video_blob_info(
                     match video.frame_at(render_ctx, decode_stream_id, timestamp_in_seconds) {
                         Ok(VideoFrameTexture {
                             texture,
+                            time_range,
                             is_pending,
                             show_spinner,
                         }) => {
@@ -274,6 +275,23 @@ fn show_video_blob_info(
                                 );
                                 egui::Spinner::new().paint_at(ui, smaller_rect);
                             }
+
+                            response.on_hover_ui(|ui| {
+                                // Prevent `Area` auto-sizing from shrinking tooltips with dynamic content.
+                                // See https://github.com/emilk/egui/issues/5167
+                                ui.set_max_width(ui.spacing().tooltip_width);
+
+                                let timescale = video.data().timescale;
+                                ui.label(format!(
+                                    "Frame at {} - {}",
+                                    re_format::format_timestamp_seconds(
+                                        time_range.start.into_secs(timescale),
+                                    ),
+                                    re_format::format_timestamp_seconds(
+                                        time_range.end.into_secs(timescale),
+                                    ),
+                                ));
+                            });
                         }
 
                         Err(err) => {

--- a/crates/viewer/re_renderer/src/video/decoder/mod.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/mod.rs
@@ -233,6 +233,7 @@ impl VideoDecoder {
 
                 Ok(VideoFrameTexture {
                     texture: self.video_texture.texture.clone(),
+                    time_range: self.video_texture.time_range.clone(),
                     is_pending,
                     show_spinner,
                 })

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -1,6 +1,6 @@
 mod decoder;
 
-use std::{collections::hash_map::Entry, sync::Arc};
+use std::{collections::hash_map::Entry, ops::Range, sync::Arc};
 
 use ahash::HashMap;
 use parking_lot::Mutex;
@@ -68,6 +68,9 @@ pub type FrameDecodingResult = Result<VideoFrameTexture, DecodingError>;
 pub struct VideoFrameTexture {
     /// The texture to show.
     pub texture: GpuTexture2D,
+
+    /// What part of the video this video frame covers.
+    pub time_range: Range<re_video::Time>,
 
     /// If true, the texture is outdated. Keep polling for a fresh one.
     pub is_pending: bool,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -197,7 +197,7 @@ impl VideoFrameReferenceVisualizer {
                 match video.frame_at(render_ctx, decode_stream_id, video_timestamp.as_seconds()) {
                     Ok(VideoFrameTexture {
                         texture,
-                        time_range,
+                        time_range: _, // TODO(emilk): maybe add to `PickableTexturedRect` and `PickingHitType::TexturedRect` so we can show on hover?
                         is_pending,
                         show_spinner,
                     }) => {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -197,6 +197,7 @@ impl VideoFrameReferenceVisualizer {
                 match video.frame_at(render_ctx, decode_stream_id, video_timestamp.as_seconds()) {
                     Ok(VideoFrameTexture {
                         texture,
+                        time_range,
                         is_pending,
                         show_spinner,
                     }) => {


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/7647

<img width="299" alt="Screenshot 2024-10-11 at 09 12 23" src="https://github.com/user-attachments/assets/37491c98-7329-4077-8057-14b487008636">

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7685?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7685?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7685)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.