### PR TITLE
remote store gRPC spec update: introduce application level errors for registration response

### DIFF
--- a/crates/store/re_remote_store_types/proto/rerun/v0/common.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/common.proto
@@ -163,9 +163,9 @@ enum SparseFillStrategy {
 }
 
 // Error codes for application level errors
-enum Code {
+enum ErrorCode {
     // unused
-    _NO_ERROR = 0;
+    _UNUSED = 0;
 
     // object store access error
     OBJECT_STORE_ERROR = 1;

--- a/crates/store/re_remote_store_types/proto/rerun/v0/common.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/common.proto
@@ -161,3 +161,15 @@ enum SparseFillStrategy {
     NONE = 0;
     LATEST_AT_GLOBAL = 1;
 }
+
+// Error codes for application level errors
+enum Code {
+    // unused
+    _NO_ERROR = 0;
+
+    // object store access error
+    OBJECT_STORE_ERROR = 1;
+
+    // metadata database access error
+    METADATA_DB_ERROR = 2;
+}

--- a/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
@@ -27,11 +27,27 @@ message ObjectStorage {
 }
 
 message RegisterRecordingsResponse {
+    oneof response {
+        RegistrationSuccess success = 1;
+        RegistrationError error = 2;
+    }
+}
+
+message RegistrationSuccess {
     // Note / TODO(zehiko): this implies we read the record (for example go through entire .rrd file
     // chunk by chunk) and extract the metadata. So we might want to 1/ not do this i.e.
     // only do it as part of explicit GetMetadata request or 2/ do it if Request has "include_metadata=true"
     // or 3/ do it always
     repeated RecordingMetadata metadata = 2;
+}
+
+message RegistrationError {
+    // error code
+    Code code = 1;
+    // url of the recording that failed to register
+    string url = 2;
+    // human readable details about the error
+    string message = 3;
 }
 
 // ---------------- GetRecordingMetadata  -----------------

--- a/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
@@ -37,7 +37,7 @@ message RegisterRecordingsResponse {
 // Server can include details about the error as part of gRPC error (Status)
 message RegistrationError {
     // error code
-    Code code = 1;
+    ErrorCode code = 1;
     // url of the recording that failed to register
     string url = 2;
     // human readable details about the error

--- a/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
@@ -27,13 +27,6 @@ message ObjectStorage {
 }
 
 message RegisterRecordingsResponse {
-    oneof response {
-        RegistrationSuccess success = 1;
-        RegistrationError error = 2;
-    }
-}
-
-message RegistrationSuccess {
     // Note / TODO(zehiko): this implies we read the record (for example go through entire .rrd file
     // chunk by chunk) and extract the metadata. So we might want to 1/ not do this i.e.
     // only do it as part of explicit GetMetadata request or 2/ do it if Request has "include_metadata=true"
@@ -41,6 +34,7 @@ message RegistrationSuccess {
     repeated RecordingMetadata metadata = 2;
 }
 
+// Server can include details about the error as part of gRPC error (Status)
 message RegistrationError {
     // error code
     Code code = 1;

--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -312,6 +312,18 @@ pub mod v0 {
             }
         }
     }
+
+    // ------- Application level errors -------
+    impl std::error::Error for RegistrationError {}
+
+    impl std::fmt::Display for RegistrationError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_fmt(format_args!(
+                "Failed to register recording: {}, error code: {}, error message: {}",
+                self.url, self.code, self.message
+            ))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
@@ -212,22 +212,22 @@ impl SparseFillStrategy {
 /// Error codes for application level errors
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
-pub enum Code {
+pub enum ErrorCode {
     /// unused
-    NoError = 0,
+    Unused = 0,
     /// object store access error
     ObjectStoreError = 1,
     /// metadata database access error
     MetadataDbError = 2,
 }
-impl Code {
+impl ErrorCode {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
-            Self::NoError => "_NO_ERROR",
+            Self::Unused => "_UNUSED",
             Self::ObjectStoreError => "OBJECT_STORE_ERROR",
             Self::MetadataDbError => "METADATA_DB_ERROR",
         }
@@ -235,7 +235,7 @@ impl Code {
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
-            "_NO_ERROR" => Some(Self::NoError),
+            "_UNUSED" => Some(Self::Unused),
             "OBJECT_STORE_ERROR" => Some(Self::ObjectStoreError),
             "METADATA_DB_ERROR" => Some(Self::MetadataDbError),
             _ => None,
@@ -272,7 +272,7 @@ pub struct RegisterRecordingsResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegistrationError {
     /// error code
-    #[prost(enumeration = "Code", tag = "1")]
+    #[prost(enumeration = "ErrorCode", tag = "1")]
     pub code: i32,
     /// url of the recording that failed to register
     #[prost(string, tag = "2")]

--- a/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
@@ -209,6 +209,39 @@ impl SparseFillStrategy {
         }
     }
 }
+/// Error codes for application level errors
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Code {
+    /// unused
+    NoError = 0,
+    /// object store access error
+    ObjectStoreError = 1,
+    /// metadata database access error
+    MetadataDbError = 2,
+}
+impl Code {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::NoError => "_NO_ERROR",
+            Self::ObjectStoreError => "OBJECT_STORE_ERROR",
+            Self::MetadataDbError => "METADATA_DB_ERROR",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "_NO_ERROR" => Some(Self::NoError),
+            "OBJECT_STORE_ERROR" => Some(Self::ObjectStoreError),
+            "METADATA_DB_ERROR" => Some(Self::MetadataDbError),
+            _ => None,
+        }
+    }
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterRecordingsRequest {
     #[prost(string, tag = "1")]
@@ -228,12 +261,39 @@ pub struct ObjectStorage {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterRecordingsResponse {
+    #[prost(oneof = "register_recordings_response::Response", tags = "1, 2")]
+    pub response: ::core::option::Option<register_recordings_response::Response>,
+}
+/// Nested message and enum types in `RegisterRecordingsResponse`.
+pub mod register_recordings_response {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Response {
+        #[prost(message, tag = "1")]
+        Success(super::RegistrationSuccess),
+        #[prost(message, tag = "2")]
+        Error(super::RegistrationError),
+    }
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegistrationSuccess {
     /// Note / TODO(zehiko): this implies we read the record (for example go through entire .rrd file
     /// chunk by chunk) and extract the metadata. So we might want to 1/ not do this i.e.
     /// only do it as part of explicit GetMetadata request or 2/ do it if Request has "include_metadata=true"
     /// or 3/ do it always
     #[prost(message, repeated, tag = "2")]
     pub metadata: ::prost::alloc::vec::Vec<RecordingMetadata>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegistrationError {
+    /// error code
+    #[prost(enumeration = "Code", tag = "1")]
+    pub code: i32,
+    /// url of the recording that failed to register
+    #[prost(string, tag = "2")]
+    pub url: ::prost::alloc::string::String,
+    /// human readable details about the error
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetRecordingMetadataRequest {

--- a/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
@@ -261,21 +261,6 @@ pub struct ObjectStorage {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegisterRecordingsResponse {
-    #[prost(oneof = "register_recordings_response::Response", tags = "1, 2")]
-    pub response: ::core::option::Option<register_recordings_response::Response>,
-}
-/// Nested message and enum types in `RegisterRecordingsResponse`.
-pub mod register_recordings_response {
-    #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Response {
-        #[prost(message, tag = "1")]
-        Success(super::RegistrationSuccess),
-        #[prost(message, tag = "2")]
-        Error(super::RegistrationError),
-    }
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RegistrationSuccess {
     /// Note / TODO(zehiko): this implies we read the record (for example go through entire .rrd file
     /// chunk by chunk) and extract the metadata. So we might want to 1/ not do this i.e.
     /// only do it as part of explicit GetMetadata request or 2/ do it if Request has "include_metadata=true"
@@ -283,6 +268,7 @@ pub struct RegistrationSuccess {
     #[prost(message, repeated, tag = "2")]
     pub metadata: ::prost::alloc::vec::Vec<RecordingMetadata>,
 }
+/// Server can include details about the error as part of gRPC error (Status)
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RegistrationError {
     /// error code


### PR DESCRIPTION
### What

remote store errors can be split into 2 categories:
- gRPC layer errors that are always ~~non-retryable errors~~ (see comment  [below](https://github.com/rerun-io/rerun/pull/7904#pullrequestreview-2394842976)) where remote store signals that it wants to cut the responses stream immediately
- application level errors where at the gRPC layer we return a successful response (i.e. ``Status::OK``), but the response itself contains application error

This change introduces application level error for the ``register_record()`` API call, but it is only leveraged for gRPC error, specific for ``Status::details`` .

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7904?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7904?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7904)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.