### PR TITLE
Add screenshot/live viewer to the dataframe view doc

### DIFF
--- a/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
@@ -5,7 +5,6 @@ namespace rerun.blueprint.views;
 /// Any data from the store can be shown, using a flexibly, user-configurable query.
 ///
 /// \example views/dataframe title="Use a blueprint to customize a DataframeView." image="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1200w.png"
-//TODO(#6896): add a thumbnail when the example becomes interesting
 table DataframeView (
     "attr.rerun.view_identifier": "Dataframe",
     "attr.docs.unreleased"

--- a/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
@@ -4,7 +4,7 @@ namespace rerun.blueprint.views;
 ///
 /// Any data from the store can be shown, using a flexibly, user-configurable query.
 ///
-/// \example views/dataframe title="Use a blueprint to customize a DataframeView." image="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png"
+/// \example views/dataframe title="Use a blueprint to customize a DataframeView." image="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1200w.png"
 //TODO(#6896): add a thumbnail when the example becomes interesting
 table DataframeView (
     "attr.rerun.view_identifier": "Dataframe",

--- a/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/views/dataframe.fbs
@@ -4,7 +4,7 @@ namespace rerun.blueprint.views;
 ///
 /// Any data from the store can be shown, using a flexibly, user-configurable query.
 ///
-/// \example views/dataframe title="Use a blueprint to customize a DataframeView."
+/// \example views/dataframe title="Use a blueprint to customize a DataframeView." image="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png"
 //TODO(#6896): add a thumbnail when the example becomes interesting
 table DataframeView (
     "attr.rerun.view_identifier": "Dataframe",

--- a/docs/content/reference/types/views/dataframe_view.md
+++ b/docs/content/reference/types/views/dataframe_view.md
@@ -28,11 +28,11 @@ Query of the dataframe.
 snippet: views/dataframe
 
 <picture data-inline-viewer="snippets/dataframe">
-  <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/480w.png">
-  <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/768w.png">
-  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1024w.png">
-  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png">
-  <img src="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/full.png">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1200w.png">
+  <img src="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/full.png">
 </picture>
 
 

--- a/docs/content/reference/types/views/dataframe_view.md
+++ b/docs/content/reference/types/views/dataframe_view.md
@@ -27,6 +27,14 @@ Query of the dataframe.
 
 snippet: views/dataframe
 
+<picture data-inline-viewer="snippets/dataframe">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png">
+  <img src="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/full.png">
+</picture>
+
 
 ## Visualized archetypes
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/dataframe_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/dataframe_view.py
@@ -57,6 +57,15 @@ class DataframeView(SpaceView):
 
     rr.send_blueprint(blueprint)
     ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png">
+      <img src="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/full.png" width="640">
+    </picture>
+    </center>
 
     """
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/views/dataframe_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/views/dataframe_view.py
@@ -59,11 +59,11 @@ class DataframeView(SpaceView):
     ```
     <center>
     <picture>
-      <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/480w.png">
-      <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/768w.png">
-      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1024w.png">
-      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/1200w.png">
-      <img src="https://static.rerun.io/dataframe_view/6c2cf85f7caa94392953869567fad4818fce78e3/full.png" width="640">
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/1200w.png">
+      <img src="https://static.rerun.io/dataframe_view/f89ae330b04baaa9b7576765dce37b5d4e7cef4e/full.png" width="640">
     </picture>
     </center>
 


### PR DESCRIPTION
### What

Add a screenshot (and thus a live viewer) to the dataframe view generated docs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7805?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7805?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7805)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.