### PR TITLE
Update pixi to 0.34 and add new script to check pixi / rust versions

### DIFF
--- a/.github/workflows/auto_approve.yml
+++ b/.github/workflows/auto_approve.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Wait a few seconds
         run: |

--- a/.github/workflows/checkboxes.yml
+++ b/.github/workflows/checkboxes.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Check PR checkboxes
         run: |

--- a/.github/workflows/contrib_checks.yml
+++ b/.github/workflows/contrib_checks.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Python format check
         run: pixi run py-fmt-check
@@ -63,7 +63,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: py-docs
 
       - name: Build via mkdocs
@@ -82,7 +82,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Codegen check
         run: pixi run codegen --force --check
@@ -95,7 +95,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Rust checks & tests
         run: pixi run rs-check --skip individual_crates docs_slow
@@ -108,7 +108,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Rerun lints
         run: pixi run lint-rerun
@@ -153,7 +153,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: cpp
 
       # TODO(emilk): make this work somehow. Right now this just results in

--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: wheel-test-min
 
       - name: Build rerun-cli

--- a/.github/workflows/on_pull_request_target_contrib.yml
+++ b/.github/workflows/on_pull_request_target_contrib.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Update PR description
         run: |

--- a/.github/workflows/on_push_docs.yml
+++ b/.github/workflows/on_push_docs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Get version
         id: versioning
@@ -58,7 +58,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: py-docs
 
       - name: Install rerun-sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Update crate versions
         id: versioning
@@ -398,7 +398,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: git config
         run: |

--- a/.github/workflows/reusable_bench.yml
+++ b/.github/workflows/reusable_bench.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           # Only has the deps for round-trips. Not all examples.
           environments: wheel-test-min
 
@@ -169,7 +169,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -164,7 +164,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Build web-viewer (release)
         run: pixi run rerun-build-web-release

--- a/.github/workflows/reusable_build_and_upload_wheels.yml
+++ b/.github/workflows/reusable_build_and_upload_wheels.yml
@@ -189,7 +189,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Get sha
         id: get-sha

--- a/.github/workflows/reusable_build_examples.yml
+++ b/.github/workflows/reusable_build_examples.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: wheel-test
 
       - name: Download Wheel

--- a/.github/workflows/reusable_build_js.yml
+++ b/.github/workflows/reusable_build_js.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Install yarn dependencies
         run: pixi run yarn --cwd rerun_js install

--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Build web-viewer (release)
         run: |

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -62,7 +62,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Codegen check
         run: pixi run codegen --force --check
@@ -79,7 +79,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -118,7 +118,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Run linter
         run: |
@@ -154,7 +154,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: prettier --check
         run: pixi run misc-fmt-check

--- a/.github/workflows/reusable_checks.yml
+++ b/.github/workflows/reusable_checks.yml
@@ -122,11 +122,11 @@ jobs:
 
       - name: Run linter
         run: |
-          # double quoting because pixi does its own glob expansion
-          pixi run mdlint --glob "'docs/content/**/*.md'"
-          pixi run mdlint --glob "'examples/python/*/README.md'"
-          pixi run mdlint --glob "'examples/cpp/*/README.md'"
-          pixi run mdlint --glob "'examples/rust/*/README.md'"
+          # Single quoted because pixi does its own glob expansion
+          pixi run mdlint --glob 'docs/content/**/*.md'
+          pixi run mdlint --glob 'examples/python/*/README.md'
+          pixi run mdlint --glob 'examples/cpp/*/README.md'
+          pixi run mdlint --glob 'examples/rust/*/README.md'
 
   # ---------------------------------------------------------------------------
 

--- a/.github/workflows/reusable_checks_cpp.yml
+++ b/.github/workflows/reusable_checks_cpp.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: cpp
 
       - name: Set up Rust

--- a/.github/workflows/reusable_checks_python.yml
+++ b/.github/workflows/reusable_checks_python.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Python format check
         run: pixi run py-fmt-check
@@ -55,7 +55,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: py-docs
 
       - name: Build via mkdocs

--- a/.github/workflows/reusable_checks_rust.yml
+++ b/.github/workflows/reusable_checks_rust.yml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Rust checks & tests
         if: ${{ inputs.CHANNEL == 'pr' }}
@@ -103,7 +103,7 @@ jobs:
       # Building with `--all-features` requires extra build tools like `nasm`.
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Download test assets
         run: pixi run python ./tests/assets/download_test_assets.py

--- a/.github/workflows/reusable_deploy_docs.yml
+++ b/.github/workflows/reusable_deploy_docs.yml
@@ -73,7 +73,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: py-docs
 
       - name: Set up git author
@@ -145,7 +145,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Delete existing /target/doc
         run: rm -rf ./target/doc
