### PR TITLE
Use published re_rav1d

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,29 +4757,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1d"
-version = "1.0.0"
-source = "git+https://github.com/rerun-io/rav1d?rev=a9059f6a02e68cf2aba3795cc370c72f695c4730#a9059f6a02e68cf2aba3795cc370c72f695c4730"
-dependencies = [
- "assert_matches",
- "atomig",
- "av-data",
- "bitflags 2.6.0",
- "cc",
- "cfg-if",
- "cfg_aliases 0.2.1",
- "libc",
- "nasm-rs",
- "parking_lot",
- "paste",
- "raw-cpuid",
- "static_assertions",
- "strum",
- "to_method",
- "zerocopy",
-]
-
-[[package]]
 name = "raw-cpuid"
 version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5401,6 +5378,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_rav1d"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9505a568b5cf6d270ab1aabc8159f0b67f43d46c1dd27088a7cd11f845a1fd6"
+dependencies = [
+ "assert_matches",
+ "atomig",
+ "av-data",
+ "bitflags 2.6.0",
+ "cc",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "nasm-rs",
+ "parking_lot",
+ "paste",
+ "raw-cpuid",
+ "static_assertions",
+ "strum",
+ "to_method",
+ "zerocopy",
+]
+
+[[package]]
 name = "re_renderer"
 version = "0.19.0-alpha.3"
 dependencies = [
@@ -5942,9 +5943,9 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "parking_lot",
- "rav1d",
  "re_log",
  "re_mp4",
+ "re_rav1d",
  "re_tracing",
  "re_video",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,12 @@ re_web_viewer_server = { path = "crates/viewer/re_web_viewer_server", version = 
 ewebsock = "0.6.0"
 re_math = "0.20.0"
 
+# If this package fails to build, install `nasm` locally, or build through `pixi`.
+# NOTE: we use `dav1d` as an alias for our own re_rav1d crate
+# See https://github.com/rerun-io/re_rav1d/pull/2
+dav1d = { package = "re_rav1d", version = "0.1.0", default-features = false }
+# dav1d = { version = "0.10.3" } # Requires separate install of `dav1d` library. Fast in debug builds. Useful for development.
+
 # egui-crates:
 ecolor = "0.29.1"
 eframe = { version = "0.29.1", default-features = false, features = [

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -52,14 +52,12 @@ thiserror.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
-# See https://github.com/rerun-io/rav1d/pull/1
-# TODO(#7588): publish this fork of rav1d
-dav1d = { git = "https://github.com/rerun-io/rav1d", rev = "a9059f6a02e68cf2aba3795cc370c72f695c4730", package = "rav1d", optional = true, default-features = false, features = [
-  # We opt-out of wasm features so we don't need  `nasm` installed. It's still pretty fast.
+# NOTE: we use `dav1d` as an alias for our own re_rav1d crate
+# See https://github.com/rerun-io/re_rav1d/pull/2
+dav1d = { workspace = true, optional = true, default-features = false, features = [
+  # We opt-out of wasm features so we don't need `nasm` installed. It's still pretty fast.
   "bitdepth_8",
 ] }
-
-# dav1d = { version = "0.10.3",  optional = true } # Requires separate install of `dav1d` library. Fast in debug builds. Useful for development.
 
 [dev-dependencies]
 indicatif.workspace = true


### PR DESCRIPTION
With this we should be able to publish an alpha-release of our crates

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7723?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7723?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7723)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.