### PR TITLE
Make explicit recordings work without calling rr.init()

### DIFF
--- a/rerun_py/rerun_sdk/rerun/sinks.py
+++ b/rerun_py/rerun_sdk/rerun/sinks.py
@@ -13,6 +13,12 @@ from ._spawn import _spawn_viewer
 # --- Sinks ---
 
 
+def is_recording_enabled(recording: RecordingStream | None) -> bool:
+    if recording is not None:
+        return bindings.is_enabled(recording.inner)  # type: ignore[no-any-return]
+    return bindings.is_enabled()  # type: ignore[no-any-return]
+
+
 def connect(
     addr: str | None = None,
     *,
@@ -47,7 +53,7 @@ def connect(
 
     """
 
-    if not bindings.is_enabled():
+    if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - connect() call ignored")
         return
 
@@ -102,7 +108,7 @@ def save(
 
     """
 
-    if not bindings.is_enabled():
+    if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - save() call ignored. You must call rerun.init before saving a recording.")
         return
 
@@ -149,7 +155,7 @@ def stdout(default_blueprint: BlueprintLike | None = None, recording: RecordingS
 
     """
 
-    if not bindings.is_enabled():
+    if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - save() call ignored. You must call rerun.init before saving a recording.")
         return
 
@@ -234,7 +240,7 @@ def serve(
 
     """
 
-    if not bindings.is_enabled():
+    if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - serve() call ignored")
         return
 
@@ -346,7 +352,7 @@ def spawn(
 
     """
 
-    if not bindings.is_enabled():
+    if not is_recording_enabled(recording):
         logging.warning("Rerun is disabled - spawn() call ignored.")
         return
 


### PR DESCRIPTION
### What
Our recording functions would always check the global recording state even though they could validly operate just on a manually-created recording.

With this change, this becomes valid:
```
import rerun as rr

rec = rr.new_recording("rerun_example_cube_flat")

rec.log("points", rr.Points3D([1, 2, 3]))

rec.save("output.rrd")
```

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
