### PR TITLE
Update walkers to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8794,9 +8794,9 @@ dependencies = [
 
 [[package]]
 name = "walkers"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a94019e3577a09c8d14077be3e9caf328e9047c2ce297e8f5c6b08855ee8f"
+checksum = "7193ce72e3e6a0a2910b60596a444ac0af9d1a76e4cc47ab3e238cd5c2ff84ba"
 dependencies = [
  "egui",
  "egui_extras",

--- a/crates/store/re_types/definitions/rerun/blueprint/components/zoom_level.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/zoom_level.fbs
@@ -10,5 +10,5 @@ table ZoomLevel (
     "attr.docs.unreleased"
 ) {
     /// Zoom level: 0 being the lowest zoom level (fully zoomed out) and 22 being the highest (fully zoomed in).
-    zoom: rerun.datatypes.Float32 (order: 100);
+    zoom: rerun.datatypes.Float64 (order: 100);
 }

--- a/crates/store/re_types/src/blueprint/components/zoom_level.rs
+++ b/crates/store/re_types/src/blueprint/components/zoom_level.rs
@@ -22,7 +22,7 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Default)]
 pub struct ZoomLevel(
     /// Zoom level: 0 being the lowest zoom level (fully zoomed out) and 22 being the highest (fully zoomed in).
-    pub crate::datatypes::Float32,
+    pub crate::datatypes::Float64,
 );
 
 impl ::re_types_core::SizeBytes for ZoomLevel {
@@ -33,35 +33,35 @@ impl ::re_types_core::SizeBytes for ZoomLevel {
 
     #[inline]
     fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
+        <crate::datatypes::Float64>::is_pod()
     }
 }
 
