### PR TITLE
Improve profiling scopes covering viewer startup

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -621,6 +621,7 @@ impl Chunk {
         timelines: BTreeMap<Timeline, TimeColumn>,
         components: BTreeMap<ComponentName, ArrowListArray<i32>>,
     ) -> ChunkResult<Self> {
+        re_tracing::profile_function!();
         let row_ids = row_ids
             .to_arrow()
             // NOTE: impossible, but better safe than sorry.

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -65,6 +65,7 @@ pub fn arrays_to_list_array(
     let data = if arrays_dense.is_empty() {
         arrow2::array::new_empty_array(array_datatype.clone())
     } else {
+        re_tracing::profile_scope!("concatenate", arrays_dense.len().to_string());
         arrow2::compute::concatenate::concatenate(&arrays_dense)
             .map_err(|err| {
                 re_log::warn_once!("failed to concatenate arrays: {err}");

--- a/crates/store/re_data_loader/src/loader_external.rs
+++ b/crates/store/re_data_loader/src/loader_external.rs
@@ -27,7 +27,7 @@ pub const EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE: i32 = 66;
 /// filter data on a much more fine-grained basis that just file extensions (e.g. checking the file
 /// itself for magic bytes).
 pub static EXTERNAL_LOADER_PATHS: Lazy<Vec<std::path::PathBuf>> = Lazy::new(|| {
-    re_tracing::profile_function!();
+    re_tracing::profile_scope!("initialize-external-loaders");
 
     let dir_separator = if cfg!(target_os = "windows") {
         ';'
@@ -48,6 +48,7 @@ pub static EXTERNAL_LOADER_PATHS: Lazy<Vec<std::path::PathBuf>> = Lazy::new(|| {
 
     let mut executables = HashMap::<String, Vec<std::path::PathBuf>>::default();
     for dirpath in dirpaths {
+        re_tracing::profile_scope!("dir", dirpath.to_string_lossy());
         let Ok(dir) = std::fs::read_dir(dirpath) else {
             continue;
         };
@@ -90,6 +91,7 @@ pub static EXTERNAL_LOADER_PATHS: Lazy<Vec<std::path::PathBuf>> = Lazy::new(|| {
 /// Iterator over all registered external [`crate::DataLoader`]s.
 #[inline]
 pub fn iter_external_loaders() -> impl ExactSizeIterator<Item = std::path::PathBuf> {
+    re_tracing::profile_wait!("EXTERNAL_LOADER_PATHS");
     EXTERNAL_LOADER_PATHS.iter().cloned()
 }
 
@@ -122,12 +124,17 @@ impl crate::DataLoader for ExternalLoader {
 
         re_tracing::profile_function!(filepath.display().to_string());
 
+        let external_loaders = {
+            re_tracing::profile_wait!("EXTERNAL_LOADER_PATHS");
+            EXTERNAL_LOADER_PATHS.iter()
+        };
+
         #[derive(PartialEq, Eq)]
         struct CompatibleLoaderFound;
         let (tx_feedback, rx_feedback) = std::sync::mpsc::channel::<CompatibleLoaderFound>();
 
         let args = settings.to_cli_args();
-        for exe in EXTERNAL_LOADER_PATHS.iter() {
+        for exe in external_loaders {
             let args = args.clone();
             let filepath = filepath.clone();
             let tx = tx.clone();


### PR DESCRIPTION
### What
Tested with `pixi run rerun-release --profile ../test-videos/` with a folder with a bunch of videos.

With my SDD cache hot (i.e. after a few runs) the time-to-photon for a 650MB video is ~350ms, which is acceptable.

Interestingly enough, "concatenating" a SINGLE arrow array (with nothing) can take 90ms.

![image](https://github.com/user-attachments/assets/b13d6336-5d48-408f-9f29-13cb05f8ecd4)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)