### PR TITLE
Ignore dreaded mediapipe URL

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -132,6 +132,7 @@ exclude = [
   'https://edge.meilisearch.com',
   'https://eu.posthog.com/project/',                      # Requires to be logged in on PostHog.
   'https://github.com/rerun-io/internal-test-assets/\.*',
+  'https://github.com/google/mediapipe/issues/5188',      # For some reason that link has always failed.
 
   # Temporarily down or not accessible.
   'https://cs.nyu.edu/~silberman/datasets/nyu_depth_v2.html',       # Nyud links are down every now and then.


### PR DESCRIPTION
For some reason this one URL does not pass link check. I don't know why.