### PR TITLE
re-export all the types needed to build QueryExpression

### DIFF
--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -17,6 +17,8 @@ pub use self::external::re_chunk_store::Index;
 #[doc(no_inline)]
 pub use self::external::re_chunk_store::IndexRange;
 #[doc(no_inline)]
+pub use self::external::re_chunk_store::IndexValue;
+#[doc(no_inline)]
 pub use self::external::re_chunk_store::JoinEncoding;
 #[doc(no_inline)]
 pub use self::external::re_chunk_store::QueryExpression;
@@ -27,11 +29,14 @@ pub use self::external::re_chunk_store::TimeColumnSelector;
 #[doc(no_inline)]
 pub use self::external::re_chunk_store::ViewContentsSelector;
 #[doc(no_inline)]
+pub use self::external::re_log_types::Timeline;
+#[doc(no_inline)]
 pub use self::external::re_query::Caches as QueryCache;
 
 pub mod external {
     pub use re_chunk;
     pub use re_chunk_store;
+    pub use re_log_types;
     pub use re_query;
 
     pub use arrow2;

--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -9,27 +9,12 @@ pub use self::query::QueryHandle;
 #[doc(no_inline)]
 pub use self::external::arrow2::chunk::Chunk as ArrowChunk;
 #[doc(no_inline)]
-pub use self::external::re_chunk_store::ColumnSelector;
+pub use self::external::re_chunk_store::{
+    ColumnSelector, ComponentColumnSelector, Index, IndexRange, IndexValue, JoinEncoding,
+    QueryExpression, SparseFillStrategy, TimeColumnSelector, ViewContentsSelector,
+};
 #[doc(no_inline)]
-pub use self::external::re_chunk_store::ComponentColumnSelector;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::Index;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::IndexRange;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::IndexValue;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::JoinEncoding;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::QueryExpression;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::SparseFillStrategy;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::TimeColumnSelector;
-#[doc(no_inline)]
-pub use self::external::re_chunk_store::ViewContentsSelector;
-#[doc(no_inline)]
-pub use self::external::re_log_types::Timeline;
+pub use self::external::re_log_types::{TimeInt, Timeline};
 #[doc(no_inline)]
 pub use self::external::re_query::Caches as QueryCache;
 

--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -9,6 +9,24 @@ pub use self::query::QueryHandle;
 #[doc(no_inline)]
 pub use self::external::arrow2::chunk::Chunk as ArrowChunk;
 #[doc(no_inline)]
+pub use self::external::re_chunk_store::ColumnSelector;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::ComponentColumnSelector;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::Index;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::IndexRange;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::JoinEncoding;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::QueryExpression;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::SparseFillStrategy;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::TimeColumnSelector;
+#[doc(no_inline)]
+pub use self::external::re_chunk_store::ViewContentsSelector;
+#[doc(no_inline)]
 pub use self::external::re_query::Caches as QueryCache;
 
 pub mod external {


### PR DESCRIPTION
### What

Without these exports anyone taking a dependency on ``re_dataframe`` will have to deal with 

```rust

import re_dataframe::external::re_chunk_store::...;
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7709?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7709?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7709)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.