### PR TITLE
Fix dataframe table view auto-scroll bug

### DIFF
--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -239,24 +239,29 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                             .painter()
                             .layout(text, font_id, text_color, f32::INFINITY);
 
+                        // Extra padding for this being a button.
+                        let size = galley.size() + 2.0 * ui.spacing().button_padding;
+
                         // Put the text leftmost in the clip rect (so it is always visible)
                         let mut pos = egui::Align2::LEFT_CENTER
                             .anchor_size(
                                 ui.clip_rect().shrink(Self::LEFT_RIGHT_MARGIN).left_center(),
-                                galley.size(),
+                                size,
                             )
                             .min;
 
                         // … but not so far to the right that it doesn't fit.
-                        pos.x = pos.x.at_most(ui.max_rect().right() - galley.size().x);
+                        pos.x = pos.x.at_most(ui.max_rect().right() - size.x);
 
                         let item = re_viewer_context::Item::from(entity_path.clone());
                         let is_selected = self.ctx.selection().contains_item(&item);
                         let response = ui.put(
-                            egui::Rect::from_min_size(pos, galley.size()),
+                            egui::Rect::from_min_size(pos, size),
                             egui::SelectableLabel::new(is_selected, galley),
                         );
                         self.ctx.select_hovered_on_click(&response, item);
+
+                        // TODO(emilk): expand column(s) to make sure the text fits
                     }
                 } else if cell.row_nr == 1 {
                     let column = &self.selected_columns[cell.col_range.start];

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -261,7 +261,7 @@ impl<'a> egui_table::TableDelegate for DataframeTableDelegate<'a> {
                         );
                         self.ctx.select_hovered_on_click(&response, item);
 
-                        // TODO(emilk): expand column(s) to make sure the text fits
+                        // TODO(emilk): expand column(s) to make sure the text fits (requires egui_table fix).
                     }
                 } else if cell.row_nr == 1 {
                     let column = &self.selected_columns[cell.col_range.start];


### PR DESCRIPTION
### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7774?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7774?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7774)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.