### PR TITLE
Trying to ban some symbols via `clippy` but it doesn't seem to work?

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -49,6 +49,8 @@ disallowed-methods = [
   { path = "std::env::temp_dir", reason = "Use the tempdir crate instead" },
   { path = "std::panic::catch_unwind", reason = "We compile with `panic = 'abort'`" },
   { path = "std::thread::spawn", reason = "Use `std::thread::Builder` and name the thread" },
+  { path = "arrow2::compute::filter::filter", reason = "Use `re_chunk::util::filter_array` instead, which has proper early outs" },
+  { path = "arrow2::compute::take::take", reason = "Use `re_chunk::util::take_array` instead, which has proper early outs" },
 
   # There are many things that aren't allowed on wasm,
   # but we cannot disable them all here (because of e.g. https://github.com/rust-lang/rust-clippy/issues/10406)


### PR DESCRIPTION
Why doesn't this work? :angry: 

* [x] no