### PR TITLE
gRPC: Add protocol and comms implementation for FetchRecording

### DIFF
--- a/crates/store/re_remote_store_types/.gitattributes
+++ b/crates/store/re_remote_store_types/.gitattributes
@@ -1,0 +1,1 @@
+src/v0/rerun.remote_store.v0.rs linguist-generated=true

--- a/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
@@ -7,6 +7,7 @@ import "rerun/v0/common.proto";
 service StorageNode {
     rpc ListRecordings(ListRecordingsRequest) returns (ListRecordingsResponse) {}
     rpc Query(QueryRequest) returns (stream QueryResponse) {}
+    rpc FetchRecording(FetchRecordingRequest) returns (stream FetchRecordingResponse) {}
     rpc GetRecordingMetadata(GetRecordingMetadataRequest) returns (GetRecordingMetadataResponse) {}
     // TODO(zehiko) - should this be singular recording registration? Currently we can have 1 rrd => many recordings
     rpc RegisterRecordings(RegisterRecordingsRequest) returns (RegisterRecordingsResponse) {}
@@ -114,4 +115,21 @@ message RecordingInfo {
 
 enum RecordingType {
     RRD = 0;
+}
+
+// ----------------- FetchRecording -----------------
+
+message FetchRecordingRequest {
+    RecordingId id = 1;
+}
+
+// TODO(jleibs): Eventually this becomes either query-mediated in some way, but for now
+// it's useful to be able to just get back the whole RRD somehow.
+message FetchRecordingResponse {
+    // TODO(zehiko) we need to expand this to become something like 'encoder options'
+    // as we will need to specify additional options like compression, including schema
+    // in payload, etc.
+    EncoderVersion encoder_version = 1;
+    // payload is raw bytes that the relevant codec can interpret
+    bytes payload = 2;
 }

--- a/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_remote_store_types/proto/rerun/v0/remote_store.proto
@@ -120,7 +120,7 @@ enum RecordingType {
 // ----------------- FetchRecording -----------------
 
 message FetchRecordingRequest {
-    RecordingId id = 1;
+    RecordingId recording_id = 1;
 }
 
 // TODO(jleibs): Eventually this becomes either query-mediated in some way, but for now

--- a/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
@@ -358,7 +358,7 @@ pub struct RecordingInfo {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FetchRecordingRequest {
     #[prost(message, optional, tag = "1")]
-    pub id: ::core::option::Option<RecordingId>,
+    pub recording_id: ::core::option::Option<RecordingId>,
 }
 /// TODO(jleibs): Eventually this becomes either query-mediated in some way, but for now
 /// it's useful to be able to just get back the whole RRD somehow.

--- a/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_remote_store_types/src/v0/rerun.remote_store.v0.rs
@@ -355,6 +355,24 @@ pub struct RecordingInfo {
     #[prost(enumeration = "RecordingType", tag = "5")]
     pub typ: i32,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchRecordingRequest {
+    #[prost(message, optional, tag = "1")]
+    pub id: ::core::option::Option<RecordingId>,
+}
+/// TODO(jleibs): Eventually this becomes either query-mediated in some way, but for now
+/// it's useful to be able to just get back the whole RRD somehow.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FetchRecordingResponse {
+    /// TODO(zehiko) we need to expand this to become something like 'encoder options'
+    /// as we will need to specify additional options like compression, including schema
+    /// in payload, etc.
+    #[prost(enumeration = "EncoderVersion", tag = "1")]
+    pub encoder_version: i32,
+    /// payload is raw bytes that the relevant codec can interpret
+    #[prost(bytes = "vec", tag = "2")]
+    pub payload: ::prost::alloc::vec::Vec<u8>,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum EncoderVersion {
@@ -530,6 +548,27 @@ pub mod storage_node_client {
             ));
             self.inner.server_streaming(req, path, codec).await
         }
+        pub async fn fetch_recording(
+            &mut self,
+            request: impl tonic::IntoRequest<super::FetchRecordingRequest>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::FetchRecordingResponse>>,
+            tonic::Status,
+        > {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/rerun.remote_store.v0.StorageNode/FetchRecording",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new(
+                "rerun.remote_store.v0.StorageNode",
+                "FetchRecording",
+            ));
+            self.inner.server_streaming(req, path, codec).await
+        }
         pub async fn get_recording_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRecordingMetadataRequest>,
@@ -597,6 +636,15 @@ pub mod storage_node_server {
             &self,
             request: tonic::Request<super::QueryRequest>,
         ) -> std::result::Result<tonic::Response<Self::QueryStream>, tonic::Status>;
+        /// Server streaming response type for the FetchRecording method.
+        type FetchRecordingStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::FetchRecordingResponse, tonic::Status>,
+            > + std::marker::Send
+            + 'static;
+        async fn fetch_recording(
+            &self,
+            request: tonic::Request<super::FetchRecordingRequest>,
+        ) -> std::result::Result<tonic::Response<Self::FetchRecordingStream>, tonic::Status>;
         async fn get_recording_metadata(
             &self,
             request: tonic::Request<super::GetRecordingMetadataRequest>,
@@ -746,6 +794,50 @@ pub mod storage_node_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = QuerySvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/rerun.remote_store.v0.StorageNode/FetchRecording" => {
+                    #[allow(non_camel_case_types)]
+                    struct FetchRecordingSvc<T: StorageNode>(pub Arc<T>);
+                    impl<T: StorageNode>
+                        tonic::server::ServerStreamingService<super::FetchRecordingRequest>
+                        for FetchRecordingSvc<T>
+                    {
+                        type Response = super::FetchRecordingResponse;
+                        type ResponseStream = T::FetchRecordingStream;
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::FetchRecordingRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as StorageNode>::fetch_recording(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = FetchRecordingSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
### What
This basically makes it possible to use the storage node as a proxy to fetch the full contents of all the chunks for the giving recording from the store.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7909?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7909?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7909)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.