### PR TITLE
Update "Migration Guides" redirect to point to 0.19.

### DIFF
--- a/docs/content/reference/migration.md
+++ b/docs/content/reference/migration.md
@@ -1,5 +1,5 @@
 ---
 title: Migration Guides
 order: 1000
-redirect: reference/migration/migration-0-18
+redirect: reference/migration/migration-0-19
 ---


### PR DESCRIPTION
### What

Update "Migration Guides" redirect to point to 0.19, so visitors see the 0.19 guide first instead of the 0.18 guide.

### Checklist
* [X] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [X] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG