### PR TITLE
Make sure to always write out end-of-stream markers during encoding

### DIFF
--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -216,7 +216,7 @@ impl RetryableFileReader {
 mod tests {
     use re_build_info::CrateVersion;
     use re_chunk::RowId;
-    use re_log_encoding::{decoder, encoder::Encoder};
+    use re_log_encoding::{decoder, encoder::DroppableEncoder};
     use re_log_types::{
         ApplicationId, LogMsg, SetStoreInfo, StoreId, StoreInfo, StoreKind, StoreSource, Time,
     };
@@ -247,7 +247,7 @@ mod tests {
             .open(rrd_file_path.to_str().unwrap())
             .unwrap();
 
-        let mut encoder = Encoder::new(
+        let mut encoder = DroppableEncoder::new(
             re_build_info::CrateVersion::LOCAL,
             re_log_encoding::EncodingOptions::UNCOMPRESSED,
             rrd_file,

--- a/crates/store/re_log_encoding/src/encoder.rs
+++ b/crates/store/re_log_encoding/src/encoder.rs
@@ -48,7 +48,7 @@ pub fn encode_to_bytes<'a>(
 
 // ----------------------------------------------------------------------------
 
-/// An [`Encoder`] that can be dropped.
+/// An [`Encoder`] that properly closes the stream on drop.
 ///
 /// When dropped, it will automatically insert an end-of-stream marker, if that wasn't already done manually.
 pub struct DroppableEncoder<W: std::io::Write> {

--- a/crates/store/re_log_encoding/src/file_sink.rs
+++ b/crates/store/re_log_encoding/src/file_sink.rs
@@ -75,7 +75,7 @@ impl FileSink {
 
         let file = std::fs::File::create(&path)
             .map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-        let encoder = crate::encoder::Encoder::new(
+        let encoder = crate::encoder::DroppableEncoder::new(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
             file,
@@ -97,7 +97,7 @@ impl FileSink {
 
         re_log::debug!("Writing to stdout…");
 
-        let encoder = crate::encoder::Encoder::new(
+        let encoder = crate::encoder::DroppableEncoder::new(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
             std::io::stdout(),
@@ -127,7 +127,7 @@ impl FileSink {
 /// Set `filepath` to `None` to stream to standard output.
 fn spawn_and_stream<W: std::io::Write + Send + 'static>(
     filepath: Option<&std::path::Path>,
-    mut encoder: crate::encoder::Encoder<W>,
+    mut encoder: crate::encoder::DroppableEncoder<W>,
     rx: Receiver<Option<Command>>,
 ) -> Result<std::thread::JoinHandle<()>, FileSinkError> {
     let (name, target) = if let Some(filepath) = filepath {

--- a/crates/top/re_sdk/src/binary_stream_sink.rs
+++ b/crates/top/re_sdk/src/binary_stream_sink.rs
@@ -133,7 +133,7 @@ impl BinaryStreamSink {
 
         let (tx, rx) = std::sync::mpsc::channel();
 
-        let encoder = re_log_encoding::encoder::Encoder::new(
+        let encoder = re_log_encoding::encoder::DroppableEncoder::new(
             re_build_info::CrateVersion::LOCAL,
             encoding_options,
             storage.inner.clone(),
@@ -167,7 +167,7 @@ impl LogSink for BinaryStreamSink {
 
 /// Spawn the encoder thread that will write log messages to the binary stream.
 fn spawn_and_stream<W: std::io::Write + Send + 'static>(
-    mut encoder: re_log_encoding::encoder::Encoder<W>,
+    mut encoder: re_log_encoding::encoder::DroppableEncoder<W>,
     rx: Receiver<Option<Command>>,
 ) -> Result<std::thread::JoinHandle<()>, BinaryStreamSinkError> {
     std::thread::Builder::new()

--- a/crates/top/re_sdk/src/log_sink.rs
+++ b/crates/top/re_sdk/src/log_sink.rs
@@ -2,8 +2,8 @@ use std::fmt;
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use re_log_encoding::encoder::EncodeError;
-use re_log_encoding::encoder::{encode_as_bytes_local, local_encoder};
+use re_log_encoding::encoder::encode_as_bytes_local;
+use re_log_encoding::encoder::{local_raw_encoder, EncodeError};
 use re_log_types::{BlueprintActivationCommand, LogMsg, StoreId};
 
 use crate::RecordingStream;
@@ -250,7 +250,7 @@ impl MemorySinkStorage {
     /// This automatically takes care of flushing the underlying [`crate::RecordingStream`].
     #[inline]
     pub fn concat_memory_sinks_as_bytes(sinks: &[&Self]) -> Result<Vec<u8>, EncodeError> {
-        let mut encoder = local_encoder()?;
+        let mut encoder = local_raw_encoder()?;
 
         for sink in sinks {
             // NOTE: It's fine, this is an in-memory sink so by definition there's no I/O involved
@@ -263,6 +263,8 @@ impl MemorySinkStorage {
                 encoder.append(message)?;
             }
         }
+
+        encoder.finish()?;
 
         Ok(encoder.into_inner())
     }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -950,7 +950,7 @@ fn stream_to_rrd_on_disk(
     let encoding_options = re_log_encoding::EncodingOptions::COMPRESSED;
     let file =
         std::fs::File::create(path).map_err(|err| FileSinkError::CreateFile(path.clone(), err))?;
-    let mut encoder = re_log_encoding::encoder::Encoder::new(
+    let mut encoder = re_log_encoding::encoder::DroppableEncoder::new(
         re_build_info::CrateVersion::LOCAL,
         encoding_options,
         file,

--- a/crates/top/rerun/src/commands/rrd/filter.rs
+++ b/crates/top/rerun/src/commands/rrd/filter.rs
@@ -84,7 +84,7 @@ impl FilterCommand {
                     // TODO(cmc): encoding options & version should match the original.
                     let version = CrateVersion::LOCAL;
                     let options = re_log_encoding::EncodingOptions::COMPRESSED;
-                    re_log_encoding::encoder::Encoder::new(version, options, &mut rrd_out)
+                    re_log_encoding::encoder::DroppableEncoder::new(version, options, &mut rrd_out)
                         .context("couldn't init encoder")?
                 };
 
@@ -93,6 +93,7 @@ impl FilterCommand {
                     size_bytes += encoder.append(&msg).context("encoding failure")?;
                 }
 
+                drop(encoder);
                 rrd_out.flush().context("couldn't flush output")?;
 
                 Ok(size_bytes)


### PR DESCRIPTION
Saving Rerun RRD data can happen in many, many different ways, and it must always make sure to include the end-of-stream marker.
This is unfortunately not trivial because many things want to partial move out of `Encoder`, which rules out `impl Drop`.

This PR introduces a `DroppableEncoder` that can be used in many cases, or makes sure to properly `finish()` otherwise.

This fixes half of the issues described in:
* #7791 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7796?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7796?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7796)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.