### PR TITLE
Make sure arrow concatenation kernel early outs where needed

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -51,8 +51,10 @@ disallowed-methods = [
   { path = "std::thread::spawn", reason = "Use `std::thread::Builder` and name the thread" },
 
   # Specify both `arrow2` and `re_arrow2` -- clippy gets lost in all the package renaming happening.
+  { path = "arrow2::compute::concatenate::concatenate", reason = "Use `re_chunk::util::concat_arrays` instead, which has proper early outs" },
   { path = "arrow2::compute::filter::filter", reason = "Use `re_chunk::util::filter_array` instead, which has proper early outs" },
   { path = "arrow2::compute::take::take", reason = "Use `re_chunk::util::take_array` instead, which has proper early outs" },
+  { path = "re_arrow2::compute::concatenate::concatenate", reason = "Use `re_chunk::util::concat_arrays` instead, which has proper early outs" },
   { path = "re_arrow2::compute::filter::filter", reason = "Use `re_chunk::util::filter_array` instead, which has proper early outs" },
   { path = "re_arrow2::compute::take::take", reason = "Use `re_chunk::util::take_array` instead, which has proper early outs" },
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -50,6 +50,12 @@ disallowed-methods = [
   { path = "std::panic::catch_unwind", reason = "We compile with `panic = 'abort'`" },
   { path = "std::thread::spawn", reason = "Use `std::thread::Builder` and name the thread" },
 
+  # Specify both `arrow2` and `re_arrow2` -- clippy gets lost in all the package renaming happening.
+  { path = "arrow2::compute::filter::filter", reason = "Use `re_chunk::util::filter_array` instead, which has proper early outs" },
+  { path = "arrow2::compute::take::take", reason = "Use `re_chunk::util::take_array` instead, which has proper early outs" },
+  { path = "re_arrow2::compute::filter::filter", reason = "Use `re_chunk::util::filter_array` instead, which has proper early outs" },
+  { path = "re_arrow2::compute::take::take", reason = "Use `re_chunk::util::take_array` instead, which has proper early outs" },
+
   # There are many things that aren't allowed on wasm,
   # but we cannot disable them all here (because of e.g. https://github.com/rust-lang/rust-clippy/issues/10406)
   # so we do that in `clippy_wasm.toml` instead.

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -47,7 +47,7 @@ impl Chunk {
         let row_ids = {
             re_tracing::profile_scope!("row_ids");
 
-            let row_ids = arrow2::compute::concatenate::concatenate(&[&cl.row_ids, &cr.row_ids])?;
+            let row_ids = crate::util::concat_arrays(&[&cl.row_ids, &cr.row_ids])?;
             #[allow(clippy::unwrap_used)]
             // concatenating 2 RowId arrays must yield another RowId array
             row_ids
@@ -86,11 +86,8 @@ impl Chunk {
                             re_format::format_uint(rhs_list_array.values().len()),
                         ));
 
-                        let list_array = arrow2::compute::concatenate::concatenate(&[
-                            lhs_list_array,
-                            rhs_list_array,
-                        ])
-                        .ok()?;
+                        let list_array =
+                            crate::util::concat_arrays(&[lhs_list_array, rhs_list_array]).ok()?;
                         let list_array = list_array
                             .as_any()
                             .downcast_ref::<ArrowListArray<i32>>()?
@@ -131,11 +128,8 @@ impl Chunk {
                             re_format::format_uint(rhs_list_array.values().len()),
                         ));
 
-                        let list_array = arrow2::compute::concatenate::concatenate(&[
-                            lhs_list_array,
-                            rhs_list_array,
-                        ])
-                        .ok()?;
+                        let list_array =
+                            crate::util::concat_arrays(&[lhs_list_array, rhs_list_array]).ok()?;
                         let list_array = list_array
                             .as_any()
                             .downcast_ref::<ArrowListArray<i32>>()?
@@ -260,7 +254,7 @@ impl TimeColumn {
 
         let time_range = self.time_range.union(rhs.time_range);
 
-        let times = arrow2::compute::concatenate::concatenate(&[&self.times, &rhs.times]).ok()?;
+        let times = crate::util::concat_arrays(&[&self.times, &rhs.times]).ok()?;
         let times = times
             .as_any()
             .downcast_ref::<ArrowPrimitiveArray<i64>>()?

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -276,7 +276,7 @@ impl Chunk {
                     ArrowOffsets::try_from_lengths(sorted_arrays.iter().map(|array| array.len()))
                         .unwrap();
                 #[allow(clippy::unwrap_used)] // these are slices of the same outer array
-                let values = arrow2::compute::concatenate::concatenate(&sorted_arrays).unwrap();
+                let values = crate::util::concat_arrays(&sorted_arrays).unwrap();
                 let validity = original
                     .validity()
                     .map(|validity| swaps.iter().map(|&from| validity.get_bit(from)).collect());

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -344,6 +344,7 @@ pub fn filter_array<A: ArrowArray + Clone>(array: &A, filter: &ArrowBooleanArray
         "filter masks with validity bits are technically valid, but generally a sign that something went wrong",
     );
 
+    #[allow(clippy::disallowed_methods)] // that's the whole point
     #[allow(clippy::unwrap_used)]
     arrow2::compute::filter::filter(array, filter)
         // Unwrap: this literally cannot fail.
@@ -402,6 +403,7 @@ pub fn take_array<A: ArrowArray + Clone, O: arrow2::types::Index>(
         }
     }
 
+    #[allow(clippy::disallowed_methods)] // that's the whole point
     #[allow(clippy::unwrap_used)]
     arrow2::compute::take::take(array, indices)
         // Unwrap: this literally cannot fail.

--- a/crates/store/re_chunk/src/util.rs
+++ b/crates/store/re_chunk/src/util.rs
@@ -322,6 +322,21 @@ pub fn new_list_array_of_empties(child_datatype: ArrowDatatype, len: usize) -> A
     )
 }
 
+/// Applies a [concatenate] kernel to the given `arrays`.
+///
+/// Early outs where it makes sense (e.g. `arrays.len() == 1`).
+///
+/// Returns an error if the arrays don't share the exact same datatype.
+///
+/// [concatenate]: arrow2::compute::concatenate::concatenate
+pub fn concat_arrays(arrays: &[&dyn ArrowArray]) -> arrow2::error::Result<Box<dyn ArrowArray>> {
+    if arrays.len() == 1 {
+        return Ok(arrays[0].to_boxed());
+    }
+
+    arrow2::compute::concatenate::concatenate(arrays)
+}
+
 /// Applies a [filter] kernel to the given `array`.
 ///
 /// Panics iff the length of the filter doesn't match the length of the array.

--- a/crates/store/re_chunk/tests/memory_test.rs
+++ b/crates/store/re_chunk/tests/memory_test.rs
@@ -120,9 +120,8 @@ fn concat_single_is_noop() {
         let unconcatenated =
             memory_use(|| ArrowPrimitiveArray::from_vec((0..NUM_SCALARS).collect_vec()).to_boxed());
 
-        let concatenated = memory_use(|| {
-            re_chunk::util::concat_arrays(&[&*unconcatenated.0]).unwrap()
-        });
+        let concatenated =
+            memory_use(|| re_chunk::util::concat_arrays(&[&*unconcatenated.0]).unwrap());
 
         (unconcatenated, concatenated)
     });

--- a/crates/store/re_chunk/tests/memory_test.rs
+++ b/crates/store/re_chunk/tests/memory_test.rs
@@ -90,7 +90,7 @@ fn concat_does_allocate() {
             .collect_vec();
 
         let concatenated =
-            memory_use(|| arrow2::compute::concatenate::concatenate(&unconcatenated_refs).unwrap());
+            memory_use(|| re_chunk::util::concat_arrays(&unconcatenated_refs).unwrap());
 
         (unconcatenated, concatenated)
     });
@@ -121,7 +121,7 @@ fn concat_single_is_noop() {
             memory_use(|| ArrowPrimitiveArray::from_vec((0..NUM_SCALARS).collect_vec()).to_boxed());
 
         let concatenated = memory_use(|| {
-            arrow2::compute::concatenate::concatenate(&[&*unconcatenated.0]).unwrap()
+            re_chunk::util::concat_arrays(&[&*unconcatenated.0]).unwrap()
         });
 
         (unconcatenated, concatenated)

--- a/crates/store/re_chunk/tests/memory_test.rs
+++ b/crates/store/re_chunk/tests/memory_test.rs
@@ -63,6 +63,103 @@ use arrow2::{
 };
 use itertools::Itertools;
 
+// --- concat ---
+
+#[test]
+fn concat_does_allocate() {
+    re_log::setup_logging();
+
+    const NUM_SCALARS: i64 = 10_000_000;
+
+    let (
+        ((_unconcatenated, unconcatenated_size_bytes), (_concatenated, concatenated_size_bytes)),
+        total_size_bytes,
+    ) = memory_use(|| {
+        let unconcatenated = memory_use(|| {
+            std::iter::repeat(NUM_SCALARS as usize / 10)
+                .take(10)
+                .map(|_| {
+                    ArrowPrimitiveArray::from_vec((0..NUM_SCALARS / 10).collect_vec()).to_boxed()
+                })
+                .collect_vec()
+        });
+        let unconcatenated_refs = unconcatenated
+            .0
+            .iter()
+            .map(|a| &**a as &dyn ArrowArray)
+            .collect_vec();
+
+        let concatenated =
+            memory_use(|| arrow2::compute::concatenate::concatenate(&unconcatenated_refs).unwrap());
+
+        (unconcatenated, concatenated)
+    });
+
+    eprintln!(
+        "unconcatenated={} concatenated={} total={}",
+        re_format::format_bytes(unconcatenated_size_bytes as _),
+        re_format::format_bytes(concatenated_size_bytes as _),
+        re_format::format_bytes(total_size_bytes as _),
+    );
+
+    assert!(unconcatenated_size_bytes + concatenated_size_bytes <= total_size_bytes);
+    assert!(unconcatenated_size_bytes as f64 >= concatenated_size_bytes as f64 * 0.95);
+    assert!(unconcatenated_size_bytes as f64 <= concatenated_size_bytes as f64 * 1.05);
+}
+
+#[test]
+fn concat_single_is_noop() {
+    re_log::setup_logging();
+
+    const NUM_SCALARS: i64 = 10_000_000;
+
+    let (
+        ((unconcatenated, unconcatenated_size_bytes), (concatenated, concatenated_size_bytes)),
+        total_size_bytes,
+    ) = memory_use(|| {
+        let unconcatenated =
+            memory_use(|| ArrowPrimitiveArray::from_vec((0..NUM_SCALARS).collect_vec()).to_boxed());
+
+        let concatenated = memory_use(|| {
+            arrow2::compute::concatenate::concatenate(&[&*unconcatenated.0]).unwrap()
+        });
+
+        (unconcatenated, concatenated)
+    });
+
+    eprintln!(
+        "unconcatenated={} concatenated={} total={}",
+        re_format::format_bytes(unconcatenated_size_bytes as _),
+        re_format::format_bytes(concatenated_size_bytes as _),
+        re_format::format_bytes(total_size_bytes as _),
+    );
+
+    assert!(concatenated_size_bytes < 100);
+    assert!(unconcatenated_size_bytes as f64 >= total_size_bytes as f64 * 0.95);
+    assert!(unconcatenated_size_bytes as f64 <= total_size_bytes as f64 * 1.05);
+
+    {
+        let unconcatenated = unconcatenated
+            .as_any()
+            .downcast_ref::<ArrowPrimitiveArray<i64>>()
+            .unwrap();
+        let concatenated = concatenated
+            .as_any()
+            .downcast_ref::<ArrowPrimitiveArray<i64>>()
+            .unwrap();
+
+        assert!(
+            std::ptr::eq(
+                unconcatenated.values().as_ptr_range().start,
+                concatenated.values().as_ptr_range().start
+            ),
+            "whole thing should be a noop -- pointers should match"
+        );
+    }
+}
+
+// --- filter ---
+
 #[test]
 fn filter_does_allocate() {
     re_log::setup_logging();
@@ -190,6 +287,8 @@ fn filter_empty_or_full_is_noop() {
         );
     }
 }
+
+// --- take ---
 
 #[test]
 // TODO(cmc): That's the end goal, but it is simply impossible with `ListArray`'s encoding.


### PR DESCRIPTION
Same thing we did for `take` and `filter`.

Once again, the kernel unsurprisingly copies a whole bunch of data even in trivial cases.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7873?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7873?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7873)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.