### PR TITLE
Warn when selection only includes static data

### DIFF
--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -529,7 +529,8 @@ impl PyRecordingView {
             .filter(|c| matches!(c, ColumnDescriptor::Component(_)))
             .collect::<Vec<_>>();
 
-        if !available_data_columns.is_empty()
+        if self.query_expression.using_index_values.is_none()
+            && !available_data_columns.is_empty()
             && available_data_columns.iter().all(|c| c.is_static())
         {
             py_rerun_warn("RecordingView::select: contents only include static columns. No results will be returned. Either include non-static data or consider using `select_static()` instead.")?;


### PR DESCRIPTION
### What
Based on top of:
- https://github.com/rerun-io/rerun/pull/7754
- Will need rebase after merging ^

This tries to alleviates a possible footgun where a user creates what appears to be a valid view expression but it only includes static data. In these cases the results of `.select()` won't produce any data since there are no row-providing columns.

There are many possible ways to end up in this state but the logic here should not be too likely for false-warnings while producing a reasonable degree of user safety.

If the user:
- Writes a content expression that only matches static content
- AND writes a select statement that queries static data
- AND does not call `using_index_values(...)`

Then we will produce a warning.

The most likely false positive where this would introduce a spurious warning would be a user wanting to query for a mixture of static and non-static data in a circumstance where sometimes none of the non-static data is logged and the user expects to (correctly) get no rows in this case.  However, these circumstances generally imply a more advanced user that could then work around then with a mixed query + join anyways.

Future work:
- https://github.com/rerun-io/rerun/issues/7759

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7758?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7758?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7758)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.