### PR TITLE
Disable `re_rav1d` on Linux ARM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5937,6 +5937,7 @@ dependencies = [
 name = "re_video"
 version = "0.19.0-alpha.9"
 dependencies = [
+ "cfg_aliases 0.2.1",
  "crossbeam",
  "econtext",
  "indicatif",

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -64,12 +64,10 @@ dav1d = { workspace = true, optional = true, default-features = false, features 
 [dev-dependencies]
 indicatif.workspace = true
 
-[build-dependencies]
-re_build_tools.workspace = true
-
 
 # For build.rs:
 [build-dependencies]
+re_build_tools.workspace = true
 cfg_aliases.workspace = true
 
 

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -48,8 +48,10 @@ parking_lot.workspace = true
 re_mp4.workspace = true
 thiserror.workspace = true
 
-# Native dependencies:
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# We enable re_rav1d on native, UNLESS we're on Linux Arm64
+# See https://github.com/rerun-io/rerun/issues/7755
+[target.'cfg(all(not(target_arch = "wasm32"), not(all(target_os = "linux", target_arch = "arm64"))))'.dependencies]
+
 
 # If this package fails to build, install `nasm` locally, or build through `pixi`.
 # NOTE: we use `dav1d` as an alias for our own re_rav1d crate
@@ -64,6 +66,11 @@ indicatif.workspace = true
 
 [build-dependencies]
 re_build_tools.workspace = true
+
+
+# For build.rs:
+[build-dependencies]
+cfg_aliases.workspace = true
 
 
 [[example]]

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -50,7 +50,7 @@ thiserror.workspace = true
 
 # We enable re_rav1d on native, UNLESS we're on Linux Arm64
 # See https://github.com/rerun-io/rerun/issues/7755
-[target.'cfg(all(not(target_arch = "wasm32"), not(all(target_os = "linux", target_arch = "arm64"))))'.dependencies]
+[target.'cfg(all(not(target_arch = "wasm32"), not(all(target_os = "linux", target_arch = "aarch64"))))'.dependencies]
 
 
 # If this package fails to build, install `nasm` locally, or build through `pixi`.

--- a/crates/store/re_video/build.rs
+++ b/crates/store/re_video/build.rs
@@ -8,7 +8,7 @@ fn main() {
 
     cfg_aliases::cfg_aliases! {
         native: { not(target_arch = "wasm32") },
-        linux_arm64: { all(target_os = "linux", target_arch = "arm64") },
+        linux_arm64: { all(target_os = "linux", target_arch = "aarch64") },
         with_dav1d: { all(native, not(linux_arm64)) }, // https://github.com/rerun-io/rerun/issues/7755
     }
 }

--- a/crates/store/re_video/build.rs
+++ b/crates/store/re_video/build.rs
@@ -1,3 +1,14 @@
 fn main() {
     re_build_tools::export_build_info_vars_for_crate(env!("CARGO_PKG_NAME"));
+
+    // uncomment these when we update to Rust 1.80: https://blog.rust-lang.org/2024/05/06/check-cfg.html
+    // println!("cargo::rustc-check-cfg=cfg(native)");
+    // println!("cargo::rustc-check-cfg=cfg(linux_arm64)");
+    // println!("cargo::rustc-check-cfg=cfg(with_dav1d)");
+
+    cfg_aliases::cfg_aliases! {
+        native: { not(target_arch = "wasm32") },
+        linux_arm64: { all(target_os = "linux", target_arch = "arm64") },
+        with_dav1d: { all(native, not(linux_arm64)) }, // https://github.com/rerun-io/rerun/issues/7755
+    }
 }

--- a/crates/store/re_video/build.rs
+++ b/crates/store/re_video/build.rs
@@ -9,6 +9,6 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         native: { not(target_arch = "wasm32") },
         linux_arm64: { all(target_os = "linux", target_arch = "aarch64") },
-        with_dav1d: { all(native, not(linux_arm64)) }, // https://github.com/rerun-io/rerun/issues/7755
+        with_dav1d: { all(feature = "av1", native, not(linux_arm64)) }, // https://github.com/rerun-io/rerun/issues/7755
     }
 }

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -136,6 +136,7 @@ pub fn new_decoder(
     );
 
     match &video.config.stsd.contents {
+        #[cfg(feature = "av1")]
         re_mp4::StsdBoxContent::Av01(_av01_box) => {
             #[cfg(linux_arm64)]
             {

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -77,7 +77,7 @@
 //! supporting HDR content at which point more properties will be important!
 //!
 
-#[cfg(feature = "av1")]
+#[cfg(with_dav1d)]
 #[cfg(not(target_arch = "wasm32"))]
 pub mod av1;
 
@@ -96,15 +96,19 @@ pub enum Error {
     #[error("Unsupported codec: {0}")]
     UnsupportedCodec(String),
 
-    #[cfg(feature = "av1")]
+    #[cfg(with_dav1d)]
     #[cfg(not(target_arch = "wasm32"))]
     #[error("dav1d: {0}")]
     Dav1d(#[from] dav1d::Error),
 
-    #[cfg(feature = "av1")]
+    #[cfg(with_dav1d)]
     #[cfg(not(target_arch = "wasm32"))]
     #[error("To enabled native AV1 decoding, compile Rerun with the `nasm` feature enabled.")]
     Dav1dWithoutNasm,
+
+    #[error("Rerun does not yet support native AV1 decoding on Linux ARM64. See https://github.com/rerun-io/rerun/issues/7755")]
+    #[cfg(linux_arm64)]
+    NoDav1dOnLinuxArm64,
 }
 
 pub type Result<T = (), E = Error> = std::result::Result<T, E>;
@@ -127,7 +131,7 @@ pub fn new_decoder(
     debug_name: String,
     video: &crate::VideoData,
 ) -> Result<Box<dyn SyncDecoder + Send + 'static>> {
-    #![allow(unused_variables)] // With some feature flags
+    #![allow(unused_variables, clippy::needless_return)] // With some feature flags
 
     re_log::trace!(
         "Looking for decoder for {}",
@@ -135,10 +139,17 @@ pub fn new_decoder(
     );
 
     match &video.config.stsd.contents {
-        #[cfg(feature = "av1")]
         re_mp4::StsdBoxContent::Av01(_av01_box) => {
-            re_log::trace!("Decoding AV1…");
-            Ok(Box::new(av1::SyncDav1dDecoder::new(debug_name)?))
+            #[cfg(linux_arm64)]
+            {
+                return Err(Error::NoDav1dOnLinuxArm64);
+            }
+
+            #[cfg(with_dav1d)]
+            {
+                re_log::trace!("Decoding AV1…");
+                return Ok(Box::new(av1::SyncDav1dDecoder::new(debug_name)?));
+            }
         }
 
         _ => Err(Error::UnsupportedCodec(video.human_readable_codec_string())),

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -78,7 +78,6 @@
 //!
 
 #[cfg(with_dav1d)]
-#[cfg(not(target_arch = "wasm32"))]
 pub mod av1;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -97,12 +96,10 @@ pub enum Error {
     UnsupportedCodec(String),
 
     #[cfg(with_dav1d)]
-    #[cfg(not(target_arch = "wasm32"))]
     #[error("dav1d: {0}")]
     Dav1d(#[from] dav1d::Error),
 
     #[cfg(with_dav1d)]
-    #[cfg(not(target_arch = "wasm32"))]
     #[error("To enabled native AV1 decoding, compile Rerun with the `nasm` feature enabled.")]
     Dav1dWithoutNasm,
 

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -58,8 +58,8 @@ pub enum DecodingError {
     UnsupportedCodec { codec: String },
 
     #[cfg(not(target_arch = "wasm32"))]
-    #[error("Native video decoding not supported in native debug builds.")]
-    NoNativeDebug,
+    #[error("Native AV1 video decoding not supported in debug builds.")]
+    NoNativeAv1Debug,
 
     #[error("Failed to create gpu texture from decoded video data: {0}")]
     ImageDataToTextureError(#[from] crate::resource_managers::ImageDataToTextureError),

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -27,7 +27,8 @@ snippet: archetypes/video_auto_frames
 Video support is new in Rerun, and has a few limitations:
 
 * [#7354](https://github.com/rerun-io/rerun/issues/7354): Only the MP4 container format is supported
-* [#7298](https://github.com/rerun-io/rerun/issues/7298): Only the AV1 codec is supported in the native viewer
+* [#7298](https://github.com/rerun-io/rerun/issues/7298): On native, only the AV1 codec is supported
+* [#7755](https://github.com/rerun-io/rerun/issues/7755): No AV1 support on Linux ARM
 * [#5181](https://github.com/rerun-io/rerun/issues/5181): There is no audio support
 * [#7594](https://github.com/rerun-io/rerun/issues/7594): HDR video is not supported
 * There is no video encoder in the Rerun SDK, so you need to create the video file yourself


### PR DESCRIPTION
### What
* Related to https://github.com/rerun-io/rerun/issues/7755

This simply disables AV1 video decoding on Linux ARM.

We can hopefully fix this for 0.20, either by fixing `re_rav1d`, or decoding via FFMPEG instead.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7769?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7769?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7769)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.