### PR TITLE
Dataframe v2: new static semantics

### DIFF
--- a/crates/store/re_dataframe/examples/query.rs
+++ b/crates/store/re_dataframe/examples/query.rs
@@ -59,15 +59,18 @@ fn main() -> anyhow::Result<()> {
             cache: &query_cache,
         };
 
-        let mut query = QueryExpression::new(timeline);
-        query.view_contents = Some(
-            query_engine
-                .iter_entity_paths(&entity_path_filter)
-                .map(|entity_path| (entity_path, None))
-                .collect(),
-        );
-        query.filtered_index_range = Some(ResolvedTimeRange::new(time_from, time_to));
-        query.sparse_fill_strategy = SparseFillStrategy::LatestAtGlobal;
+        let query = QueryExpression {
+            filtered_index: Some(timeline),
+            view_contents: Some(
+                query_engine
+                    .iter_entity_paths(&entity_path_filter)
+                    .map(|entity_path| (entity_path, None))
+                    .collect(),
+            ),
+            filtered_index_range: Some(ResolvedTimeRange::new(time_from, time_to)),
+            sparse_fill_strategy: SparseFillStrategy::LatestAtGlobal,
+            ..Default::default()
+        };
         eprintln!("{query:#?}:");
 
         let query_handle = query_engine.query(query.clone());

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -96,7 +96,7 @@ struct QueryHandleState {
 
     /// The actual index filter in use, since the user-specified one is optional.
     ///
-    /// This just defaults to `Index::default()` if ther user hasn't specified any: the actual
+    /// This just defaults to `Index::default()` if the user hasn't specified any: the actual
     /// value is irrelevant since this means we are only concerned with static data anyway.
     filtered_index: Index,
 

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -1209,9 +1209,7 @@ mod tests {
 
         // static
         {
-            let query = QueryExpression {
-                ..Default::default()
-            };
+            let query = QueryExpression::default();
             eprintln!("{query:#?}:");
 
             let query_handle = query_engine.query(query.clone());

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -145,7 +145,7 @@ mode sets the default time range to _everything_. You can override this in the s
 
         let mut dataframe_query = re_chunk_store::QueryExpression {
             view_contents: Some(view_contents),
-            filtered_index: view_query.timeline(ctx)?,
+            filtered_index: Some(view_query.timeline(ctx)?),
             filtered_index_range: Some(view_query.filter_by_range()?),
             filtered_point_of_view: view_query.filter_by_event()?,
             sparse_fill_strategy,

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -458,11 +458,21 @@ impl PyRecordingView {
     }
 
     fn filter_range_sequence(&self, start: i64, end: i64) -> PyResult<Self> {
-        if self.query_expression.filtered_index.typ() != TimeType::Sequence {
-            return Err(PyValueError::new_err(format!(
-                "Index for {} is not a sequence.",
-                self.query_expression.filtered_index.name()
-            )));
+        match self.query_expression.filtered_index.as_ref() {
+            Some(filtered_index) if filtered_index.typ() != TimeType::Sequence => {
+                return Err(PyValueError::new_err(format!(
+                    "Index for {} is not a sequence.",
+                    filtered_index.name()
+                )));
+            }
+
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
         }
 
         let start = if let Ok(seq) = re_chunk::TimeInt::try_from(start) {
@@ -499,11 +509,21 @@ impl PyRecordingView {
     }
 
     fn filter_range_seconds(&self, start: f64, end: f64) -> PyResult<Self> {
-        if self.query_expression.filtered_index.typ() != TimeType::Time {
-            return Err(PyValueError::new_err(format!(
-                "Index for {} is not temporal.",
-                self.query_expression.filtered_index.name()
-            )));
+        match self.query_expression.filtered_index.as_ref() {
+            Some(filtered_index) if filtered_index.typ() != TimeType::Time => {
+                return Err(PyValueError::new_err(format!(
+                    "Index for {} is not temporal.",
+                    filtered_index.name()
+                )));
+            }
+
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
         }
 
         let start = re_sdk::Time::from_seconds_since_epoch(start);
@@ -521,11 +541,21 @@ impl PyRecordingView {
     }
 
     fn filter_range_nanos(&self, start: i64, end: i64) -> PyResult<Self> {
-        if self.query_expression.filtered_index.typ() != TimeType::Time {
-            return Err(PyValueError::new_err(format!(
-                "Index for {} is not temporal.",
-                self.query_expression.filtered_index.name()
-            )));
+        match self.query_expression.filtered_index.as_ref() {
+            Some(filtered_index) if filtered_index.typ() != TimeType::Time => {
+                return Err(PyValueError::new_err(format!(
+                    "Index for {} is not temporal.",
+                    filtered_index.name()
+                )));
+            }
+
+            Some(_) => {}
+
+            None => {
+                return Err(PyValueError::new_err(
+                    "Specify an index to filter on first.".to_owned(),
+                ));
+            }
         }
 
         let start = re_sdk::Time::from_ns_since_epoch(start);
@@ -673,7 +703,7 @@ impl PyRecording {
             include_semantically_empty_columns: false,
             include_indicator_columns: false,
             include_tombstone_columns: false,
-            filtered_index: timeline.timeline,
+            filtered_index: Some(timeline.timeline),
             filtered_index_range: None,
             filtered_index_values: None,
             using_index_values: None,


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/dc27f2d6-4ab7-44c4-b6c4-4242b9570e22)


After:
![image](https://github.com/user-attachments/assets/8788dd9c-cfca-489b-8adb-998c9bb8f3b6)

* Fixes https://github.com/rerun-io/rerun/issues/7668

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7696?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7696?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7696)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.