### PR TITLE
Storage handles 1: Introduce `ChunkStoreHandle`

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -16,6 +16,11 @@ command = [
 need_stdout = false
 watch = ["tests", "benches", "examples"]
 
+[jobs.libs]
+command = ["cargo", "clippy", "--lib", "--all-features", "--color=always"]
+need_stdout = false
+watch = ["tests", "benches", "examples"]
+
 [jobs.wasm]
 command = [
   "cargo",

--- a/crates/store/re_chunk_store/Cargo.toml
+++ b/crates/store/re_chunk_store/Cargo.toml
@@ -45,7 +45,7 @@ indent.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
-parking_lot.workspace = true
+parking_lot = { workspace = true, features = ["arc_lock"] }
 thiserror.workspace = true
 web-time.workspace = true
 

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -32,7 +32,9 @@ pub use self::dataframe::{
 pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::stats::{ChunkStoreChunkStats, ChunkStoreStats};
-pub use self::store::{ChunkStore, ChunkStoreConfig, ChunkStoreGeneration, ColumnMetadata};
+pub use self::store::{
+    ChunkStore, ChunkStoreConfig, ChunkStoreGeneration, ChunkStoreHandle, ColumnMetadata,
+};
 pub use self::subscribers::{ChunkStoreSubscriber, ChunkStoreSubscriberHandle};
 
 pub(crate) use self::store::ColumnMetadataState;

--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -152,11 +152,11 @@ impl StoreBundle {
     /// The closest neighbor is the next recording when sorted by (app ID, time), if any, or the
     /// previous one otherwise. This is used to update the selected recording when the current one
     /// is deleted.
-    pub fn find_closest_recording(&self, id: &StoreId) -> Option<&StoreId> {
+    pub fn find_closest_recording(&self, id: &StoreId) -> Option<StoreId> {
         let mut recs = self.recordings().collect_vec();
         recs.sort_by_key(|entity_db| entity_db.sort_key());
 
-        let cur_pos = recs.iter().position(|rec| rec.store_id() == id);
+        let cur_pos = recs.iter().position(|rec| rec.store_id() == *id);
 
         if let Some(cur_pos) = cur_pos {
             if recs.len() > cur_pos + 1 {
@@ -172,7 +172,7 @@ impl StoreBundle {
     }
 
     /// Returns the [`StoreId`] of the oldest modified recording, according to [`EntityDb::last_modified_at`].
-    pub fn find_oldest_modified_recording(&self) -> Option<&StoreId> {
+    pub fn find_oldest_modified_recording(&self) -> Option<StoreId> {
         let mut entity_dbs = self
             .entity_dbs
             .values()

--- a/crates/store/re_query/src/range.rs
+++ b/crates/store/re_query/src/range.rs
@@ -21,12 +21,13 @@ impl QueryCache {
     /// This is a cached API -- data will be lazily cached upon access.
     pub fn range(
         &self,
-        store: &ChunkStore,
         query: &RangeQuery,
         entity_path: &EntityPath,
         component_names: impl IntoIterator<Item = ComponentName>,
     ) -> RangeResults {
         re_tracing::profile_function!(entity_path.to_string());
+
+        let store = self.store.read();
 
         let mut results = RangeResults::new(query.clone());
 
@@ -51,7 +52,7 @@ impl QueryCache {
 
             cache.handle_pending_invalidation();
 
-            let cached = cache.range(store, query, entity_path, component_name);
+            let cached = cache.range(&store, query, entity_path, component_name);
             if !cached.is_empty() {
                 results.add(component_name, cached);
             }

--- a/crates/top/rerun/src/commands/rrd/compare.rs
+++ b/crates/top/rerun/src/commands/rrd/compare.rs
@@ -122,6 +122,12 @@ fn compute_uber_table(
             .app_id()
             .cloned()
             .unwrap_or_else(re_log_types::ApplicationId::unknown),
-        store.store().iter_chunks().map(Arc::clone).collect_vec(),
+        store
+            .store()
+            // NOTE: using `read_arc` so the borrow checker can make sense of the partial borrow of `stores`.
+            .read_arc()
+            .iter_chunks()
+            .map(Arc::clone)
+            .collect_vec(),
     ))
 }

--- a/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
+++ b/crates/viewer/re_blueprint_tree/src/blueprint_tree.rs
@@ -900,8 +900,8 @@ fn reset_blueprint_button_ui(ctx: &ViewerContext<'_>, ui: &mut egui::Ui) {
     let mut disabled_reason = None;
 
     if let Some(default_blueprint) = default_blueprint {
-        let active_is_clone_of_default =
-            Some(default_blueprint.store_id()) == ctx.store_context.blueprint.cloned_from();
+        let active_is_clone_of_default = Some(default_blueprint.store_id()).as_ref()
+            == ctx.store_context.blueprint.cloned_from();
         let last_modified_at_the_same_time =
             default_blueprint.latest_row_id() == ctx.store_context.blueprint.latest_row_id();
         if active_is_clone_of_default && last_modified_at_the_same_time {

--- a/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_store_ui.rs
@@ -84,9 +84,9 @@ impl DatastoreUi {
             } else {
                 self.chunk_store_ui(
                     ui,
-                    match self.store_kind {
-                        StoreKind::Recording => ctx.recording_store(),
-                        StoreKind::Blueprint => ctx.blueprint_store(),
+                    &*match self.store_kind {
+                        StoreKind::Recording => ctx.recording_store().read(),
+                        StoreKind::Blueprint => ctx.blueprint_store().read(),
                     },
                     datastore_ui_active,
                     time_zone,

--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_space_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_space_view.rs
@@ -92,7 +92,7 @@ fn recommended_space_views_for_selection(
     let space_view_class_registry = ctx.viewer_context.space_view_class_registry;
     let recording = ctx.viewer_context.recording();
     let applicable_entities_per_visualizer =
-        space_view_class_registry.applicable_entities_for_visualizer_systems(recording.store_id());
+        space_view_class_registry.applicable_entities_for_visualizer_systems(&recording.store_id());
 
     for entry in space_view_class_registry.iter_registry() {
         let Some(suggested_root) = entry

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -47,6 +47,8 @@ impl<'a> DataUi for ComponentPathLatestAtResults<'a> {
             UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => num_instances,
         };
 
+        let store = db.store().read();
+
         // Display data time and additional diagnostic information for static components.
         if !ui_layout.is_single_line() {
             let time = self
@@ -56,9 +58,8 @@ impl<'a> DataUi for ComponentPathLatestAtResults<'a> {
 
             // if the component is static, we display extra diagnostic information
             if time.is_static() {
-                let static_message_count = db
-                    .store()
-                    .num_static_events_for_component(entity_path, *component_name);
+                let static_message_count =
+                    store.num_static_events_for_component(entity_path, *component_name);
                 if static_message_count > 1 {
                     ui.label(ui.ctx().warning_text(format!(
                         "Static component value was overridden {} times",
@@ -71,12 +72,11 @@ impl<'a> DataUi for ComponentPathLatestAtResults<'a> {
                     );
                 }
 
-                let temporal_message_count =
-                    db.store().num_temporal_events_for_component_on_timeline(
-                        &query.timeline(),
-                        entity_path,
-                        *component_name,
-                    );
+                let temporal_message_count = store.num_temporal_events_for_component_on_timeline(
+                    &query.timeline(),
+                    entity_path,
+                    *component_name,
+                );
                 if temporal_message_count > 0 {
                     ui.label(ui.ctx().error_text(format!(
                         "Static component has {} event{} logged on timelines",

--- a/crates/viewer/re_data_ui/src/component_path.rs
+++ b/crates/viewer/re_data_ui/src/component_path.rs
@@ -23,9 +23,9 @@ impl DataUi for ComponentPath {
                 "Indicator component for the {archetype_name} archetype"
             ));
         } else {
-            let results =
-                db.query_caches()
-                    .latest_at(db.store(), query, entity_path, [*component_name]);
+            let results = db
+                .query_caches()
+                .latest_at(query, entity_path, [*component_name]);
             if let Some(unit) = results.components.get(component_name) {
                 crate::ComponentPathLatestAtResults {
                     component_path: self.clone(),
@@ -33,7 +33,7 @@ impl DataUi for ComponentPath {
                 }
                 .data_ui(ctx, ui, ui_layout, query, db);
             } else if ctx.recording().tree().subtree(entity_path).is_some() {
-                if db.store().entity_has_component_on_timeline(
+                if db.store().read().entity_has_component_on_timeline(
                     &query.timeline(),
                     entity_path,
                     component_name,

--- a/crates/viewer/re_data_ui/src/entity_db.rs
+++ b/crates/viewer/re_data_ui/src/entity_db.rs
@@ -108,7 +108,7 @@ impl crate::DataUi for EntityDb {
                     chunk_max_bytes,
                     chunk_max_rows,
                     chunk_max_rows_if_unsorted,
-                } = self.store().config();
+                } = self.store().read().config();
 
                 ui.grid_left_hand_label("Compaction");
                 ui.label(format!(
@@ -163,10 +163,11 @@ impl crate::DataUi for EntityDb {
         });
 
         let hub = ctx.store_context.hub;
+        let store_id = Some(self.store_id());
 
         match self.store_kind() {
             StoreKind::Recording => {
-                if Some(self.store_id()) == hub.active_recording_id() {
+                if store_id.as_ref() == hub.active_recording_id() {
                     ui.add_space(8.0);
                     ui.label("This is the active recording");
                 }
@@ -177,9 +178,9 @@ impl crate::DataUi for EntityDb {
 
                 if is_active_app_id {
                     let is_default =
-                        hub.default_blueprint_id_for_app(active_app_id) == Some(self.store_id());
+                        hub.default_blueprint_id_for_app(active_app_id) == store_id.as_ref();
                     let is_active =
-                        hub.active_blueprint_id_for_app(active_app_id) == Some(self.store_id());
+                        hub.active_blueprint_id_for_app(active_app_id) == store_id.as_ref();
 
                     match (is_default, is_active) {
                         (false, false) => {}
@@ -190,7 +191,8 @@ impl crate::DataUi for EntityDb {
                             if let Some(active_blueprint) =
                                 hub.active_blueprint_for_app(active_app_id)
                             {
-                                if active_blueprint.cloned_from() == Some(self.store_id()) {
+                                if active_blueprint.cloned_from() == Some(self.store_id()).as_ref()
+                                {
                                     // The active blueprint is a clone of the selected blueprint.
                                     if self.latest_row_id() == active_blueprint.latest_row_id() {
                                         ui.label(

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -36,6 +36,7 @@ impl DataUi for InstancePath {
 
         let Some(components) = ctx
             .recording_store()
+            .read()
             .all_components_on_timeline(&query.timeline(), entity_path)
         else {
             if ctx.recording().is_known_entity(entity_path) {
@@ -121,9 +122,9 @@ fn latest_at(
     let components: Vec<(ComponentName, UnitChunkShared)> = components
         .iter()
         .filter_map(|&component_name| {
-            let mut results =
-                db.query_caches()
-                    .latest_at(db.store(), query, entity_path, [component_name]);
+            let mut results = db
+                .query_caches()
+                .latest_at(query, entity_path, [component_name]);
 
             // We ignore components that are unset at this point in time
             results
@@ -173,6 +174,7 @@ fn component_list_ui(
             let component_path = ComponentPath::new(entity_path.clone(), component_name);
             let is_static = db
                 .store()
+                .read()
                 .entity_has_static_component(entity_path, &component_name);
             let icon = if is_static {
                 &re_ui::icons::COMPONENT_STATIC

--- a/crates/viewer/re_data_ui/src/item_ui.rs
+++ b/crates/viewer/re_data_ui/src/item_ui.rs
@@ -171,6 +171,7 @@ pub fn instance_path_icon(
         // It is an entity path
         if db
             .store()
+            .read()
             .all_components_on_timeline(timeline, &instance_path.entity_path)
             .is_some()
         {
@@ -337,6 +338,8 @@ fn entity_tree_stats_ui(
         " (excluding subtree)"
     };
 
+    let store = db.store().read();
+
     let (static_stats, timeline_stats) = if include_subtree {
         (
             db.subtree_stats_static(&tree.path),
@@ -344,8 +347,8 @@ fn entity_tree_stats_ui(
         )
     } else {
         (
-            db.store().entity_stats_static(&tree.path),
-            db.store().entity_stats_on_timeline(&tree.path, timeline),
+            store.entity_stats_static(&tree.path),
+            store.entity_stats_on_timeline(&tree.path, timeline),
         )
     };
 
@@ -380,7 +383,7 @@ fn entity_tree_stats_ui(
 
     if 0 < timeline_stats.total_size_bytes && 1 < num_temporal_rows {
         // Try to estimate data-rate:
-        if let Some(time_range) = db.store().entity_time_range(timeline, &tree.path) {
+        if let Some(time_range) = store.entity_time_range(timeline, &tree.path) {
             let min_time = time_range.min();
             let max_time = time_range.max();
             if min_time < max_time {
@@ -458,7 +461,7 @@ pub fn component_path_button_to(
     db: &re_entity_db::EntityDb,
 ) -> egui::Response {
     let item = Item::ComponentPath(component_path.clone());
-    let is_static = db.store().entity_has_static_component(
+    let is_static = db.store().read().entity_has_static_component(
         component_path.entity_path(),
         component_path.component_name(),
     );

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -193,12 +193,13 @@ fn active_defaults(
     // even if they are listed in `all_components`.
     ctx.blueprint_db()
         .store()
+        .read()
         .all_components_on_timeline(&blueprint_timeline(), &view.defaults_path)
         .unwrap_or_default()
         .into_iter()
         .filter(|c| {
             db.query_caches()
-                .latest_at(db.store(), query, &view.defaults_path, [*c])
+                .latest_at(query, &view.defaults_path, [*c])
                 .component_batch_raw(c)
                 .map_or(false, |data| !data.is_empty())
         })

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -161,6 +161,7 @@ impl SelectionPanel {
                 let (query, db) = guess_query_and_db_for_selected_entity(ctx, entity_path);
                 let is_static = db
                     .store()
+                    .read()
                     .entity_has_static_component(entity_path, component_name);
 
                 ui.list_item_flat_noninteractive(
@@ -727,6 +728,7 @@ fn item_tile(
             let (_query, db) = guess_query_and_db_for_selected_entity(ctx, entity_path);
             let is_static = db
                 .store()
+                .read()
                 .entity_has_static_component(entity_path, component_name);
 
             Some(

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -554,7 +554,7 @@ fn available_inactive_visualizers(
     let applicable_entities_per_visualizer = ctx
         .viewer_ctx
         .space_view_class_registry
-        .applicable_entities_for_visualizer_systems(entity_db.store_id());
+        .applicable_entities_for_visualizer_systems(&entity_db.store_id());
 
     let visualizable_entities = space_view
         .class(ctx.viewer_ctx.space_view_class_registry)

--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -42,7 +42,6 @@ pub fn range_with_blueprint_resolved_data(
     component_set.retain(|component| !overrides.components.contains_key(component));
 
     let results = ctx.recording().query_caches().range(
-        ctx.recording_store(),
         range_query,
         &data_result.entity_path,
         component_set.iter().copied(),
@@ -53,7 +52,6 @@ pub fn range_with_blueprint_resolved_data(
     // component_set.retain(|component| !results.components.contains_key(component));
 
     let defaults = ctx.viewer_ctx.blueprint_db().query_caches().latest_at(
-        ctx.viewer_ctx.store_context.blueprint.store(),
         ctx.viewer_ctx.blueprint_query,
         ctx.defaults_path,
         component_set.iter().copied(),
@@ -99,7 +97,6 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     }
 
     let results = ctx.viewer_ctx.recording().query_caches().latest_at(
-        ctx.viewer_ctx.recording_store(),
         latest_at_query,
         &data_result.entity_path,
         component_set.iter().copied(),
@@ -110,7 +107,6 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     // component_set.retain(|component| !results.components.contains_key(component));
 
     let defaults = ctx.viewer_ctx.blueprint_db().query_caches().latest_at(
-        ctx.viewer_ctx.store_context.blueprint.store(),
         ctx.viewer_ctx.blueprint_query,
         ctx.defaults_path,
         component_set.iter().copied(),
@@ -195,20 +191,16 @@ fn query_overrides<'a>(
                     // currently. This may want to use range_query instead depending on how
                     // component override data-references are resolved.
                     ctx.store_context.blueprint.query_caches().latest_at(
-                        ctx.store_context.blueprint.store(),
                         &current_query,
                         &override_value.path,
                         [*component_name],
                     )
                 }
-                re_log_types::StoreKind::Blueprint => {
-                    ctx.store_context.blueprint.query_caches().latest_at(
-                        ctx.store_context.blueprint.store(),
-                        &current_query,
-                        &override_value.path,
-                        [*component_name],
-                    )
-                }
+                re_log_types::StoreKind::Blueprint => ctx
+                    .store_context
+                    .blueprint
+                    .query_caches()
+                    .latest_at(&current_query, &override_value.path, [*component_name]),
             };
 
             // If we successfully find a non-empty override, add it to our results.

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -128,7 +128,7 @@ mode sets the default time range to _everything_. You can override this in the s
         let view_query = view_query::Query::from_blueprint(ctx, query.space_view_id);
 
         let query_engine = re_dataframe::QueryEngine {
-            store: ctx.recording().store(),
+            store: ctx.recording().store().clone(),
             cache: ctx.recording().query_caches(),
         };
 

--- a/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/view_query/ui.rs
@@ -173,6 +173,7 @@ impl Query {
 
         let all_components = ctx
             .recording_store()
+            .read()
             .all_components_on_timeline(timeline, &filter_entity)
             .unwrap_or_default();
 
@@ -430,6 +431,7 @@ fn all_pov_entities_for_space_view(
             if !node.data_result.tree_prefix_only {
                 let comp_for_entity = ctx
                     .recording_store()
+                    .read()
                     .all_components_on_timeline(timeline, &node.data_result.entity_path);
                 if comp_for_entity.is_some_and(|components| !components.is_empty()) {
                     all_entities.insert(node.data_result.entity_path.clone());

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -727,7 +727,7 @@ fn transforms_at(
     re_tracing::profile_function!();
 
     let potential_transform_components =
-        TransformComponentTracker::access(entity_db.store_id(), |tracker| {
+        TransformComponentTracker::access(&entity_db.store_id(), |tracker| {
             tracker.potential_transform_components(entity_path).cloned()
         })
         .flatten()

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -119,7 +119,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
 
         // For a 2D space view, the origin of the subspace defined by the common ancestor is always
         // better.
-        SpatialTopology::access(entity_db.store_id(), |topo| {
+        SpatialTopology::access(&entity_db.store_id(), |topo| {
             topo.subspace_for_entity(&common_ancestor).origin.clone()
         })
     }
@@ -135,7 +135,7 @@ impl SpaceViewClass for SpatialSpaceView2D {
         // If the topology hasn't changed, we don't need to recompute any of this.
         // Also, we arrive at the same `VisualizableFilterContext` for lots of different origins!
 
-        let context = SpatialTopology::access(entity_db.store_id(), |topo| {
+        let context = SpatialTopology::access(&entity_db.store_id(), |topo| {
             let primary_space = topo.subspace_for_entity(space_origin);
             if !primary_space.supports_2d_content() {
                 // If this is strict 3D space, only display the origin entity itself.
@@ -178,15 +178,16 @@ impl SpaceViewClass for SpatialSpaceView2D {
             SpatialSpaceViewKind::TwoD,
         );
 
-        let image_dimensions = MaxImageDimensions::access(ctx.recording_id(), |image_dimensions| {
-            image_dimensions.clone()
-        })
-        .unwrap_or_default();
+        let image_dimensions =
+            MaxImageDimensions::access(&ctx.recording_id(), |image_dimensions| {
+                image_dimensions.clone()
+            })
+            .unwrap_or_default();
 
         // Spawn a space view at each subspace that has any potential 2D content.
         // Note that visualizability filtering is all about being in the right subspace,
         // so we don't need to call the visualizers' filter functions here.
-        SpatialTopology::access(ctx.recording_id(), |topo| {
+        SpatialTopology::access(&ctx.recording_id(), |topo| {
             SpaceViewSpawnHeuristics::new(topo.iter_subspaces().flat_map(|subspace| {
                 if !subspace.supports_2d_content()
                     || subspace.entities.is_empty()
@@ -283,6 +284,7 @@ fn count_non_nested_images_with_component(
         // bool true -> 1
         entity_db
             .store()
+            .read()
             .entity_has_component(&subtree.path, component_name) as usize
     } else if !entity_bucket
         .iter()

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -103,7 +103,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         //
         // Also, if a ViewCoordinate3D is logged somewhere between the common ancestor and the
         // subspace origin, we use it as origin.
-        SpatialTopology::access(entity_db.store_id(), |topo| {
+        SpatialTopology::access(&entity_db.store_id(), |topo| {
             let common_ancestor_subspace = topo.subspace_for_entity(&common_ancestor);
 
             // Consider the case where the common ancestor might be in a 2D space that is connected
@@ -145,7 +145,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         // If the topology hasn't changed, we don't need to recompute any of this.
         // Also, we arrive at the same `VisualizableFilterContext` for lots of different origins!
 
-        let context = SpatialTopology::access(entity_db.store_id(), |topo| {
+        let context = SpatialTopology::access(&entity_db.store_id(), |topo| {
             let primary_space = topo.subspace_for_entity(space_origin);
             if !primary_space.supports_3d_content() {
                 // If this is strict 2D space, only display the origin entity itself.
@@ -278,12 +278,9 @@ impl SpaceViewClass for SpatialSpaceView3D {
         // It's tempting to add a visualizer for view coordinates so that it's already picked up via `entities_with_indicator_for_visualizer_kind`.
         // Is there a nicer way for this or do we want a visualizer for view coordinates anyways?
         // There's also a strong argument to be made that ViewCoordinates implies a 3D space, thus changing the SpacialTopology accordingly!
+        let store = ctx.recording().store().read();
         ctx.recording().tree().visit_children_recursively(|path| {
-            if ctx
-                .recording()
-                .store()
-                .entity_has_component(path, &ViewCoordinates::name())
-            {
+            if store.entity_has_component(path, &ViewCoordinates::name()) {
                 indicated_entities.insert(path.clone());
             }
         });
@@ -291,7 +288,7 @@ impl SpaceViewClass for SpatialSpaceView3D {
         // Spawn a space view at each subspace that has any potential 3D content.
         // Note that visualizability filtering is all about being in the right subspace,
         // so we don't need to call the visualizers' filter functions here.
-        SpatialTopology::access(ctx.recording_id(), |topo| {
+        SpatialTopology::access(&ctx.recording_id(), |topo| {
             SpaceViewSpawnHeuristics::new(
                 topo.iter_subspaces()
                     .filter_map(|subspace| {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -405,7 +405,6 @@ fn latest_at_query_video_from_datastore(
     let query = ctx.current_query();
 
     let results = ctx.recording().query_caches().latest_at(
-        ctx.recording_store(),
         &query,
         entity_path,
         AssetVideo::all_components().iter().copied(),

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -439,7 +439,7 @@ impl SeriesLineSystem {
                 &data_result.entity_path,
                 time_per_pixel,
                 points,
-                ctx.recording_store(),
+                &ctx.recording_store().read(),
                 view_query,
                 series_name.into(),
                 aggregator,
@@ -461,7 +461,6 @@ fn collect_recursive_clears(
     let mut clear_entity_path = entity_path.clone();
     loop {
         let results = ctx.recording().query_caches().range(
-            ctx.recording_store(),
             query,
             &clear_entity_path,
             [ClearIsRecursive::name()],

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -472,7 +472,7 @@ impl SeriesPointSystem {
                 &data_result.entity_path,
                 time_per_pixel,
                 points,
-                ctx.recording_store(),
+                &ctx.recording_store().read(),
                 view_query,
                 series_name.into(),
                 // Aggregation for points is not supported.

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -707,12 +707,11 @@ fn visit_relevant_chunks(
 ) {
     re_tracing::profile_function!();
 
+    let store = db.store().read();
     let query = RangeQuery::new(timeline, time_range);
 
     if let Some(component_name) = component_name {
-        let chunks = db
-            .store()
-            .range_relevant_chunks(&query, entity_path, component_name);
+        let chunks = store.range_relevant_chunks(&query, entity_path, component_name);
 
         for chunk in chunks {
             let Some(num_events) = chunk.num_events_for_component(component_name) else {
@@ -727,10 +726,7 @@ fn visit_relevant_chunks(
         }
     } else if let Some(subtree) = db.tree().subtree(entity_path) {
         subtree.visit_children_recursively(|entity_path| {
-            for chunk in db
-                .store()
-                .range_relevant_chunks_for_all_components(&query, entity_path)
-            {
+            for chunk in store.range_relevant_chunks_for_all_components(&query, entity_path) {
                 let Some(chunk_timeline) = chunk.timelines().get(&timeline) else {
                     continue;
                 };

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -751,35 +751,32 @@ impl TimePanel {
             );
         }
 
+        let store = entity_db.store().read();
+
         // If this is an entity:
-        if let Some(components) = entity_db.store().all_components_for_entity(&tree.path) {
+        if let Some(components) = store.all_components_for_entity(&tree.path) {
             for component_name in sorted_component_list_for_ui(components.iter()) {
-                let is_static = entity_db
-                    .store()
-                    .entity_has_static_component(&tree.path, &component_name);
+                let is_static = store.entity_has_static_component(&tree.path, &component_name);
 
                 let component_path = ComponentPath::new(tree.path.clone(), component_name);
                 let short_component_name = component_path.component_name.short_name();
                 let item = TimePanelItem::component_path(component_path.clone());
                 let timeline = time_ctrl.timeline();
 
-                let component_has_data_in_current_timeline =
-                    entity_db.store().entity_has_component_on_timeline(
+                let component_has_data_in_current_timeline = store
+                    .entity_has_component_on_timeline(
                         time_ctrl.timeline(),
                         &tree.path,
                         &component_name,
                     );
 
-                let num_static_messages = entity_db
-                    .store()
-                    .num_static_events_for_component(&tree.path, component_name);
-                let num_temporal_messages = entity_db
-                    .store()
-                    .num_temporal_events_for_component_on_timeline(
-                        time_ctrl.timeline(),
-                        &tree.path,
-                        component_name,
-                    );
+                let num_static_messages =
+                    store.num_static_events_for_component(&tree.path, component_name);
+                let num_temporal_messages = store.num_temporal_events_for_component_on_timeline(
+                    time_ctrl.timeline(),
+                    &tree.path,
+                    component_name,
+                );
                 let total_num_messages = num_static_messages + num_temporal_messages;
 
                 let response = ui

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -802,7 +802,7 @@ impl App {
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::PrintChunkStore => {
                 if let Some(ctx) = store_context {
-                    let text = format!("{}", ctx.recording.store());
+                    let text = format!("{}", ctx.recording.store().read());
                     egui_ctx.output_mut(|o| o.copied_text = text.clone());
                     println!("{text}");
                 }
@@ -810,7 +810,7 @@ impl App {
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::PrintBlueprintStore => {
                 if let Some(ctx) = store_context {
-                    let text = format!("{}", ctx.blueprint.store());
+                    let text = format!("{}", ctx.blueprint.store().read());
                     egui_ctx.output_mut(|o| o.copied_text = text.clone());
                     println!("{text}");
                 }
@@ -868,7 +868,7 @@ impl App {
             return;
         };
         let rec_id = entity_db.store_id();
-        let Some(rec_cfg) = self.state.recording_config_mut(rec_id) else {
+        let Some(rec_cfg) = self.state.recording_config_mut(&rec_id) else {
             return;
         };
         let time_ctrl = rec_cfg.time_ctrl.get_mut();

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -112,7 +112,7 @@ impl AppState {
         store_context: Option<&StoreContext<'_>>,
     ) -> Option<(re_entity_db::Timeline, ResolvedTimeRangeF)> {
         let rec_id = store_context.as_ref()?.recording.store_id();
-        let rec_cfg = self.recording_configs.get(rec_id)?;
+        let rec_cfg = self.recording_configs.get(&rec_id)?;
 
         // is there an active loop selection?
         let time_ctrl = rec_cfg.time_ctrl.read();
@@ -206,9 +206,9 @@ impl AppState {
         );
 
         let applicable_entities_per_visualizer = space_view_class_registry
-            .applicable_entities_for_visualizer_systems(recording.store_id());
+            .applicable_entities_for_visualizer_systems(&recording.store_id());
         let indicated_entities_per_visualizer =
-            space_view_class_registry.indicated_entities_per_visualizer(recording.store_id());
+            space_view_class_registry.indicated_entities_per_visualizer(&recording.store_id());
 
         // Execute the queries for every `SpaceView`
         let mut query_results = {

--- a/crates/viewer/re_viewer/src/blueprint/validation.rs
+++ b/crates/viewer/re_viewer/src/blueprint/validation.rs
@@ -4,7 +4,7 @@ use re_log_types::Timeline;
 use re_types_core::Component;
 
 pub(crate) fn validate_component<C: Component>(blueprint: &EntityDb) -> bool {
-    if let Some(data_type) = blueprint.data_store().lookup_datatype(&C::name()) {
+    if let Some(data_type) = blueprint.store().read().lookup_datatype(&C::name()) {
         if data_type != &C::arrow_datatype() {
             // If the schemas don't match, we definitely have a problem
             re_log::debug!(
@@ -22,7 +22,7 @@ pub(crate) fn validate_component<C: Component>(blueprint: &EntityDb) -> bool {
             for path in blueprint.entity_paths() {
                 if let Some(array) = blueprint
                     .query_caches()
-                    .latest_at(blueprint.store(), &query, path, [C::name()])
+                    .latest_at(&query, path, [C::name()])
                     .component_batch_raw(&C::name())
                 {
                     if let Err(err) = C::from_arrow_opt(&*array) {

--- a/crates/viewer/re_viewer_context/src/item.rs
+++ b/crates/viewer/re_viewer_context/src/item.rs
@@ -190,6 +190,7 @@ pub fn resolve_mono_instance_path(
         // NOTE: While we normally frown upon direct queries to the datastore, `all_components` is fine.
         let Some(component_names) = entity_db
             .store()
+            .read()
             .all_components_on_timeline(&query.timeline(), &instance.entity_path)
         else {
             // No components at all, return unindexed entity.
@@ -199,12 +200,7 @@ pub fn resolve_mono_instance_path(
         for component_name in component_names {
             if let Some(array) = entity_db
                 .query_caches()
-                .latest_at(
-                    entity_db.store(),
-                    query,
-                    &instance.entity_path,
-                    [component_name],
-                )
+                .latest_at(query, &instance.entity_path, [component_name])
                 .component_batch_raw(&component_name)
             {
                 if array.len() > 1 {

--- a/crates/viewer/re_viewer_context/src/space_view/view_context.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/view_context.rs
@@ -47,7 +47,7 @@ impl<'a> ViewContext<'a> {
 
     /// The chunk store of the active recording.
     #[inline]
-    pub fn recording_store(&self) -> &re_chunk_store::ChunkStore {
+    pub fn recording_store(&self) -> &re_chunk_store::ChunkStoreHandle {
         self.viewer_ctx.recording_store()
     }
 
@@ -59,7 +59,7 @@ impl<'a> ViewContext<'a> {
 
     /// The `StoreId` of the active recording.
     #[inline]
-    pub fn recording_id(&self) -> &re_log_types::StoreId {
+    pub fn recording_id(&self) -> re_log_types::StoreId {
         self.viewer_ctx.recording_id()
     }
 

--- a/crates/viewer/re_viewer_context/src/store_context.rs
+++ b/crates/viewer/re_viewer_context/src/store_context.rs
@@ -33,6 +33,6 @@ pub struct StoreContext<'a> {
 
 impl StoreContext<'_> {
     pub fn is_active(&self, store_id: &StoreId) -> bool {
-        self.recording.store_id() == store_id || self.blueprint.store_id() == store_id
+        self.recording.store_id() == *store_id || self.blueprint.store_id() == *store_id
     }
 }

--- a/crates/viewer/re_viewer_context/src/test_context.rs
+++ b/crates/viewer/re_viewer_context/src/test_context.rs
@@ -130,7 +130,7 @@ impl TestContext {
             let command_name = format!("{command:?}");
             match command {
                 SystemCommand::UpdateBlueprint(store_id, chunks) => {
-                    assert_eq!(&store_id, self.blueprint_store.store_id());
+                    assert_eq!(store_id, self.blueprint_store.store_id());
 
                     for chunk in chunks {
                         self.blueprint_store
@@ -140,7 +140,7 @@ impl TestContext {
                 }
 
                 SystemCommand::DropEntity(store_id, entity_path) => {
-                    assert_eq!(&store_id, self.blueprint_store.store_id());
+                    assert_eq!(store_id, self.blueprint_store.store_id());
                     self.blueprint_store
                         .drop_entity_path_recursive(&entity_path);
                 }
@@ -150,7 +150,7 @@ impl TestContext {
                 }
 
                 SystemCommand::SetActiveTimeline { rec_id, timeline } => {
-                    assert_eq!(&rec_id, self.recording_store.store_id());
+                    assert_eq!(rec_id, self.recording_store.store_id());
                     self.active_timeline = timeline;
                 }
 

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -47,7 +47,6 @@ impl ContainerBlueprint {
         // ----
 
         let results = blueprint_db.query_caches().latest_at(
-            blueprint_db.store(),
             query,
             &id.as_entity_path(),
             blueprint_archetypes::ContainerBlueprint::all_components()

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -132,7 +132,6 @@ impl SpaceViewBlueprint {
         re_tracing::profile_function!();
 
         let results = blueprint_db.query_caches().latest_at(
-            blueprint_db.store(),
             query,
             &id.as_entity_path(),
             blueprint_archetypes::SpaceViewBlueprint::all_components()
@@ -262,6 +261,7 @@ impl SpaceViewBlueprint {
                         store_context.blueprint_timepoint_for_writes(),
                         blueprint
                             .store()
+                            .read()
                             .all_components_on_timeline(&query.timeline(), path)
                             .into_iter()
                             .flat_map(|v| v.into_iter())
@@ -275,7 +275,7 @@ impl SpaceViewBlueprint {
                             .filter_map(|component_name| {
                                 let array = blueprint
                                     .query_caches()
-                                    .latest_at(blueprint.store(), query, path, [component_name])
+                                    .latest_at(query, path, [component_name])
                                     .component_batch_raw(&component_name);
                                 array.map(|array| (component_name, array))
                             }),

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -381,6 +381,8 @@ impl DataQueryPropertyResolver<'_> {
         recursive_property_overrides: &IntMap<ComponentName, OverridePath>,
         handle: DataResultHandle,
     ) {
+        let blueprint_store = blueprint.store().read();
+
         if let Some((child_handles, recursive_property_overrides)) =
             query_result.tree.lookup_node_mut(handle).map(|node| {
                 let individual_override_path = self
@@ -425,19 +427,13 @@ impl DataQueryPropertyResolver<'_> {
                 if let Some(recursive_override_subtree) =
                     blueprint.tree().subtree(&recursive_override_path)
                 {
-                    for component_name in blueprint
-                        .store()
+                    for component_name in blueprint_store
                         .all_components_for_entity(&recursive_override_subtree.path)
                         .unwrap_or_default()
                     {
                         if let Some(component_data) = blueprint
                             .query_caches()
-                            .latest_at(
-                                blueprint.store(),
-                                blueprint_query,
-                                &recursive_override_path,
-                                [component_name],
-                            )
+                            .latest_at(blueprint_query, &recursive_override_path, [component_name])
                             .component_batch_raw(&component_name)
                         {
                             if !component_data.is_empty() {
@@ -460,19 +456,13 @@ impl DataQueryPropertyResolver<'_> {
                 if let Some(individual_override_subtree) =
                     blueprint.tree().subtree(&individual_override_path)
                 {
-                    for component_name in blueprint
-                        .store()
+                    for component_name in blueprint_store
                         .all_components_for_entity(&individual_override_subtree.path)
                         .unwrap_or_default()
                     {
                         if let Some(component_data) = blueprint
                             .query_caches()
-                            .latest_at(
-                                blueprint.store(),
-                                blueprint_query,
-                                &individual_override_path,
-                                [component_name],
-                            )
+                            .latest_at(blueprint_query, &individual_override_path, [component_name])
                             .component_batch_raw(&component_name)
                         {
                             if !component_data.is_empty() {

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -69,7 +69,6 @@ impl ViewportBlueprint {
         re_tracing::profile_function!();
 
         let results = blueprint_db.query_caches().latest_at(
-            blueprint_db.store(),
             query,
             &VIEWPORT_PATH.into(),
             blueprint_archetypes::ViewportBlueprint::all_components()

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -62,7 +62,6 @@ impl VisualizerSystem for InstanceColorSystem {
             // …gather all colors and their instance ids.
 
             let results = ctx.recording().query_caches().latest_at(
-                ctx.recording_store(),
                 &ctx.current_query(),
                 &data_result.entity_path,
                 [Color::name()],

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -132,6 +132,7 @@ fn entity_ui(
     // Each entity can have many components (e.g. position, color, radius, …):
     if let Some(components) = entity_db
         .store()
+        .read()
         .all_components_on_timeline(&timeline, entity_path)
     {
         for component in components {
@@ -153,12 +154,9 @@ fn component_ui(
     // just show the last value logged for each component:
     let query = re_chunk_store::LatestAtQuery::latest(timeline);
 
-    let results = entity_db.query_caches().latest_at(
-        entity_db.store(),
-        &query,
-        entity_path,
-        [component_name],
-    );
+    let results = entity_db
+        .query_caches()
+        .latest_at(&query, entity_path, [component_name]);
 
     if let Some(data) = results.component_batch_raw(&component_name) {
         egui::ScrollArea::vertical()

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -19,9 +19,9 @@ use pyo3::{
 };
 
 use re_chunk_store::{
-    ChunkStore, ChunkStoreConfig, ColumnDescriptor, ColumnSelector, ComponentColumnDescriptor,
-    ComponentColumnSelector, QueryExpression, SparseFillStrategy, TimeColumnDescriptor,
-    TimeColumnSelector, VersionPolicy, ViewContentsSelector,
+    ChunkStore, ChunkStoreConfig, ChunkStoreHandle, ColumnDescriptor, ColumnSelector,
+    ComponentColumnDescriptor, ComponentColumnSelector, QueryExpression, SparseFillStrategy,
+    TimeColumnDescriptor, TimeColumnSelector, VersionPolicy, ViewContentsSelector,
 };
 use re_dataframe::QueryEngine;
 use re_log_types::{EntityPathFilter, ResolvedTimeRange, TimeType};
@@ -566,7 +566,7 @@ impl PySchema {
 /// to retrieve the data.
 #[pyclass(name = "Recording")]
 pub struct PyRecording {
-    store: ChunkStore,
+    store: ChunkStoreHandle,
     cache: re_dataframe::QueryCache,
 }
 
@@ -1142,7 +1142,7 @@ impl PyRecordingView {
 impl PyRecording {
     fn engine(&self) -> QueryEngine<'_> {
         QueryEngine {
-            store: &self.store,
+            store: self.store.clone(),
             cache: &self.cache,
         }
     }
@@ -1154,6 +1154,7 @@ impl PyRecording {
         };
 
         self.store
+            .read()
             .resolve_component_selector(&selector)
             .component_name
     }
@@ -1248,7 +1249,7 @@ impl PyRecording {
     /// The schema describing all the columns available in the recording.
     fn schema(&self) -> PySchema {
         PySchema {
-            schema: self.store.schema(),
+            schema: self.store.read().schema(),
         }
     }
 
@@ -1330,7 +1331,7 @@ impl PyRecording {
             timeline: index.into(),
         };
 
-        let timeline = borrowed_self.store.resolve_time_selector(&selector);
+        let timeline = borrowed_self.store.read().resolve_time_selector(&selector);
 
         let contents = borrowed_self.extract_contents_expr(contents)?;
 
@@ -1358,13 +1359,14 @@ impl PyRecording {
 
     /// The recording ID of the recording.
     fn recording_id(&self) -> String {
-        self.store.id().as_str().to_owned()
+        self.store.read().id().as_str().to_owned()
     }
 
     /// The application ID of the recording.
     fn application_id(&self) -> PyResult<String> {
         Ok(self
             .store
+            .read()
             .info()
             .ok_or(PyValueError::new_err(
                 "Recording is missing application id.",
@@ -1381,7 +1383,7 @@ impl PyRecording {
 #[pyclass(frozen, name = "RRDArchive")]
 #[derive(Clone)]
 pub struct PyRRDArchive {
-    pub datasets: BTreeMap<StoreId, ChunkStore>,
+    pub datasets: BTreeMap<StoreId, ChunkStoreHandle>,
 }
 
 #[pymethods]
@@ -1401,7 +1403,7 @@ impl PyRRDArchive {
             .iter()
             .filter(|(id, _)| matches!(id.kind, StoreKind::Recording))
             .map(|(_, store)| {
-                let cache = re_dataframe::external::re_query::QueryCache::new(store);
+                let cache = re_dataframe::QueryCache::new(store.clone());
                 PyRecording {
                     store: store.clone(),
                     cache,
@@ -1460,7 +1462,10 @@ pub fn load_recording(path_to_rrd: std::path::PathBuf) -> PyResult<PyRecording> 
 pub fn load_archive(path_to_rrd: std::path::PathBuf) -> PyResult<PyRRDArchive> {
     let stores =
         ChunkStore::from_rrd_filepath(&ChunkStoreConfig::DEFAULT, path_to_rrd, VersionPolicy::Warn)
-            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
+            .into_iter()
+            .map(|(store_id, store)| (store_id, ChunkStoreHandle::new(store)))
+            .collect();
 
     let archive = PyRRDArchive { datasets: stores };
 


### PR DESCRIPTION
This introduces `ChunkStoreHandle`, a `Send`+`Sync`+`Clone` handle to a `ChunkStore`.

Shoe-horning a sharable, thread-safe, read-write handle into an existing codebase that A) makes heavy use of work stealing and B) carries its handles both in temporary contexts, and `self`, and function parameters is pretty scary -- it's a recipe for non-deterministic deadlocks and nasty race conditions.

That said:
* We know we have to do this for various reasons (query streaming, parallel ingestion, etc), so we have to start somewhere.
* The codebase until now was borrowck compliant, which means there's very little chance to screw things up at the moment -- it'll get scary as things evolve into a more parallel-heavy design from there.

But yes, we have a lot of refactoring work ahead of us to get this in a sane place. One step at a time...
This work will probably happen as part of #4298.

NOTE: This PR does not update tests, so they will fail to compile (all libs and binaries work). That's on purpose: the next PR will break all these same tests again with the introduction of the `QueryCacheHandle`, fixing them now will be a pure waste of time.
I still want this to be its own PR though, that is complex enough as is.

* Part 1/2 of #7486 
* DNM: needs to be merged at the same time as part 2

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7917?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7917?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7917)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.