### PR TITLE
Make the entity path in the table view clickable

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -250,9 +250,13 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                         // … but not so far to the right that it doesn't fit.
                         pos.x = pos.x.at_most(ui.max_rect().right() - galley.size().x);
 
-                        ui.put(
+                        let response = ui.put(
                             egui::Rect::from_min_size(pos, galley.size()),
-                            egui::Label::new(galley),
+                            egui::Button::new(galley),
+                        );
+                        self.ctx.select_hovered_on_click(
+                            &response,
+                            re_viewer_context::Item::from(entity_path.clone()),
                         );
                     }
                 } else if cell.row_nr == 1 {

--- a/crates/viewer/re_viewer_context/src/item.rs
+++ b/crates/viewer/re_viewer_context/src/item.rs
@@ -65,6 +65,13 @@ impl From<ComponentPath> for Item {
     }
 }
 
+impl From<EntityPath> for Item {
+    #[inline]
+    fn from(entity_path: EntityPath) -> Self {
+        Self::InstancePath(InstancePath::from(entity_path))
+    }
+}
+
 impl From<InstancePath> for Item {
     #[inline]
     fn from(instance_path: InstancePath) -> Self {


### PR DESCRIPTION
### What
![clickable-table-paths](https://github.com/user-attachments/assets/da287409-323a-4ea9-9285-4e99f82b0dc4)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7746?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7746?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7746)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.