### PR TITLE
Remove py-tasks feature from py-docs env

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -55,7 +55,7 @@ default = ["base", "wheel-build"]
 py = ["base", "wheel-build", "python-dev", "python-tasks", "py-test-deps"]
 
 # The py-docs environment is for building docs for the python package.
-py-docs = ["base", "python-docs", "python-tasks"]
+py-docs = ["base", "python-docs"]
 
 # The cpp environment is for building any code that depends on the C++ `rerun-sdk`.
 cpp = ["base", "cpp"]


### PR DESCRIPTION
### What
Fixes task ambiguity on the `py-build` task:
```
➜  pixi run py-build
? The task 'py-build' can be run in multiple environments.

Please select an environment to run the task in: ›
❯ py
  py-docs
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7835?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7835?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7835)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.