### PR TITLE
Fix doc links from cleanup in #7776

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,7 +262,7 @@ API usage examples:
 
 The Rerun datastore now continuously compacts data as it comes in, in order find a sweet spot between ingestion speed, query performance and memory overhead.
 
-This is very similar to, and has many parallels with, the [micro-batching mechanism running on the SDK side](https://rerun.io/docs/reference/sdk-micro-batching).
+This is very similar to, and has many parallels with, the [micro-batching mechanism running on the SDK side](https://rerun.io/docs/reference/sdk/micro-batching).
 
 You can read more about this in the [dedicated documentation entry](https://rerun.io/docs/reference/store-compaction).
 
@@ -1961,7 +1961,7 @@ Other highlights:
    - This can be used as an alternative to the previous `MsgSender::with_time` APIs.
  - The Rerun SDK now defaults to 8ms long microbatches instead of 50ms. This makes the default behavior more suitable
 for use-cases like real-time video feeds. [#2220](https://github.com/rerun-io/rerun/pull/2220)
-   - Check out [the microbatching docs](https://www.rerun.io/docs/reference/sdk-micro-batching) for more information
+   - Check out [the microbatching docs](https://www.rerun.io/docs/reference/sdk/micro-batching) for more information
    on fine-tuning the micro-batching behavior.
  - The web viewer now incremental loads `.rrd` files when streaming over HTTP. [#2412](https://github.com/rerun-io/rerun/pull/2412)
 
@@ -2292,7 +2292,7 @@ here's a smaller release packed with useful improvements 🎉
 - ⚠️ BREAKING: You must now call `rr.init` if you want logging to work.
 - ⚠️ BREAKING: `set_enabled` has been removed.
   In order to disable logging at runtime, call `set_global_data_recording(None)`.
-  See also [the doc section on this topic](https://www.rerun.io/docs/reference/sdk-logging-controls#dynamically-turn-logging-onoff).
+  See also [the doc section on this topic](https://www.rerun.io/docs/reference/sdk/logging-controls#dynamically-turn-logging-onoff).
 - `log_mesh_file`: accept either path or bytes [#2098](https://github.com/rerun-io/rerun/pull/2098)
 - Add `draw_order` to 2D primitives [#2138](https://github.com/rerun-io/rerun/pull/2138)
 - Add `rr.version()` [#2084](https://github.com/rerun-io/rerun/pull/2084)
@@ -2305,7 +2305,7 @@ here's a smaller release packed with useful improvements 🎉
 #### 🦀 Rust SDK
 - ⚠️ BREAKING: `set_enabled` has been removed.
   In order to disable logging at runtime, create a no-op recording via `RecordingStream::disabled()`.
-  See also [the doc section on this topic](https://www.rerun.io/docs/reference/sdk-logging-controls#dynamically-turn-logging-onoff).
+  See also [the doc section on this topic](https://www.rerun.io/docs/reference/sdk/logging-controls#dynamically-turn-logging-onoff).
 - ⚠️ BREAKING: `Session` has been replaced by `RecordingStream` [#1983](https://github.com/rerun-io/rerun/pull/1983)
 - ⚠️ BREAKING: `native_viewer` is now an opt-in feature of the `rerun` library [#2064](https://github.com/rerun-io/rerun/pull/2064)
 - Rust SDK: bring back support for implicit splats [#2059](https://github.com/rerun-io/rerun/pull/2059)

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -883,7 +883,7 @@ impl RecordingStream {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     ///
-    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
+    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk/micro-batching
     /// [component bundle]: [`AsComponents`]
     #[inline]
     pub fn log(
@@ -966,7 +966,7 @@ impl RecordingStream {
     ///
     /// See also [`Self::log`].
     ///
-    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
+    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk/micro-batching
     /// [component bundle]: [`AsComponents`]
     #[inline]
     pub fn log_static(
@@ -1009,7 +1009,7 @@ impl RecordingStream {
     /// transport.
     /// See [SDK Micro Batching] for more information.
     ///
-    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
+    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk/micro-batching
     /// [component bundle]: [`AsComponents`]
     #[inline]
     pub fn log_with_static(
@@ -1051,7 +1051,7 @@ impl RecordingStream {
     /// transport.
     /// See [SDK Micro Batching] for more information.
     ///
-    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk-micro-batching
+    /// [SDK Micro Batching]: https://www.rerun.io/docs/reference/sdk/micro-batching
     pub fn log_component_batches<'a>(
         &self,
         ent_path: impl Into<EntityPath>,

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -22,7 +22,7 @@
 //! trying to achieve and whether the viewer is running in the same process as your code, in
 //! another process, or even as a separate web application.
 //!
-//! Checkout [SDK Operating Modes](https://www.rerun.io/docs/reference/sdk-operating-modes) for an
+//! Checkout [SDK Operating Modes](https://www.rerun.io/docs/reference/sdk/operating-modes) for an
 //! overview of what's possible and how.
 //!
 //! If you get stuck on anything, open an issue at <https://github.com/rerun-io/rerun/issues>.

--- a/crates/viewer/re_viewer/data/quick_start_guides/how_does_it_work.md
+++ b/crates/viewer/re_viewer/data/quick_start_guides/how_does_it_work.md
@@ -2,7 +2,7 @@
 
 Rerun's goal is to make handling and visualizing multimodal data streams easy and performant.
 
-Rerun is made of two main building blocks: the SDK and the Viewer. The data provided by the user code is serialized by the SDK and transferred (via a log file, a TCP socket, a WebSocket, etc.) to the Viewer process for visualization. You can learn more about Rerun's operating modes [here](https://www.rerun.io/docs/reference/sdk-operating-modes).
+Rerun is made of two main building blocks: the SDK and the Viewer. The data provided by the user code is serialized by the SDK and transferred (via a log file, a TCP socket, a WebSocket, etc.) to the Viewer process for visualization. You can learn more about Rerun's operating modes [here](https://www.rerun.io/docs/reference/sdk/operating-modes).
 
 In the example above, the SDK connects via a TCP socket to the viewer.
 

--- a/docs/content/getting-started/data-out/analyze-and-log.md
+++ b/docs/content/getting-started/data-out/analyze-and-log.md
@@ -1,0 +1,6 @@
+---
+title: Analyze the data and send back the results
+order: 3
+redirect: data-out/analyze-and-send
+hidden: true
+---

--- a/docs/content/getting-started/data-out/analyze-and-log.md
+++ b/docs/content/getting-started/data-out/analyze-and-log.md
@@ -1,7 +1,7 @@
 ---
 title: Analyze the data and send back the results
 order: 3
-redirect: data-out/analyze-and-send
+redirect: getting-started/data-out/analyze-and-send
 hidden: true
 ---
 <!--Published blog posts refer to this page-->

--- a/docs/content/getting-started/data-out/analyze-and-log.md
+++ b/docs/content/getting-started/data-out/analyze-and-log.md
@@ -4,3 +4,4 @@ order: 3
 redirect: data-out/analyze-and-send
 hidden: true
 ---
+<!--Published blog posts refer to this page-->

--- a/docs/content/howto/embed-rerun-viewer.md
+++ b/docs/content/howto/embed-rerun-viewer.md
@@ -62,7 +62,7 @@ The first argument for `start` determines the recordings to open in the viewer. 
 - a URL string to open a single recording
 - an array of strings to open multiple recordings
 
-Each URL can be either a file served over `http` or a connection to an SDK using our [serve](https://www.rerun.io/docs/reference/sdk-operating-modes#serve) API. See [web-viewer-serve-example](https://github.com/rerun-io/web-viewer-serve-example) for a full example of how to log data from our Python SDK to an embedded Rerun Viewer.
+Each URL can be either a file served over `http` or a connection to an SDK using our [serve](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API. See [web-viewer-serve-example](https://github.com/rerun-io/web-viewer-serve-example) for a full example of how to log data from our Python SDK to an embedded Rerun Viewer.
 
 ### Controlling the canvas
 

--- a/docs/content/reference/data-loaders/overview.md
+++ b/docs/content/reference/data-loaders/overview.md
@@ -22,7 +22,7 @@ The easiest way to create your own `DataLoader` is by implementing what we call 
 
 This executable takes a file path as a command line argument and outputs Rerun logs on `stdout`.
 It will be called by the Rerun Viewer/SDK when the user opens a file, and be passed the path to that file.
-From there, it can log data as usual, using the [`stdout` logging sink](../../reference/sdk-operating-modes.md#standard-inputoutput).
+From there, it can log data as usual, using the [`stdout` logging sink](../../reference/sdk/operating-modes.md#standard-inputoutput).
 
 The Rerun Viewer/SDK will then automatically load the data streamed to the external loader's standard output.
 

--- a/docs/content/reference/sdk-micro-batching.md
+++ b/docs/content/reference/sdk-micro-batching.md
@@ -1,0 +1,6 @@
+---
+title: Micro Batching
+order: 700
+redirect: reference/sdk/micro-batching
+hidden: true
+---

--- a/docs/content/reference/sdk-micro-batching.md
+++ b/docs/content/reference/sdk-micro-batching.md
@@ -4,3 +4,4 @@ order: 700
 redirect: reference/sdk/micro-batching
 hidden: true
 ---
+<!--Published blog posts refer to this page-->

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -1,0 +1,6 @@
+---
+title: Operating Modes
+order: 800
+redirect: reference/sdk/operating-modes
+hidden: true
+---

--- a/docs/content/reference/sdk-operating-modes.md
+++ b/docs/content/reference/sdk-operating-modes.md
@@ -4,3 +4,4 @@ order: 800
 redirect: reference/sdk/operating-modes
 hidden: true
 ---
+<!--Published blog posts refer to this page-->

--- a/docs/content/reference/sdk/micro-batching.md
+++ b/docs/content/reference/sdk/micro-batching.md
@@ -8,7 +8,7 @@ The Rerun SDK automatically handles micro-batching in a background thread in ord
 
 The flushing is triggered by both time and space thresholds, whichever happens to trigger first.
 
-This is very similar to, and has many parallels with, the [compaction mechanism running on the datastore side](./store-compaction.md).
+This is very similar to, and has many parallels with, the [compaction mechanism running on the datastore side](../store-compaction.md).
 
 You can configure these thresholds using the following environment variables:
 

--- a/docs/content/reference/store-compaction.md
+++ b/docs/content/reference/store-compaction.md
@@ -8,7 +8,7 @@ The Rerun datastore continuously compacts data as it comes in, in order find a s
 
 The compaction is triggered by both number of rows and number of bytes thresholds, whichever happens to trigger first.
 
-This is very similar to, and has many parallels with, the [micro-batching mechanism running on the SDK side](./sdk-micro-batching.md).
+This is very similar to, and has many parallels with, the [micro-batching mechanism running on the SDK side](./sdk/micro-batching.md).
 
 You can configure these thresholds using the following environment variables:
 

--- a/rerun_cpp/src/rerun/recording_stream.hpp
+++ b/rerun_cpp/src/rerun/recording_stream.hpp
@@ -52,7 +52,7 @@ namespace rerun {
     ///
     /// Internally, the stream will automatically micro-batch multiple log calls to optimize
     /// transport.
-    /// See [SDK Micro Batching](https://www.rerun.io/docs/reference/sdk-micro-batching) for
+    /// See [SDK Micro Batching](https://www.rerun.io/docs/reference/sdk/micro-batching) for
     /// more information.
     ///
     /// The data will be timestamped automatically based on the `RecordingStream`'s

--- a/rerun_js/web-viewer-react/README.md
+++ b/rerun_js/web-viewer-react/README.md
@@ -36,7 +36,7 @@ export default function App() {
 
 The `rrd` in the snippet above should be a URL pointing to either:
 - A hosted `.rrd` file, such as <https://app.rerun.io/version/0.19.0-alpha.13/examples/dna.rrd>
-- A WebSocket connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk-operating-modes#serve) API
+- A WebSocket connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.
 This can be disabled by setting the `hide_welcome_screen` prop to `true`.

--- a/rerun_js/web-viewer/README.md
+++ b/rerun_js/web-viewer/README.md
@@ -42,7 +42,7 @@ viewer.stop();
 
 The `rrd` in the snippet above should be a URL pointing to either:
 - A hosted `.rrd` file, such as <https://app.rerun.io/version/0.19.0-alpha.13/examples/dna.rrd>
-- A WebSocket connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk-operating-modes#serve) API
+- A WebSocket connection to the SDK opened via the [`serve`](https://www.rerun.io/docs/reference/sdk/operating-modes#serve) API
 
 If `rrd` is not set, the Viewer will display the same welcome screen as <https://app.rerun.io>.
 This can be disabled by setting `hide_welcome_screen` to `true` in the options object of `viewer.start`.

--- a/rerun_py/docs/gen_common_index.py
+++ b/rerun_py/docs/gen_common_index.py
@@ -432,7 +432,7 @@ There are many different ways of sending data to the Rerun Viewer depending on w
 to achieve and whether the viewer is running in the same process as your code, in another process,
 or even as a separate web application.
 
-Checkout [SDK Operating Modes](https://www.rerun.io/docs/reference/sdk-operating-modes) for an
+Checkout [SDK Operating Modes](https://www.rerun.io/docs/reference/sdk/operating-modes) for an
 overview of what's possible and how.
 
 ## APIs


### PR DESCRIPTION
### What
Links got missed during the cleanup.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7809?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7809?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7809)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.