### PR TITLE
Make component column headers clickable

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -8,7 +8,7 @@ use arrow2::{
 };
 
 use re_chunk::TimelineName;
-use re_log_types::{EntityPath, ResolvedTimeRange, TimeInt, Timeline};
+use re_log_types::{ComponentPath, EntityPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_types_core::{ArchetypeName, ComponentName};
 
 use crate::{ChunkStore, ColumnMetadata};
@@ -229,6 +229,13 @@ impl std::fmt::Display for ComponentColumnDescriptor {
 }
 
 impl ComponentColumnDescriptor {
+    pub fn component_path(&self) -> ComponentPath {
+        ComponentPath {
+            entity_path: self.entity_path.clone(),
+            component_name: self.component_name,
+        }
+    }
+
     #[inline]
     pub fn matches(&self, entity_path: &EntityPath, component_name: &str) -> bool {
         &self.entity_path == entity_path && self.component_name.matches(component_name)

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -290,7 +290,21 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                             &re_ui::icons::VISIBLE,
                             CellStyle::Header,
                             |ui| {
-                                ui.strong(column.short_name());
+                                let text = egui::RichText::new(column.short_name()).strong();
+                                let response = ui.button(text);
+                                match column {
+                                    ColumnDescriptor::Time(_) => {
+                                        // TODO: handle clicking of time columns
+                                    }
+                                    ColumnDescriptor::Component(component_column_descriptor) => {
+                                        self.ctx.select_hovered_on_click(
+                                            &response,
+                                            re_viewer_context::Item::ComponentPath(
+                                                component_column_descriptor.component_path(),
+                                            ),
+                                        );
+                                    }
+                                }
                             },
                         );
 

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -250,14 +250,13 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                         // … but not so far to the right that it doesn't fit.
                         pos.x = pos.x.at_most(ui.max_rect().right() - galley.size().x);
 
+                        let item = re_viewer_context::Item::from(entity_path.clone());
+                        let is_selected = self.ctx.selection().contains_item(&item);
                         let response = ui.put(
                             egui::Rect::from_min_size(pos, galley.size()),
-                            egui::Button::new(galley),
+                            egui::SelectableLabel::new(is_selected, galley),
                         );
-                        self.ctx.select_hovered_on_click(
-                            &response,
-                            re_viewer_context::Item::from(entity_path.clone()),
-                        );
+                        self.ctx.select_hovered_on_click(&response, item);
                     }
                 } else if cell.row_nr == 1 {
                     let column = &self.selected_columns[cell.col_range.start];

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -538,6 +538,12 @@ impl App {
                 self.state.selection_state.set_selection(item);
             }
 
+            SystemCommand::SetActiveTimeline { rec_id, timeline } => {
+                if let Some(rec_cfg) = self.state.recording_config_mut(&rec_id) {
+                    rec_cfg.time_ctrl.write().set_timeline(timeline);
+                }
+            }
+
             SystemCommand::SetFocus(item) => {
                 self.state.focused_item = Some(item);
             }

--- a/crates/viewer/re_viewer_context/src/command_sender.rs
+++ b/crates/viewer/re_viewer_context/src/command_sender.rs
@@ -65,6 +65,12 @@ pub enum SystemCommand {
     /// Set the item selection.
     SetSelection(crate::Item),
 
+    /// Set the active timeline for the given recording.
+    SetActiveTimeline {
+        rec_id: StoreId,
+        timeline: re_chunk::Timeline,
+    },
+
     /// Sets the focus to the given item.
     ///
     /// The focused item is cleared out every frame.

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -149,6 +149,11 @@ impl TestContext {
                     self.selection_state.set_selection(item);
                 }
 
+                SystemCommand::SetActiveTimeline { rec_id, timeline } => {
+                    assert_eq!(&rec_id, self.recording_store.store_id());
+                    self.active_timeline = timeline;
+                }
+
                 // not implemented
                 SystemCommand::SetFocus(_)
                 | SystemCommand::ActivateApp(_)


### PR DESCRIPTION
### What
Make the dataframe column names clickable

https://github.com/user-attachments/assets/4c987218-7abf-4ce6-b174-4e68313f93d4


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7748?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7748?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7748)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.