### PR TITLE
Require nasm for AV1 decoding, unless on arm64 macOS

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -65,7 +65,7 @@ jobs:
             --locked \
             -p rerun-cli \
             --no-default-features \
-            --features native_viewer,web_viewer \
+            --features release \
             --release \
             --target x86_64-unknown-linux-gnu
 

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -180,7 +180,7 @@ jobs:
             --locked \
             -p rerun-cli \
             --no-default-features \
-            --features native_viewer,web_viewer \
+            --features release \
             --release \
             --target ${{ needs.set-config.outputs.TARGET }}
 

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -30,9 +30,8 @@ av1 = ["dep:dav1d"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing on Linux.
 nasm = [
-  # The default feature set of our dav1d fork has asm enabled (except on Linux, see above)
+  # The default feature set of our dav1d fork has asm enabled
   "dav1d?/default",
 ]
 

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -37,14 +37,22 @@ impl SyncDav1dDecoder {
     pub fn new(debug_name: String) -> Result<Self> {
         re_tracing::profile_function!();
 
-        // TODO(#7671): enable this warning again on Linux when the `nasm` feature actually does something
-        #[allow(clippy::overly_complex_bool_expr)]
-        if !cfg!(target_os = "linux") && !cfg!(feature = "nasm") {
-            re_log::warn_once!(
-                "NOTE: native AV1 video decoder is running extra slowly. \
-                Speed it up by compiling Rerun with the `nasm` feature enabled. \
-                You'll need to also install nasm: https://nasm.us/"
-            );
+        if !cfg!(feature = "nasm") {
+            // The `nasm` feature makes AV1 decoding much faster.
+            // On Linux the difference is huge (~25x).
+            // On Windows, the difference was also pretty big (unsure how big).
+            // On an M3 Mac the difference is smalelr (2-3x),
+            // and ever without `nasm` emilk can play an 8k video at 2x speed.
+
+            if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+                re_log::warn_once!(
+                    "The native AV1 video decoder is unnecessarily slow. \
+                    Speed it up by compiling Rerun with the `nasm` feature enabled."
+                );
+            } else {
+                // Better to return an error than to be perceived as being slow
+                return Err(Error::Dav1dWithoutNasm);
+            }
         }
 
         // See https://videolan.videolan.me/dav1d/structDav1dSettings.html for settings docs

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -100,6 +100,11 @@ pub enum Error {
     #[cfg(not(target_arch = "wasm32"))]
     #[error("dav1d: {0}")]
     Dav1d(#[from] dav1d::Error),
+
+    #[cfg(feature = "av1")]
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error("To enabled native AV1 decoding, compile Rerun with the `nasm` feature enabled.")]
+    Dav1dWithoutNasm,
 }
 
 pub type Result<T = (), E = Error> = std::result::Result<T, E>;

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -12,3 +12,16 @@ pub use self::{
     demux::{Config, Sample, VideoData, VideoLoadError},
     time::{Time, Timescale},
 };
+
+/// Which features was this crate compiled with?
+pub fn features() -> Vec<&'static str> {
+    // TODO(emilk): is there a helper crate for this?
+    let mut features = vec![];
+    if cfg!(feature = "av1") {
+        features.push("av1");
+    }
+    if cfg!(feature = "nasm") {
+        features.push("nasm");
+    }
+    features
+}

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -1,102 +1,14 @@
 //! Video decoding library.
 
+mod time;
+
 pub mod decode;
 pub mod demux;
 
-pub use decode::{Chunk, Frame, PixelFormat};
-pub use demux::{Config, Sample, VideoData, VideoLoadError};
 pub use re_mp4::{TrackId, TrackKind};
 
-/// A value in time units.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Time(i64);
-
-impl Time {
-    pub const ZERO: Self = Self(0);
-    pub const MAX: Self = Self(i64::MAX);
-
-    /// Create a new value in _time units_.
-    ///
-    /// ⚠️ Don't use this for regular timestamps in seconds/milliseconds/etc.,
-    /// use the proper constructors for those instead!
-    /// This only exists for cases where you already have a value expressed in time units,
-    /// such as those received from the `WebCodecs` APIs.
-    #[inline]
-    pub fn new(v: i64) -> Self {
-        Self(v)
-    }
-
-    #[inline]
-    pub fn from_secs(v: f64, timescale: Timescale) -> Self {
-        Self((v * timescale.0 as f64).round() as i64)
-    }
-
-    #[inline]
-    pub fn from_millis(v: f64, timescale: Timescale) -> Self {
-        Self::from_secs(v / 1e3, timescale)
-    }
-
-    #[inline]
-    pub fn from_micros(v: f64, timescale: Timescale) -> Self {
-        Self::from_secs(v / 1e6, timescale)
-    }
-
-    #[inline]
-    pub fn from_nanos(v: i64, timescale: Timescale) -> Self {
-        Self::from_secs(v as f64 / 1e9, timescale)
-    }
-
-    /// Convert to a duration
-    #[inline]
-    pub fn duration(self, timescale: Timescale) -> std::time::Duration {
-        std::time::Duration::from_nanos(self.into_nanos(timescale) as _)
-    }
-
-    #[inline]
-    pub fn into_secs(self, timescale: Timescale) -> f64 {
-        self.0 as f64 / timescale.0 as f64
-    }
-
-    #[inline]
-    pub fn into_millis(self, timescale: Timescale) -> f64 {
-        self.into_secs(timescale) * 1e3
-    }
-
-    #[inline]
-    pub fn into_micros(self, timescale: Timescale) -> f64 {
-        self.into_secs(timescale) * 1e6
-    }
-
-    #[inline]
-    pub fn into_nanos(self, timescale: Timescale) -> i64 {
-        (self.into_secs(timescale) * 1e9).round() as i64
-    }
-}
-
-impl std::ops::Add for Time {
-    type Output = Self;
-
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self(self.0.saturating_add(rhs.0))
-    }
-}
-
-impl std::ops::Sub for Time {
-    type Output = Self;
-
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0.saturating_sub(rhs.0))
-    }
-}
-
-/// The number of time units per second.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Timescale(u64);
-
-impl Timescale {
-    pub(crate) fn new(v: u64) -> Self {
-        Self(v)
-    }
-}
+pub use self::{
+    decode::{Chunk, Frame, PixelFormat},
+    demux::{Config, Sample, VideoData, VideoLoadError},
+    time::{Time, Timescale},
+};

