### PR TITLE
Fix space-view heuristics for videos

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -152,13 +152,9 @@ fn size_from_blob(blob: &dyn Array, media_type: Option<&dyn Array>) -> Option<[u
         reader.into_dimensions().ok().map(|size| size.into())
     } else if media_type.is_video() {
         re_tracing::profile_scope!("video");
-        if true {
-            None // TODO(#7821): Use the VideoCache here so we make sure we only load each video ONCE
-        } else {
-            re_video::VideoData::load_from_bytes(&blob, &media_type)
-                .ok()
-                .map(|video| video.dimensions())
-        }
+        re_video::VideoData::load_from_bytes(&blob, &media_type)
+            .ok()
+            .map(|video| video.dimensions())
     } else {
         None
     }


### PR DESCRIPTION
### What
This is now feasible thanks to @jprochazk's
* https://github.com/rerun-io/rerun/pull/7860

![image](https://github.com/user-attachments/assets/0cd063d9-7e44-4892-a751-022784e12d5d)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7869?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7869?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7869)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.