### PR TITLE
Implement support for in-place drag-n-drop

### DIFF
--- a/crates/store/re_data_loader/src/lib.rs
+++ b/crates/store/re_data_loader/src/lib.rs
@@ -53,8 +53,6 @@ pub struct DataLoaderSettings {
     pub application_id: Option<re_log_types::ApplicationId>,
 
     /// The [`re_log_types::ApplicationId`] that is currently opened in the viewer, if any.
-    //
-    // TODO(#5350): actually support this
     pub opened_application_id: Option<re_log_types::ApplicationId>,
 
     /// The recommended [`re_log_types::StoreId`] to log the data to, based on the surrounding context.
@@ -64,8 +62,6 @@ pub struct DataLoaderSettings {
     pub store_id: re_log_types::StoreId,
 
     /// The [`re_log_types::StoreId`] that is currently opened in the viewer, if any.
-    //
-    // TODO(#5350): actually support this
     pub opened_store_id: Option<re_log_types::StoreId>,
 
     /// What should the logged entity paths be prefixed with?
@@ -318,39 +314,18 @@ impl DataLoaderError {
 /// most convenient for them, whether it is raw components, arrow chunks or even
 /// full-on [`LogMsg`]s.
 pub enum LoadedData {
-    Chunk(Chunk),
-    ArrowMsg(ArrowMsg),
+    Chunk(re_log_types::StoreId, Chunk),
+    ArrowMsg(re_log_types::StoreId, ArrowMsg),
     LogMsg(LogMsg),
-}
-
-impl From<Chunk> for LoadedData {
-    #[inline]
-    fn from(value: Chunk) -> Self {
-        Self::Chunk(value)
-    }
-}
-
-impl From<ArrowMsg> for LoadedData {
-    #[inline]
-    fn from(value: ArrowMsg) -> Self {
-        Self::ArrowMsg(value)
-    }
-}
-
-impl From<LogMsg> for LoadedData {
-    #[inline]
-    fn from(value: LogMsg) -> Self {
-        Self::LogMsg(value)
-    }
 }
 
 impl LoadedData {
     /// Pack the data into a [`LogMsg`].
-    pub fn into_log_msg(self, store_id: &re_log_types::StoreId) -> ChunkResult<LogMsg> {
+    pub fn into_log_msg(self) -> ChunkResult<LogMsg> {
         match self {
-            Self::Chunk(chunk) => Ok(LogMsg::ArrowMsg(store_id.clone(), chunk.to_arrow_msg()?)),
+            Self::Chunk(store_id, chunk) => Ok(LogMsg::ArrowMsg(store_id, chunk.to_arrow_msg()?)),
 
-            Self::ArrowMsg(msg) => Ok(LogMsg::ArrowMsg(store_id.clone(), msg)),
+            Self::ArrowMsg(store_id, msg) => Ok(LogMsg::ArrowMsg(store_id, msg)),
 
             Self::LogMsg(msg) => Ok(msg),
         }

--- a/crates/store/re_data_loader/src/load_file.rs
+++ b/crates/store/re_data_loader/src/load_file.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
 
+use ahash::{HashMap, HashMapExt};
 use re_log_types::{FileSource, LogMsg};
 use re_smart_channel::Sender;
 
-use crate::{extension, DataLoaderError, LoadedData};
+use crate::{DataLoaderError, LoadedData};
 
 // ---
 
@@ -36,16 +37,7 @@ pub fn load_from_path(
 
     let rx = load(settings, path, None)?;
 
-    // TODO(cmc): should we always unconditionally set store info though?
-    // If we reach this point, then at least one compatible `DataLoader` has been found.
-    let store_info = prepare_store_info(&settings.store_id, file_source, path);
-    if let Some(store_info) = store_info {
-        if tx.send(store_info).is_err() {
-            return Ok(()); // other end has hung up.
-        }
-    }
-
-    send(rx, tx);
+    send(settings.clone(), file_source, path.to_owned(), rx, tx);
 
     Ok(())
 }
@@ -72,16 +64,7 @@ pub fn load_from_file_contents(
 
     let data = load(settings, filepath, Some(contents))?;
 
-    // TODO(cmc): should we always unconditionally set store info though?
-    // If we reach this point, then at least one compatible `DataLoader` has been found.
-    let store_info = prepare_store_info(&settings.store_id, file_source, filepath);
-    if let Some(store_info) = store_info {
-        if tx.send(store_info).is_err() {
-            return Ok(()); // other end has hung up.
-        }
-    }
-
-    send(data, tx);
+    send(settings.clone(), file_source, filepath.to_owned(), data, tx);
 
     Ok(())
 }
@@ -93,7 +76,7 @@ pub(crate) fn prepare_store_info(
     store_id: &re_log_types::StoreId,
     file_source: FileSource,
     path: &std::path::Path,
-) -> Option<LogMsg> {
+) -> LogMsg {
     re_tracing::profile_function!(path.display().to_string());
 
     use re_log_types::SetStoreInfo;
@@ -101,27 +84,17 @@ pub(crate) fn prepare_store_info(
     let app_id = re_log_types::ApplicationId(path.display().to_string());
     let store_source = re_log_types::StoreSource::File { file_source };
 
-    let ext = extension(path);
-    let is_rrd = crate::SUPPORTED_RERUN_EXTENSIONS.contains(&ext.as_str());
-
-    (!is_rrd).then(|| {
-        LogMsg::SetStoreInfo(SetStoreInfo {
-            row_id: *re_chunk::RowId::new(),
-            info: re_log_types::StoreInfo {
-                application_id: app_id.clone(),
-                store_id: store_id.clone(),
-                cloned_from: None,
-                is_official_example: false,
-                started: re_log_types::Time::now(),
-                store_source,
-                // NOTE: If this is a natively supported file, it will go through one of the
-                // builtin dataloaders, i.e. the local version.
-                // Otherwise, it will go through an arbitrary external loader, at which point we
-                // have no certainty what the version is.
-                store_version: crate::is_supported_file_extension(ext.as_str())
-                    .then_some(re_build_info::CrateVersion::LOCAL),
-            },
-        })
+    LogMsg::SetStoreInfo(SetStoreInfo {
+        row_id: *re_chunk::RowId::new(),
+        info: re_log_types::StoreInfo {
+            application_id: app_id.clone(),
+            store_id: store_id.clone(),
+            cloned_from: None,
+            is_official_example: false,
+            started: re_log_types::Time::now(),
+            store_source,
+            store_version: Some(re_build_info::CrateVersion::LOCAL),
+        },
     })
 }
 
@@ -287,9 +260,17 @@ pub(crate) fn load(
 /// Forwards the data in `rx_loader` to `tx`, taking care of necessary conversions, if any.
 ///
 /// Runs asynchronously from another thread on native, synchronously on wasm.
-pub(crate) fn send(rx_loader: std::sync::mpsc::Receiver<LoadedData>, tx: &Sender<LogMsg>) {
+pub(crate) fn send(
+    settings: crate::DataLoaderSettings,
+    file_source: FileSource,
+    path: std::path::PathBuf,
+    rx_loader: std::sync::mpsc::Receiver<LoadedData>,
+    tx: &Sender<LogMsg>,
+) {
     spawn({
         re_tracing::profile_function!();
+
+        let mut store_info_tracker: HashMap<re_log_types::StoreId, bool> = HashMap::new();
 
         let tx = tx.clone();
         move || {
@@ -300,13 +281,41 @@ pub(crate) fn send(rx_loader: std::sync::mpsc::Receiver<LoadedData>, tx: &Sender
             // doesn't get stuck.
             for data in rx_loader {
                 let msg = match data.into_log_msg() {
-                    Ok(msg) => msg,
+                    Ok(msg) => {
+                        let store_info = match &msg {
+                            LogMsg::SetStoreInfo(set_store_info) => {
+                                Some((set_store_info.info.store_id.clone(), true))
+                            }
+                            LogMsg::ArrowMsg(store_id, _arrow_msg) => {
+                                Some((store_id.clone(), false))
+                            }
+                            LogMsg::BlueprintActivationCommand(_) => None,
+                        };
+
+                        if let Some((store_id, store_info_created)) = store_info {
+                            *store_info_tracker.entry(store_id).or_default() |= store_info_created;
+                        }
+
+                        msg
+                    }
                     Err(err) => {
                         re_log::error!(%err, "Couldn't serialize component data");
                         continue;
                     }
                 };
                 tx.send(msg).ok();
+            }
+
+            for (store_id, store_info_already_created) in store_info_tracker {
+                let is_a_preexisting_recording =
+                    Some(&store_id) == settings.opened_store_id.as_ref();
+
+                if store_info_already_created || is_a_preexisting_recording {
+                    continue;
+                }
+
+                let store_info = prepare_store_info(&store_id, file_source.clone(), &path);
+                tx.send(store_info).ok();
             }
 
             tx.quit(None).ok();

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -50,7 +50,7 @@ impl DataLoader for ArchetypeLoader {
 
     fn load_from_file_contents(
         &self,
-        _settings: &crate::DataLoaderSettings,
+        settings: &crate::DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<LoadedData>,
@@ -133,8 +133,13 @@ impl DataLoader for ArchetypeLoader {
             )?);
         }
 
+        let store_id = settings
+            .opened_store_id
+            .clone()
+            .unwrap_or_else(|| settings.store_id.clone());
         for row in rows {
-            if tx.send(row.into()).is_err() {
+            let data = LoadedData::Chunk(store_id.clone(), row);
+            if tx.send(data).is_err() {
                 break; // The other end has decided to hang up, not our problem.
             }
         }

--- a/crates/store/re_data_loader/src/loader_external.rs
+++ b/crates/store/re_data_loader/src/loader_external.rs
@@ -6,6 +6,8 @@ use std::{
 use ahash::HashMap;
 use once_cell::sync::Lazy;
 
+use crate::LoadedData;
+
 // ---
 
 /// To register a new external data loader, simply add an executable in your $PATH whose name
@@ -318,7 +320,9 @@ fn decode_and_stream<R: std::io::Read>(
                 continue;
             }
         };
-        if tx.send(msg.into()).is_err() {
+
+        let data = LoadedData::LogMsg(msg);
+        if tx.send(data).is_err() {
             break; // The other end has decided to hang up, not our problem.
         }
     }

--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -4,6 +4,8 @@ use re_log_encoding::decoder::Decoder;
 use crossbeam::channel::Receiver;
 use re_log_types::{ApplicationId, StoreId};
 
+use crate::LoadedData;
+
 // ---
 
 /// Loads data from any `rrd` file or in-memory contents.
@@ -193,7 +195,8 @@ fn decode_and_stream<R: std::io::Read>(
             msg
         };
 
-        if tx.send(msg.into()).is_err() {
+        let data = LoadedData::LogMsg(msg);
+        if tx.send(data).is_err() {
             break; // The other end has decided to hang up, not our problem.
         }
     }

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -164,7 +164,11 @@ impl DataSource {
                 // or not.
                 let shared_store_id =
                     re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
-                let settings = re_data_loader::DataLoaderSettings::recommended(shared_store_id);
+                let settings = re_data_loader::DataLoaderSettings {
+                    opened_application_id: file_source.recommended_application_id().cloned(),
+                    opened_store_id: file_source.recommended_recording_id().cloned(),
+                    ..re_data_loader::DataLoaderSettings::recommended(shared_store_id)
+                };
                 re_data_loader::load_from_path(&settings, file_source, &path, &tx)
                     .with_context(|| format!("{path:?}"))?;
 
@@ -188,7 +192,11 @@ impl DataSource {
                 // or not.
                 let shared_store_id =
                     re_log_types::StoreId::random(re_log_types::StoreKind::Recording);
-                let settings = re_data_loader::DataLoaderSettings::recommended(shared_store_id);
+                let settings = re_data_loader::DataLoaderSettings {
+                    opened_application_id: file_source.recommended_application_id().cloned(),
+                    opened_store_id: file_source.recommended_recording_id().cloned(),
+                    ..re_data_loader::DataLoaderSettings::recommended(shared_store_id)
+                };
                 re_data_loader::load_from_file_contents(
                     &settings,
                     file_source,

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -248,12 +248,15 @@ fn test_data_source_from_uri() {
     ];
     let ws = ["ws://foo.zip", "wss://foo.zip", "127.0.0.1"];
 
-    let file_source = FileSource::DragAndDrop;
+    let file_source = FileSource::DragAndDrop {
+        recommended_application_id: None,
+        recommended_recording_id: None,
+    };
 
     for uri in file {
         assert!(
             matches!(
-                DataSource::from_uri(file_source, uri.to_owned()),
+                DataSource::from_uri(file_source.clone(), uri.to_owned()),
                 DataSource::FilePath { .. }
             ),
             "Expected {uri:?} to be categorized as FilePath"
@@ -263,7 +266,7 @@ fn test_data_source_from_uri() {
     for uri in http {
         assert!(
             matches!(
-                DataSource::from_uri(file_source, uri.to_owned()),
+                DataSource::from_uri(file_source.clone(), uri.to_owned()),
                 DataSource::RrdHttpUrl { .. }
             ),
             "Expected {uri:?} to be categorized as RrdHttpUrl"
@@ -273,7 +276,7 @@ fn test_data_source_from_uri() {
     for uri in ws {
         assert!(
             matches!(
-                DataSource::from_uri(file_source, uri.to_owned()),
+                DataSource::from_uri(file_source.clone(), uri.to_owned()),
                 DataSource::WebSocketAddr(_)
             ),
             "Expected {uri:?} to be categorized as WebSocketAddr"

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -433,6 +433,38 @@ pub enum FileSource {
     Sdk,
 }
 
+impl FileSource {
+    #[inline]
+    pub fn recommended_application_id(&self) -> Option<&ApplicationId> {
+        match self {
+            Self::FileDialog {
+                recommended_application_id,
+                ..
+            }
+            | Self::DragAndDrop {
+                recommended_application_id,
+                ..
+            } => recommended_application_id.as_ref(),
+            Self::Cli | Self::Sdk => None,
+        }
+    }
+
+    #[inline]
+    pub fn recommended_recording_id(&self) -> Option<&StoreId> {
+        match self {
+            Self::FileDialog {
+                recommended_recording_id,
+                ..
+            }
+            | Self::DragAndDrop {
+                recommended_recording_id,
+                ..
+            } => recommended_recording_id.as_ref(),
+            Self::Cli | Self::Sdk => None,
+        }
+    }
+}
+
 /// The source of a recording or blueprint.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -420,7 +420,15 @@ pub enum FileSource {
         recommended_recording_id: Option<StoreId>,
     },
 
-    FileDialog,
+    FileDialog {
+        /// The [`ApplicationId`] that the viewer heuristically recommends should be used when loading
+        /// this data source, based on the surrounding context.
+        recommended_application_id: Option<ApplicationId>,
+
+        /// The [`StoreId`] that the viewer heuristically recommends should be used when loading
+        /// this data source, based on the surrounding context.
+        recommended_recording_id: Option<StoreId>,
+    },
 
     Sdk,
 }
@@ -468,7 +476,7 @@ impl std::fmt::Display for StoreSource {
             Self::File { file_source, .. } => match file_source {
                 FileSource::Cli => write!(f, "File via CLI"),
                 FileSource::DragAndDrop { .. } => write!(f, "File via drag-and-drop"),
-                FileSource::FileDialog => write!(f, "File via file dialog"),
+                FileSource::FileDialog { .. } => write!(f, "File via file dialog"),
                 FileSource::Sdk => write!(f, "File via SDK"),
             },
             Self::Viewer => write!(f, "Viewer-generated"),

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -405,12 +405,23 @@ impl std::fmt::Display for PythonVersion {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum FileSource {
     Cli,
-    DragAndDrop,
+
+    DragAndDrop {
+        /// The [`ApplicationId`] that the viewer heuristically recommends should be used when loading
+        /// this data source, based on the surrounding context.
+        recommended_application_id: Option<ApplicationId>,
+
+        /// The [`StoreId`] that the viewer heuristically recommends should be used when loading
+        /// this data source, based on the surrounding context.
+        recommended_recording_id: Option<StoreId>,
+    },
+
     FileDialog,
+
     Sdk,
 }
 
@@ -456,7 +467,7 @@ impl std::fmt::Display for StoreSource {
             Self::RustSdk { rustc_version, .. } => write!(f, "Rust SDK (rustc {rustc_version})"),
             Self::File { file_source, .. } => match file_source {
                 FileSource::Cli => write!(f, "File via CLI"),
-                FileSource::DragAndDrop => write!(f, "File via drag-and-drop"),
+                FileSource::DragAndDrop { .. } => write!(f, "File via drag-and-drop"),
                 FileSource::FileDialog => write!(f, "File via file dialog"),
                 FileSource::Sdk => write!(f, "File via SDK"),
             },

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -591,7 +591,10 @@ impl App {
                 for file_path in open_file_dialog_native() {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
-                            FileSource::FileDialog,
+                            FileSource::FileDialog {
+                                recommended_application_id: None,
+                                recommended_recording_id: None,
+                            },
                             file_path,
                         )));
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1289,27 +1289,31 @@ impl App {
             .and_then(|store_hub| store_hub.active_recording())
     }
 
-    fn handle_dropping_files(&mut self, egui_ctx: &egui::Context) {
+    // NOTE: Relying on `self` is dangerous, as this is called during a time where some internal
+    // fields may have been temporarily `take()`n out. Keep this a static method.
+    fn handle_dropping_files(
+        egui_ctx: &egui::Context,
+        store_ctx: Option<&StoreContext<'_>>,
+        command_sender: &CommandSender,
+    ) {
         preview_files_being_dropped(egui_ctx);
 
         let dropped_files = egui_ctx.input_mut(|i| std::mem::take(&mut i.raw.dropped_files));
 
-        let active_application_id = self
-            .store_hub
-            .as_ref()
-            .and_then(|hub| hub.active_app())
-            .cloned();
-        let active_recording_id = self
-            .store_hub
-            .as_ref()
-            .and_then(|hub| hub.active_recording_id())
+        if dropped_files.is_empty() {
+            return;
+        }
+
+        let active_application_id = store_ctx.and_then(|ctx| ctx.hub.active_app()).cloned();
+        let active_recording_id = store_ctx
+            .and_then(|ctx| ctx.hub.active_recording_id())
             .cloned();
 
         for file in dropped_files {
             if let Some(bytes) = file.bytes {
                 // This is what we get on Web.
-                self.command_sender
-                    .send_system(SystemCommand::LoadDataSource(DataSource::FileContents(
+                command_sender.send_system(SystemCommand::LoadDataSource(
+                    DataSource::FileContents(
                         FileSource::DragAndDrop {
                             recommended_application_id: active_application_id.clone(),
                             recommended_recording_id: active_recording_id.clone(),
@@ -1318,20 +1322,20 @@ impl App {
                             name: file.name.clone(),
                             bytes: bytes.clone(),
                         },
-                    )));
+                    ),
+                ));
                 continue;
             }
 
             #[cfg(not(target_arch = "wasm32"))]
             if let Some(path) = file.path {
-                self.command_sender
-                    .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
-                        FileSource::DragAndDrop {
-                            recommended_application_id: active_application_id.clone(),
-                            recommended_recording_id: active_recording_id.clone(),
-                        },
-                        path,
-                    )));
+                command_sender.send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
+                    FileSource::DragAndDrop {
+                        recommended_application_id: active_application_id.clone(),
+                        recommended_recording_id: active_recording_id.clone(),
+                    },
+                    path,
+                )));
             }
         }
     }
@@ -1694,7 +1698,7 @@ impl eframe::App for App {
             self.command_sender.send_ui(cmd);
         }
 
-        self.handle_dropping_files(egui_ctx);
+        Self::handle_dropping_files(egui_ctx, store_context.as_ref(), &self.command_sender);
 
         // Run pending commands last (so we don't have to wait for a repaint before they are run):
         self.run_pending_ui_commands(egui_ctx, &app_blueprint, store_context.as_ref());

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1591,7 +1591,10 @@ impl eframe::App for App {
                 for file in files {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FileContents(
-                            FileSource::FileDialog,
+                            FileSource::FileDialog {
+                                recommended_application_id: None,
+                                recommended_recording_id: None,
+                            },
                             file.clone(),
                         )));
                 }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1291,12 +1291,26 @@ impl App {
 
         let dropped_files = egui_ctx.input_mut(|i| std::mem::take(&mut i.raw.dropped_files));
 
+        let active_application_id = self
+            .store_hub
+            .as_ref()
+            .and_then(|hub| hub.active_app())
+            .cloned();
+        let active_recording_id = self
+            .store_hub
+            .as_ref()
+            .and_then(|hub| hub.active_recording_id())
+            .cloned();
+
         for file in dropped_files {
             if let Some(bytes) = file.bytes {
                 // This is what we get on Web.
                 self.command_sender
                     .send_system(SystemCommand::LoadDataSource(DataSource::FileContents(
-                        FileSource::DragAndDrop,
+                        FileSource::DragAndDrop {
+                            recommended_application_id: active_application_id.clone(),
+                            recommended_recording_id: active_recording_id.clone(),
+                        },
                         FileContents {
                             name: file.name.clone(),
                             bytes: bytes.clone(),
@@ -1309,7 +1323,10 @@ impl App {
             if let Some(path) = file.path {
                 self.command_sender
                     .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
-                        FileSource::DragAndDrop,
+                        FileSource::DragAndDrop {
+                            recommended_application_id: active_application_id.clone(),
+                            recommended_recording_id: active_recording_id.clone(),
+                        },
                         path,
                     )));
             }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1304,7 +1304,14 @@ impl App {
             return;
         }
 
-        let active_application_id = store_ctx.and_then(|ctx| ctx.hub.active_app()).cloned();
+        let active_application_id = store_ctx
+            .and_then(|ctx| {
+                ctx.hub
+                    .active_app()
+                    // Don't redirect data to the welcome screen.
+                    .filter(|&app_id| app_id != &StoreHub::welcome_screen_app_id())
+            })
+            .cloned();
         let active_recording_id = store_ctx
             .and_then(|ctx| ctx.hub.active_recording_id())
             .cloned();

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -76,7 +76,7 @@ pub fn open_recording(
             S::File { file_source } => match file_source {
                 re_log_types::FileSource::Cli => "file_cli".to_owned(),
                 re_log_types::FileSource::DragAndDrop { .. } => "file_drag_and_drop".to_owned(),
-                re_log_types::FileSource::FileDialog => "file_dialog".to_owned(),
+                re_log_types::FileSource::FileDialog { .. } => "file_dialog".to_owned(),
                 re_log_types::FileSource::Sdk => "file_sdk".to_owned(),
             },
             S::Viewer => "viewer".to_owned(),

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -75,7 +75,7 @@ pub fn open_recording(
             S::RustSdk { .. } => "rust_sdk".to_owned(),
             S::File { file_source } => match file_source {
                 re_log_types::FileSource::Cli => "file_cli".to_owned(),
-                re_log_types::FileSource::DragAndDrop => "file_drag_and_drop".to_owned(),
+                re_log_types::FileSource::DragAndDrop { .. } => "file_drag_and_drop".to_owned(),
                 re_log_types::FileSource::FileDialog => "file_dialog".to_owned(),
                 re_log_types::FileSource::Sdk => "file_sdk".to_owned(),
             },

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -9,7 +9,7 @@
 use rerun::{
     external::{anyhow, re_build_info, re_data_loader, re_log},
     log::{Chunk, RowId},
-    EntityPath, TimePoint,
+    EntityPath, LoadedData, TimePoint,
 };
 
 fn main() -> anyhow::Result<std::process::ExitCode> {
@@ -34,7 +34,7 @@ impl re_data_loader::DataLoader for HashLoader {
 
     fn load_from_path(
         &self,
-        _settings: &rerun::external::re_data_loader::DataLoaderSettings,
+        settings: &rerun::external::re_data_loader::DataLoaderSettings,
         path: std::path::PathBuf,
         tx: std::sync::mpsc::Sender<re_data_loader::LoadedData>,
     ) -> Result<(), re_data_loader::DataLoaderError> {
@@ -42,21 +42,22 @@ impl re_data_loader::DataLoader for HashLoader {
         if path.is_dir() {
             return Err(re_data_loader::DataLoaderError::Incompatible(path)); // simply not interested
         }
-        hash_and_log(&tx, &path, &contents)
+        hash_and_log(settings, &tx, &path, &contents)
     }
 
     fn load_from_file_contents(
         &self,
-        _settings: &rerun::external::re_data_loader::DataLoaderSettings,
+        settings: &rerun::external::re_data_loader::DataLoaderSettings,
         filepath: std::path::PathBuf,
         contents: std::borrow::Cow<'_, [u8]>,
         tx: std::sync::mpsc::Sender<re_data_loader::LoadedData>,
     ) -> Result<(), re_data_loader::DataLoaderError> {
-        hash_and_log(&tx, &filepath, &contents)
+        hash_and_log(settings, &tx, &filepath, &contents)
     }
 }
 
 fn hash_and_log(
+    settings: &rerun::external::re_data_loader::DataLoaderSettings,
     tx: &std::sync::mpsc::Sender<re_data_loader::LoadedData>,
     filepath: &std::path::Path,
     contents: &[u8],
@@ -76,7 +77,12 @@ fn hash_and_log(
         .with_archetype(RowId::new(), TimePoint::default(), &doc)
         .build()?;
 
-    tx.send(chunk.into()).ok();
+    let store_id = settings
+        .opened_store_id
+        .clone()
+        .unwrap_or_else(|| settings.store_id.clone());
+    let data = LoadedData::Chunk(store_id, chunk);
+    tx.send(data).ok();
 
     Ok(())
 }


### PR DESCRIPTION
It is pretty tricky to get right (unsurprisingly) -- `StoreId`s and `RecordingId`s and `SetStoreInfo`s are all pretty finicky constructs and a lot can go wrong when loading arbitrarily things in place. But it works pretty nicely overall!


https://github.com/user-attachments/assets/43f4e647-317a-47b5-a570-bee70716a2de

* Fixes https://github.com/rerun-io/rerun/issues/5350

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7880?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7880?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7880)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.