### PR TITLE
Add some more `pixi` build targets

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -141,11 +141,13 @@ rerun-build-release = "cargo build --package rerun-cli --release --no-default-fe
 # You can also give an argument for what to view (e.g. an .rrd file).
 rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --release --"
 
-rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features web_viewer,native_viewer,nasm --", depends_on = [
+# Compile `rerun-cli` with the same feature set as we build for releases.
+rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features release --", depends_on = [
   "rerun-build-web",
 ] }
 
-rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features web_viewer,native_viewer,nasm --release --", depends_on = [
+# Compile `rerun-cli` with the same feature set as we build for releases.
+rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features release --release --", depends_on = [
   "rerun-build-web-release",
 ] }
 
@@ -292,14 +294,16 @@ py-build-common = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 ma
   "rerun-build", # We need to build rerun-cli since it is bundled in the python package.
 ] }
 
-py-build-common-web-viewer = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --features web_viewer,nasm --extras=tests", depends_on = [
-  "rerun-build-native-and-web", # We need to build rerun-cli since it is bundled in the python package.
-] }
-
 py-build-common-release = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --release --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
   "rerun-build-release", # We need to build rerun-cli since it is bundled in the python package.
 ] }
 
+# Build and install the `rerun-sdk` package with the `web_viewer` feature.
+py-build-common-web-viewer = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --features web_viewer,nasm --extras=tests", depends_on = [
+  "rerun-build-native-and-web", # We need to build rerun-cli since it is bundled in the python package.
+] }
+
+# Build and install the `rerun-sdk` package with the `web_viewer` feature.
 py-build-common-web-viewer-release = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --release --manifest-path rerun_py/Cargo.toml --features web_viewer,nasm --extras=tests", depends_on = [
   "rerun-build-native-and-web-release", # We need to build rerun-cli since it is bundled in the python package.
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -141,6 +141,14 @@ rerun-build-release = "cargo build --package rerun-cli --release --no-default-fe
 # You can also give an argument for what to view (e.g. an .rrd file).
 rerun-release = "cargo run --package rerun-cli --no-default-features --features native_viewer,nasm --release --"
 
+rerun-build-native-and-web = { cmd = "cargo build --package rerun-cli --no-default-features --features web_viewer,native_viewer,nasm --", depends_on = [
+  "rerun-build-web",
+] }
+
+rerun-build-native-and-web-release = { cmd = "cargo build --package rerun-cli --no-default-features --features web_viewer,native_viewer,nasm --release --", depends_on = [
+  "rerun-build-web-release",
+] }
+
 # Compile and run the web-viewer via rerun-cli.
 #
 # You can also give an argument for what to view (e.g. an .rrd file).
@@ -283,8 +291,17 @@ js-build-all = { cmd = "yarn --cwd rerun_js workspaces run build", depends_on = 
 py-build-common = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
   "rerun-build", # We need to build rerun-cli since it is bundled in the python package.
 ] }
+
+py-build-common-web-viewer = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --manifest-path rerun_py/Cargo.toml --features web_viewer,nasm --extras=tests", depends_on = [
+  "rerun-build-native-and-web", # We need to build rerun-cli since it is bundled in the python package.
+] }
+
 py-build-common-release = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --release --manifest-path rerun_py/Cargo.toml --extras=tests", depends_on = [
   "rerun-build-release", # We need to build rerun-cli since it is bundled in the python package.
+] }
+
+py-build-common-web-viewer-release = { cmd = "PIP_REQUIRE_VIRTUALENV=0 RERUN_ALLOW_MISSING_BIN=1 maturin develop --release --manifest-path rerun_py/Cargo.toml --features web_viewer,nasm --extras=tests", depends_on = [
+  "rerun-build-native-and-web-release", # We need to build rerun-cli since it is bundled in the python package.
 ] }
 
 


### PR DESCRIPTION
### What

Adds
- `rerun-build-native-and-web`
- `rerun-build-native-and-web-release`
- `py-build-common-web-viewer`
- `py-build-common-web-viewer-release`

To make it easier to build with certain features (as we end all the existing tasks with `--`, which prevents adding more flags to `cargo`)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7848?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7848?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7848)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.