### PR TITLE
Include a `view.schema()` API and improved support for static data

### DIFF
--- a/crates/store/re_chunk_store/src/dataframe.rs
+++ b/crates/store/re_chunk_store/src/dataframe.rs
@@ -62,6 +62,14 @@ impl ColumnDescriptor {
             Self::Component(descr) => descr.component_name.short_name().to_owned(),
         }
     }
+
+    #[inline]
+    pub fn is_static(&self) -> bool {
+        match self {
+            Self::Time(_) => false,
+            Self::Component(descr) => descr.is_static,
+        }
+    }
 }
 
 /// Describes a time column, such as `log_time`.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -170,6 +170,9 @@ class RecordingView:
         ...
 
     def select(self, *args: AnyColumn, columns: Optional[Sequence[AnyColumn]] = None) -> pa.RecordBatchReader: ...
+    def select_static(
+        self, *args: AnyColumn, columns: Optional[Sequence[AnyColumn]] = None
+    ) -> pa.RecordBatchReader: ...
 
 class Recording:
     """A single recording."""

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -92,6 +92,10 @@ class RecordingView:
     increasing when data is sent from a single process.
     """
 
+    def schema(self) -> Schema:
+        """The schema of the view."""
+        ...
+
     def filter_range_sequence(self, start: int, end: int) -> RecordingView:
         """
         Filter the view to only include data between the given index sequence numbers.

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -166,7 +166,49 @@ class Recording:
     """A single recording."""
 
     def schema(self) -> Schema: ...
-    def view(self, *, index: str, contents: ViewContentsLike) -> RecordingView: ...
+    def view(
+        self,
+        *,
+        index: str,
+        contents: ViewContentsLike,
+        include_semantically_empty_columns: bool = False,
+        include_indicator_columns: bool = False,
+        include_tombstone_columns: bool = False,
+    ) -> RecordingView:
+        """
+        Create a view of the recording according to a particular index and content specification.
+
+        Parameters
+        ----------
+        index : str
+            The index to use for the view. This is typically a timeline name.
+        contents : ViewContentsLike
+            The content specification for the view. This must specify one or more EntityPath expressions
+            as well as optionally a list of columns. If only providing a single EntityPath, use a string,
+            otherwise provide a dictionary mapping EntityPaths to a list of column names.
+        include_semantically_empty_columns : bool, optional
+            Whether to include columns that are semantically empty, by default False.
+        include_indicator_columns : bool, optional
+            Whether to include indicator columns, by default False.
+        include_tombstone_columns : bool, optional
+            Whether to include tombstone columns, by default False.
+            Tombstone columns are components used to represent clears. However, even without the clear
+            tombstone columns, the view will still apply the clear semantics when resolving row contents.
+
+        Examples
+        --------
+        All the data in the recording on the timeline "my_index":
+        ```python
+        recording.view(index="my_index", contents="/**")
+        ```
+
+        Just the Position3D components in the "points" entity:
+        ```python
+        recording.view(index="my_index", contents={"points": "Position3D"})
+        ```
+
+        """
+        ...
     def recording_id(self) -> str: ...
     def application_id(self) -> str: ...
 

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -1,5 +1,5 @@
 import os
-from typing import Optional, Sequence
+from typing import Iterator, Optional, Sequence, Union
 
 import pyarrow as pa
 
@@ -14,6 +14,11 @@ class IndexColumnDescriptor:
 
         This property is read-only.
         """
+        ...
+
+    @property
+    def is_static(self) -> bool:
+        """ColumnDescriptor interface: always False for Index."""
         ...
 
 class IndexColumnSelector:
@@ -83,6 +88,7 @@ class ComponentColumnSelector:
 class Schema:
     """The schema representing all columns in a [`Recording`][]."""
 
+    def __iter__(self) -> Iterator[Union[IndexColumnDescriptor, ComponentColumnDescriptor]]: ...
     def index_columns(self) -> list[IndexColumnDescriptor]: ...
     def component_columns(self) -> list[ComponentColumnDescriptor]: ...
     def column_for(self, entity_path: str, component: ComponentLike) -> Optional[ComponentColumnDescriptor]: ...

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -49,6 +49,15 @@ class ComponentColumnDescriptor:
         """
         ...
 