@@ -199,7 +199,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Doxygen C++ docs
         run: pixi run -e cpp cpp-docs

--- a/.github/workflows/reusable_pr_summary.yml
+++ b/.github/workflows/reusable_pr_summary.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - id: "auth"
         uses: google-github-actions/auth@v2

--- a/.github/workflows/reusable_publish_js.yml
+++ b/.github/workflows/reusable_publish_js.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Publish packages
         env:

--- a/.github/workflows/reusable_publish_web.yml
+++ b/.github/workflows/reusable_publish_web.yml
@@ -76,7 +76,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: wheel-test
 
       # built by `reusable_build_and_publish_wheels`

--- a/.github/workflows/reusable_publish_wheels.yml
+++ b/.github/workflows/reusable_publish_wheels.yml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - id: "auth"
         uses: google-github-actions/auth@v2

--- a/.github/workflows/reusable_release_crates.yml
+++ b/.github/workflows/reusable_release_crates.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Build web-viewer (release)
         run: pixi run rerun-build-web-release

--- a/.github/workflows/reusable_run_notebook.yml
+++ b/.github/workflows/reusable_run_notebook.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           environments: wheel-test
 
       - name: Download Wheel

--- a/.github/workflows/reusable_sync_release_assets.yml
+++ b/.github/workflows/reusable_sync_release_assets.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - id: "auth"
         uses: google-github-actions/auth@v2

--- a/.github/workflows/reusable_test_wheels.yml
+++ b/.github/workflows/reusable_test_wheels.yml
@@ -147,7 +147,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
           # Only has the deps for round-trips. Not all examples.
           environments: wheel-test-min
 

--- a/.github/workflows/reusable_track_size.yml
+++ b/.github/workflows/reusable_track_size.yml
@@ -191,7 +191,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Render benchmark result
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/reusable_update_pr_body.yml
+++ b/.github/workflows/reusable_update_pr_body.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.25.0
+          pixi-version: v0.34.0
 
       - name: Update PR description
         run: |

--- a/BUILD.md
+++ b/BUILD.md
@@ -31,6 +31,12 @@ If you are using an Apple-silicon Mac (M1, M2), make sure `rustc -vV` outputs `h
 rustup set default-host aarch64-apple-darwin && rustup install 1.79.0
 ```
 
+## Validating your environment
+You can validate your environment is set up correctly by running:
+```sh
+pixi run check-env
+```
+
 
 ## Building and running the Viewer
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,6 +9,11 @@
 #
 # https://prefix.dev/docs/pixi/overview
 
+# We currently assume pixi version 0.34.0
+# You can check that your environment is correct by running:
+# - python scripts/check_env.py
+# - pixi run check-env
+
 [project]
 name = "rerun"
 authors = ["rerun.io <opensource@rerun.io>"]
@@ -113,6 +118,9 @@ examples-pypi = ["examples-common", "python-pypi"]
 
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.
+
+# Check that your environment is set up correctly
+check-env = "python scripts/check_env.py"
 
 # Run the codegen. Optionally pass `--profile` argument if you want.
 codegen = "cargo --quiet run --package re_types_builder -- "

--- a/scripts/check_env.py
+++ b/scripts/check_env.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+
+"""Checks that the dev environment is set up correctly."""
+
+from __future__ import annotations
+
+import subprocess
+
+PIXI_VERSION = "0.34.0"
+CARGO_VERSION = "1.79.0"
+RUST_VERSION = "1.79.0"
+
+
+def check_version(cmd: str, expected: str, update: str, install: str) -> bool:
+    try:
+        output = subprocess.check_output([cmd, "--version"])
+
+        version = output.strip().decode("utf-8").split(" ")[1]
+
+        if version != expected:
+            print(f"Expected {cmd} version {expected}, got {version}")
+            print(f"Please run `{update}`")
+            return False
+        else:
+            print(f"{cmd} version {version} is correct")
+            return True
+
+    except FileNotFoundError:
+        print(f"{cmd} not found in PATH. Please install via {install}")
+        return False
+
+
+def main() -> int:
+    success = True
+
+    success &= check_version(
+        "pixi",
+        PIXI_VERSION,
+        f"pixi self-update --version {PIXI_VERSION}",
+        "https://pixi.sh/latest/",
+    )
+
+    success &= check_version(
+        "cargo",
+        CARGO_VERSION,
+        f"rustup install {CARGO_VERSION}",
+        "https://rustup.rs/",
+    )
+
+    success &= check_version(
+        "rustc",
+        RUST_VERSION,
+        f"rustup install {RUST_VERSION}",
+        "https://rustup.rs/",
+    )
+
+    if success:
+        exit(0)
+    else:
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What
- These things are managed outside of pixi itself. It's nice to have an easy way to sanity check them.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7893?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7893?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7893)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.