### PR TITLE
Add missing items to 0.19.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Read more about our video supports (and its limits) [in our video docs](https://
 - BGR(A) image format support [#7238](https://github.com/rerun-io/rerun/pull/7238)
 - Tensor & depth image value ranges can now be configured, from UI & code [#7549](https://github.com/rerun-io/rerun/pull/7549)
 - New planar pixel formats: `Y_U_V24`/`Y_U_V16`/`Y_U_V12` - `_LimitedRange`/`FullRange` [#7666](https://github.com/rerun-io/rerun/pull/7666)
+- Add `ShowLabels` component, which controls whether instances’ labels are shown [#7249](https://github.com/rerun-io/rerun/pull/7249) (thanks [@kpreid](https://github.com/kpreid)!)
 - Refactor `MediaType` guessing [#7326](https://github.com/rerun-io/rerun/pull/7326)
 
 #### 🌊 C++ API
@@ -69,6 +70,7 @@ Read more about our video supports (and its limits) [in our video docs](https://
 #### 🌁 Viewer improvements
 - The viewer will tail an .rrd that's is being written to [#7475](https://github.com/rerun-io/rerun/pull/7475)
 - Native video support for AV1 [#7557](https://github.com/rerun-io/rerun/pull/7557)
+- Allow splitting entity path expressions with whitespace [#7782](https://github.com/rerun-io/rerun/pull/7782)
 
 #### 🚀 Performance improvements
 - Improve performance for scenes with many entities & transforms [#7456](https://github.com/rerun-io/rerun/pull/7456)
@@ -80,7 +82,7 @@ Read more about our video supports (and its limits) [in our video docs](https://
 
 #### 🧑‍🏫 Examples
 - Add drone LiDAR example [#7336](https://github.com/rerun-io/rerun/pull/7336)
-- add instant_splat example [#7751](https://github.com/rerun-io/rerun/pull/7751) (thanks [@pablovela5620](https://github.com/pablovela5620)!)
+- Add `instant_splat` example [#7751](https://github.com/rerun-io/rerun/pull/7751) (thanks [@pablovela5620](https://github.com/pablovela5620)!)
 
 #### 📚 Docs
 - Add video reference docs [#7533](https://github.com/rerun-io/rerun/pull/7533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,20 @@
 
 ## [0.19.0](https://github.com/rerun-io/rerun/compare/0.18.2...0.19.0) - Dataframes & Video support
 
-
-<!-- TODO(emilk): insert a screenshot and/or code sample here -->
-
-📖 Release blogpost: Coming soon! <!-- TODO(niko): link to it! -->
+📖 Release blogpost: https://rerun.io/blog/dataframe
 
 🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-19
 
 ### ✨ Overview & highlights
 This release introduces two powerful features: a dataframe API (and view), as well as video support.
 
-#### ☰ Dataframe Python API
-We now have a Python API for querying the contents of an .rrd file. This integrates with popular packages such as [Pandas](https://pandas.pydata.org), [Polars](https://pola.rs), and [DuckDB](https://duckdb.org).
+#### ☰ Dataframe API
+We now have an API for querying the contents of an .rrd file. This integrates with popular packages such as [Pandas](https://pandas.pydata.org), [Polars](https://pola.rs), and [DuckDB](https://duckdb.org).
 
-You can read more in [the Dataframe API how-to guide](https://rerun.io/docs/content/howto/dataframe-api).
+You can read more in [the Dataframe API how-to guide](https://rerun.io/docs/howto/dataframe-api).
 
 We have also added a matching dataframe view inside the Rerun Viewer.
-Read more [here](https://rerun.io/docs/content/reference/types/views/dataframe_view).
+Read more [here](https://rerun.io/docs/reference/types/views/dataframe_view).
 
 #### 🎬 Video
 Rerun now supports logging MP4 videos using the new [`AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video) archetype.
@@ -33,7 +30,7 @@ Read more about our video supports (and its limits) [in our video docs](https://
 
 ### ⚠️ Breaking changes
 * 🗾 Blueprint files (.rbl) from previous Rerun versions will no longer load _automatically_
-* 🐧 Linux: Rerun now require glibc 2.17+
+* 🐧 Linux: Rerun now requires glibc 2.17+
 * 🦀 Rust: The minimum supported Rust version is now 1.79
 
 🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-19
@@ -43,6 +40,7 @@ Read more about our video supports (and its limits) [in our video docs](https://
  📑 Raw changelog: https://github.com/rerun-io/rerun/compare/0.18.2...0.19.0
 
 #### 🪵 Log API
+- BGR(A) image format support [#7238](https://github.com/rerun-io/rerun/pull/7238)
 - Tensor & depth image value ranges can now be configured, from UI & code [#7549](https://github.com/rerun-io/rerun/pull/7549)
 - New planar pixel formats: `Y_U_V24`/`Y_U_V16`/`Y_U_V12` - `_LimitedRange`/`FullRange` [#7666](https://github.com/rerun-io/rerun/pull/7666)
 - Refactor `MediaType` guessing [#7326](https://github.com/rerun-io/rerun/pull/7326)

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -123,16 +123,44 @@ def print_section(title: str, items: list[str]) -> None:
         print()
 
 
+def commit_range(new_version: str) -> str:
+    parts = new_version.split(".")
+    assert len(parts) == 3, "Expected version to be on the format X.Y.Z"
+    major = int(parts[0])
+    minor = int(parts[1])
+    patch = int(parts[2])
+
+    if 0 < patch:
+        # A patch release.
+        # Include changes since last patch release.
+        # This assumes we've cherry-picked stuff for this release.
+        diff_since_version = f"0.{minor}.{patch - 1}"
+    elif 0 < minor:
+        # A minor release
+        # The diff should span everything since the last minor release.
+        # The script later excludes duplicated automatically, so we don't include stuff that
+        # was part of intervening patch releases.
+        diff_since_version = f"{major}.{minor - 1}.0"
+    else:
+        # A major release
+        # The diff should span everything since the last major release.
+        # The script later excludes duplicated automatically, so we don't include stuff that
+        # was part of intervening minor/patch releases.
+        diff_since_version = f"{major - 1}.{minor}.0"
+
+    return f"{diff_since_version}..HEAD"
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate a changelog.")
-    parser.add_argument("--commit-range", required=True, help="e.g. 0.11.0..HEAD")
+    parser.add_argument("--version", required=True, help="The version of the new release, e.g. 0.42.0")
     args = parser.parse_args()
 
     # Because how we branch, we sometimes get duplicate commits in the changelog unless we check for it
     previous_changelog = open("CHANGELOG.md", encoding="utf8").read()
 
     repo = Repo(".")
-    commits = list(repo.iter_commits(args.commit_range))
+    commits = list(repo.iter_commits(commit_range(args.version)))
     commits.reverse()  # Most recent last
     commit_infos = list(map(get_commit_info, commits))
 


### PR DESCRIPTION
### What
* Closes #7825

When generating the changelog, I accidentally wrote 

> scripts/generate_changelog.py --commit-range 0.18.2..HEAD

and should have done

> scripts/generate_changelog.py --commit-range 0.18.0..HEAD

I've updated `generate_changelog.py` to make the same mistake impossible in the future.

I've already updated [the GitHub release notes](https://github.com/rerun-io/rerun/releases/tag/0.19.0) with the changes in this PR.

* Sibling PR: https://github.com/rerun-io/rerun_template/pull/17

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7844?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7844?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7844)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.