+    @property
+    def is_static(self) -> bool:
+        """
+        Whether the column is static.
+
+        This property is read-only.
+        """
+        ...
+
 class ComponentColumnSelector:
     """A selector for a component column."""
 

--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .rerun_bindings import (
         ComponentColumnDescriptor as ComponentColumnDescriptor,
         ComponentColumnSelector as ComponentColumnSelector,
-        IndexColumnSelector as IndexColumnDescriptor,
+        IndexColumnDescriptor as IndexColumnDescriptor,
         IndexColumnSelector as IndexColumnSelector,
     )
 
@@ -24,6 +24,7 @@ AnyColumn: TypeAlias = Union[
     "IndexColumnDescriptor",
     "IndexColumnSelector",
 ]
+
 
 AnyComponentColumn: TypeAlias = Union[
     "ComponentColumnDescriptor",

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -758,15 +758,22 @@ impl PyRecording {
         }
     }
 
+    #[allow(clippy::fn_params_excessive_bools)]
     #[pyo3(signature = (
         *,
         index,
-        contents
+        contents,
+        include_semantically_empty_columns = false,
+        include_indicator_columns = false,
+        include_tombstone_columns = false,
     ))]
     fn view(
         slf: Bound<'_, Self>,
         index: &str,
         contents: Bound<'_, PyAny>,
+        include_semantically_empty_columns: bool,
+        include_indicator_columns: bool,
+        include_tombstone_columns: bool,
     ) -> PyResult<PyRecordingView> {
         let borrowed_self = slf.borrow();
 
@@ -781,9 +788,9 @@ impl PyRecording {
 
         let query = QueryExpression {
             view_contents: Some(contents),
-            include_semantically_empty_columns: false,
-            include_indicator_columns: false,
-            include_tombstone_columns: false,
+            include_semantically_empty_columns,
+            include_indicator_columns,
+            include_tombstone_columns,
             filtered_index: Some(timeline.timeline),
             filtered_index_range: None,
             filtered_index_values: None,

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -125,6 +125,11 @@ impl PyComponentColumnDescriptor {
     fn component_name(&self) -> &str {
         &self.0.component_name
     }
+
+    #[getter]
+    fn is_static(&self) -> bool {
+        self.0.is_static
+    }
 }
 
 impl From<PyComponentColumnDescriptor> for ComponentColumnDescriptor {

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -331,7 +331,6 @@ impl FromPyObject<'_> for ComponentLike {
     }
 }
 
-// TODO(jleibs): Maybe this whole thing moves to the View/Recording
 #[pyclass(frozen, name = "Schema")]
 #[derive(Clone)]
 pub struct PySchema {
@@ -410,6 +409,22 @@ pub struct PyRecordingView {
 /// increasing when data is sent from a single process.
 #[pymethods]
 impl PyRecordingView {
+    fn schema(&self, py: Python<'_>) -> PySchema {
+        let borrowed = self.recording.borrow(py);
+        let engine = borrowed.engine();
+
+        let mut query_expression = self.query_expression.clone();
+        query_expression.selection = None;
+
+        let query_handle = engine.query(query_expression);
+
+        let contents = query_handle.view_contents();
+
+        PySchema {
+            schema: contents.to_vec(),
+        }
+    }
+
     #[pyo3(signature = (
         *args,
         columns = None

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -352,6 +352,7 @@ impl SchemaIterator {
     fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
         slf
     }
+
     fn __next__(mut slf: PyRefMut<'_, Self>) -> Option<PyObject> {
         slf.iter.next()
     }

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -95,7 +95,7 @@ class TestDataframe:
         assert self.recording.application_id() == APP_ID
         assert self.recording.recording_id() == str(RECORDING_ID)
 
-    def test_schema(self) -> None:
+    def test_schema_recording(self) -> None:
         schema = self.recording.schema()
 
         assert len(schema.index_columns()) == 3
@@ -111,6 +111,21 @@ class TestDataframe:
         assert schema.component_columns()[1].component_name == "rerun.components.Points3DIndicator"
         assert schema.component_columns()[2].entity_path == "/points"
         assert schema.component_columns()[2].component_name == "rerun.components.Position3D"
+
+    def test_schema_view(self) -> None:
+        schema = self.recording.view(index="my_index", contents="/**").schema()
+
+        assert len(schema.index_columns()) == 3
+        # Position3D, Color
+        assert len(schema.component_columns()) == 2
+
+        assert schema.index_columns()[0].name == "log_tick"
+        assert schema.index_columns()[1].name == "log_time"
+        assert schema.index_columns()[2].name == "my_index"
+        assert schema.component_columns()[0].entity_path == "/points"
+        assert schema.component_columns()[0].component_name == "rerun.components.Color"
+        assert schema.component_columns()[1].entity_path == "/points"
+        assert schema.component_columns()[1].component_name == "rerun.components.Position3D"
 
     def test_full_view(self) -> None:
         view = self.recording.view(index="my_index", contents="points")

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -49,7 +49,7 @@ class TestDataframe:
         rr.init(APP_ID, recording_id=RECORDING_ID)
 
         rr.set_time_sequence("my_index", 1)
-        rr.log("points", rr.Points3D([[1, 2, 3], [4, 5, 6], [7, 8, 9]]))
+        rr.log("points", rr.Points3D([[1, 2, 3], [4, 5, 6], [7, 8, 9]], radii=[]))
         rr.set_time_sequence("my_index", 7)
         rr.log("points", rr.Points3D([[10, 11, 12]], colors=[[255, 0, 0]]))
 
@@ -98,9 +98,10 @@ class TestDataframe:
     def test_schema_recording(self) -> None:
         schema = self.recording.schema()
 
+        # log_tick, log_time, my_index
         assert len(schema.index_columns()) == 3
-        # Points3DIndicator, Position3D, Color
-        assert len(schema.component_columns()) == 3
+        # Color, Points3DIndicator, Position3D, Radius
+        assert len(schema.component_columns()) == 4
 
         assert schema.index_columns()[0].name == "log_tick"
         assert schema.index_columns()[1].name == "log_time"
@@ -111,6 +112,8 @@ class TestDataframe:
         assert schema.component_columns()[1].component_name == "rerun.components.Points3DIndicator"
         assert schema.component_columns()[2].entity_path == "/points"
         assert schema.component_columns()[2].component_name == "rerun.components.Position3D"
+        assert schema.component_columns()[3].entity_path == "/points"
+        assert schema.component_columns()[3].component_name == "rerun.components.Radius"
 
     def test_schema_view(self) -> None:
         schema = self.recording.view(index="my_index", contents="/**").schema()
@@ -126,6 +129,18 @@ class TestDataframe:
         assert schema.component_columns()[0].component_name == "rerun.components.Color"
         assert schema.component_columns()[1].entity_path == "/points"
         assert schema.component_columns()[1].component_name == "rerun.components.Position3D"
+
+        # Force radius to be included
+        schema = self.recording.view(
+            index="my_index",
+            contents="/**",
+            include_semantically_empty_columns=True,
+        ).schema()
+
+        assert len(schema.index_columns()) == 3
+        # Color, Position3D, Radius
+        assert len(schema.component_columns()) == 3
+        assert schema.component_columns()[2].component_name == "rerun.components.Radius"
 
     def test_full_view(self) -> None:
         view = self.recording.view(index="my_index", contents="points")


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7601
- Makes it possible to see the schema of just a view
- Adds optional params to view creation for:
  - include_semantically_empty_columns,
  - include_indicator_columns,
  - include_tombstone_columns,
- Include ability to check whether columns are static
- Add a `select_static` API variant to getting just the static data from a view 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7754?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7754?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7754)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.