### PR TITLE
`QueryExpression::filtered_point_of_view` -> `QueryExpression::filtered_is_not_null`

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -542,7 +542,7 @@ pub struct QueryExpression {
     /// Examples: `Some(Timeline("frame"))`, `None` (only static data).
     //
     // TODO(cmc): this has to be a selector otherwise this is a horrible UX.
-    pub filtered_index: Option<Timeline>,
+    pub filtered_index: Option<Index>,
 
     /// The range of index values used to filter out _rows_ from the view contents.
     ///
@@ -589,7 +589,7 @@ pub struct QueryExpression {
     /// Example: `ComponentColumnSelector("rerun.components.Position3D")`.
     //
     // TODO(cmc): multi-pov support
-    pub filtered_point_of_view: Option<ComponentColumnSelector>,
+    pub filtered_is_not_null: Option<ComponentColumnSelector>,
 
     /// Specifies how null values should be filled in the returned dataframe.
     ///
@@ -792,7 +792,7 @@ impl ChunkStore {
             filtered_index_range: _,
             filtered_index_values: _,
             using_index_values: _,
-            filtered_point_of_view: _,
+            filtered_is_not_null: _,
             sparse_fill_strategy: _,
             selection: _,
         } = query;

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -445,11 +445,7 @@ impl QueryHandle<'_> {
         query: &RangeQuery,
         view_contents: &[ColumnDescriptor],
     ) -> (Option<usize>, Vec<Vec<(AtomicU64, Chunk)>>) {
-        let mut view_pov_chunks_idx = self
-            .query
-            .filtered_point_of_view
-            .as_ref()
-            .map(|_| usize::MAX);
+        let mut view_pov_chunks_idx = self.query.filtered_is_not_null.as_ref().map(|_| usize::MAX);
 
         let view_chunks = view_contents
             .iter()
@@ -462,7 +458,7 @@ impl QueryHandle<'_> {
                         .fetch_chunks(query, &column.entity_path, [column.component_name])
                         .unwrap_or_default();
 
-                    if let Some(pov) = self.query.filtered_point_of_view.as_ref() {
+                    if let Some(pov) = self.query.filtered_is_not_null.as_ref() {
                         if pov.entity_path == column.entity_path
                             && column.component_name.matches(&pov.component_name)
                         {
@@ -1196,7 +1192,7 @@ mod tests {
     // * [x] filtered_index_values
     // * [x] view_contents
     // * [x] selection
-    // * [x] filtered_point_of_view
+    // * [x] filtered_is_not_null
     // * [x] sparse_fill_strategy
     // * [x] using_index_values
     //
@@ -1551,7 +1547,7 @@ mod tests {
     }
 
     #[test]
-    fn filtered_point_of_view() -> anyhow::Result<()> {
+    fn filtered_is_not_null() -> anyhow::Result<()> {
         re_log::setup_logging();
 
         let store = create_nasty_store()?;
@@ -1569,7 +1565,7 @@ mod tests {
         {
             let query = QueryExpression {
                 filtered_index,
-                filtered_point_of_view: Some(ComponentColumnSelector {
+                filtered_is_not_null: Some(ComponentColumnSelector {
                     entity_path: "no/such/entity".into(),
                     component_name: MyPoint::name().to_string(),
                 }),
@@ -1598,7 +1594,7 @@ mod tests {
         {
             let query = QueryExpression {
                 filtered_index,
-                filtered_point_of_view: Some(ComponentColumnSelector {
+                filtered_is_not_null: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: "AComponentColumnThatDoesntExist".into(),
                 }),
@@ -1627,7 +1623,7 @@ mod tests {
         {
             let query = QueryExpression {
                 filtered_index,
-                filtered_point_of_view: Some(ComponentColumnSelector {
+                filtered_is_not_null: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyPoint::name().to_string(),
                 }),
@@ -1666,7 +1662,7 @@ mod tests {
         {
             let query = QueryExpression {
                 filtered_index,
-                filtered_point_of_view: Some(ComponentColumnSelector {
+                filtered_is_not_null: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyColor::name().to_string(),
                 }),
@@ -2180,7 +2176,7 @@ mod tests {
         {
             let query = QueryExpression {
                 filtered_index,
-                filtered_point_of_view: Some(ComponentColumnSelector {
+                filtered_is_not_null: Some(ComponentColumnSelector {
                     entity_path: entity_path.clone(),
                     component_name: MyPoint::name().to_string(),
                 }),

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -49,7 +49,7 @@ pub(crate) fn dataframe_ui(
     // salt.
     let table_id_salt = egui::Id::new("__dataframe__")
         .with(&selected_columns)
-        .with(&query_handle.query().filtered_point_of_view);
+        .with(&query_handle.query().filtered_is_not_null);
 
     // For the row expansion cache, we invalidate more aggressively for now.
     let row_expansion_id_salt = egui::Id::new("__dataframe_row_exp__")

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -147,7 +147,7 @@ mode sets the default time range to _everything_. You can override this in the s
             view_contents: Some(view_contents),
             filtered_index: Some(view_query.timeline(ctx)?),
             filtered_index_range: Some(view_query.filter_by_range()?),
-            filtered_point_of_view: view_query.filter_is_not_null()?,
+            filtered_is_not_null: view_query.filter_is_not_null()?,
             sparse_fill_strategy,
             selection: None,
 

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -570,7 +570,7 @@ impl PyRecordingView {
         let column = column.into_selector();
 
         let mut query_expression = self.query_expression.clone();
-        query_expression.filtered_point_of_view = Some(column);
+        query_expression.filtered_is_not_null = Some(column);
 
         Self {
             recording: self.recording.clone(),
@@ -743,7 +743,7 @@ impl PyRecording {
             filtered_index_range: None,
             filtered_index_values: None,
             using_index_values: None,
-            filtered_point_of_view: None,
+            filtered_is_not_null: None,
             sparse_fill_strategy: SparseFillStrategy::None,
             selection: None,
         };


### PR DESCRIPTION
Fix the last remaining naming misalignment between Rust<>Python<>Blueprint

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7749?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7749?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7749)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.