### PR TITLE
`highlight_issues.py --list-external` to list all open external issues

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -33,6 +33,7 @@ OFFICIAL_RERUN_DEVS = [
     "nikolausWest",
     "teh-cmc",
     "Wumpf",
+    "zehiko",
 ]
 
 

--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-"""Generate a list of GitHub issues that needs attention."""
+"""Generate a list of GitHub issues that need attention."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ OFFICIAL_RERUN_DEVS = [
     "roym899",
     "teh-cmc",
     "Wumpf",
-    "zehiko"
+    "zehiko",
 ]
 
 
@@ -63,7 +63,7 @@ def fetch_issue(issue_json: dict) -> dict:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Generate a changelog.")
+    parser = argparse.ArgumentParser(description="Generate a list of GitHub issues that need attention.")
     parser.add_argument("--list-external", action="store_true", help="List all external issues")
     args = parser.parse_args()
 

--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import argparse
 import multiprocessing
 import sys
 
@@ -62,6 +63,10 @@ def fetch_issue(issue_json: dict) -> dict:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a changelog.")
+    parser.add_argument("--list-external", action="store_true", help="List all external issues")
+    args = parser.parse_args()
+
     access_token = get_github_token()
 
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -108,6 +113,10 @@ def main() -> None:
         comments = issue["comments"]
         state = issue["state"]
         labels = [label["name"] for label in issue["labels"]]
+
+        if args.list_external and state == "open" and author not in OFFICIAL_RERUN_DEVS:
+            print(f"{html_url} by {author}")
+            continue
 
         if "👀 needs triage" in labels:
             print(f"{html_url} by {author} needs triage")

--- a/scripts/highlight_issues.py
+++ b/scripts/highlight_issues.py
@@ -24,6 +24,7 @@ OFFICIAL_RERUN_DEVS = [
     "roym899",
     "teh-cmc",
     "Wumpf",
+    "zehiko"
 ]
 
 


### PR DESCRIPTION
Title.

Very useful for self-triaging, except `self=$not_rerun`.

* [x] yes