### PR TITLE
Docs: move "roadmap" down to "development"

### DIFF
--- a/docs/content/development/architecture.md
+++ b/docs/content/development/architecture.md
@@ -1,5 +1,5 @@
 ---
 title: Architecture
-order: 0
+order: 50
 redirect: https://github.com/rerun-io/rerun/blob/main/ARCHITECTURE.md
 ---

--- a/docs/content/development/code_of_conduct.md
+++ b/docs/content/development/code_of_conduct.md
@@ -1,5 +1,5 @@
 ---
 title: Code of Conduct
-order: 1
+order: 100
 redirect: https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md
 ---

--- a/docs/content/development/contributing.md
+++ b/docs/content/development/contributing.md
@@ -1,5 +1,5 @@
 ---
 title: Contributing
-order: 2
+order: 200
 redirect: https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md
 ---

--- a/docs/content/development/roadmap.md
+++ b/docs/content/development/roadmap.md
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-order: 200
+order: 0
 ---
 Rerun is building a data management and visualization engine for multimodal data that changes over time.
 We aim to make it fast, and easy to use, and easy to adapt and integrate into your existing workflows.


### PR DESCRIPTION
Vertical space is very precious in "reference".

![image](https://github.com/user-attachments/assets/6977397b-b4f6-4513-bcf2-8d06d28df91d)

* [x] yes
