### PR TITLE
add instant_splat example

### DIFF
--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -100,6 +100,7 @@ examples = [
   "differentiable_blocks_world",
   "stereo_vision_slam",
   "glomap",
+  "instant_splat",
   "signed_distance_fields",
   "raw_mesh",
 ]

--- a/examples/python/instant_splat/README.md
+++ b/examples/python/instant_splat/README.md
@@ -1,0 +1,24 @@
+<!--[metadata]
+title = "InstantSplat"
+tags = ["2D", "3D", "HuggingFace", "Pinhole camera", "Point cloud"]
+source = "https://github.com/pablovela5620/InstantSplat"
+thumbnail = "https://static.rerun.io/final_instantsplat/e488f427179b0f439e60b6a0c29440fc836860dd/480w.png"
+thumbnail_dimensions = [480, 268]
+-->
+
+
+https://vimeo.com/1019845514?loop=1&autopause=0&background=1&muted=1&ratio=2802:1790
+
+## Background
+InstantSplat is a sparse-view, SfM-free framework for large-scale scene reconstruction method using Gaussian Splatting. It allows for extremely fast reconstruction by using Dust3r, a multiview stereo network, to initialize camera poses and dense point cloud for all training views. To enhance pose accuracy and tune scene parameters a gradient-based joint optimization framework from self-supervision is used.  By employing this simplified framework, InstantSplat achieves a substantial reduction in training time, from hours to mere seconds, and demonstrates robust performance across various numbers of views in diverse datasets
+
+## Run the code
+This is an external example. Check the [repository](https://github.com/pablovela5620/InstantSplat) for more information.
+
+You can try the example on HuggingFace space [here](https://huggingface.co/spaces/pablovela5620/instant-splat).
+
+It is highly recommended to run this example locally by cloning the above repo and running (make sure you have [Pixi](https://pixi.sh/latest/#installation) installed):
+```
+git clone https://github.com/pablovela5620/InstantSplat.git
+pixi run app
+```


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What
https://github.com/user-attachments/assets/64bf9178-3147-4f67-9ca2-ca5a59cec5d8

add python external example for InstantSplat


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7751?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7751?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7751)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.