### PR TITLE
Dataframe v2: no more encodings

### DIFF
--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -26,8 +26,8 @@ mod writes;
 
 pub use self::dataframe::{
     ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor, ComponentColumnSelector, Index,
-    IndexRange, IndexValue, JoinEncoding, QueryExpression, SparseFillStrategy,
-    TimeColumnDescriptor, TimeColumnSelector, ViewContentsSelector,
+    IndexRange, IndexValue, QueryExpression, SparseFillStrategy, TimeColumnDescriptor,
+    TimeColumnSelector, ViewContentsSelector,
 };
 pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -23,8 +23,7 @@ use re_chunk::{
 };
 use re_chunk_store::{
     ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor, ComponentColumnSelector, Index,
-    IndexValue, JoinEncoding, QueryExpression, SparseFillStrategy, TimeColumnDescriptor,
-    TimeColumnSelector,
+    IndexValue, QueryExpression, SparseFillStrategy, TimeColumnDescriptor, TimeColumnSelector,
 };
 use re_log_types::ResolvedTimeRange;
 use re_types_core::components::ClearIsRecursive;
@@ -399,7 +398,6 @@ impl QueryHandle<'_> {
                         let ComponentColumnSelector {
                             entity_path: selected_entity_path,
                             component_name: selected_component_name,
-                            join_encoding: _,
                         } = selected_column;
 
                         view_contents
@@ -425,7 +423,6 @@ impl QueryHandle<'_> {
                                                 selected_component_name.clone(),
                                             ),
                                             store_datatype: arrow2::datatypes::DataType::Null,
-                                            join_encoding: JoinEncoding::default(),
                                             is_static: false,
                                             is_indicator: false,
                                             is_tombstone: false,
@@ -1575,7 +1572,6 @@ mod tests {
                 filtered_point_of_view: Some(ComponentColumnSelector {
                     entity_path: "no/such/entity".into(),
                     component_name: MyPoint::name().to_string(),
-                    join_encoding: Default::default(),
                 }),
                 ..Default::default()
             };
@@ -1605,7 +1601,6 @@ mod tests {
                 filtered_point_of_view: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: "AComponentColumnThatDoesntExist".into(),
-                    join_encoding: Default::default(),
                 }),
                 ..Default::default()
             };
@@ -1635,7 +1630,6 @@ mod tests {
                 filtered_point_of_view: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyPoint::name().to_string(),
-                    join_encoding: Default::default(),
                 }),
                 ..Default::default()
             };
@@ -1675,7 +1669,6 @@ mod tests {
                 filtered_point_of_view: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyColor::name().to_string(),
-                    join_encoding: Default::default(),
                 }),
                 ..Default::default()
             };
@@ -1901,22 +1894,18 @@ mod tests {
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: MyColor::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: MyColor::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: "non_existing_entity".into(),
                         component_name: MyColor::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: "AComponentColumnThatDoesntExist".into(),
-                        join_encoding: Default::default(),
                     }),
                 ]),
                 ..Default::default()
@@ -1993,17 +1982,14 @@ mod tests {
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: MyPoint::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: MyColor::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                     ColumnSelector::Component(ComponentColumnSelector {
                         entity_path: entity_path.clone(),
                         component_name: MyLabel::name().to_string(),
-                        join_encoding: Default::default(),
                     }),
                 ]),
                 ..Default::default()
@@ -2197,7 +2183,6 @@ mod tests {
                 filtered_point_of_view: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyPoint::name().to_string(),
-                    join_encoding: Default::default(),
                 }),
                 ..Default::default()
             };

--- a/rerun_notebook/package-lock.json
+++ b/rerun_notebook/package-lock.json
@@ -17,7 +17,7 @@
     },
     "../rerun_js/web-viewer": {
       "name": "@rerun-io/web-viewer",
-      "version": "0.19.0-alpha.1+dev",
+      "version": "0.19.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "dts-buddy": "^0.3.0",

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -16,13 +16,10 @@ class IndexColumnSelector:
 class ComponentColumnDescriptor:
     """A column containing the component data."""
 
-    def with_dictionary_encoding(self) -> ComponentColumnDescriptor: ...
-
 class ComponentColumnSelector:
     """A selector for a component column."""
 
     def __init__(self, entity_path: str, component: ComponentLike): ...
-    def with_dictionary_encoding(self) -> ComponentColumnSelector: ...
 
 class Schema:
     """The schema representing all columns in a [`Recording`][]."""

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -94,14 +94,6 @@ impl From<ComponentColumnDescriptor> for PyComponentColumnDescriptor {
 
 #[pymethods]
 impl PyComponentColumnDescriptor {
-    fn with_dictionary_encoding(&self) -> Self {
-        Self(
-            self.0
-                .clone()
-                .with_join_encoding(re_chunk_store::JoinEncoding::DictionaryEncode),
-        )
-    }
-
     fn __repr__(&self) -> String {
         format!(
             "Component({}:{})",
@@ -134,16 +126,7 @@ impl PyComponentColumnSelector {
         Self(ComponentColumnSelector {
             entity_path: entity_path.into(),
             component_name: component_name.0,
-            join_encoding: Default::default(),
         })
-    }
-
-    fn with_dictionary_encoding(&self) -> Self {
-        Self(
-            self.0
-                .clone()
-                .with_join_encoding(re_chunk_store::JoinEncoding::DictionaryEncode),
-        )
     }
 
     fn __repr__(&self) -> String {
@@ -630,7 +613,6 @@ impl PyRecording {
         let selector = ComponentColumnSelector {
             entity_path: entity_path.clone(),
             component_name: component_name.into(),
-            join_encoding: Default::default(),
         };
 
         self.store


### PR DESCRIPTION
Removes `JoinEncoding` and all things related.

We'll bring that back in one form or another once we actually support it -- for now it just makes the public API more complex for no upside.

* Fix https://github.com/rerun-io/rerun/issues/7693

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7711?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7711?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7711)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.