### PR TITLE
Move `query_archetype_with_history` to make it more globally available

### DIFF
--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -6,7 +6,7 @@ use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
 use re_log_types::{TimeInt, Timeline};
 use re_query::LatestAtResults;
 use re_types_core::{Archetype, ComponentName};
-use re_viewer_context::{DataResult, QueryRange, ViewContext, ViewerContext};
+use re_viewer_context::{DataResult, QueryRange, ViewContext, ViewQuery, ViewerContext};
 
 // ---
 
@@ -239,9 +239,7 @@ pub trait DataResultQuery {
     fn query_archetype_with_history<'a, A: re_types_core::Archetype>(
         &'a self,
         ctx: &'a ViewContext<'a>,
-        timeline: &Timeline,
-        timeline_cursor: TimeInt,
-        query_range: &QueryRange,
+        view_query: &ViewQuery<'_>,
     ) -> HybridResults<'a>;
 
     fn best_fallback_for<'a>(
@@ -271,15 +269,13 @@ impl DataResultQuery for DataResult {
     fn query_archetype_with_history<'a, A: Archetype>(
         &'a self,
         ctx: &'a ViewContext<'a>,
-        timeline: &Timeline,
-        timeline_cursor: TimeInt,
-        query_range: &QueryRange,
+        view_query: &ViewQuery<'_>,
     ) -> HybridResults<'a> {
         query_archetype_with_history(
             ctx,
-            timeline,
-            timeline_cursor,
-            query_range,
+            &view_query.timeline,
+            view_query.latest_at,
+            self.query_range(),
             A::all_components().iter().copied(),
             self,
         )

--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -1,12 +1,12 @@
 use nohash_hasher::IntSet;
 
-use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
-use re_log_types::TimeInt;
-use re_query::LatestAtResults;
-use re_types_core::ComponentName;
-use re_viewer_context::{DataResult, ViewContext, ViewerContext};
-
 use crate::results_ext::{HybridLatestAtResults, HybridRangeResults};
+use crate::HybridResults;
+use re_chunk_store::{LatestAtQuery, RangeQuery, RowId};
+use re_log_types::{TimeInt, Timeline};
+use re_query::LatestAtResults;
+use re_types_core::{Archetype, ComponentName};
+use re_viewer_context::{DataResult, QueryRange, ViewContext, ViewerContext};
 
 // ---
 
@@ -122,6 +122,48 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     }
 }
 
+pub fn query_archetype_with_history<'a>(
+    ctx: &'a ViewContext<'a>,
+    timeline: &Timeline,
+    timeline_cursor: TimeInt,
+    query_range: &QueryRange,
+    component_names: impl IntoIterator<Item = ComponentName>,
+    data_result: &'a re_viewer_context::DataResult,
+) -> HybridResults<'a> {
+    match query_range {
+        QueryRange::TimeRange(time_range) => {
+            let range_query = RangeQuery::new(
+                *timeline,
+                re_log_types::ResolvedTimeRange::from_relative_time_range(
+                    time_range,
+                    timeline_cursor,
+                ),
+            );
+            let results = range_with_blueprint_resolved_data(
+                ctx,
+                None,
+                &range_query,
+                data_result,
+                component_names,
+            );
+            (range_query, results).into()
+        }
+        QueryRange::LatestAt => {
+            let latest_query = LatestAtQuery::new(*timeline, timeline_cursor);
+            let query_shadowed_defaults = false;
+            let results = latest_at_with_blueprint_resolved_data(
+                ctx,
+                None,
+                &latest_query,
+                data_result,
+                component_names,
+                query_shadowed_defaults,
+            );
+            (latest_query, results).into()
+        }
+    }
+}
+
 fn query_overrides<'a>(
     ctx: &ViewerContext<'_>,
     data_result: &re_viewer_context::DataResult,
@@ -194,6 +236,14 @@ pub trait DataResultQuery {
         latest_at_query: &'a LatestAtQuery,
     ) -> HybridLatestAtResults<'a>;
 
+    fn query_archetype_with_history<'a, A: re_types_core::Archetype>(
+        &'a self,
+        ctx: &'a ViewContext<'a>,
+        timeline: &Timeline,
+        timeline_cursor: TimeInt,
+        query_range: &QueryRange,
+    ) -> HybridResults<'a>;
+
     fn best_fallback_for<'a>(
         &self,
         ctx: &'a ViewContext<'a>,
