### PR TITLE
Pin sysroot to 2.17 to ensure cpp builds are linking against correct libc

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -466,6 +466,12 @@ meilisearch = "1.5.1.*" # not available for linux-aarch64
 [target.osx-arm64.dependencies]
 meilisearch = "1.5.1.*"
 
+[feature.cpp.target.linux-64.dependencies]
+sysroot_linux-64 = ">=2.17,<3" # rustc 1.64+ requires glibc 2.17+, see https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
+
+[feature.cpp.target.linux-aarch64.dependencies]
+sysroot_linux-aarch64 = ">=2.17,<3" # rustc 1.64+ requires glibc 2.17+, see https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html
+
 [feature.cpp.target.unix.dependencies]
 clang = "16.0.6"
 ninja = "1.11.1"


### PR DESCRIPTION
### What

As indicated by the lack of pixi.lock changes, this was already the case.
Making it explicit to avoid issues when removing dependencies & to hedge against copy&paste surprises.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7792?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7792?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7792)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.