### PR TITLE
Fix CpuMesh.albedo_factor overwriting

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -55,7 +55,9 @@ impl LoadedMesh {
         // Overwriting albedo_factor of CpuMesh if specified in the Asset3D
         if let Some(albedo_factor) = albedo_factor {
             for instance in &cpu_model.instances {
-                cpu_model.meshes[instance.mesh].materials[0].albedo_factor = albedo_factor.0.into();
+                for material in &mut cpu_model.meshes[instance.mesh].materials {
+                    material.albedo_factor = albedo_factor.0.into();
+                }
             }
         }
 

--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -52,7 +52,7 @@ impl LoadedMesh {
             _ => anyhow::bail!("{media_type} files are not supported"),
         };
 
-        // Overwriting albedo_factor of CpuMesh in specified in the Asset3D
+        // Overwriting albedo_factor of CpuMesh if specified in the Asset3D
         if let Some(albedo_factor) = albedo_factor {
             for instance in &cpu_model.instances {
                 cpu_model.meshes[instance.mesh].materials[0].albedo_factor = albedo_factor.0.into();

--- a/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_loader.rs
@@ -53,10 +53,11 @@ impl LoadedMesh {
         };
 
         // Overwriting albedo_factor of CpuMesh in specified in the Asset3D
-        cpu_model.instances.iter().for_each(|instance| {
-            cpu_model.meshes[instance.mesh].materials[0].albedo_factor =
-                albedo_factor.map_or(re_renderer::Rgba::WHITE, |c| c.0.into());
-        });
+        if let Some(albedo_factor) = albedo_factor {
+            for instance in &cpu_model.instances {
+                cpu_model.meshes[instance.mesh].materials[0].albedo_factor = albedo_factor.0.into();
+            }
+        }
 
         let bbox = cpu_model.calculate_bounding_box();
         let mesh_instances = cpu_model.into_gpu_meshes(render_ctx)?;


### PR DESCRIPTION
### What
If `Asset3D.albedo_factor` isn't specified, `CpuMesh.albedo_factor` will always be set to `re_renderer::Rgba::WHITE`.
However, in some cases `CpuMesh.albedo_factor` may contain a color that we don't want to be overwritten.


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7914?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7914?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7914)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.