### PR TITLE
Enable (n)asm rav1d on Mac & Windows via `nasm` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "rav1d"
 version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#a9059f6a02e68cf2aba3795cc370c72f695c4730"
+source = "git+https://github.com/rerun-io/rav1d?rev=a9059f6a02e68cf2aba3795cc370c72f695c4730#a9059f6a02e68cf2aba3795cc370c72f695c4730"
 dependencies = [
  "assert_matches",
  "atomig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "rav1d"
 version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?branch=emilk/dav1d-interface#d3acfb077eac7759f94279ec9a81edd7d0c409ed"
+source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#10fcffa0584e4a731d74d4bc0c6207c272979c9b"
 dependencies = [
  "assert_matches",
  "atomig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "rav1d"
 version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#10fcffa0584e4a731d74d4bc0c6207c272979c9b"
+source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#28081ae155ab69be40819d44664bbc0d06bddcfd"
 dependencies = [
  "assert_matches",
  "atomig",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "rav1d"
 version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#2b8dc8022a7da67b0e2433a7e3b93b492df54756"
+source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#a9059f6a02e68cf2aba3795cc370c72f695c4730"
 dependencies = [
  "assert_matches",
  "atomig",
@@ -4766,6 +4766,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cc",
  "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
  "nasm-rs",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4758,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "rav1d"
 version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#28081ae155ab69be40819d44664bbc0d06bddcfd"
+source = "git+https://github.com/rerun-io/rav1d?branch=andreas/disable-asm-linux#2b8dc8022a7da67b0e2433a7e3b93b492df54756"
 dependencies = [
  "assert_matches",
  "atomig",

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -32,7 +32,10 @@ av1 = ["dep:dav1d"]
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
 # TODO(#7671): this feature flag currently does nothing on Linux.
-nasm = ["dav1d?/default"] # The default feature set of our dav1d fork has asm for linux enabled
+nasm = [
+  # The default feature set of our dav1d fork has asm for linux enabled.
+  "dav1d?/default",
+]
 
 [dependencies]
 re_log.workspace = true
@@ -51,7 +54,7 @@ thiserror.workspace = true
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
 # See https://github.com/rerun-io/rav1d/pull/1
 # TODO(#7588): publish this fork of rav1d
-dav1d = { git = "https://github.com/rerun-io/rav1d", branch = "andreas/disable-asm-linux", package = "rav1d", optional = true, default-features = false, features = [
+dav1d = { git = "https://github.com/rerun-io/rav1d", rev = "a9059f6a02e68cf2aba3795cc370c72f695c4730", package = "rav1d", optional = true, default-features = false, features = [
   # We opt-out of wasm features so we don't need  `nasm` installed. It's still pretty fast.
   "bitdepth_8",
 ] }

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -31,9 +31,8 @@ av1 = ["dep:dav1d"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing
-# nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
-nasm = [] ## TODO(#7671): fix Linux build
+# TODO(#7671): this feature flag currently does nothing on Linux.
+nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
 
 [dependencies]
 re_log.workspace = true
@@ -52,7 +51,7 @@ thiserror.workspace = true
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
 # See https://github.com/rerun-io/rav1d/pull/1
 # TODO(#7588): publish this fork of rav1d
-dav1d = { git = "https://github.com/rerun-io/rav1d", branch = "emilk/dav1d-interface", package = "rav1d", optional = true, default-features = false, features = [
+dav1d = { git = "https://github.com/rerun-io/rav1d", branch = "andreas/disable-asm-linux", package = "rav1d", optional = true, default-features = false, features = [
   # We opt-out of wasm features so we don't need  `nasm` installed. It's still pretty fast.
   "bitdepth_8",
 ] }

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -33,7 +33,7 @@ av1 = ["dep:dav1d"]
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
 # TODO(#7671): this feature flag currently does nothing on Linux.
 nasm = [
-  # The default feature set of our dav1d fork has asm for linux enabled.
+  # The default feature set of our dav1d fork has asm enabled (except on Linux, see above)
   "dav1d?/default",
 ]
 

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -32,7 +32,7 @@ av1 = ["dep:dav1d"]
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
 # TODO(#7671): this feature flag currently does nothing on Linux.
-nasm = ["dav1d?/default"] # The default feature set of dav1d has asm enabled
+nasm = ["dav1d?/default"] # The default feature set of our dav1d fork has asm for linux enabled
 
 [dependencies]
 re_log.workspace = true

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -16,9 +16,9 @@ impl SyncDav1dDecoder {
     pub fn new() -> Result<Self> {
         re_tracing::profile_function!();
 
-        // TODO(#7671): enable this warning again when the `nasm` feature actually does something
+        // TODO(#7671): enable this warning again on Linux when the `nasm` feature actually does something
         #[allow(clippy::overly_complex_bool_expr)]
-        if false && !cfg!(feature = "nasm") {
+        if !cfg!(target_os = "linux") && !cfg!(feature = "nasm") {
             re_log::warn_once!(
                 "NOTE: native AV1 video decoder is running extra slowly. \
                 Speed it up by compiling Rerun with the `nasm` feature enabled. \

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -43,7 +43,7 @@ default = ["native_viewer", "web_viewer"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing
+# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["rerun/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -73,7 +73,7 @@ log = ["dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing
+# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["re_video/nasm"]
 
 ## Support spawning a native viewer.

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -30,7 +30,7 @@ extension-module = ["pyo3/extension-module"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing
+# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.


### PR DESCRIPTION
### What

Related to
* #7671
* #7605
* #7588

Biting the bullet and split the feature on our rav1d fork:
https://github.com/rerun-io/rav1d/compare/emilk/dav1d-interface...rerun-io:rav1d:andreas/disable-asm-linux

Testing done:
* wsl linux release build works now (didn't before)
* windows build still works
    * shows no-asm warning if compiled with out nasm
    * works otherwise
* added a `panic` under `cfg(asm)` in one of the interface functions (now removed again) .. then:
    * linux still worked
    * windows hit that panic when compiled with nasm feature 

### Checklist
* [x] main ci passes
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7694?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7694?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7694)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.