### PR TITLE
Remove recursive dependency of `re_video` on itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5946,7 +5946,6 @@ dependencies = [
  "re_mp4",
  "re_rav1d",
  "re_tracing",
- "re_video",
  "thiserror",
 ]
 

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -61,7 +61,6 @@ dav1d = { workspace = true, optional = true, default-features = false, features 
 
 [dev-dependencies]
 indicatif.workspace = true
-re_video = { workspace = true, features = ["av1"] } # For the `frames` example
 
 
 [[example]]

--- a/crates/store/re_video/examples/frames.rs
+++ b/crates/store/re_video/examples/frames.rs
@@ -13,8 +13,6 @@ use std::{
 use indicatif::ProgressBar;
 use parking_lot::Mutex;
 
-use re_video::{decode::SyncDecoder, VideoData};
-
 fn main() {
     // frames <video.mp4>
     let args: Vec<_> = std::env::args().collect();
@@ -36,7 +34,8 @@ fn main() {
         video.config.coded_height
     );
 
-    let mut decoder = re_video::decode::new_decoder(&video).expect("Failed to create decoder");
+    let mut decoder = re_video::decode::new_decoder(video_path.to_string(), &video)
+        .expect("Failed to create decoder");
 
     write_video_frames(&video, decoder.as_mut(), &output_dir);
 }

--- a/crates/store/re_video/examples/frames.rs
+++ b/crates/store/re_video/examples/frames.rs
@@ -1,4 +1,4 @@
-//! Decodes an mp4 with AV1 in it to a folder of images.
+//! Decodes an mp4 to a folder of images.
 
 #![allow(clippy::unwrap_used)]
 
@@ -36,20 +36,9 @@ fn main() {
         video.config.coded_height
     );
 
-    let mut decoder = create_decoder(video_path, &video);
+    let mut decoder = re_video::decode::new_decoder(&video).expect("Failed to create decoder");
 
     write_video_frames(&video, decoder.as_mut(), &output_dir);
-}
-
-fn create_decoder(debug_name: &str, video: &VideoData) -> Box<dyn SyncDecoder> {
-    if video.config.is_av1() {
-        Box::new(
-            re_video::decode::av1::SyncDav1dDecoder::new(debug_name.to_owned())
-                .expect("Failed to start AV1 decoder"),
-        )
-    } else {
-        panic!("Unsupported codec: {}", video.human_readable_codec_string());
-    }
 }
 
 fn write_video_frames(

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -122,6 +122,8 @@ pub fn new_decoder(
     debug_name: String,
     video: &crate::VideoData,
 ) -> Result<Box<dyn SyncDecoder + Send + 'static>> {
+    #![allow(unused_variables)] // With some feature flags
+
     re_log::trace!(
         "Looking for decoder for {}",
         video.human_readable_codec_string()

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -152,8 +152,7 @@ def get_sorted_publishable_crates(ctx: Context, crates: dict[str, Crate]) -> dic
     ) -> None:
         crate = crates[name]
         for dependency in crate_deps(crate.manifest):
-            if dependency.name == name:
-                continue  # The crate may have itself as a dev-dependency for examples
+            assert dependency.name != name, "Crate {name} had itself as a dependency"
             if dependency.name not in crates:
                 continue
             if dependency.name in visited:
@@ -469,7 +468,7 @@ def publish_unpublished_crates_in_parallel(all_crates: dict[str, Crate], version
         dependency_graph[name] = dependencies
 
     # walk the dependency graph in parallel and publish each crate
-    print("Publishing crates…")
+    print(f"Publishing {len(unpublished_crates)} crates…")
     env = {**os.environ.copy(), "RERUN_IS_PUBLISHING": "yes"}
     DAG(dependency_graph).walk_parallel(
         lambda name: publish_crate(unpublished_crates[name], token, version, env),  # noqa: E731

--- a/scripts/ci/dag.py
+++ b/scripts/ci/dag.py
@@ -162,6 +162,8 @@ class _State(Generic[_T]):
 
         self._queue.extend(state.node for state in self._node_states.values() if state.pending_dependencies == 0)
 
+        assert len(self._node_states) == 0 or 0 < len(self._queue), "No sources in DAG - we have a cyclic depednency!"
+
     def _get_or_insert(self, node: _T) -> _NodeState[_T]:
         if node not in self._node_states:
             self._node_states[node] = _NodeState(node)

--- a/scripts/ci/dag.py
+++ b/scripts/ci/dag.py
@@ -162,7 +162,7 @@ class _State(Generic[_T]):
 
         self._queue.extend(state.node for state in self._node_states.values() if state.pending_dependencies == 0)
 
-        assert len(self._node_states) == 0 or 0 < len(self._queue), "No sources in DAG - we have a cyclic depednency!"
+        assert len(self._node_states) == 0 or 0 < len(self._queue), "No sources in DAG - we have a cyclic dependency!"
 
     def _get_or_insert(self, node: _T) -> _NodeState[_T]:
         if node not in self._node_states:


### PR DESCRIPTION
### What
Our crate publishing hanged due to a cyclic (dev-)dependency. This PR has two fixes:

A) Remove that cyclic dependency
B) Produce a good error message the next time we have a cyclic dependency

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7732?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7732?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7732)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.