### PR TITLE
Fix too short picking ray in pinhole-only scenarios

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/ui_3d.rs
@@ -888,8 +888,14 @@ fn add_picking_ray(
     let mut line_batch = line_builder.batch("picking ray");
 
     let origin = ray.point_along(0.0);
+
     // No harm in making this ray _very_ long. (Infinite messes with things though!)
-    let fallback_ray_end = ray.point_along(scene_bbox.size().length() * 10.0);
+    //
+    // There are some degenerated cases where just taking the scene bounding box isn't enough:
+    // For instance, we don't add pinholes & depth images to the bounding box since
+    // the default size of a pinhole visualization itself is determined by the bounding box.
+    let fallback_ray_end =
+        ray.point_along((scene_bbox.size().length() * 10.0).at_least(thick_ray_length * 10.0));
     let main_ray_end = ray.point_along(thick_ray_length);
 
     line_batch


### PR DESCRIPTION
### What
Details in the code comment.
I tried at first fixing the lack of contribution to the bounding box but then realized that this is a can of worms.

![image](https://github.com/user-attachments/assets/83c03582-5641-45f5-aa40-78abfe7cfcbf)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7899?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7899?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7899)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.