### PR TITLE
Implement `Menu > Import` and associated command

### DIFF
--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -14,6 +14,7 @@ pub trait UICommandSender {
 pub enum UICommand {
     // Listed in the order they show up in the command palette by default!
     Open,
+    Import,
     SaveRecording,
     SaveRecordingSelection,
     SaveBlueprint,
@@ -111,7 +112,8 @@ impl UICommand {
 
             Self::SaveBlueprint => ("Save blueprint…", "Save the current viewer setup as a Rerun blueprint file (.rbl)"),
 
-            Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …)"),
+            Self::Open => ("Open…", "Open any supported files (.rrd, images, meshes, …) in a new recording"),
+            Self::Import => ("Import…", "Import any supported files (.rrd, images, meshes, …) in the current recording"),
 
             Self::CloseCurrentRecording => (
                 "Close current recording",
@@ -271,6 +273,10 @@ impl UICommand {
             KeyboardShortcut::new(Modifiers::COMMAND, key)
         }
 
+        fn cmd_shift(key: Key) -> KeyboardShortcut {
+            KeyboardShortcut::new(Modifiers::COMMAND.plus(Modifiers::SHIFT), key)
+        }
+
         fn cmd_alt(key: Key) -> KeyboardShortcut {
             KeyboardShortcut::new(Modifiers::COMMAND.plus(Modifiers::ALT), key)
         }
@@ -284,6 +290,7 @@ impl UICommand {
             Self::SaveRecordingSelection => Some(cmd_alt(Key::S)),
             Self::SaveBlueprint => None,
             Self::Open => Some(cmd(Key::O)),
+            Self::Import => Some(cmd_shift(Key::O)),
             Self::CloseCurrentRecording => None,
             Self::CloseAllRecordings => None,
 

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -37,6 +37,7 @@ impl App {
             ui.add_space(SPACING);
 
             UICommand::Open.menu_button_ui(ui, &self.command_sender);
+            UICommand::Import.menu_button_ui(ui, &self.command_sender);
 
             self.save_buttons_ui(ui, _store_context);
 


### PR DESCRIPTION
The last missing piece in the "open data in-place" story.

It does what you think it does: `Menu > Import` is like `Menu > Open`, but imports the data in the current recording rather than create a new one.

![image](https://github.com/user-attachments/assets/68afe0b7-959b-4588-8eb9-5af17358a7b3)


* DNM: requires #7880 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7882?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7882?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7882)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.