### PR TITLE
Officially deprecate support for python 3.8

### DIFF
--- a/docs/content/reference/migration/migration-0-20.md
+++ b/docs/content/reference/migration/migration-0-20.md
@@ -25,3 +25,8 @@ You can learn more about Rerun's application model and the different servers and
 `re_query::Caches` has been renamed `re_query::QueryCache`, and similarly for `re_query::CacheKey`.
 
 Note that this doesn't affect `re_dataframe`, where this type was already re-exported as `QueryCache`.
+
+## ❗ Deprecations
+
+Support for Python 3.8 is being deprecated. Python 3.8 is past end-of-life. See: https://devguide.python.org/versions/
+In the next release, we will fully drop support and switch to Python 3.9 as the minimum supported version.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import functools
 import random
+import sys
+import warnings
 from typing import Any, Callable, TypeVar, cast
 from uuid import UUID
 
@@ -9,6 +11,13 @@ import numpy as np
 
 __version__ = "0.20.0-alpha.1+dev"
 __version_info__ = (0, 20, 0, "alpha.1")
+
+
+if sys.version_info < (3, 9):
+    warnings.warn(
+        "Python 3.8 is past EOL (https://devguide.python.org/versions/). Rerun version 0.21 will drop support/testing of Python 3.8.",
+        DeprecationWarning,
+    )
 
 # =====================================
 # API RE-EXPORTS


### PR DESCRIPTION
### What
- Resolves: https://github.com/rerun-io/rerun/issues/7830

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7933?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7933?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7933)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.