### PR TITLE
Doc page improvements for instancing & video

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
@@ -6,13 +6,15 @@ namespace rerun.archetypes;
 /// If both [archetypes.InstancePoses3D] and [archetypes.Transform3D] are present,
 /// first the tree propagating [archetypes.Transform3D] is applied, then [archetypes.InstancePoses3D].
 ///
-/// Currently, many visualizers support only a single instance transform per entity.
-/// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
-///
 /// From the point of view of the entity's coordinate system,
 /// all components are applied in the inverse order they are listed here.
 /// E.g. if both a translation and a max3x3 transform are present,
 /// the 3x3 matrix is applied first, followed by the translation.
+///
+/// Currently, many visualizers support only a single instance transform per entity.
+/// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
+/// Some visualizers like the mesh visualizer used for [`archetype.Mesh3D`],
+/// will draw an object for every pose, a behavior also known as "instancing".
 ///
 /// \example archetypes/instance_poses3d_combined title="Regular & instance transforms in tandem" image="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/1200w.png"
 /// \example archetypes/mesh3d_instancing !api title="3D mesh with instancing" image="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png"

--- a/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/instance_poses3d.fbs
@@ -15,6 +15,7 @@ namespace rerun.archetypes;
 /// the 3x3 matrix is applied first, followed by the translation.
 ///
 /// \example archetypes/instance_poses3d_combined title="Regular & instance transforms in tandem" image="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/1200w.png"
