### PR TITLE
Allow splitting entity path expressions with whitespace

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web, 🪵 Log & send APIs"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log-API, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web, 🪵 Log & send APIs"
+          labels: "📊 analytics, 🟦 blueprint, 🪳 bug, 🌊 C++ API, CLI, codegen/idl, 🧑‍💻 dev experience, dependencies, 📖 documentation, 💬 discussion, examples, exclude from changelog, 🪵 Log & send APIs, 📉 performance, 🐍 Python API, ⛃ re_datastore, 🔍 re_query, 📺 re_viewer, 🔺 re_renderer, 🚜 refactor, ⛴ release, 🦀 Rust API, 🔨 testing, ui, 🕸️ web"

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -314,7 +314,6 @@ impl EntityPathFilter {
         subst_env: &EntityPathSubs,
     ) -> Result<Self, EntityPathFilterParseError> {
         let split_rules = split_whitespace_smart(rules);
-
         Self::from_query_expressions_strict(split_rules, subst_env)
     }
 

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -192,6 +192,7 @@ fn split_whitespace_smart(path: &'_ str) -> Vec<&'_ str> {
         let mut i = 0;
         let mut is_in_escape = false;
         let mut is_include_exclude = false;
+        let mut new_token = true;
 
         // Find the next unescaped whitespace character not following a '+' or '-' character
         while i < bytes.len() {
@@ -206,9 +207,10 @@ fn split_whitespace_smart(path: &'_ str) -> Vec<&'_ str> {
             is_in_escape = bytes[i] == b'\\';
 
             if bytes[i] == b'+' || bytes[i] == b'-' {
-                is_include_exclude = true;
+                is_include_exclude = new_token;
             } else if !is_unescaped_whitespace {
                 is_include_exclude = false;
+                new_token = false;
             }
 
             i += 1;
@@ -976,6 +978,10 @@ fn test_split_whitespace_smart() {
     assert_eq!(
         split_whitespace_smart("+ a -\n b + c"),
         vec!["+ a", "-", "b", "+ c"]
+    );
+    assert_eq!(
+        split_whitespace_smart("/weird/path- +/oth- erpath"),
+        vec!["/weird/path-", "+/oth-", "erpath"]
     );
     assert_eq!(
         split_whitespace_smart(r"+world/** -/world/points"),

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -173,6 +173,25 @@ class TestDataframe:
         assert table.num_columns == 1
         assert table.num_rows == 1
 
+    def test_content_filters(self) -> None:
+        filter_expressions = [
+            "+/** -/static_text",
+            """
+            +/**
+            -/static_text
+            """,
+            {"/** -/static_text": ["Position3D", "Color"]},
+        ]
+
+        for expr in filter_expressions:
+            view = self.recording.view(index="my_index", contents=expr)
+
+            table = view.select().read_all()
+
+            # my_index, log_time, log_tick, points, colors
+            assert table.num_columns == 5
+            assert table.num_rows == 2
+
     def test_select_columns(self) -> None:
         view = self.recording.view(index="my_index", contents="points")
         index_col = rr.dataframe.IndexColumnSelector("my_index")


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7740

This is a little tricky since we don't want to split on whitespace that happens to show up between a + or - and the expression.

Logic seems correct from testing.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7782?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7782?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7782)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.