### PR TITLE
Dataframe v2: inline deduped latest logic

### DIFF
--- a/scripts/ci/check_large_files_allow_list.txt
+++ b/scripts/ci/check_large_files_allow_list.txt
@@ -1,6 +1,7 @@
-Cargo.lock
 CHANGELOG.md
+Cargo.lock
 crates/build/re_types_builder/src/reflection.rs
+crates/store/re_dataframe/src/query.rs
 crates/store/re_types/src/datatypes/tensor_buffer.rs
 crates/viewer/re_ui/data/Inter-Medium.otf
 crates/viewer/re_viewer/src/reflection/mod.rs


### PR DESCRIPTION
It is impossible for `Chunk::deduped_latest_at_index` to be fast with current Arrow limitations.

This PR works around that by inlining that logic into the dataframe walk directly.

Before:
![image](https://github.com/user-attachments/assets/44e011fb-4817-4c7b-ae0e-9b80e277f7c9)


After:
![image](https://github.com/user-attachments/assets/1b67bdf6-8901-4486-a6cd-d2d4b0f2ea4b)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7705?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7705?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7705)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.