### PR TITLE
Add NOLINT block to `lint.py`

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -882,6 +882,10 @@ def lint_markdown(filepath: str, lines_in: list[str]) -> tuple[list[str], list[s
         if in_metadata and line.startswith("-->"):
             in_metadata = False
 
+        if "NOLINT" in line:
+            lines_out.append(line)
+            continue
+
         if not in_code_block:
             if not in_metadata:
                 # Check the casing on markdown headers

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -974,19 +974,19 @@ class SourceFile:
         self.content = "".join(self.lines)
 
         # gather lines with a `NOLINT` marker
-        self.no_lints = set()
-        is_in_no_lint_block = False
+        self.nolints = set()
+        is_in_nolint_block = False
         for i, line in enumerate(self.lines):
             if "NOLINT" in line:
-                self.no_lints.add(i)
+                self.nolints.add(i)
 
             if "NOLINT_START" in line:
-                is_in_no_lint_block = True
+                is_in_nolint_block = True
 
-            if is_in_no_lint_block:
-                self.no_lints.add(i)
+            if is_in_nolint_block:
+                self.nolints.add(i)
                 if "NOLINT_END" in line:
-                    is_in_no_lint_block = False
+                    is_in_nolint_block = False
 
     def rewrite(self, new_lines: list[str]) -> None:
         """Rewrite the contents of the file."""
@@ -1006,7 +1006,7 @@ class SourceFile:
 
         if to_line is None:
             to_line = from_line
-        return any(i in self.no_lints for i in range(from_line - 1, to_line + 1))
+        return any(i in self.nolints for i in range(from_line - 1, to_line + 1))
 
     def should_ignore_index(self, start_idx: int, end_idx: int | None = None) -> bool:
         """Same as `should_ignore` but takes 0-based indices instead of line numbers."""


### PR DESCRIPTION
### What

Add `NOLINT_START`/`NOLINT_END` markers to `lint.py`, to exclude entire blocks. Useful eg. for documentation, where output of commands is shown verbatim.

TODO: 
- [x] support NOLINT, etc. for markdown docs too


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7720?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7720?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7720)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.