### PR TITLE
Show chroma subsampling & monochromeness on Blob properties

### DIFF
--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -15,6 +15,28 @@ use super::{Time, Timescale};
 
 use crate::{Chunk, TrackId, TrackKind};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChromaSubsamplingModes {
+    /// No subsampling.
+    Yuv444,
+
+    /// Subsampling in X only.
+    Yuv422,
+
+    /// Subsampling in both X and Y.
+    Yuv420,
+}
+
+impl std::fmt::Display for ChromaSubsamplingModes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Yuv444 => write!(f, "4:4:4"),
+            Self::Yuv422 => write!(f, "4:2:2"),
+            Self::Yuv420 => write!(f, "4:2:0"),
+        }
+    }
+}
+
 /// Decoded video data.
 #[derive(Clone)]
 pub struct VideoData {
@@ -114,6 +136,93 @@ impl VideoData {
     #[inline]
     pub fn num_samples(&self) -> usize {
         self.samples.len()
+    }
+
+    /// Returns the subsampling mode of the video.
+    ///
+    /// Returns None if not detected or unknown.
+    pub fn subsampling_mode(&self) -> Option<ChromaSubsamplingModes> {
+        match &self.config.stsd.contents {
+            re_mp4::StsdBoxContent::Av01(av01_box) => {
+                // These are boolean options, see https://aomediacodec.github.io/av1-isobmff/#av1codecconfigurationbox-semantics
+                match (
+                    av01_box.av1c.chroma_subsampling_x != 0,
+                    av01_box.av1c.chroma_subsampling_y != 0,
+                ) {
+                    (true, true) => Some(ChromaSubsamplingModes::Yuv420),
+                    (true, false) => Some(ChromaSubsamplingModes::Yuv422),
+                    (false, true) => None, // Downsampling in Y but not in X is unheard of!
+                    // Either that or monochrome.
+                    // See https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=131
+                    (false, false) => Some(ChromaSubsamplingModes::Yuv444),
+                }
+            }
+            re_mp4::StsdBoxContent::Avc1(_)
+            | re_mp4::StsdBoxContent::Hvc1(_)
+            | re_mp4::StsdBoxContent::Hev1(_) => {
+                // Surely there's a way to get this!
+                None
+            }
+
+            re_mp4::StsdBoxContent::Vp08(vp08_box) => {
+                // Via https://www.ffmpeg.org/doxygen/4.3/vpcc_8c_source.html#l00116
+                // enum VPX_CHROMA_SUBSAMPLING
+                // {
+                //     VPX_SUBSAMPLING_420_VERTICAL = 0,
+                //     VPX_SUBSAMPLING_420_COLLOCATED_WITH_LUMA = 1,
+                //     VPX_SUBSAMPLING_422 = 2,
+                //     VPX_SUBSAMPLING_444 = 3,
+                // };
+                match vp08_box.vpcc.chroma_subsampling {
+                    0 | 1 => Some(ChromaSubsamplingModes::Yuv420),
+                    2 => Some(ChromaSubsamplingModes::Yuv422),
+                    3 => Some(ChromaSubsamplingModes::Yuv444),
+                    _ => None, // Unknown mode.
+                }
+            }
+            re_mp4::StsdBoxContent::Vp09(vp09_box) => {
+                // As above!
+                match vp09_box.vpcc.chroma_subsampling {
+                    0 | 1 => Some(ChromaSubsamplingModes::Yuv420),
+                    2 => Some(ChromaSubsamplingModes::Yuv422),
+                    3 => Some(ChromaSubsamplingModes::Yuv444),
+                    _ => None, // Unknown mode.
+                }
+            }
+
+            re_mp4::StsdBoxContent::Mp4a(_)
+            | re_mp4::StsdBoxContent::Tx3g(_)
+            | re_mp4::StsdBoxContent::Unknown(_) => None,
+        }
+    }
+
+    /// Per color component bit depth.
+    ///
+    /// Usually 8, but 10 for HDR (for example).
+    pub fn bit_depth(&self) -> Option<u8> {
+        self.config.stsd.contents.bit_depth()
+    }
+
+    /// Returns None if the mp4 doesn't specify whether the video is monochrome or
+    /// we haven't yet implemented the logic to determine this.
+    pub fn is_monochrome(&self) -> Option<bool> {
+        match &self.config.stsd.contents {
+            re_mp4::StsdBoxContent::Av01(av01_box) => Some(av01_box.av1c.monochrome),
+            re_mp4::StsdBoxContent::Avc1(_)
+            | re_mp4::StsdBoxContent::Hvc1(_)
+            | re_mp4::StsdBoxContent::Hev1(_) => {
+                // It should be possible to extract this from the picture parameter set.
+                None
+            }
+            re_mp4::StsdBoxContent::Vp08(_) | re_mp4::StsdBoxContent::Vp09(_) => {
+                // Similar to AVC/HEVC, this information is likely accessible.
+                None
+            }
+
+            re_mp4::StsdBoxContent::Mp4a(_)
+            | re_mp4::StsdBoxContent::Tx3g(_)
+            | re_mp4::StsdBoxContent::Unknown(_) => None,
+        }
     }
 
     /// Determines the presentation timestamps of all frames inside a video, returning raw time values.

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -194,9 +194,23 @@ fn show_video_blob_info(
                     )),
                 );
                 if let Some(bit_depth) = data.config.stsd.contents.bit_depth() {
+                    let mut bit_depth = bit_depth.to_string();
+                    if data.is_monochrome() == Some(true) {
+                        bit_depth = format!("{bit_depth} (monochrome)");
+                    }
+
                     ui.list_item_flat_noninteractive(
-                        PropertyContent::new("Bit depth").value_text(bit_depth.to_string()),
+                        PropertyContent::new("Bit depth").value_text(bit_depth),
                     );
+                }
+                if let Some(subsampling_mode) = data.subsampling_mode() {
+                    // Don't show subsampling mode for monochrome, doesn't make sense usually.
+                    if data.is_monochrome() != Some(true) {
+                        ui.list_item_flat_noninteractive(
+                            PropertyContent::new("Subsampling mode")
+                                .value_text(subsampling_mode.to_string()),
+                        );
+                    }
                 }
                 ui.list_item_flat_noninteractive(
                     PropertyContent::new("Duration")


### PR DESCRIPTION
### What

* Related to #7672 

<img width="249" alt="image" src="https://github.com/user-attachments/assets/b6c0e30d-7c5d-420b-86fd-a497c03b36aa">
<img width="262" alt="image" src="https://github.com/user-attachments/assets/2ce8023e-55e8-4097-acde-162c61174023">
<img width="263" alt="image" src="https://github.com/user-attachments/assets/e7891b8a-fb28-4ff2-a502-aa3c3153304f">

Wanted to also show full/limited range which the mp4 parser should be able to read just fine, but doesn't do yet.
Which is understandable because for AV1 that requires parsing the entire [Sequence Header OBU](https://aomediacodec.github.io/av1-spec/av1-spec.pdf#page=41) which gets quite complicated quickly. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7721?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7721?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7721)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.