### PR TITLE
Fix Rerun 3.9 compatibility: Remove imports of `TypeAlias`

### DIFF
--- a/examples/python/ocr/ocr.py
+++ b/examples/python/ocr/ocr.py
@@ -8,7 +8,7 @@ import logging
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any, Final, Iterable, Optional, TypeAlias
+from typing import Any, Final, Iterable, Optional
 
 import cv2 as cv2
 import numpy as np
@@ -21,6 +21,7 @@ import rerun.blueprint as rrb
 import tqdm
 from paddleocr import PPStructure
 from paddleocr.ppstructure.recovery.recovery_to_doc import sorted_layout_boxes
+from typing_extensions import TypeAlias
 
 EXAMPLE_DIR: Final = Path(os.path.dirname(__file__))
 DATASET_DIR: Final = EXAMPLE_DIR / "dataset"

--- a/rerun_py/rerun_bindings/__init__.py
+++ b/rerun_py/rerun_bindings/__init__.py
@@ -1,5 +1,3 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias, Union
-
 from .rerun_bindings import *

--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Union
+from typing import TYPE_CHECKING, Sequence, Type, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -34,7 +34,7 @@ AnyComponentColumn: TypeAlias = Union[
 ]
 """A type alias for any component-column-like object."""
 
-ComponentLike: TypeAlias = Union[str, type["ComponentMixin"]]
+ComponentLike: TypeAlias = Union[str, Type["ComponentMixin"]]
 """
 A type alias for a component-like object used for content-expressions and column selectors.
 

--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence, Type, Union
+from typing import TYPE_CHECKING, Dict, Sequence, Type, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -51,7 +51,7 @@ Examples:
 
 ViewContentsLike: TypeAlias = Union[
     str,
-    dict[str, Union[AnyColumn, Sequence[ComponentLike]]],
+    Dict[str, Union[AnyColumn, Sequence[ComponentLike]]],
 ]
 """
 A type alias for specifying the contents of a view.


### PR DESCRIPTION
### What
* This should fix https://github.com/rerun-io/rerun/issues/7793

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.