### PR TITLE
Enable dataframe streaming across Python FFI

### DIFF
--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -737,21 +737,12 @@ impl PyRecordingView {
         let metadata = schema.metadata.clone().into_iter().collect();
         let schema = arrow::datatypes::Schema::new(fields).with_metadata(metadata);
 
-        // TODO(jleibs): Need to keep the engine alive
-        /*
         let reader = RecordBatchIterator::new(
             query_handle
                 .into_batch_iter()
                 .map(|batch| batch.try_to_arrow_record_batch()),
             std::sync::Arc::new(schema),
         );
-        */
-        let batches = query_handle
-            .into_batch_iter()
-            .map(|batch| batch.try_to_arrow_record_batch())
-            .collect::<Vec<_>>();
-
-        let reader = RecordBatchIterator::new(batches.into_iter(), std::sync::Arc::new(schema));
 
         Ok(PyArrowType(Box::new(reader)))
     }
@@ -829,21 +820,12 @@ impl PyRecordingView {
         let metadata = schema.metadata.clone().into_iter().collect();
         let schema = arrow::datatypes::Schema::new(fields).with_metadata(metadata);
 
-        // TODO(jleibs): Need to keep the engine alive
-        /*
         let reader = RecordBatchIterator::new(
             query_handle
                 .into_batch_iter()
                 .map(|batch| batch.try_to_arrow_record_batch()),
             std::sync::Arc::new(schema),
         );
-        */
-        let batches = query_handle
-            .into_batch_iter()
-            .map(|batch| batch.try_to_arrow_record_batch())
-            .collect::<Vec<_>>();
-
-        let reader = RecordBatchIterator::new(batches.into_iter(), std::sync::Arc::new(schema));
 
         Ok(PyArrowType(Box::new(reader)))
     }


### PR DESCRIPTION
Title.

Just trying _not_ to bury the actual important thing into the previous mammoth PR :melting_face: 

* DNM: requires #7934 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7935?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7935?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7935)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.