### PR TITLE
[bugfix] Make sure blueprint gets sent to the notebook view being created

### DIFF
--- a/rerun_py/rerun_sdk/rerun/notebook.py
+++ b/rerun_py/rerun_sdk/rerun/notebook.py
@@ -92,9 +92,6 @@ class Viewer:
 
         self._recording = recording
 
-        if blueprint is not None:
-            self._recording.send_blueprint(blueprint)  # type: ignore[attr-defined]
-
         self._viewer = _Viewer(
             width=width if width is not None else _default_width,
             height=height if height is not None else _default_height,
@@ -104,6 +101,9 @@ class Viewer:
             recording=RecordingStream.to_native(self._recording),
             callback=self._flush_hook,
         )
+
+        if blueprint is not None:
+            self._recording.send_blueprint(blueprint)  # type: ignore[attr-defined]
 
     def display(self, block_until_ready: bool = True) -> None:
         """


### PR DESCRIPTION
### What

Without this the blueprint goes to the old view before the new view gets set up.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7811?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7811?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7811)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.