### PR TITLE
C++: Improve error message when finding X11 macro `Unsorted`

### DIFF
--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -11,7 +11,10 @@
 // X.h (of X11) has a macro called `Unsorted`
 // See <https://codebrowser.dev/kde/include/X11/X.h.html#_M/Unsorted>
 // and <https://github.com/rerun-io/rerun/issues/7846>.
-#undef Unsorted
+#ifdef Unsorted
+#error \
+    "Found a macro 'Unsorted' (probably from X11), conflicting with `rerun::SortingStatus::Unsorted`. Add '#undef Unsorted' before '#include <rerun.hpp>' to work around this."
+#endif
 
 struct rr_time_column;
 

--- a/rerun_cpp/src/rerun/time_column.hpp
+++ b/rerun_cpp/src/rerun/time_column.hpp
@@ -8,6 +8,11 @@
 #include "error.hpp"
 #include "timeline.hpp"
 
+// X.h (of X11) has a macro called `Unsorted`
+// See <https://codebrowser.dev/kde/include/X11/X.h.html#_M/Unsorted>
+// and <https://github.com/rerun-io/rerun/issues/7846>.
+#undef Unsorted
+
 struct rr_time_column;
 
 namespace arrow {


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/7846

Some C library uses macros for constants, which makes those identifiers unusable by any other library in the same global namespace. So anyone including both `X.h` and `rerun.hpp` in the same compilation unit (in that order) would have problems. It's a dumpster-fire.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7855?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7855?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7855)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.