+/// \example archetypes/mesh3d_instancing !api title="3D mesh with instancing" image="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png"
 table InstancePoses3D (
   "attr.docs.category": "Spatial 3D",
   "attr.docs.view_types": "Spatial3DView, Spatial2DView: if logged above active projection",

--- a/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -10,7 +10,7 @@ namespace rerun.archetypes;
 ///
 /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-/// it will be resolved to a transform with only a rotation.]
+/// it will be resolved to a transform with only a rotation.
 ///
 /// For transforms that affect only a single entity and do not propagate along the entity tree refer to [archetypes.InstancePoses3D].
 ///

--- a/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/transform3d.fbs
@@ -10,7 +10,9 @@ namespace rerun.archetypes;
 ///
 /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-/// it will be resolved to a transform with only a rotation.
+/// it will be resolved to a transform with only a rotation.]
+///
+/// For transforms that affect only a single entity and do not propagate along the entity tree refer to [archetypes.InstancePoses3D].
 ///
 /// \example archetypes/transform3d_simple title="Variety of 3D transforms" image="https://static.rerun.io/transform3d_simple/141368b07360ce3fcb1553079258ae3f42bdb9ac/1200w.png"
 /// \example archetypes/transform3d_hierarchy title="Transform hierarchy" image="https://static.rerun.io/transform_hierarchy/cb7be7a5a31fcb2efc02ba38e434849248f87554/1200w.png"

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -23,13 +23,15 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// If both [`archetypes::InstancePoses3D`][crate::archetypes::InstancePoses3D] and [`archetypes::Transform3D`][crate::archetypes::Transform3D] are present,
 /// first the tree propagating [`archetypes::Transform3D`][crate::archetypes::Transform3D] is applied, then [`archetypes::InstancePoses3D`][crate::archetypes::InstancePoses3D].
 ///
-/// Currently, many visualizers support only a single instance transform per entity.
-/// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
-///
 /// From the point of view of the entity's coordinate system,
 /// all components are applied in the inverse order they are listed here.
 /// E.g. if both a translation and a max3x3 transform are present,
 /// the 3x3 matrix is applied first, followed by the translation.
+///
+/// Currently, many visualizers support only a single instance transform per entity.
+/// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
+/// Some visualizers like the mesh visualizer used for [`archetype.Mesh3D`],
+/// will draw an object for every pose, a behavior also known as "instancing".
 ///
 /// ## Example
 ///

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -27,7 +27,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-/// it will be resolved to a transform with only a rotation.]
+/// it will be resolved to a transform with only a rotation.
 ///
 /// For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes::InstancePoses3D`][crate::archetypes::InstancePoses3D].
 ///

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -27,7 +27,9 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///
 /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-/// it will be resolved to a transform with only a rotation.
+/// it will be resolved to a transform with only a rotation.]
+///
+/// For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes::InstancePoses3D`][crate::archetypes::InstancePoses3D].
 ///
 /// ## Examples
 ///

--- a/docs/content/reference/types/archetypes/instance_poses3d.md
+++ b/docs/content/reference/types/archetypes/instance_poses3d.md
@@ -30,7 +30,7 @@ the 3x3 matrix is applied first, followed by the translation.
  * 🐍 [Python API docs for `InstancePoses3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.InstancePoses3D)
  * 🦀 [Rust API docs for `InstancePoses3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.InstancePoses3D.html)
 
-## Example
+## Examples
 
 ### Regular & instance transforms in tandem
 
@@ -42,5 +42,17 @@ snippet: archetypes/instance_poses3d_combined
   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/1024w.png">
   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/1200w.png">
   <img src="https://static.rerun.io/leaf_transform3d/41674f0082d6de489f8a1cd1583f60f6b5820ddf/full.png">
+</picture>
+
+### 3D mesh with instancing
+
+snippet: archetypes/mesh3d_instancing
+
+<picture data-inline-viewer="snippets/mesh3d_instancing">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/1200w.png">
+  <img src="https://static.rerun.io/mesh3d_leaf_transforms3d/c2d0ee033129da53168f5705625a9b033f3a3d61/full.png">
 </picture>
 

--- a/docs/content/reference/types/archetypes/instance_poses3d.md
+++ b/docs/content/reference/types/archetypes/instance_poses3d.md
@@ -8,13 +8,15 @@ One or more transforms between the current entity and its parent. Unlike [`arche
 If both [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d) and [`archetypes.Transform3D`](https://rerun.io/docs/reference/types/archetypes/transform3d) are present,
 first the tree propagating [`archetypes.Transform3D`](https://rerun.io/docs/reference/types/archetypes/transform3d) is applied, then [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d).
 
-Currently, many visualizers support only a single instance transform per entity.
-Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
-
 From the point of view of the entity's coordinate system,
 all components are applied in the inverse order they are listed here.
 E.g. if both a translation and a max3x3 transform are present,
 the 3x3 matrix is applied first, followed by the translation.
+
+Currently, many visualizers support only a single instance transform per entity.
+Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
+Some visualizers like the mesh visualizer used for [`archetype.Mesh3D`],
+will draw an object for every pose, a behavior also known as "instancing".
 
 ## Components
 

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -12,7 +12,7 @@ the 3x3 matrix is applied first, followed by the translation.
 
 Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 This means that if you first log a transform with only a translation, and then log one with only a rotation,
-it will be resolved to a transform with only a rotation.]
+it will be resolved to a transform with only a rotation.
 
 For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d).
 

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -12,7 +12,9 @@ the 3x3 matrix is applied first, followed by the translation.
 
 Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
 This means that if you first log a transform with only a translation, and then log one with only a rotation,
-it will be resolved to a transform with only a rotation.
+it will be resolved to a transform with only a rotation.]
+
+For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes.InstancePoses3D`](https://rerun.io/docs/reference/types/archetypes/instance_poses3d).
 
 ## Components
 

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -85,7 +85,7 @@ At the moment, we test the following codecs:
 [^7]: Only supported if hardware encoding is available. Therefore always affected by Windows stuttering issues, see above.
 
 Beyond this, for best compatibility we recommend:
-* avoid RGB (as opposed to Yuv) & greyscale formats
+* prefer YUV over RGB & monochrome formats
 * don't use more than 8bit per color channel
 * keep resolutions at 8k & lower (see also [#3782](https://github.com/rerun-io/rerun/issues/3782))
 

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -57,11 +57,11 @@ It is implemented by all modern browsers, but with varying levels of support for
 
 With that in mind, here are the browsers which we have tested and verified to generally work:
 
-|            | Linux  | macOS | Windows |
-| ---------- | ------ | ----- | ------- |
-| Firefox    | ✅[^1] | ✅    | ✅      |
-| Chrome[^2] | ✅     | ✅    | ✅[^3]  |
-| Safari     |        | ✅    |         |
+|            | Linux | macOS | Windows |
+| ---------- | ----- | ----- | ------- |
+| Firefox    | ✅[^1] | ✅     | ✅       |
+| Chrome[^2] | ✅     | ✅     | ✅[^3]   |
+| Safari     |       | ✅     |         |
 
 [^1]: Firefox on Linux has been observed to [stutter when playing back H.264 video](https://github.com/rerun-io/rerun/issues/7532).
 [^2]: Any Chromium-based browser should work, but we don't test all of them.
@@ -75,15 +75,19 @@ At the moment, we test the following codecs:
 
 |            | Linux Firefox | Linux Chrome | macOS Firefox | macOS Chrome | macOS Safari | Windows Firefox | Windows Chrome |
 | ---------- | ------------- | ------------ | ------------- | ------------ | ------------ | --------------- | -------------- |
-| AV1        | ✅            | ✅           | ✅           | ✅           | 🚧[^4]        | ✅               | ✅             |
-| H.264/avc  | ✅            | ✅           | ✅           | ✅           | ✅            | ✅               | ✅             |
-| H.265/hevc | ❌            | ❌           | ❌           | ✅           | 🚧[^6]        | ❌               | 🚧[^7]         |
+| AV1        | ✅             | ✅            | ✅             | ✅            | 🚧[^4]        | ✅               | ✅              |
+| H.264/avc  | ✅             | ✅            | ✅             | ✅            | ✅            | ✅               | ✅              |
+| H.265/hevc | ❌             | ❌            | ❌             | ✅            | 🚧[^6]        | ❌               | 🚧[^7]          |
 
 [^4]: Safari/WebKit does not support AV1 decoding except on [Apple Silicon devices with hardware support](https://webkit.org/blog/14445/webkit-features-in-safari-17-0/).
 [^5]: Firefox does not support H.265 decoding on any platform.
 [^6]: Safari/WebKit has been observed suttering when playing `hvc1` but working fine with `hevc1`. Despite support being advertised Safari 16.5 has been observed not support H.265 decoding.
-[^7]: Only supported if hardware encoding is available. Therefore always affected by Windows stuttering issues, see [^3].
+[^7]: Only supported if hardware encoding is available. Therefore always affected by Windows stuttering issues, see above.
 
+Beyond this, for best compatibility we recommend:
+* avoid RGB (as opposed to Yuv) & greyscale formats
+* don't use more than 8bit per color channel
+* keep resolutions at 8k & lower (see also [#3782](https://github.com/rerun-io/rerun/issues/3782))
 
 ## Links
 * [Web video codec guide, by Mozilla](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)

--- a/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/instance_poses3d.hpp
@@ -25,13 +25,15 @@ namespace rerun::archetypes {
     /// If both `archetypes::InstancePoses3D` and `archetypes::Transform3D` are present,
     /// first the tree propagating `archetypes::Transform3D` is applied, then `archetypes::InstancePoses3D`.
     ///
-    /// Currently, many visualizers support only a single instance transform per entity.
-    /// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
-    ///
     /// From the point of view of the entity's coordinate system,
     /// all components are applied in the inverse order they are listed here.
     /// E.g. if both a translation and a max3x3 transform are present,
     /// the 3x3 matrix is applied first, followed by the translation.
+    ///
+    /// Currently, many visualizers support only a single instance transform per entity.
+    /// Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
+    /// Some visualizers like the mesh visualizer used for [`archetype.Mesh3D`],
+    /// will draw an object for every pose, a behavior also known as "instancing".
     ///
     /// ## Example
     ///

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -33,7 +33,9 @@ namespace rerun::archetypes {
     ///
     /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
     /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-    /// it will be resolved to a transform with only a rotation.
+    /// it will be resolved to a transform with only a rotation.]
+    ///
+    /// For transforms that affect only a single entity and do not propagate along the entity tree refer to `archetypes::InstancePoses3D`.
     ///
     /// ## Examples
     ///

--- a/rerun_cpp/src/rerun/archetypes/transform3d.hpp
+++ b/rerun_cpp/src/rerun/archetypes/transform3d.hpp
@@ -33,7 +33,7 @@ namespace rerun::archetypes {
     ///
     /// Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
     /// This means that if you first log a transform with only a translation, and then log one with only a rotation,
-    /// it will be resolved to a transform with only a rotation.]
+    /// it will be resolved to a transform with only a rotation.
     ///
     /// For transforms that affect only a single entity and do not propagate along the entity tree refer to `archetypes::InstancePoses3D`.
     ///

--- a/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/instance_poses3d.py
@@ -26,13 +26,15 @@ class InstancePoses3D(Archetype):
     If both [`archetypes.InstancePoses3D`][rerun.archetypes.InstancePoses3D] and [`archetypes.Transform3D`][rerun.archetypes.Transform3D] are present,
     first the tree propagating [`archetypes.Transform3D`][rerun.archetypes.Transform3D] is applied, then [`archetypes.InstancePoses3D`][rerun.archetypes.InstancePoses3D].
 
-    Currently, many visualizers support only a single instance transform per entity.
-    Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
-
     From the point of view of the entity's coordinate system,
     all components are applied in the inverse order they are listed here.
     E.g. if both a translation and a max3x3 transform are present,
     the 3x3 matrix is applied first, followed by the translation.
+
+    Currently, many visualizers support only a single instance transform per entity.
+    Check archetype documentations for details - if not otherwise specified, only the first instance transform is applied.
+    Some visualizers like the mesh visualizer used for [`archetype.Mesh3D`],
+    will draw an object for every pose, a behavior also known as "instancing".
 
     Example
     -------

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -28,7 +28,7 @@ class Transform3D(Transform3DExt, Archetype):
 
     Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
     This means that if you first log a transform with only a translation, and then log one with only a rotation,
-    it will be resolved to a transform with only a rotation.]
+    it will be resolved to a transform with only a rotation.
 
     For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes.InstancePoses3D`][rerun.archetypes.InstancePoses3D].
 

--- a/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/transform3d.py
@@ -28,7 +28,9 @@ class Transform3D(Transform3DExt, Archetype):
 
     Whenever you log this archetype, it will write all components, even if you do not explicitly set them.
     This means that if you first log a transform with only a translation, and then log one with only a rotation,
-    it will be resolved to a transform with only a rotation.
+    it will be resolved to a transform with only a rotation.]
+
+    For transforms that affect only a single entity and do not propagate along the entity tree refer to [`archetypes.InstancePoses3D`][rerun.archetypes.InstancePoses3D].
 
     Examples
     --------


### PR DESCRIPTION
### What

* more cross linking
* recycle instancing example
* general advice on picking browser compatible video formats 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7778?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7778?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7778)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.