### PR TITLE
Finish dataframe reference page

### DIFF
--- a/docs/content/reference/dataframes.md
+++ b/docs/content/reference/dataframes.md
@@ -58,7 +58,7 @@ Then log that blueprint file in addition to the data itself:
 
 snippet: reference/dataframe_view_query_external
 
-Check out the blueprint API reference to learn more about all the ways that data can be searched and filtered:
+Check out the blueprint API and `log_file_from_path` references to learn more:
 * [🐍 Python blueprint API reference](https://ref.rerun.io/docs/python/latest/common/blueprint_apis/)
 * [🐍 Python `log_file_from_path`](https://ref.rerun.io/docs/python/latest/common/logging_functions/#rerun.log_file_from_path)
 * [🦀 Rust `log_file_from_path`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)

--- a/docs/content/reference/dataframes.md
+++ b/docs/content/reference/dataframes.md
@@ -21,25 +21,54 @@ For an in-depth introduction to the dataframe API and the possible workflows it 
 
 ### Using the dataframe API
 
-The following snippet demonstrates how to query the first 10 rows in a Rerun recording:
+The following snippet demonstrates how to query the first 10 rows in a Rerun recording using latest-at (i.e. time-aligned) semantics:
 
 snippet: reference/dataframe_query
 
 Check out the API reference to learn more about all the ways that data can be searched and filtered:
 * [🐍 Python API reference](https://ref.rerun.io/docs/python/stable/common/dataframe/)
-* [🐍 Python example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/python/dataframe_query/dataframe_query.py)
-* [🦀 Rust API reference](https://docs.rs/crate/rerun/latest)
-* [🦀 Rust example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/rust/dataframe_query/src/main.rs)
+  * [Example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/python/dataframe_query/dataframe_query.py)
+* [🦀 Rust API reference](https://docs.rs/rerun/latest/rerun/dataframe/index.html)
+  * [Example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/rust/dataframe_query/src/main.rs)
 
 
 ### Using the blueprint API to configure a dataframe view
 
-TODO(cmc): incoming.
+The following snippet demonstrates how to query the first 10 rows in a Rerun recording using latest-at (i.e. time-aligned) semantics, and display them in a [dataframe view](types/views/dataframe_view):
+
+snippet: reference/dataframe_view_query
+
+<picture>
+  <img src="https://static.rerun.io/dataframe_query_example/d3dc908edb09377fbdc4c8f16b1b35a7a35a5e7d/full.png" alt="">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/dataframe_query_example/d3dc908edb09377fbdc4c8f16b1b35a7a35a5e7d/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/dataframe_query_example/d3dc908edb09377fbdc4c8f16b1b35a7a35a5e7d/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/dataframe_query_example/d3dc908edb09377fbdc4c8f16b1b35a7a35a5e7d/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/dataframe_query_example/d3dc908edb09377fbdc4c8f16b1b35a7a35a5e7d/1200w.png">
+</picture>
+
+#### Aside: re-using blueprint files from other SDKs
+
+While the blueprint APIs are currently only available in Python, blueprints can be saved and re-logged as needed from any language our SDKs support.
+
+First, save the blueprint to a file (`.rbl` by convention) using either the viewer (`Menu > Save blueprint`) or the python API:
+
+snippet: reference/dataframe_save_blueprint
+
+Then log that blueprint file in addition to the data itself:
+
+snippet: reference/dataframe_view_query_external
 
 Check out the blueprint API reference to learn more about all the ways that data can be searched and filtered:
 * [🐍 Python blueprint API reference](https://ref.rerun.io/docs/python/latest/common/blueprint_apis/)
+* [🐍 Python `log_file_from_path`](https://ref.rerun.io/docs/python/latest/common/logging_functions/#rerun.log_file_from_path)
+* [🦀 Rust `log_file_from_path`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)
+* [🌊 C++ `log_file_from_path`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a20798d7ea74cce5c8174e5cacd0a2c47)
 
 
 ### Setting up dataframe view manually in the UI
 
-TODO(cmc): incoming.
+The same [dataframe view](types/views/dataframe_view) shown above can be configured purely from the UI:
+
+<video width="100%" autoplay loop muted controls>
+    <source src="https://static.rerun.io/dataframe/df-dna-demo.webm" type="video/webm" />
+</video>

--- a/docs/content/reference/dataframes.md
+++ b/docs/content/reference/dataframes.md
@@ -34,7 +34,7 @@ Check out the API reference to learn more about all the ways that data can be se
 
 ### Using the blueprint API to configure a dataframe view
 
-The following snippet demonstrates how to query the first 10 rows in a Rerun recording using latest-at (i.e. time-aligned) semantics, and display them in a [dataframe view](types/views/dataframe_view):
+The following snippet demonstrates how visualize an entire Rerun recording using latest-at (i.e. time-aligned) semantics by displaying the results in a [dataframe view](types/views/dataframe_view):
 
 snippet: reference/dataframe_view_query
 

--- a/docs/snippets/all/reference/dataframe_query.rs
+++ b/docs/snippets/all/reference/dataframe_query.rs
@@ -1,7 +1,5 @@
 //! Query and display the first 10 rows of a recording.
 
-#![allow(clippy::unwrap_used)]
-
 use rerun::{
     dataframe::{QueryCache, QueryEngine, QueryExpression, SparseFillStrategy, Timeline},
     ChunkStore, ChunkStoreConfig, VersionPolicy,
@@ -18,7 +16,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         path_to_rrd,
         VersionPolicy::Warn,
     )?;
-    let (_, store) = stores.first_key_value().unwrap();
+    let Some((_, store)) = stores.first_key_value() else {
+        return Ok(());
+    };
 
     let query_cache = QueryCache::new(store);
     let query_engine = QueryEngine {

--- a/docs/snippets/all/reference/dataframe_save_blueprint.py
+++ b/docs/snippets/all/reference/dataframe_save_blueprint.py
@@ -1,0 +1,17 @@
+"""Craft a blueprint with the python API and save it to a file for future use."""
+
+import sys
+
+import rerun.blueprint as rrb
+
+path_to_rbl = sys.argv[1]
+
+rrb.Blueprint(
+    rrb.DataframeView(
+        origin="/",
+        query=rrb.archetypes.DataframeQuery(
+            timeline="log_time",
+            apply_latest_at=True,
+        ),
+    ),
+).save("rerun_example_dataframe_view_query", path_to_rbl)

--- a/docs/snippets/all/reference/dataframe_view_query.py
+++ b/docs/snippets/all/reference/dataframe_view_query.py
@@ -1,0 +1,24 @@
+"""Query and display the first 10 rows of a recording in a dataframe view."""
+
+import sys
+
+import rerun as rr
+import rerun.blueprint as rrb
+
+path_to_rrd = sys.argv[1]
+
+rr.init("rerun_example_dataframe_view_query", spawn=True)
+
+rr.log_file_from_path(path_to_rrd)
+
+blueprint = rrb.Blueprint(
+    rrb.DataframeView(
+        origin="/",
+        query=rrb.archetypes.DataframeQuery(
+            timeline="log_time",
+            apply_latest_at=True,
+        ),
+    ),
+)
+
+rr.send_blueprint(blueprint)

--- a/docs/snippets/all/reference/dataframe_view_query_external.cpp
+++ b/docs/snippets/all/reference/dataframe_view_query_external.cpp
@@ -1,0 +1,27 @@
+//! Query and display the first 10 rows of a recording in a dataframe view.
+//!
+//! The blueprint is being loaded from an existing blueprint recording file.
+
+// ./dataframe_view_query_external /tmp/dna.rrd /tmp/dna.rbl
+
+#include <string>
+
+#include <rerun.hpp>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        return 1;
+    }
+
+    std::string path_to_rrd = argv[1];
+    std::string path_to_rbl = argv[2];
+
+    const auto rec = rerun::RecordingStream("rerun_example_dataframe_view_query_external");
+    rec.spawn().exit_on_failure();
+
+    // Log the files
+    rec.log_file_from_path(path_to_rrd);
+    rec.log_file_from_path(path_to_rbl);
+
+    return 0;
+}

--- a/docs/snippets/all/reference/dataframe_view_query_external.py
+++ b/docs/snippets/all/reference/dataframe_view_query_external.py
@@ -1,0 +1,19 @@
+"""
+Query and display the first 10 rows of a recording in a dataframe view.
+
+The blueprint is being loaded from an existing blueprint recording file.
+"""
+
+# python dataframe_view_query_external.py /tmp/dna.rrd /tmp/dna.rbl
+
+import sys
+
+import rerun as rr
+
+path_to_rrd = sys.argv[1]
+path_to_rbl = sys.argv[2]
+
+rr.init("rerun_example_dataframe_view_query_external", spawn=True)
+
+rr.log_file_from_path(path_to_rrd)
+rr.log_file_from_path(path_to_rbl)

--- a/docs/snippets/all/reference/dataframe_view_query_external.rs
+++ b/docs/snippets/all/reference/dataframe_view_query_external.rs
@@ -1,0 +1,20 @@
+//! Query and display the first 10 rows of a recording in a dataframe view.
+//!
+//! The blueprint is being loaded from an existing blueprint recording file.
+
+// cargo r -p snippets -- dataframe_view_query_external /tmp/dna.rrd /tmp/dna.rbl
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = std::env::args().collect::<Vec<_>>();
+
+    let path_to_rrd = &args[1];
+    let path_to_rbl = &args[2];
+
+    let rec = rerun::RecordingStreamBuilder::new("rerun_example_dataframe_view_query_external")
+        .spawn()?;
+
+    rec.log_file_from_path(path_to_rrd, None /* prefix */, false /* static */)?;
+    rec.log_file_from_path(path_to_rbl, None /* prefix */, false /* static */)?;
+
+    Ok(())
+}

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -42,7 +42,22 @@ views = [
   "rust",
   "py",
 ]
-"reference/dataframe_query" = [ # Requires RRD files, which are unstable
+"reference/dataframe_query" = [ # No output
+  "cpp",
+  "rust",
+  "py",
+]
+"reference/dataframe_save_blueprint" = [ # No output
+  "cpp",
+  "rust",
+  "py",
+]
+"reference/dataframe_view_query" = [ # No output
+  "cpp",
+  "rust",
+  "py",
+]
+"reference/dataframe_view_query_external" = [ # No output
   "cpp",
   "rust",
   "py",


### PR DESCRIPTION
We were missing a bunch of features and assets to be able to finish this, but now we have it all.

* DNM: requires #7864 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7865?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7865?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7865)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.