### PR TITLE
Mention in migration guide that .rbl files will no longer load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD) - Dataframe & Video
 
-TODO(emilk): insert a screenshot and/or code sample here
+<!-- TODO(emilk): insert a screenshot and/or code sample here -->
 
-📖 Release blogpost: TODO(emilk): add link
+📖 Release blogpost: Coming soon! <!-- TODO(niko): link to it! -->
 
 🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ While the web viewer supports a variety of codecs, the native viewer supports on
 Read more about our video supports (and its limits) [in our video docs](https://rerun.io/docs/reference/video).
 
 ### ⚠️ Breaking changes
-* 🗾 Blueprint files (.rbl) from previous Rerun versions will no longer load
+* 🗾 Blueprint files (.rbl) from previous Rerun versions will no longer load _automatically_
 * 🐧 Linux: Rerun now require glibc 2.17+
 * 🦀 Rust: The minimum supported Rust version is now 1.79
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ While the web viewer supports a variety of codecs, the native viewer supports on
 Read more about our video supports (and its limits) [in our video docs](https://rerun.io/docs/reference/video).
 
 ### ⚠️ Breaking changes
+* 🗾 Blueprint files (.rbl) from previous Rerun versions will no longer load
 * 🐧 Linux: Rerun now require glibc 2.17+
 * 🦀 Rust: The minimum supported Rust version is now 1.79
 

--- a/docs/content/reference/migration/migration-0-19.md
+++ b/docs/content/reference/migration/migration-0-19.md
@@ -3,7 +3,7 @@ title: Migrating from 0.18 to 0.19
 order: 190
 ---
 
-Blueprint files (.rbl) from previous Rerun versions will no longer load
+Blueprint files (.rbl) from previous Rerun versions will no longer load _automatically_.
 
 ### 🐧 Linux
 Rerun now require glibc 2.17 or higher.

--- a/docs/content/reference/migration/migration-0-19.md
+++ b/docs/content/reference/migration/migration-0-19.md
@@ -3,11 +3,13 @@ title: Migrating from 0.18 to 0.19
 order: 190
 ---
 
+Blueprint files (.rbl) from previous Rerun versions will no longer load
+
 ### 🐧 Linux
 Rerun now require glibc 2.17 or higher.
 
 This is because we updated the Rust version. See <https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html> for more details.
 
-### Rust
+### 🦀 Rust
 - Update MSRV to Rust 1.79 [#7563](https://github.com/rerun-io/rerun/pull/7563)
 - Update ndarray to 0.16 and ndarray-rand to 0.15 [#7358](https://github.com/rerun-io/rerun/pull/7358) (thanks [@benliepert](https://github.com/benliepert)!)


### PR DESCRIPTION
* [x] checkbox