### PR TITLE
Link checker now runs with reported failures if a markdown changes or on nightly channel

### DIFF
--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -181,6 +181,8 @@ jobs:
     needs: markdown-paths-filter
     if: inputs.CHANNEL == 'nightly' || needs.markdown-paths-filter.outputs.md_changes == 'true'
     runs-on: ubuntu-latest
+    # do not fail entire workflow (e.g. nightly) if this is the only failing check
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -189,6 +191,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:
+          fail: true
           lycheeVersion: "0.15.1"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           # Pass --verbose, so that all considered links are printed, making it easier to debug.

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -181,8 +181,6 @@ jobs:
     needs: markdown-paths-filter
     if: inputs.CHANNEL == 'nightly' || needs.markdown-paths-filter.outputs.md_changes == 'true'
     runs-on: ubuntu-latest
-    # do not fail entire workflow (e.g. nightly) if this is the only failing check
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -161,8 +161,25 @@ jobs:
 
   # ---------------------------------------------------------------------------
 
+  markdown-paths-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      md_changes: ${{ steps.filter.outputs.md_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || '' }}
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            md_changes:
+              - '**/*.md'
+
   link-checker:
     name: Check links
+    needs: markdown-paths-filter
+    if: inputs.CHANNEL == 'nightly' || needs.markdown-paths-filter.outputs.md_changes == 'true'
     runs-on: ubuntu-latest
     # do not fail entire workflow (e.g. nightly) if this is the only failing check
     continue-on-error: true
@@ -174,7 +191,6 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.10.0
         with:
-          fail: ${{ inputs.CHANNEL == 'nightly' }}
           lycheeVersion: "0.15.1"
           # When given a directory, lychee checks only markdown, html and text files, everything else we have to glob in manually.
           # Pass --verbose, so that all considered links are printed, making it easier to debug.

--- a/docs/content/getting-started/data-in/cpp.md
+++ b/docs/content/getting-started/data-in/cpp.md
@@ -190,6 +190,8 @@ Notably, the [`RecordingStream::log`](https://github.com/rerun-io/rerun/blob/d96
 will handle any data type that implements the [`AsComponents<T>`](https://github.com/rerun-io/rerun/blob/latest/rerun_cpp/src/rerun/as_components.hpp) trait, making it easy to add your own data.
 For more information on how to supply your own components see [Use custom data](../../howto/extend/custom-data.md).
 
+TODO: test change!
+
 ### Entities & hierarchies
 
 Note the two strings we're passing in: `"dna/structure/left"` and `"dna/structure/right"`.

--- a/docs/content/getting-started/data-in/cpp.md
+++ b/docs/content/getting-started/data-in/cpp.md
@@ -190,8 +190,6 @@ Notably, the [`RecordingStream::log`](https://github.com/rerun-io/rerun/blob/d96
 will handle any data type that implements the [`AsComponents<T>`](https://github.com/rerun-io/rerun/blob/latest/rerun_cpp/src/rerun/as_components.hpp) trait, making it easy to add your own data.
 For more information on how to supply your own components see [Use custom data](../../howto/extend/custom-data.md).
 
-TODO: test change!
-
 ### Entities & hierarchies
 
 Note the two strings we're passing in: `"dna/structure/left"` and `"dna/structure/right"`.


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7887

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7888?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7888?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7888)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.