--- a/crates/store/re_video/src/time.rs
+++ b/crates/store/re_video/src/time.rs
@@ -1,0 +1,93 @@
+/// The number of time units per second.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Timescale(u64);
+
+impl Timescale {
+    pub(crate) fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+/// A value in time units.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Time(pub i64);
+
+impl Time {
+    pub const ZERO: Self = Self(0);
+    pub const MAX: Self = Self(i64::MAX);
+
+    /// Create a new value in _time units_.
+    ///
+    /// ⚠️ Don't use this for regular timestamps in seconds/milliseconds/etc.,
+    /// use the proper constructors for those instead!
+    /// This only exists for cases where you already have a value expressed in time units,
+    /// such as those received from the `WebCodecs` APIs.
+    #[inline]
+    pub fn new(v: i64) -> Self {
+        Self(v)
+    }
+
+    #[inline]
+    pub fn from_secs(v: f64, timescale: Timescale) -> Self {
+        Self((v * timescale.0 as f64).round() as i64)
+    }
+
+    #[inline]
+    pub fn from_millis(v: f64, timescale: Timescale) -> Self {
+        Self::from_secs(v / 1e3, timescale)
+    }
+
+    #[inline]
+    pub fn from_micros(v: f64, timescale: Timescale) -> Self {
+        Self::from_secs(v / 1e6, timescale)
+    }
+
+    #[inline]
+    pub fn from_nanos(v: i64, timescale: Timescale) -> Self {
+        Self::from_secs(v as f64 / 1e9, timescale)
+    }
+
+    /// Convert to a duration
+    #[inline]
+    pub fn duration(self, timescale: Timescale) -> std::time::Duration {
+        std::time::Duration::from_nanos(self.into_nanos(timescale) as _)
+    }
+
+    #[inline]
+    pub fn into_secs(self, timescale: Timescale) -> f64 {
+        self.0 as f64 / timescale.0 as f64
+    }
+
+    #[inline]
+    pub fn into_millis(self, timescale: Timescale) -> f64 {
+        self.into_secs(timescale) * 1e3
+    }
+
+    #[inline]
+    pub fn into_micros(self, timescale: Timescale) -> f64 {
+        self.into_secs(timescale) * 1e6
+    }
+
+    #[inline]
+    pub fn into_nanos(self, timescale: Timescale) -> i64 {
+        (self.into_secs(timescale) * 1e9).round() as i64
+    }
+}
+
+impl std::ops::Add for Time {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_add(rhs.0))
+    }
+}
+
+impl std::ops::Sub for Time {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+}

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -43,7 +43,6 @@ default = ["native_viewer", "web_viewer"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["rerun/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -37,9 +37,15 @@ path = "src/bin/rerun.rs"
 doc = false
 
 [features]
-# The default is what the user gets when they call `cargo install rerun-cli --locked`,
-# so wer have all the bells and wistles here
+## The default is what the user gets when they call `cargo install rerun-cli --locked`,
+## so we have all the bells and wistles here, except those that may require extra tools
+## (like "nasm").
+## That is: `cargo install rerun-cli --locked` should work for _everyone_.
 default = ["native_viewer", "web_viewer"]
+
+## The features we enable when we build the pre-built binaries during our releases.
+## This may enable features that require extra build tools that not everyone heas.
+release = ["default", "nasm"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -73,7 +73,6 @@ log = ["dep:env_logger", "dep:log"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["re_video/nasm"]
 
 ## Support spawning a native viewer.

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -553,6 +553,7 @@ where
 
     if args.version {
         println!("{build_info}");
+        println!("Video features: {}", re_video::features().join(" "));
         return Ok(0);
     }
 

--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -30,7 +30,6 @@ extension-module = ["pyo3/extension-module"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
-# TODO(#7671): this feature flag currently does nothing on linux.
 nasm = ["re_video/nasm"]
 
 ## Support serving a web viewer over HTTP with `serve()`.


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/7669
* Closes https://github.com/rerun-io/rerun/issues/7671

* Disable AV1 decoding unless the `nasm` feature is turned on
* Turn on the `nasm` feature when building pre-built binaries
* Print enabled video features with `rerun --version` to make testing of the above easy

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
