### PR TITLE
Refactor `MaxImageDimensionSubscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5888,6 +5888,7 @@ dependencies = [
  "mimalloc",
  "nohash-hasher",
  "once_cell",
+ "re_arrow2",
  "re_chunk_store",
  "re_data_ui",
  "re_entity_db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6307,6 +6307,7 @@ dependencies = [
  "re_types",
  "re_types_core",
  "re_ui",
+ "re_video",
  "rfd",
  "serde",
  "slotmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5903,6 +5903,7 @@ dependencies = [
  "re_tracing",
  "re_types",
  "re_ui",
+ "re_video",
  "re_viewer_context",
  "re_viewport_blueprint",
  "serde",

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -39,8 +39,10 @@ impl DataLoader for ArchetypeLoader {
 
         re_tracing::profile_function!(filepath.display().to_string());
 
-        let contents = std::fs::read(&filepath)
-            .with_context(|| format!("Failed to read file {filepath:?}"))?;
+        let contents = {
+            re_tracing::profile_scope!("fs::read");
+            std::fs::read(&filepath).with_context(|| format!("Failed to read file {filepath:?}"))?
+        };
         let contents = std::borrow::Cow::Owned(contents);
 
         self.load_from_file_contents(settings, filepath, contents, tx)

--- a/crates/store/re_types/src/components/media_type_ext.rs
+++ b/crates/store/re_types/src/components/media_type_ext.rs
@@ -228,6 +228,11 @@ impl MediaType {
     pub fn is_image(&self) -> bool {
         self.as_str().starts_with("image/")
     }
+
+    /// Returns `true` if this is an video media type.
+    pub fn is_video(&self) -> bool {
+        self.as_str().starts_with("video/")
+    }
 }
 
 impl std::fmt::Display for MediaType {

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -75,6 +75,7 @@ impl VideoData {
     /// TODO(andreas, jan): This should not copy the data, but instead store slices into a shared buffer.
     /// at the very least the should be a way to extract only metadata.
     pub fn load_from_bytes(data: &[u8], media_type: &str) -> Result<Self, VideoLoadError> {
+        re_tracing::profile_function!();
         match media_type {
             "video/mp4" => Self::load_mp4(data),
 
@@ -96,6 +97,12 @@ impl VideoData {
     #[inline]
     pub fn duration(&self) -> std::time::Duration {
         std::time::Duration::from_nanos(self.duration.into_nanos(self.timescale) as _)
+    }
+
+    /// Natural width and height of the video
+    #[inline]
+    pub fn dimensions(&self) -> [u32; 2] {
+        [self.width(), self.height()]
     }
 
     /// Natural width of the video.

--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -6,7 +6,11 @@ use crate::{Time, Timescale};
 
 impl VideoData {
     pub fn load_mp4(bytes: &[u8]) -> Result<Self, VideoLoadError> {
-        let mp4 = re_mp4::Mp4::read_bytes(bytes)?;
+        re_tracing::profile_function!();
+        let mp4 = {
+            re_tracing::profile_scope!("Mp4::read_bytes");
+            re_mp4::Mp4::read_bytes(bytes)?
+        };
 
         let mp4_tracks = mp4.tracks().iter().map(|(k, t)| (*k, t.kind)).collect();
 

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -5,7 +5,7 @@ use std::{collections::hash_map::Entry, ops::Range, sync::Arc};
 use ahash::HashMap;
 use parking_lot::Mutex;
 
-use re_video::VideoLoadError;
+use re_video::VideoData;
 
 use crate::{resource_managers::GpuTexture2D, RenderContext};
 
@@ -160,19 +160,17 @@ impl Video {
     /// - `video/mp4`
     pub fn load(
         debug_name: String,
-        data: &[u8],
-        media_type: &str,
+        data: Arc<VideoData>,
         decode_hw_acceleration: DecodeHardwareAcceleration,
-    ) -> Result<Self, VideoLoadError> {
-        let data = Arc::new(re_video::VideoData::load_from_bytes(data, media_type)?);
+    ) -> Self {
         let decoders = Mutex::new(HashMap::default());
 
-        Ok(Self {
+        Self {
             debug_name,
             data,
             decoders,
             decode_hw_acceleration,
-        })
+        }
     }
 
     /// The video data

--- a/crates/viewer/re_space_view_spatial/Cargo.toml
+++ b/crates/viewer/re_space_view_spatial/Cargo.toml
@@ -40,6 +40,7 @@ re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 re_space_view.workspace = true
 
+arrow2.workspace = true
 ahash.workspace = true
 anyhow.workspace = true
 bitflags.workspace = true

--- a/crates/viewer/re_space_view_spatial/Cargo.toml
+++ b/crates/viewer/re_space_view_spatial/Cargo.toml
@@ -33,12 +33,13 @@ re_renderer = { workspace = true, features = [
   "import-obj",
   "import-stl",
 ] }
-re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
+re_space_view.workspace = true
 re_tracing.workspace = true
+re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
 re_ui.workspace = true
+re_video.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
-re_space_view.workspace = true
 
 arrow2.workspace = true
 ahash.workspace = true

--- a/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -152,9 +152,13 @@ fn size_from_blob(blob: &dyn Array, media_type: Option<&dyn Array>) -> Option<[u
         reader.into_dimensions().ok().map(|size| size.into())
     } else if media_type.is_video() {
         re_tracing::profile_scope!("video");
-        re_video::VideoData::load_from_bytes(&blob, &media_type)
-            .ok()
-            .map(|video| video.dimensions())
+        if true {
+            None // TODO(#7821): Use the VideoCache here so we make sure we only load each video ONCE
+        } else {
+            re_video::VideoData::load_from_bytes(&blob, &media_type)
+                .ok()
+                .map(|video| video.dimensions())
+        }
     } else {
         None
     }

--- a/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -1,14 +1,14 @@
 use ahash::HashMap;
+use arrow2::array::Array;
 use nohash_hasher::IntMap;
 use once_cell::sync::OnceCell;
 
 use re_chunk_store::{ChunkStore, ChunkStoreSubscriber, ChunkStoreSubscriberHandle};
 use re_log_types::{EntityPath, StoreId};
 use re_types::{
-    archetypes::EncodedImage,
     components::{Blob, ImageFormat, MediaType},
     external::image,
-    Archetype, Loggable,
+    Loggable,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -76,6 +76,7 @@ impl ChunkStoreSubscriber for MaxImageDimensionSubscriber {
                 continue;
             }
 
+            // Handle `Image`, `DepthImage`, `SegmentationImage`…
             if let Some(all_dimensions) = event.diff.chunk.components().get(&ImageFormat::name()) {
                 for new_dim in all_dimensions.iter().filter_map(|array| {
                     array
@@ -89,62 +90,57 @@ impl ChunkStoreSubscriber for MaxImageDimensionSubscriber {
                         .entry(event.diff.chunk.entity_path().clone())
                         .or_default();
 
-                    max_dim.height = max_dim.height.max(new_dim.height);
                     max_dim.width = max_dim.width.max(new_dim.width);
+                    max_dim.height = max_dim.height.max(new_dim.height);
                 }
             }
 
-            // TODO(jleibs): Image blob/mediatypes should have their own component
-            // Is there a more canonical way to check the indicators for a chunk?
-            if event
-                .diff
-                .chunk
-                .components()
-                .get(&EncodedImage::indicator().name())
-                .is_some()
-            {
-                let media_types = event.diff.chunk.iter_component_arrays(&MediaType::name());
-                let blobs = event.diff.chunk.iter_component_arrays(&Blob::name());
-                for (media, blob) in media_types.zip(blobs) {
-                    let Ok(media) = MediaType::from_arrow_opt(media.as_ref()) else {
-                        continue;
-                    };
-                    let Ok(blob) = Blob::from_arrow_opt(blob.as_ref()) else {
-                        continue;
-                    };
-                    if let (media, Some(Some(blob))) = (media.first(), blob.first()) {
-                        let image_bytes = blob.0.as_slice();
-
-                        let mut reader = image::io::Reader::new(std::io::Cursor::new(image_bytes));
-
-                        if let Some(Some(media)) = media {
-                            if let Some(format) = image::ImageFormat::from_mime_type(&media.0) {
-                                reader.set_format(format);
-                            }
-                        }
-
-                        if reader.format().is_none() {
-                            if let Ok(format) = image::guess_format(image_bytes) {
-                                // Weirdly enough, `reader.decode` doesn't do this for us.
-                                reader.set_format(format);
-                            }
-                        }
-
-                        if let Ok((width, height)) = reader.into_dimensions() {
-                            let max_dim = self
-                                .max_dimensions
-                                .entry(event.store_id.clone())
-                                .or_default()
-                                .0
-                                .entry(event.diff.chunk.entity_path().clone())
-                                .or_default();
-
-                            max_dim.height = max_dim.height.max(height);
-                            max_dim.width = max_dim.width.max(width);
-                        }
-                    }
+            // Handle `ImageEncoded`…
+            let blobs = event.diff.chunk.iter_component_arrays(&Blob::name());
+            let media_types = event.diff.chunk.iter_component_arrays(&MediaType::name());
+            for (blob, media_type) in itertools::izip!(blobs, media_types) {
+                if let Some([width, height]) = size_from_blob(blob.as_ref(), media_type.as_ref()) {
+                    let max_dim = self
+                        .max_dimensions
+                        .entry(event.store_id.clone())
+                        .or_default()
+                        .0
+                        .entry(event.diff.chunk.entity_path().clone())
+                        .or_default();
+                    max_dim.width = max_dim.width.max(width);
+                    max_dim.height = max_dim.height.max(height);
                 }
             }
         }
+    }
+}
+
+fn size_from_blob(blob: &dyn Array, media_type: &dyn Array) -> Option<[u32; 2]> {
+    let blob = Blob::from_arrow_opt(blob).ok()?.first()?.clone()?;
+    let media: Option<MediaType> = MediaType::from_arrow_opt(media_type)
+        .ok()
+        .and_then(|list| list.first().cloned())
+        .flatten();
+    let media = MediaType::or_guess_from_data(media, &blob)?;
+
+    if media.is_image() {
+        let image_bytes = blob.0.as_slice();
+
+        let mut reader = image::io::Reader::new(std::io::Cursor::new(image_bytes));
+
+        if let Some(format) = image::ImageFormat::from_mime_type(&media.0) {
+            reader.set_format(format);
+        }
+
+        if reader.format().is_none() {
+            if let Ok(format) = image::guess_format(image_bytes) {
+                // Weirdly enough, `reader.decode` doesn't do this for us.
+                reader.set_format(format);
+            }
+        }
+
+        reader.into_dimensions().ok().map(|size| size.into())
+    } else {
+        None // TODO(emilk): handle video files
     }
 }

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -35,6 +35,7 @@ re_tracing.workspace = true
 re_types = { workspace = true, features = ["ecolor", "glam", "image"] }
 re_types_core.workspace = true
 re_ui.workspace = true
+re_video.workspace = true
 
 ahash.workspace = true
 anyhow.workspace = true

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -43,7 +43,7 @@ impl VideoCache {
         media_type: Option<&MediaType>,
         hw_acceleration: DecodeHardwareAcceleration,
     ) -> Arc<Result<Video, VideoLoadError>> {
-        re_tracing::profile_function!();
+        re_tracing::profile_function!(&debug_name);
 
         // In order to avoid loading the same video multiple times with
         // known and unknown media type, we have to resolve the media type before

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -63,8 +63,8 @@ impl VideoCache {
             .or_default()
             .entry(inner_key)
             .or_insert_with(|| {
-                let video =
-                    Video::load(debug_name, video_data, media_type.as_str(), hw_acceleration);
+                let video = re_video::VideoData::load_from_bytes(video_data, &media_type)
+                    .map(|data| Video::load(debug_name, Arc::new(data), hw_acceleration));
                 Entry {
                     used_this_frame: AtomicBool::new(true),
                     video: Arc::new(video),


### PR DESCRIPTION
### What
* Part of https://github.com/rerun-io/rerun/issues/7821
* Bonus: better profiling of video loading

The change is that `MaxImageDimensionSubscriber` parses each `.mp4` to figure out its size…
…except I disabled that check last-second because we don't have access to the `VideoCache`, and so this PR would lead to each video getting parsed _twice_.

Still, I would like to get this PR merged as a necessary refactor and generally improved structure.

This is where we're heading:
![image](https://github.com/user-attachments/assets/69c8d206-6332-40c3-aa66-bb96ada3772c)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7850?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7850?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7850)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.