### PR TITLE
Fix mixup of composition & decode timestamp, causing video stuttering for videos with bframes

### DIFF
--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -74,13 +74,16 @@ impl SyncDav1dDecoder {
 
     fn submit_chunk(&mut self, chunk: Chunk, on_output: &OutputCallback) {
         re_tracing::profile_function!();
-        econtext::econtext_function_data!(format!("chunk timestamp: {:?}", chunk.timestamp));
+        econtext::econtext_function_data!(format!(
+            "chunk timestamp: {:?}",
+            chunk.composition_timestamp
+        ));
 
         re_tracing::profile_scope!("send_data");
         match self.decoder.send_data(
             chunk.data,
             None,
-            Some(chunk.timestamp.0),
+            Some(chunk.composition_timestamp.0),
             Some(chunk.duration.0),
         ) {
             Ok(()) => {}

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -170,7 +170,11 @@ pub struct Chunk {
     pub is_sync: bool,
 
     pub data: Vec<u8>,
-    pub timestamp: Time,
+
+    /// Presentation/composition timestamp for the sample in this chunk.
+    /// *not* decode timestamp.
+    pub composition_timestamp: Time,
+
     pub duration: Time,
 }
 

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -251,7 +251,7 @@ impl VideoData {
 
             Some(Chunk {
                 data: data.to_vec(),
-                timestamp: sample.decode_timestamp,
+                composition_timestamp: sample.composition_timestamp,
                 duration: sample.duration,
                 is_sync: sample.is_sync,
             })

--- a/crates/viewer/re_renderer/src/video/decoder/web.rs
+++ b/crates/viewer/re_renderer/src/video/decoder/web.rs
@@ -135,7 +135,9 @@ impl VideoChunkDecoder for WebVideoDecoder {
         };
         let web_chunk = EncodedVideoChunkInit::new(
             &data,
-            video_chunk.timestamp.into_micros(self.data.timescale),
+            video_chunk
+                .composition_timestamp
+                .into_micros(self.data.timescale),
             type_,
         );
         web_chunk.set_duration(video_chunk.duration.into_micros(self.data.timescale));


### PR DESCRIPTION
### What

This regressed during a recent refactor.
Renamed chunk.timestamp and document it to avoid future blunders. Todo for later: always call it composition timestamp.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7806?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7806?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7806)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.