### PR TITLE
Fix snippet roundtrip CI

### DIFF
--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -137,6 +137,7 @@ views = [
   "rust", # Not implemented
 ]
 "tutorials/visualization" = [
+  "py",   # Requires passing RRD as argument
   "cpp",  # Not implemented
   "rust", # Not implemented
 ]

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -45,6 +45,11 @@
   "cpp",  # Blueprint API doesn't exist for C++/Rust
   "rust", # Blueprint API doesn't exist for C++/Rust
 ]
+"concepts/app-model" = [ # Uses a non-standard logging workflow
+  "py",
+  "cpp",
+  "rust",
+]
 views = [
   "cpp",  # TODO(#5520): C++ views are not yet implemented
   "rust", # TODO(#5521): Rust views are not yet implemented
@@ -128,6 +133,10 @@ views = [
 ]
 "tutorials/data_out" = [
   "py",   # Requires context (an RRD file to be exported by the user)
+  "cpp",  # Not implemented
+  "rust", # Not implemented
+]
+"tutorials/visualization" = [
   "cpp",  # Not implemented
   "rust", # Not implemented
 ]


### PR DESCRIPTION
### What

Disable some recently introduced snippets which break roundtrip.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7910?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7910?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7910)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.