### PR TITLE
Allow component selectors to be specified as strings with flexible matching

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -422,9 +422,7 @@ pub struct ComponentColumnSelector {
     pub entity_path: EntityPath,
 
     /// Semantic name associated with this data.
-    //
-    // TODO(cmc): this should be `component_name`.
-    pub component: ComponentName,
+    pub component_name: ComponentName,
 
     /// How to join the data into the `RecordBatch`.
     //
@@ -437,7 +435,7 @@ impl From<ComponentColumnDescriptor> for ComponentColumnSelector {
     fn from(desc: ComponentColumnDescriptor) -> Self {
         Self {
             entity_path: desc.entity_path.clone(),
-            component: desc.component_name,
+            component_name: desc.component_name,
             join_encoding: desc.join_encoding,
         }
     }
@@ -449,7 +447,7 @@ impl ComponentColumnSelector {
     pub fn new<C: re_types_core::Component>(entity_path: EntityPath) -> Self {
         Self {
             entity_path,
-            component: C::name(),
+            component_name: C::name(),
             join_encoding: JoinEncoding::default(),
         }
     }
@@ -459,7 +457,7 @@ impl ComponentColumnSelector {
     pub fn new_for_component_name(entity_path: EntityPath, component: ComponentName) -> Self {
         Self {
             entity_path,
-            component,
+            component_name: component,
             join_encoding: JoinEncoding::default(),
         }
     }
@@ -476,7 +474,7 @@ impl std::fmt::Display for ComponentColumnSelector {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             entity_path,
-            component,
+            component_name: component,
             join_encoding: _,
         } = self;
 
@@ -799,7 +797,7 @@ impl ChunkStore {
             is_tombstone,
             is_semantically_empty,
         } = self
-            .lookup_column_metadata(&selector.entity_path, &selector.component)
+            .lookup_column_metadata(&selector.entity_path, &selector.component_name)
             .unwrap_or(ColumnMetadata {
                 is_static: false,
                 is_indicator: false,
@@ -808,7 +806,7 @@ impl ChunkStore {
             });
 
         let datatype = self
-            .lookup_datatype(&selector.component)
+            .lookup_datatype(&selector.component_name)
             .cloned()
             .unwrap_or_else(|| ArrowDatatype::Null);
 
@@ -816,7 +814,7 @@ impl ChunkStore {
             entity_path: selector.entity_path.clone(),
             archetype_name: None,
             archetype_field_name: None,
-            component_name: selector.component,
+            component_name: selector.component_name,
             store_datatype: ArrowListArray::<i32>::default_datatype(datatype.clone()),
             join_encoding: selector.join_encoding,
             is_static,

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -795,6 +795,8 @@ impl ChunkStore {
         selector: &ComponentColumnSelector,
     ) -> ComponentColumnDescriptor {
         // Happy path if this string is a valid component
+        // TODO(#7699) This currently interns every string ever queried which could be wasteful, especially
+        // in long-running servers. In practice this probably doesn't matter.
         let direct_component = ComponentName::from(selector.component_name.clone());
 
         let component_name = if self.all_components().contains(&direct_component) {

--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -422,6 +422,9 @@ pub struct ComponentColumnSelector {
     pub entity_path: EntityPath,
 
     /// Semantic name associated with this data.
+    ///
+    /// This string will be flexibly matched against the available component names.
+    /// Valid matches are case invariant matches of either the full name or the short name.
     pub component_name: String,
 
     /// How to join the data into the `RecordBatch`.

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -351,7 +351,7 @@ impl QueryHandle<'_> {
                     ColumnSelector::Component(selected_column) => {
                         let ComponentColumnSelector {
                             entity_path: selected_entity_path,
-                            component: selected_component_name,
+                            component_name: selected_component_name,
                             join_encoding: _,
                         } = selected_column;
 
@@ -418,7 +418,7 @@ impl QueryHandle<'_> {
 
                     if let Some(pov) = self.query.filtered_point_of_view.as_ref() {
                         if pov.entity_path == column.entity_path
-                            && pov.component == column.component_name
+                            && pov.component_name == column.component_name
                         {
                             view_pov_chunks_idx = Some(idx);
                         }
@@ -1437,7 +1437,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: "no/such/entity".into(),
-                component: MyPoint::name(),
+                component_name: MyPoint::name(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1464,7 +1464,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component: "AComponentColumnThatDoesntExist".into(),
+                component_name: "AComponentColumnThatDoesntExist".into(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1491,7 +1491,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component: MyPoint::name(),
+                component_name: MyPoint::name(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1528,7 +1528,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component: MyColor::name(),
+                component_name: MyColor::name(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1739,22 +1739,22 @@ mod tests {
             query.selection = Some(vec![
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: MyColor::name(),
+                    component_name: MyColor::name(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: MyColor::name(),
+                    component_name: MyColor::name(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: "non_existing_entity".into(),
-                    component: MyColor::name(),
+                    component_name: MyColor::name(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: "AComponentColumnThatDoesntExist".into(),
+                    component_name: "AComponentColumnThatDoesntExist".into(),
                     join_encoding: Default::default(),
                 }),
             ]);
@@ -1828,17 +1828,17 @@ mod tests {
                 //
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: MyPoint::name(),
+                    component_name: MyPoint::name(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: MyColor::name(),
+                    component_name: MyColor::name(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component: MyLabel::name(),
+                    component_name: MyLabel::name(),
                     join_encoding: Default::default(),
                 }),
             ]);
@@ -2020,7 +2020,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component: MyPoint::name(),
+                component_name: MyPoint::name(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -1439,7 +1439,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: "no/such/entity".into(),
-                component_name: MyPoint::name(),
+                component_name: MyPoint::name().to_string(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1493,7 +1493,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component_name: MyPoint::name(),
+                component_name: MyPoint::name().to_string(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1530,7 +1530,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component_name: MyColor::name(),
+                component_name: MyColor::name().to_string(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");
@@ -1741,17 +1741,17 @@ mod tests {
             query.selection = Some(vec![
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component_name: MyColor::name(),
+                    component_name: MyColor::name().to_string(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component_name: MyColor::name(),
+                    component_name: MyColor::name().to_string(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: "non_existing_entity".into(),
-                    component_name: MyColor::name(),
+                    component_name: MyColor::name().to_string(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
@@ -1830,17 +1830,17 @@ mod tests {
                 //
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component_name: MyPoint::name(),
+                    component_name: MyPoint::name().to_string(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component_name: MyColor::name(),
+                    component_name: MyColor::name().to_string(),
                     join_encoding: Default::default(),
                 }),
                 ColumnSelector::Component(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
-                    component_name: MyLabel::name(),
+                    component_name: MyLabel::name().to_string(),
                     join_encoding: Default::default(),
                 }),
             ]);
@@ -2022,7 +2022,7 @@ mod tests {
             let mut query = QueryExpression::new(timeline);
             query.filtered_point_of_view = Some(ComponentColumnSelector {
                 entity_path: entity_path.clone(),
-                component_name: MyPoint::name(),
+                component_name: MyPoint::name().to_string(),
                 join_encoding: Default::default(),
             });
             eprintln!("{query:#?}:");

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -364,7 +364,7 @@ impl QueryHandle<'_> {
                             })
                             .find(|(_idx, view_descr)| {
                                 view_descr.entity_path == *selected_entity_path
-                                    && view_descr.component_name == *selected_component_name
+                                    && view_descr.component_name.matches(selected_component_name)
                             })
                             .map_or_else(
                                 || {
@@ -374,7 +374,9 @@ impl QueryHandle<'_> {
                                             entity_path: selected_entity_path.clone(),
                                             archetype_name: None,
                                             archetype_field_name: None,
-                                            component_name: *selected_component_name,
+                                            component_name: ComponentName::from(
+                                                selected_component_name.clone(),
+                                            ),
                                             store_datatype: arrow2::datatypes::DataType::Null,
                                             join_encoding: JoinEncoding::default(),
                                             is_static: false,
@@ -418,7 +420,7 @@ impl QueryHandle<'_> {
 
                     if let Some(pov) = self.query.filtered_point_of_view.as_ref() {
                         if pov.entity_path == column.entity_path
-                            && pov.component_name == column.component_name
+                            && column.component_name.matches(&pov.component_name)
                         {
                             view_pov_chunks_idx = Some(idx);
                         }

--- a/crates/store/re_types/src/blueprint/components/component_column_selector_ext.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector_ext.rs
@@ -1,9 +1,8 @@
 use re_log_types::EntityPath;
-use re_types_core::ComponentName;
 
 impl super::ComponentColumnSelector {
     /// Create a [`Self`] from an [`EntityPath`] and a [`ComponentName`].
-    pub fn new(entity_path: &EntityPath, component_name: ComponentName) -> Self {
+    pub fn new(entity_path: &EntityPath, component_name: &str) -> Self {
         crate::blueprint::datatypes::ComponentColumnSelector::new(entity_path, component_name)
             .into()
     }

--- a/crates/store/re_types/src/blueprint/components/component_column_selector_ext.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector_ext.rs
@@ -1,7 +1,7 @@
 use re_log_types::EntityPath;
 
 impl super::ComponentColumnSelector {
-    /// Create a [`Self`] from an [`EntityPath`] and a [`ComponentName`].
+    /// Create a [`Self`] from an [`EntityPath`] and a [`re_types_core::ComponentName`] expressed as string.
     pub fn new(entity_path: &EntityPath, component_name: &str) -> Self {
         crate::blueprint::datatypes::ComponentColumnSelector::new(entity_path, component_name)
             .into()

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector_ext.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector_ext.rs
@@ -1,7 +1,7 @@
 use re_log_types::EntityPath;
 
 impl super::ComponentColumnSelector {
-    /// Create a [`Self`] from an [`EntityPath`] and a [`ComponentName`].
+    /// Create a [`Self`] from an [`EntityPath`] and a [`re_types_core::ComponentName`] expressed as string.
     pub fn new(entity_path: &EntityPath, component_name: &str) -> Self {
         Self {
             entity_path: entity_path.into(),

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector_ext.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector_ext.rs
@@ -1,12 +1,11 @@
 use re_log_types::EntityPath;
-use re_types_core::ComponentName;
 
 impl super::ComponentColumnSelector {
     /// Create a [`Self`] from an [`EntityPath`] and a [`ComponentName`].
-    pub fn new(entity_path: &EntityPath, component_name: ComponentName) -> Self {
+    pub fn new(entity_path: &EntityPath, component_name: &str) -> Self {
         Self {
             entity_path: entity_path.into(),
-            component: component_name.as_str().into(),
+            component: component_name.into(),
         }
     }
 }

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -185,6 +185,9 @@ impl ComponentName {
         }
     }
 
+    /// Determine if component matches a string
+    ///
+    /// Valid matches are case invariant matches of either the full name or the short name.
     pub fn matches(&self, other: &str) -> bool {
         self.0.as_str() == other
             || self.full_name().to_lowercase() == other.to_lowercase()

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -184,6 +184,12 @@ impl ComponentName {
             None // A user component
         }
     }
+
+    pub fn matches(&self, other: &str) -> bool {
+        self.0.as_str() == other
+            || self.full_name().to_lowercase() == other.to_lowercase()
+            || self.short_name().to_lowercase() == other.to_lowercase()
+    }
 }
 
 // ---

--- a/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
@@ -133,15 +133,15 @@ impl Query {
                         .push(desc.timeline.as_str().into());
                 }
 
-                ColumnSelector::Component(desc) => {
-                    let blueprint_component_descriptor = datatypes::ComponentColumnSelector::new(
-                        &desc.entity_path,
-                        desc.component_name,
+                ColumnSelector::Component(selector) => {
+                    let blueprint_component_selector = datatypes::ComponentColumnSelector::new(
+                        &selector.entity_path,
+                        &selector.component_name,
                     );
 
                     selected_columns
                         .component_columns
-                        .push(blueprint_component_descriptor);
+                        .push(blueprint_component_selector);
                 }
             }
         }
@@ -259,8 +259,9 @@ impl Query {
                     component_name,
                 } => {
                     selected_columns.retain(|column| match column {
-                        ColumnSelector::Component(desc) => {
-                            desc.entity_path != entity_path || desc.component_name != component_name
+                        ColumnSelector::Component(selector) => {
+                            selector.entity_path != entity_path
+                                || !component_name.matches(&selector.component_name)
                         }
                         ColumnSelector::Time(_) => true,
                     });

--- a/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/blueprint.rs
@@ -134,8 +134,10 @@ impl Query {
                 }
 
                 ColumnSelector::Component(desc) => {
-                    let blueprint_component_descriptor =
-                        datatypes::ComponentColumnSelector::new(&desc.entity_path, desc.component);
+                    let blueprint_component_descriptor = datatypes::ComponentColumnSelector::new(
+                        &desc.entity_path,
+                        desc.component_name,
+                    );
 
                     selected_columns
                         .component_columns
@@ -258,7 +260,7 @@ impl Query {
                 } => {
                     selected_columns.retain(|column| match column {
                         ColumnSelector::Component(desc) => {
-                            desc.entity_path != entity_path || desc.component != component_name
+                            desc.entity_path != entity_path || desc.component_name != component_name
                         }
                         ColumnSelector::Time(_) => true,
                     });

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -133,7 +133,7 @@ impl PyComponentColumnSelector {
     fn new(entity_path: &str, component_name: ComponentLike) -> Self {
         Self(ComponentColumnSelector {
             entity_path: entity_path.into(),
-            component: component_name.0,
+            component_name: component_name.0,
             join_encoding: Default::default(),
         })
     }
@@ -150,7 +150,7 @@ impl PyComponentColumnSelector {
         format!(
             "Component({}:{})",
             self.0.entity_path,
-            self.0.component.short_name()
+            self.0.component_name.short_name()
         )
     }
 }

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -108,19 +108,22 @@ class TestDataframe:
     def test_select_columns(self) -> None:
         view = self.recording.view(index="my_index", contents="points")
         index_col = rr.dataframe.IndexColumnSelector("my_index")
-        pos = rr.dataframe.ComponentColumnSelector("points", rr.components.Position3D)
 
-        batches = view.select(index_col, pos)
+        selectors = [rr.components.Position3D, "rerun.components.Position3D", "Position3D", "position3D"]
+        for selector in selectors:
+            pos = rr.dataframe.ComponentColumnSelector("points", selector)
 
-        table = pa.Table.from_batches(batches, batches.schema)
-        # points
-        assert table.num_columns == 2
-        assert table.num_rows == 2
+            batches = view.select(index_col, pos)
 
-        assert table.column("my_index")[0].equals(self.expected_index0[0])
-        assert table.column("my_index")[1].equals(self.expected_index1[0])
-        assert table.column("/points:Position3D")[0].values.equals(self.expected_pos0)
-        assert table.column("/points:Position3D")[1].values.equals(self.expected_pos1)
+            table = pa.Table.from_batches(batches, batches.schema)
+            # points
+            assert table.num_columns == 2
+            assert table.num_rows == 2
+
+            assert table.column("my_index")[0].equals(self.expected_index0[0])
+            assert table.column("my_index")[1].equals(self.expected_index1[0])
+            assert table.column("/points:Position3D")[0].values.equals(self.expected_pos0)
+            assert table.column("/points:Position3D")[1].values.equals(self.expected_pos1)
 
     def test_index_values(self) -> None:
         view = self.recording.view(index="my_index", contents="points")
@@ -248,6 +251,8 @@ class TestDataframe:
             {"points": [rr.components.Position3D]},
             {"points": "rerun.components.Position3D"},
             {"points/**": "rerun.components.Position3D"},
+            {"points/**": "Position3D"},
+            {"points/**": "position3D"},
         ]
 
         for expr in good_content_expressions:


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7629
- We also do this promotion for the ComponentLike in the view contents expression on the python side

This means you can now do:
```
view = self.recording.view(index="my_index", contents={"points": "position3D"}).select("position3d")
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7695?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7695?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7695)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.