### PR TITLE
Storage handles 2: Introduce `QueryCacheHandle`

### DIFF
--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -12,15 +12,15 @@ pub use self::external::arrow2::chunk::Chunk as ArrowChunk;
 pub use self::external::re_chunk::{util::concatenate_record_batches, TransportChunk};
 #[doc(no_inline)]
 pub use self::external::re_chunk_store::{
-    ColumnSelector, ComponentColumnSelector, Index, IndexRange, IndexValue, QueryExpression,
-    SparseFillStrategy, TimeColumnSelector, ViewContentsSelector,
+    ChunkStoreHandle, ColumnSelector, ComponentColumnSelector, Index, IndexRange, IndexValue,
+    QueryExpression, SparseFillStrategy, TimeColumnSelector, ViewContentsSelector,
 };
 #[doc(no_inline)]
 pub use self::external::re_log_types::{
     EntityPath, EntityPathFilter, ResolvedTimeRange, TimeInt, Timeline,
 };
 #[doc(no_inline)]
-pub use self::external::re_query::QueryCache;
+pub use self::external::re_query::{QueryCache, QueryCacheHandle};
 
 pub mod external {
     pub use re_chunk;

--- a/crates/store/re_query/src/lib.rs
+++ b/crates/store/re_query/src/lib.rs
@@ -8,7 +8,7 @@ mod range;
 pub mod clamped_zip;
 pub mod range_zip;
 
-pub use self::cache::{QueryCache, QueryCacheKey};
+pub use self::cache::{QueryCache, QueryCacheHandle, QueryCacheKey};
 pub use self::cache_stats::{CacheStats, CachesStats};
 pub use self::clamped_zip::*;
 pub use self::latest_at::LatestAtResults;

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -145,7 +145,7 @@ pub mod dataframe {
 /// Everything needed to build custom `ChunkStoreSubscriber`s.
 pub use re_entity_db::external::re_chunk_store::{
     ChunkStore, ChunkStoreConfig, ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent,
-    ChunkStoreGeneration, ChunkStoreSubscriber, VersionPolicy,
+    ChunkStoreGeneration, ChunkStoreHandle, ChunkStoreSubscriber, VersionPolicy,
 };
 pub use re_log_types::StoreKind;
 

--- a/crates/viewer/re_data_ui/src/component_path.rs
+++ b/crates/viewer/re_data_ui/src/component_path.rs
@@ -25,6 +25,7 @@ impl DataUi for ComponentPath {
         } else {
             let results = db
                 .query_caches()
+                .read()
                 .latest_at(query, entity_path, [*component_name]);
             if let Some(unit) = results.components.get(component_name) {
                 crate::ComponentPathLatestAtResults {

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -122,9 +122,10 @@ fn latest_at(
     let components: Vec<(ComponentName, UnitChunkShared)> = components
         .iter()
         .filter_map(|&component_name| {
-            let mut results = db
-                .query_caches()
-                .latest_at(query, entity_path, [component_name]);
+            let mut results =
+                db.query_caches()
+                    .read()
+                    .latest_at(query, entity_path, [component_name]);
 
             // We ignore components that are unset at this point in time
             results

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -199,6 +199,7 @@ fn active_defaults(
         .into_iter()
         .filter(|c| {
             db.query_caches()
+                .read()
                 .latest_at(query, &view.defaults_path, [*c])
                 .component_batch_raw(c)
                 .map_or(false, |data| !data.is_empty())

--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -41,7 +41,7 @@ pub fn range_with_blueprint_resolved_data(
     // No need to query for components that have overrides.
     component_set.retain(|component| !overrides.components.contains_key(component));
 
-    let results = ctx.recording().query_caches().range(
+    let results = ctx.recording().query_caches().read().range(
         range_query,
         &data_result.entity_path,
         component_set.iter().copied(),
@@ -51,11 +51,16 @@ pub fn range_with_blueprint_resolved_data(
     // This means we over-query for defaults that will never be used.
     // component_set.retain(|component| !results.components.contains_key(component));
 
-    let defaults = ctx.viewer_ctx.blueprint_db().query_caches().latest_at(
-        ctx.viewer_ctx.blueprint_query,
-        ctx.defaults_path,
-        component_set.iter().copied(),
-    );
+    let defaults = ctx
+        .viewer_ctx
+        .blueprint_db()
+        .query_caches()
+        .read()
+        .latest_at(
+            ctx.viewer_ctx.blueprint_query,
+            ctx.defaults_path,
+            component_set.iter().copied(),
+        );
 
     HybridRangeResults {
         overrides,
@@ -96,7 +101,7 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
         component_set.retain(|component| !overrides.components.contains_key(component));
     }
 
-    let results = ctx.viewer_ctx.recording().query_caches().latest_at(
+    let results = ctx.viewer_ctx.recording().query_caches().read().latest_at(
         latest_at_query,
         &data_result.entity_path,
         component_set.iter().copied(),
@@ -106,11 +111,16 @@ pub fn latest_at_with_blueprint_resolved_data<'a>(
     // This means we over-query for defaults that will never be used.
     // component_set.retain(|component| !results.components.contains_key(component));
 
-    let defaults = ctx.viewer_ctx.blueprint_db().query_caches().latest_at(
-        ctx.viewer_ctx.blueprint_query,
-        ctx.defaults_path,
-        component_set.iter().copied(),
-    );
+    let defaults = ctx
+        .viewer_ctx
+        .blueprint_db()
+        .query_caches()
+        .read()
+        .latest_at(
+            ctx.viewer_ctx.blueprint_query,
+            ctx.defaults_path,
+            component_set.iter().copied(),
+        );
 
     HybridLatestAtResults {
         overrides,
@@ -190,7 +200,7 @@ fn query_overrides<'a>(
                     // TODO(jleibs): This probably is not right, but this code path is not used
                     // currently. This may want to use range_query instead depending on how
                     // component override data-references are resolved.
-                    ctx.store_context.blueprint.query_caches().latest_at(
+                    ctx.store_context.blueprint.query_caches().read().latest_at(
                         &current_query,
                         &override_value.path,
                         [*component_name],
@@ -200,6 +210,7 @@ fn query_overrides<'a>(
                     .store_context
                     .blueprint
                     .query_caches()
+                    .read()
                     .latest_at(&current_query, &override_value.path, [*component_name]),
             };
 

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -32,7 +32,7 @@ pub(crate) enum HideColumnAction {
 pub(crate) fn dataframe_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
-    query_handle: &re_dataframe::QueryHandle<'_>,
+    query_handle: &re_dataframe::QueryHandle,
     expanded_rows_cache: &mut ExpandedRowsCache,
     space_view_id: &SpaceViewId,
 ) -> Vec<HideColumnAction> {
@@ -182,7 +182,7 @@ impl RowsDisplayData {
 /// [`egui_table::TableDelegate`] implementation for displaying a [`QueryHandle`] in a table.
 struct DataframeTableDelegate<'a> {
     ctx: &'a ViewerContext<'a>,
-    query_handle: &'a QueryHandle<'a>,
+    query_handle: &'a QueryHandle,
     selected_columns: &'a [ColumnDescriptor],
     header_entity_paths: Vec<Option<EntityPath>>,
     display_data: anyhow::Result<RowsDisplayData>,

--- a/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_dataframe/src/space_view_class.rs
@@ -129,7 +129,7 @@ mode sets the default time range to _everything_. You can override this in the s
 
         let query_engine = re_dataframe::QueryEngine {
             store: ctx.recording().store().clone(),
-            cache: ctx.recording().query_caches(),
+            cache: ctx.recording().query_caches().clone(),
         };
 
         let view_contents = query

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -404,7 +404,7 @@ fn latest_at_query_video_from_datastore(
 ) -> Option<(Arc<Result<Video, VideoLoadError>>, Blob)> {
     let query = ctx.current_query();
 
-    let results = ctx.recording().query_caches().latest_at(
+    let results = ctx.recording().query_caches().read().latest_at(
         &query,
         entity_path,
         AssetVideo::all_components().iter().copied(),

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -460,7 +460,7 @@ fn collect_recursive_clears(
 
     let mut clear_entity_path = entity_path.clone();
     loop {
-        let results = ctx.recording().query_caches().range(
+        let results = ctx.recording().query_caches().read().range(
             query,
             &clear_entity_path,
             [ClearIsRecursive::name()],

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -818,13 +818,13 @@ impl App {
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ClearPrimaryCache => {
                 if let Some(ctx) = store_context {
-                    ctx.recording.query_caches().clear();
+                    ctx.recording.query_caches().write().clear();
                 }
             }
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::PrintPrimaryCache => {
                 if let Some(ctx) = store_context {
-                    let text = format!("{:?}", ctx.recording.query_caches());
+                    let text = format!("{:?}", ctx.recording.query_caches().read());
                     egui_ctx.output_mut(|o| o.copied_text = text.clone());
                     println!("{text}");
                 }

--- a/crates/viewer/re_viewer/src/blueprint/validation.rs
+++ b/crates/viewer/re_viewer/src/blueprint/validation.rs
@@ -22,6 +22,7 @@ pub(crate) fn validate_component<C: Component>(blueprint: &EntityDb) -> bool {
             for path in blueprint.entity_paths() {
                 if let Some(array) = blueprint
                     .query_caches()
+                    .read()
                     .latest_at(&query, path, [C::name()])
                     .component_batch_raw(&C::name())
                 {

--- a/crates/viewer/re_viewer_context/src/item.rs
+++ b/crates/viewer/re_viewer_context/src/item.rs
@@ -200,6 +200,7 @@ pub fn resolve_mono_instance_path(
         for component_name in component_names {
             if let Some(array) = entity_db
                 .query_caches()
+                .read()
                 .latest_at(query, &instance.entity_path, [component_name])
                 .component_batch_raw(&component_name)
             {

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -793,8 +793,7 @@ impl StoreHub {
 
     /// Populate a [`StoreHubStats`] based on the active app.
     //
-    // TODO(jleibs): We probably want stats for all recordings, not just
-    // the active recording.
+    // TODO(jleibs): We probably want stats for all recordings, not just the active recording.
     pub fn stats(&self) -> StoreHubStats {
         re_tracing::profile_function!();
 
@@ -810,7 +809,7 @@ impl StoreHub {
             .unwrap_or_default();
 
         let blueprint_cached_stats = blueprint
-            .map(|entity_db| entity_db.query_caches().stats())
+            .map(|entity_db| entity_db.query_caches().read().stats())
             .unwrap_or_default();
 
         let blueprint_config = blueprint
@@ -827,7 +826,7 @@ impl StoreHub {
             .unwrap_or_default();
 
         let recording_cached_stats = recording
-            .map(|entity_db| entity_db.query_caches().stats())
+            .map(|entity_db| entity_db.query_caches().read().stats())
             .unwrap_or_default();
 
         let recording_config2 = recording

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -46,7 +46,7 @@ impl ContainerBlueprint {
 
         // ----
 
-        let results = blueprint_db.query_caches().latest_at(
+        let results = blueprint_db.query_caches().read().latest_at(
             query,
             &id.as_entity_path(),
             blueprint_archetypes::ContainerBlueprint::all_components()

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -131,7 +131,7 @@ impl SpaceViewBlueprint {
     ) -> Option<Self> {
         re_tracing::profile_function!();
 
-        let results = blueprint_db.query_caches().latest_at(
+        let results = blueprint_db.query_caches().read().latest_at(
             query,
             &id.as_entity_path(),
             blueprint_archetypes::SpaceViewBlueprint::all_components()
@@ -275,6 +275,7 @@ impl SpaceViewBlueprint {
                             .filter_map(|component_name| {
                                 let array = blueprint
                                     .query_caches()
+                                    .read()
                                     .latest_at(query, path, [component_name])
                                     .component_batch_raw(&component_name);
                                 array.map(|array| (component_name, array))

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -433,6 +433,7 @@ impl DataQueryPropertyResolver<'_> {
                     {
                         if let Some(component_data) = blueprint
                             .query_caches()
+                            .read()
                             .latest_at(blueprint_query, &recursive_override_path, [component_name])
                             .component_batch_raw(&component_name)
                         {
@@ -462,6 +463,7 @@ impl DataQueryPropertyResolver<'_> {
                     {
                         if let Some(component_data) = blueprint
                             .query_caches()
+                            .read()
                             .latest_at(blueprint_query, &individual_override_path, [component_name])
                             .component_batch_raw(&component_name)
                         {

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -68,7 +68,7 @@ impl ViewportBlueprint {
     ) -> Self {
         re_tracing::profile_function!();
 
-        let results = blueprint_db.query_caches().latest_at(
+        let results = blueprint_db.query_caches().read().latest_at(
             query,
             &VIEWPORT_PATH.into(),
             blueprint_archetypes::ViewportBlueprint::all_components()

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -61,7 +61,7 @@ impl VisualizerSystem for InstanceColorSystem {
         for data_result in query.iter_visible_data_results(ctx, Self::identifier()) {
             // …gather all colors and their instance ids.
 
-            let results = ctx.recording().query_caches().latest_at(
+            let results = ctx.recording().query_caches().read().latest_at(
                 &ctx.current_query(),
                 &data_result.entity_path,
                 [Color::name()],

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -4,10 +4,9 @@ use itertools::Itertools;
 
 use rerun::{
     dataframe::{
-        concatenate_record_batches, EntityPathFilter, QueryCache, QueryEngine, QueryExpression,
-        SparseFillStrategy, Timeline,
+        concatenate_record_batches, ChunkStoreHandle, EntityPathFilter, QueryCache,
+        QueryCacheHandle, QueryEngine, QueryExpression, SparseFillStrategy, Timeline,
     },
-    external::re_chunk_store::ChunkStoreHandle,
     ChunkStore, ChunkStoreConfig, StoreKind, VersionPolicy,
 };
 
@@ -56,10 +55,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        let query_cache = QueryCache::new(store.clone());
+        let query_cache = QueryCacheHandle::new(QueryCache::new(store.clone()));
         let query_engine = QueryEngine {
             store: store.clone(),
-            cache: &query_cache,
+            cache: query_cache.clone(),
         };
 
         let query = QueryExpression {

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -156,6 +156,7 @@ fn component_ui(
 
     let results = entity_db
         .query_caches()
+        .read()
         .latest_at(&query, entity_path, [component_name]);
 
     if let Some(data) = results.component_batch_raw(&component_name) {

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -567,7 +567,7 @@ impl PySchema {
 #[pyclass(name = "Recording")]
 pub struct PyRecording {
     store: ChunkStoreHandle,
-    cache: re_dataframe::QueryCache,
+    cache: re_dataframe::QueryCacheHandle,
 }
 
 /// A view of a recording restricted to a given index, containing a specific set of entities and components.
@@ -1140,10 +1140,10 @@ impl PyRecordingView {
 }
 
 impl PyRecording {
-    fn engine(&self) -> QueryEngine<'_> {
+    fn engine(&self) -> QueryEngine {
         QueryEngine {
             store: self.store.clone(),
-            cache: &self.cache,
+            cache: self.cache.clone(),
         }
     }
 
@@ -1403,7 +1403,9 @@ impl PyRRDArchive {
             .iter()
             .filter(|(id, _)| matches!(id.kind, StoreKind::Recording))
             .map(|(_, store)| {
-                let cache = re_dataframe::QueryCache::new(store.clone());
+                let cache = re_dataframe::QueryCacheHandle::new(re_dataframe::QueryCache::new(
+                    store.clone(),
+                ));
                 PyRecording {
                     store: store.clone(),
                     cache,


### PR DESCRIPTION
Just shoehorning `QueryCacheHandle` the same way we shoehorned `ChunkStoreHandle` in the previous PR.

Now let's see if we can make things saner / less error-prone.

* Part 2/2 of #7486 
* DNM: requires #7917 

### Checklist
* [ ] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7921?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7921?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [ ] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7921)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.