### PR TITLE
Show list of enabled feature with `rerun --version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,6 +6187,8 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "parking_lot",
+ "re_build_info",
+ "re_build_tools",
  "re_log",
  "re_mp4",
  "re_rav1d",

--- a/crates/build/re_build_info/src/build_info.rs
+++ b/crates/build/re_build_info/src/build_info.rs
@@ -14,6 +14,9 @@ pub struct BuildInfo {
     /// `CARGO_PKG_NAME`
     pub crate_name: &'static str,
 
+    /// Space-separated names of all features enabled for this crate.
+    pub features: &'static str,
+
     /// Crate version, parsed from `CARGO_PKG_VERSION`, ignoring any `+metadata` suffix.
     pub version: super::CrateVersion,
 
@@ -74,6 +77,7 @@ impl std::fmt::Display for BuildInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
             crate_name,
+            features,
             version,
             rustc_version,
             llvm_version,
@@ -88,6 +92,10 @@ impl std::fmt::Display for BuildInfo {
         let llvm_version = (!llvm_version.is_empty()).then(|| format!("LLVM {llvm_version}"));
 
         write!(f, "{crate_name} {version}")?;
+
+        if !features.is_empty() {
+            write!(f, " ({features})")?;
+        }
 
         if let Some(rustc_version) = rustc_version {
             write!(f, " [{rustc_version}")?;
@@ -147,6 +155,7 @@ impl CrateVersion {
 fn crate_version_from_build_info_string() {
     let build_info = BuildInfo {
         crate_name: "re_build_info",
+        features: "default extra",
         version: CrateVersion {
             major: 0,
             minor: 10,

--- a/crates/build/re_build_info/src/lib.rs
+++ b/crates/build/re_build_info/src/lib.rs
@@ -15,6 +15,7 @@ macro_rules! build_info {
     () => {
         $crate::BuildInfo {
             crate_name: env!("CARGO_PKG_NAME"),
+            features: env!("RE_BUILD_FEATURES"),
             version: $crate::CrateVersion::parse(env!("CARGO_PKG_VERSION")),
             rustc_version: env!("RE_BUILD_RUSTC_VERSION"),
             llvm_version: env!("RE_BUILD_LLVM_VERSION"),

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -195,10 +195,15 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
         }
     }
 
-    set_env(
-        "RE_BUILD_FEATURES",
-        &enabled_features_of(crate_name).unwrap().join(" "),
-    );
+    if environment == Environment::PublishingCrates {
+        // We can't query this during `cargo publish`, but we also don't need the info.
+        set_env("RE_BUILD_FEATURES", "<unknown>");
+    } else {
+        set_env(
+            "RE_BUILD_FEATURES",
+            &enabled_features_of(crate_name).unwrap().join(" "),
+        );
+    }
 }
 
 /// ISO 8601 / RFC 3339 build time.
@@ -274,12 +279,22 @@ fn rust_llvm_versions() -> anyhow::Result<(String, String)> {
     ))
 }
 
-/// Returns info parsed from an invocation of the `cargo metadata` command
+/// Returns info parsed from an invocation of the `cargo metadata` command.
+///
+/// You may not run this during crate publishing.
 pub fn cargo_metadata() -> anyhow::Result<cargo_metadata::Metadata> {
+    // See https://github.com/rerun-io/rerun/pull/7885
+    anyhow::ensure!(
+        Environment::detect() != Environment::PublishingCrates,
+        "Can't get metadata during crate publishing - it would create a Cargo.lock file"
+    );
+
     Ok(cargo_metadata::MetadataCommand::new().exec()?)
 }
 
 /// Returns a list of all the enabled features of the given package.
+///
+/// You may not run this during crate publishing.
 pub fn enabled_features_of(crate_name: &str) -> anyhow::Result<Vec<String>> {
     let metadata = cargo_metadata()?;
 

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -194,6 +194,11 @@ pub fn export_build_info_vars_for_crate(crate_name: &str) {
             );
         }
     }
+
+    set_env(
+        "RE_BUILD_FEATURES",
+        &enabled_features_of(crate_name).unwrap().join(" "),
+    );
 }
 
 /// ISO 8601 / RFC 3339 build time.
@@ -272,4 +277,26 @@ fn rust_llvm_versions() -> anyhow::Result<(String, String)> {
 /// Returns info parsed from an invocation of the `cargo metadata` command
 pub fn cargo_metadata() -> anyhow::Result<cargo_metadata::Metadata> {
     Ok(cargo_metadata::MetadataCommand::new().exec()?)
+}
+
+/// Returns a list of all the enabled features of the given package.
+pub fn enabled_features_of(crate_name: &str) -> anyhow::Result<Vec<String>> {
+    let metadata = cargo_metadata()?;
+
+    let mut features = vec![];
+    for package in &metadata.packages {
+        if package.name == crate_name {
+            for feature in package.features.keys() {
+                println!("Checking if feature is enabled: {feature:?}");
+                let feature_in_screaming_snake_case =
+                    feature.to_ascii_uppercase().replace('-', "_");
+                if std::env::var(format!("CARGO_FEATURE_{feature_in_screaming_snake_case}")).is_ok()
+                {
+                    features.push(feature.clone());
+                }
+            }
+        }
+    }
+
+    Ok(features)
 }

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -37,6 +37,7 @@ nasm = [
 
 
 [dependencies]
+re_build_info.workspace = true
 re_log.workspace = true
 re_tracing.workspace = true
 
@@ -66,6 +67,7 @@ criterion.workspace = true
 
 # For build.rs:
 [build-dependencies]
+re_build_tools.workspace = true
 cfg_aliases.workspace = true
 
 

--- a/crates/store/re_video/build.rs
+++ b/crates/store/re_video/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    re_build_tools::export_build_info_vars_for_crate(env!("CARGO_PKG_NAME"));
+
     // uncomment these when we update to Rust 1.80: https://blog.rust-lang.org/2024/05/06/check-cfg.html
     // println!("cargo::rustc-check-cfg=cfg(native)");
     // println!("cargo::rustc-check-cfg=cfg(linux_arm64)");

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -13,15 +13,7 @@ pub use self::{
     time::{Time, Timescale},
 };
 
-/// Which features was this crate compiled with?
-pub fn features() -> Vec<&'static str> {
-    // TODO(emilk): is there a helper crate for this?
-    let mut features = vec![];
-    if cfg!(feature = "av1") {
-        features.push("av1");
-    }
-    if cfg!(feature = "nasm") {
-        features.push("nasm");
-    }
-    features
+/// Returns information about this crate
+pub fn build_info() -> re_build_info::BuildInfo {
+    re_build_info::build_info!()
 }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -553,7 +553,7 @@ where
 
     if args.version {
         println!("{build_info}");
-        println!("Video features: {}", re_video::features().join(" "));
+        println!("Video features: {}", re_video::build_info().features);
         return Ok(0);
     }
 

--- a/crates/utils/re_analytics/src/lib.rs
+++ b/crates/utils/re_analytics/src/lib.rs
@@ -345,6 +345,7 @@ impl Properties for re_build_info::BuildInfo {
         let git_hash = self.git_hash_or_tag();
         let Self {
             crate_name: _,
+            features,
             version,
             rustc_version,
             llvm_version,
@@ -355,6 +356,7 @@ impl Properties for re_build_info::BuildInfo {
             datetime,
         } = self;
 
+        event.insert("features", features);
         event.insert("git_hash", git_hash);
         event.insert("rerun_version", version.to_string());
         event.insert("rust_version", rustc_version);

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -114,6 +114,7 @@ impl App {
     fn about_rerun_ui(&self, frame: &eframe::Frame, ui: &mut egui::Ui) {
         let re_build_info::BuildInfo {
             crate_name,
+            features,
             version,
             rustc_version,
             llvm_version,
@@ -137,6 +138,12 @@ impl App {
             "{crate_name} {version} {git_hash_suffix}\n\
             {target_triple}"
         );
+
+        // It is really the features of `rerun-cli` (the `rerun` binary) that are interesting.
+        // For the web-viewer we get `crate_name: "re_viewer"` here, which is much less interesting.
+        if crate_name == "rerun-cli" && !features.is_empty() {
+            label += &format!("\n{crate_name} features: {features}");
+        }
 
         if !rustc_version.is_empty() {
             label += &format!("\nrustc {rustc_version}");


### PR DESCRIPTION
* Reverts rerun-io/rerun#7770
* Re-applies https://github.com/rerun-io/rerun/pull/7744

The revert was because during `cargo publish`, a `Cargo.lock` file materialized, and that made cargo angry:

```
Failed to publish re_sdk:
error: failed to verify package tarball

Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
  Added: /home/runner/work/rerun/rerun/target/package/re_sdk-0.19.0-alpha.9/Cargo.lock
```

So in this PR we only query about which cargo features if we're NOT in a `cargo publish` build. That should work! We'll know when we next publish some crates :)