### PR TITLE
Use published `egui_table`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,8 +2005,9 @@ dependencies = [
 
 [[package]]
 name = "egui_table"
-version = "0.28.1"
-source = "git+https://github.com/rerun-io/egui_table.git?rev=556d4f080a0259e5f46901733e4c3a02f7f0b06a#556d4f080a0259e5f46901733e4c3a02f7f0b06a"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef148ce13d97a23376b92d3c5d0dddedd98c28b17053ceb326b31b92ea45d07"
 dependencies = [
  "egui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,8 +128,9 @@ egui_extras = { version = "0.29.1", features = [
   "puffin",
   "serde",
 ] }
-egui_plot = "0.29.0"
-egui_tiles = "0.10.1"
+egui_plot = "0.29.0" # https://github.com/emilk/egui_plot
+egui_table = "0.1.0" # https://github.com/rerun-io/egui_table
+egui_tiles = "0.10.1" # https://github.com/rerun-io/egui_tiles
 egui-wgpu = "0.29.1"
 emath = "0.29.1"
 

--- a/crates/viewer/re_space_view_dataframe/Cargo.toml
+++ b/crates/viewer/re_space_view_dataframe/Cargo.toml
@@ -33,7 +33,7 @@ re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
 anyhow.workspace = true
-egui_table = { git = "https://github.com/rerun-io/egui_table.git", rev = "556d4f080a0259e5f46901733e4c3a02f7f0b06a" } # main as of 2024-09-27
+egui_table.workspace = true
 egui.workspace = true
 itertools.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
### What
* https://github.com/rerun-io/egui_table/releases/tag/0.1.0

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7718?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7718?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7718)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.