-impl<T: Into<crate::datatypes::Float32>> From<T> for ZoomLevel {
+impl<T: Into<crate::datatypes::Float64>> From<T> for ZoomLevel {
     fn from(v: T) -> Self {
         Self(v.into())
     }
 }
 
-impl std::borrow::Borrow<crate::datatypes::Float32> for ZoomLevel {
+impl std::borrow::Borrow<crate::datatypes::Float64> for ZoomLevel {
     #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
+    fn borrow(&self) -> &crate::datatypes::Float64 {
         &self.0
     }
 }
 
 impl std::ops::Deref for ZoomLevel {
-    type Target = crate::datatypes::Float32;
+    type Target = crate::datatypes::Float64;
 
     #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
+    fn deref(&self) -> &crate::datatypes::Float64 {
         &self.0
     }
 }
 
 impl std::ops::DerefMut for ZoomLevel {
     #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float64 {
         &mut self.0
     }
 }
@@ -78,7 +78,7 @@ impl ::re_types_core::Loggable for ZoomLevel {
 
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
-        crate::datatypes::Float32::arrow_datatype()
+        crate::datatypes::Float64::arrow_datatype()
     }
 
     fn to_arrow_opt<'a>(
@@ -87,7 +87,7 @@ impl ::re_types_core::Loggable for ZoomLevel {
     where
         Self: Clone + 'a,
     {
-        crate::datatypes::Float32::to_arrow_opt(data.into_iter().map(|datum| {
+        crate::datatypes::Float64::to_arrow_opt(data.into_iter().map(|datum| {
             datum.map(|datum| match datum.into() {
                 ::std::borrow::Cow::Borrowed(datum) => ::std::borrow::Cow::Borrowed(&datum.0),
                 ::std::borrow::Cow::Owned(datum) => ::std::borrow::Cow::Owned(datum.0),
@@ -101,7 +101,7 @@ impl ::re_types_core::Loggable for ZoomLevel {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow_opt(arrow_data)
+        crate::datatypes::Float64::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
     }
 
@@ -110,6 +110,6 @@ impl ::re_types_core::Loggable for ZoomLevel {
     where
         Self: Sized,
     {
-        crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+        crate::datatypes::Float64::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
     }
 }

--- a/crates/viewer/re_component_ui/src/datatype_uis/float_drag.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/float_drag.rs
@@ -86,3 +86,24 @@ fn edit_f32_zero_to_one_raw(ui: &mut egui::Ui, value: &mut MaybeMutRef<'_, f32>)
         ui.label(re_format::format_f32(**value))
     }
 }
+
+// ---
+
+/// Non monomorphized implementation for f64 float editing with a given speed.
+pub fn edit_f64_float_raw_with_speed_impl(
+    ui: &mut egui::Ui,
+    value: &mut MaybeMutRef<'_, f64>,
+    range: RangeInclusive<f64>,
+    speed: f64,
+) -> egui::Response {
+    if let Some(value) = value.as_mut() {
+        ui.add(
+            egui::DragValue::new(value)
+                .clamp_existing_to_range(false)
+                .range(range)
+                .speed(speed),
+        )
+    } else {
+        ui.label(re_format::format_f64(**value))
+    }
+}

--- a/crates/viewer/re_component_ui/src/datatype_uis/mod.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/mod.rs
@@ -9,8 +9,8 @@ mod view_id;
 pub use bool_toggle::edit_bool;
 pub use enum_combobox::edit_view_enum;
 pub use float_drag::{
-    edit_f32_float_raw_with_speed_impl, edit_f32_min_to_max_float, edit_f32_zero_to_max,
-    edit_f32_zero_to_one,
+    edit_f32_min_to_max_float, edit_f32_zero_to_max, edit_f32_zero_to_one,
+    edit_f64_float_raw_with_speed_impl,
 };
 pub use range1d::edit_view_range1d;
 pub use singleline_string::{

--- a/crates/viewer/re_component_ui/src/zoom_level.rs
+++ b/crates/viewer/re_component_ui/src/zoom_level.rs
@@ -5,20 +5,20 @@ use re_viewer_context::MaybeMutRef;
 // TODO(ab): currently set at 19 because that's what walkers has as hard-coded limit. In the future,
 // walkers will need to be more flexible (e.g. depend on the actually max zoom level for the map
 // provider). At that point, we will have to set some kind of "max ever" value here.
-const MAX_ZOOM_LEVEL: f32 = 19.0;
+const MAX_ZOOM_LEVEL: f64 = 19.0;
 
 /// Editor for a [`re_types::blueprint::components::ZoomLevel`].
 pub fn edit_zoom_level(
     _ctx: &re_viewer_context::ViewerContext<'_>,
     ui: &mut egui::Ui,
-    value: &mut MaybeMutRef<'_, impl std::ops::DerefMut<Target = datatypes::Float32>>,
+    value: &mut MaybeMutRef<'_, impl std::ops::DerefMut<Target = datatypes::Float64>>,
 ) -> egui::Response {
-    let mut value: MaybeMutRef<'_, f32> = match value {
+    let mut value: MaybeMutRef<'_, f64> = match value {
         MaybeMutRef::Ref(value) => MaybeMutRef::Ref(value),
         MaybeMutRef::MutRef(value) => MaybeMutRef::MutRef(&mut value.deref_mut().0),
     };
 
-    super::datatype_uis::edit_f32_float_raw_with_speed_impl(
+    super::datatype_uis::edit_f64_float_raw_with_speed_impl(
         ui,
         &mut value,
         0.0..=MAX_ZOOM_LEVEL,

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -31,4 +31,4 @@ re_viewport_blueprint.workspace = true
 
 egui.workspace = true
 itertools.workspace = true
-walkers = "0.25.0"
+walkers = "0.26.0"         # TODO(#7876): move to workspace

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -239,7 +239,7 @@ Displays geospatial primitives on a map.
         if Some(map_memory.zoom()) != blueprint_zoom_level {
             map_zoom.save_blueprint_component(
                 ctx,
-                &ZoomLevel(re_types::datatypes::Float32(map_memory.zoom())),
+                &ZoomLevel(re_types::datatypes::Float64(map_memory.zoom())),
             );
         }
 

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -149,15 +149,16 @@ struct GeoPointsPlugin<'a> {
 
 impl walkers::Plugin for GeoPointsPlugin<'_> {
     fn run(
-        &mut self,
+        self: Box<Self>,
+        ui: &mut egui::Ui,
         _response: &egui::Response,
-        painter: egui::Painter,
         projector: &walkers::Projector,
     ) {
         for entry in self.map_entries {
             // Project it into the position on the screen.
             let position = projector.project(entry.position).to_pos2();
-            painter.circle_filled(position, entry.radius, entry.color);
+            ui.painter()
+                .circle_filled(position, entry.radius, entry.color);
         }
     }
 }

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -39,13 +39,14 @@ impl GeoSpan {
         )
     }
 
-    pub fn zoom_for_screen_size(&self, screen_size: egui::Vec2) -> Option<f32> {
+    pub fn zoom_for_screen_size(&self, screen_size: egui::Vec2) -> Option<f64> {
         // Thanks, Claude: https://claude.site/artifacts/cb4f7f53-07a6-4ad0-bce3-eee3cb7e3177
 
         if self.min_latitude == self.max_latitude || self.min_longitude == self.max_longitude {
             return None;
         }
 
+        //TODO(ab): should use the actual tile size from the map provider (always 256 in practice)
         const TILE_SIZE: f64 = 256.0;
 
         // Convert latitude to y coordinate in mercator projection (scaled to 0..1)
@@ -68,7 +69,7 @@ impl GeoSpan {
         let zoom_y = (screen_size.y as f64 / tiles_y).ln() / 2.0_f64.ln();
 
         // Use the minimum zoom level to ensure the entire range fits
-        Some(zoom_x.min(zoom_y) as f32)
+        Some(zoom_x.min(zoom_y))
     }
 }
 

--- a/rerun_cpp/src/rerun/blueprint/components/zoom_level.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/zoom_level.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "../../datatypes/float32.hpp"
+#include "../../datatypes/float64.hpp"
 #include "../../result.hpp"
 
 #include <cstdint>
@@ -13,34 +13,34 @@ namespace rerun::blueprint::components {
     /// **Component**: A zoom level determines how much of the world is visible on a map.
     struct ZoomLevel {
         /// Zoom level: 0 being the lowest zoom level (fully zoomed out) and 22 being the highest (fully zoomed in).
-        rerun::datatypes::Float32 zoom;
+        rerun::datatypes::Float64 zoom;
 
       public:
         ZoomLevel() = default;
 
-        ZoomLevel(rerun::datatypes::Float32 zoom_) : zoom(zoom_) {}
+        ZoomLevel(rerun::datatypes::Float64 zoom_) : zoom(zoom_) {}
 
-        ZoomLevel& operator=(rerun::datatypes::Float32 zoom_) {
+        ZoomLevel& operator=(rerun::datatypes::Float64 zoom_) {
             zoom = zoom_;
             return *this;
         }
 
-        ZoomLevel(float value_) : zoom(value_) {}
+        ZoomLevel(double value_) : zoom(value_) {}
 
-        ZoomLevel& operator=(float value_) {
+        ZoomLevel& operator=(double value_) {
             zoom = value_;
             return *this;
         }
 
-        /// Cast to the underlying Float32 datatype
-        operator rerun::datatypes::Float32() const {
+        /// Cast to the underlying Float64 datatype
+        operator rerun::datatypes::Float64() const {
             return zoom;
         }
     };
 } // namespace rerun::blueprint::components
 
 namespace rerun {
-    static_assert(sizeof(rerun::datatypes::Float32) == sizeof(blueprint::components::ZoomLevel));
+    static_assert(sizeof(rerun::datatypes::Float64) == sizeof(blueprint::components::ZoomLevel));
 
     /// \private
     template <>
@@ -49,7 +49,7 @@ namespace rerun {
 
         /// Returns the arrow data type this type corresponds to.
         static const std::shared_ptr<arrow::DataType>& arrow_datatype() {
-            return Loggable<rerun::datatypes::Float32>::arrow_datatype();
+            return Loggable<rerun::datatypes::Float64>::arrow_datatype();
         }
 
         /// Serializes an array of `rerun::blueprint:: components::ZoomLevel` into an arrow array.
@@ -57,14 +57,14 @@ namespace rerun {
             const blueprint::components::ZoomLevel* instances, size_t num_instances
         ) {
             if (num_instances == 0) {
-                return Loggable<rerun::datatypes::Float32>::to_arrow(nullptr, 0);
+                return Loggable<rerun::datatypes::Float64>::to_arrow(nullptr, 0);
             } else if (instances == nullptr) {
                 return rerun::Error(
                     ErrorCode::UnexpectedNullArgument,
                     "Passed array instances is null when num_elements> 0."
                 );
             } else {
-                return Loggable<rerun::datatypes::Float32>::to_arrow(
+                return Loggable<rerun::datatypes::Float64>::to_arrow(
                     &instances->zoom,
                     num_instances
                 );

--- a/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/archetypes/map_zoom.py
@@ -23,7 +23,7 @@ __all__ = ["MapZoom"]
 class MapZoom(Archetype):
     """**Archetype**: Configuration of the map view zoom level."""
 
-    def __init__(self: Any, zoom: datatypes.Float32Like):
+    def __init__(self: Any, zoom: datatypes.Float64Like):
         """
         Create a new instance of the MapZoom archetype.
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
@@ -14,21 +14,21 @@ from ..._baseclasses import (
 __all__ = ["ZoomLevel", "ZoomLevelBatch", "ZoomLevelType"]
 
 
-class ZoomLevel(datatypes.Float32, ComponentMixin):
+class ZoomLevel(datatypes.Float64, ComponentMixin):
     """**Component**: A zoom level determines how much of the world is visible on a map."""
 
     _BATCH_TYPE = None
     # You can define your own __init__ function as a member of ZoomLevelExt in zoom_level_ext.py
 
-    # Note: there are no fields here because ZoomLevel delegates to datatypes.Float32
+    # Note: there are no fields here because ZoomLevel delegates to datatypes.Float64
     pass
 
 
-class ZoomLevelType(datatypes.Float32Type):
+class ZoomLevelType(datatypes.Float64Type):
     _TYPE_NAME: str = "rerun.blueprint.components.ZoomLevel"
 
 
-class ZoomLevelBatch(datatypes.Float32Batch, ComponentBatchMixin):
+class ZoomLevelBatch(datatypes.Float64Batch, ComponentBatchMixin):
     _ARROW_TYPE = ZoomLevelType()
 
 


### PR DESCRIPTION
### What

Updates walkers to 0.26
- Changes the `Plugin` API (which unblocks making entities coverable/selectable, etc)
- Changes the zoom level from f32 to f64
- Bonus: that new version uses one-less-zoom-level tiles to fill in while full-res tile are downloading, and it makes a hell of a difference.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7929?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7929?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7929)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.