@@ -215,6 +265,23 @@ impl DataResultQuery for DataResult {
             self,
             A::all_components().iter().copied(),
             query_shadowed_defaults,
+        )
+    }
+
+    fn query_archetype_with_history<'a, A: Archetype>(
+        &'a self,
+        ctx: &'a ViewContext<'a>,
+        timeline: &Timeline,
+        timeline_cursor: TimeInt,
+        query_range: &QueryRange,
+    ) -> HybridResults<'a> {
+        query_archetype_with_history(
+            ctx,
+            timeline,
+            timeline_cursor,
+            query_range,
+            A::all_components().iter().copied(),
+            self,
         )
     }
 

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -134,12 +134,7 @@ where
             space_view_class_identifier: view_ctx.space_view_class_identifier(),
         };
 
-        let results = data_result.query_archetype_with_history::<A>(
-            ctx,
-            &query.timeline,
-            query.latest_at,
-            data_result.query_range(),
-        );
+        let results = data_result.query_archetype_with_history::<A>(ctx, query);
 
         let mut query_ctx = ctx.query_context(data_result, &latest_at);
         query_ctx.archetype_name = Some(A::name());

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/entity_iterator.rs
@@ -1,13 +1,10 @@
 use itertools::Either;
 
-use re_chunk_store::{LatestAtQuery, RangeQuery};
 use re_log_types::{TimeInt, Timeline};
-use re_space_view::{
-    latest_at_with_blueprint_resolved_data, range_with_blueprint_resolved_data, HybridResults,
-};
+use re_space_view::{DataResultQuery as _, HybridResults};
 use re_types::Archetype;
 use re_viewer_context::{
-    IdentifiedViewSystem, QueryContext, QueryRange, SpaceViewSystemExecutionError, ViewContext,
+    IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError, ViewContext,
     ViewContextCollection, ViewQuery,
 };
 
@@ -90,47 +87,6 @@ fn test_clamped_vec() {
 
 // --- Chunk-based APIs ---
 
-pub fn query_archetype_with_history<'a, A: Archetype>(
-    ctx: &'a ViewContext<'a>,
-    timeline: &Timeline,
-    timeline_cursor: TimeInt,
-    query_range: &QueryRange,
-    data_result: &'a re_viewer_context::DataResult,
-) -> HybridResults<'a> {
-    match query_range {
-        QueryRange::TimeRange(time_range) => {
-            let range_query = RangeQuery::new(
-                *timeline,
-                re_log_types::ResolvedTimeRange::from_relative_time_range(
-                    time_range,
-                    timeline_cursor,
-                ),
-            );
-            let results = range_with_blueprint_resolved_data(
-                ctx,
-                None,
-                &range_query,
-                data_result,
-                A::all_components().iter().copied(),
-            );
-            (range_query, results).into()
-        }
-        QueryRange::LatestAt => {
-            let latest_query = LatestAtQuery::new(*timeline, timeline_cursor);
-            let query_shadowed_defaults = false;
-            let results = latest_at_with_blueprint_resolved_data(
-                ctx,
-                None,
-                &latest_query,
-                data_result,
-                A::all_components().iter().copied(),
-                query_shadowed_defaults,
-            );
-            (latest_query, results).into()
-        }
-    }
-}
-
 /// Iterates through all entity views for a given archetype.
 ///
 /// The callback passed in gets passed along a [`SpatialSceneEntityContext`] which contains
@@ -178,12 +134,11 @@ where
             space_view_class_identifier: view_ctx.space_view_class_identifier(),
         };
 
-        let results = query_archetype_with_history::<A>(
+        let results = data_result.query_archetype_with_history::<A>(
             ctx,
             &query.timeline,
             query.latest_at,
             data_result.query_range(),
-            data_result,
         );
 
         let mut query_ctx = ctx.query_context(data_result, &latest_at);


### PR DESCRIPTION
### What

Small refactor discussed with @Wumpf to make `query_archetype_with_history` consistent with `latest_at_with_blueprint_resolved_data`.

Needed by #6561 


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7863?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7863?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7863)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.