### PR TITLE
Implement usual hover and selection interactions in the map view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6197,6 +6197,7 @@ dependencies = [
  "re_query",
  "re_renderer",
  "re_space_view",
+ "re_tracing",
  "re_types",
  "re_ui",
  "re_viewer_context",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6186,8 +6186,10 @@ dependencies = [
 name = "re_space_view_map"
 version = "0.20.0-alpha.1+dev"
 dependencies = [
+ "ahash",
  "egui",
  "itertools 0.13.0",
+ "re_entity_db",
  "re_log",
  "re_log_types",
  "re_query",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6189,6 +6189,7 @@ dependencies = [
  "ahash",
  "egui",
  "itertools 0.13.0",
+ "re_data_ui",
  "re_entity_db",
  "re_log",
  "re_log_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6189,6 +6189,7 @@ dependencies = [
  "ahash",
  "egui",
  "itertools 0.13.0",
+ "nohash-hasher",
  "re_data_ui",
  "re_entity_db",
  "re_log",

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -26,6 +26,7 @@ re_log_types.workspace = true
 re_query.workspace = true
 re_renderer.workspace = true
 re_space_view.workspace = true
+re_tracing.workspace = true
 re_types.workspace = true
 re_ui.workspace = true
 re_viewer_context.workspace = true

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -36,4 +36,4 @@ ahash.workspace = true
 egui.workspace = true
 itertools.workspace = true
 nohash-hasher.workspace = true
-walkers = "0.26.0"         # TODO(#7876): move to workspace
+walkers = "0.26.0"             # TODO(#7876): move to workspace

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_data_ui.workspace = true
 re_entity_db.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_entity_db.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true
 re_query.workspace = true
@@ -29,6 +30,7 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
+ahash.workspace = true
 egui.workspace = true
 itertools.workspace = true
 walkers = "0.26.0"         # TODO(#7876): move to workspace

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -34,4 +34,5 @@ re_viewport_blueprint.workspace = true
 ahash.workspace = true
 egui.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
 walkers = "0.26.0"         # TODO(#7876): move to workspace

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -1,4 +1,6 @@
 use egui::{Context, NumExt as _};
+use walkers::{HttpTiles, Map, MapMemory, Tiles};
+
 use re_data_ui::{item_ui, DataUi};
 use re_log_types::EntityPath;
 use re_space_view::suggest_space_view_for_each_entity;
@@ -18,7 +20,6 @@ use re_viewer_context::{
     ViewQuery, ViewerContext,
 };
 use re_viewport_blueprint::ViewProperty;
-use walkers::{HttpTiles, Map, MapMemory, Tiles};
 
 use crate::map_overlays;
 use crate::visualizers::geo_points::GeoPointsVisualizer;

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -252,12 +252,12 @@ Displays geospatial primitives on a map.
                     ctx.selection_state().set_selection(Item::DataResult(
                         query.space_view_id,
                         picked_instance.instance_path.entity_path.clone().into(),
-                    ))
+                    ));
                 }
             } else if map_response.clicked() {
                 // clicked elsewhere, select the view
                 ctx.selection_state()
-                    .set_selection(Item::SpaceView(query.space_view_id))
+                    .set_selection(Item::SpaceView(query.space_view_id));
             }
 
             if map_response.double_clicked() {

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -219,11 +219,12 @@ Displays geospatial primitives on a map.
             let mut picked_instance = None;
 
             let some_tiles_manager: Option<&mut dyn Tiles> = Some(tiles);
-            let map_response = ui.add(
+            let mut map_response = ui.add(
                 Map::new(some_tiles_manager, map_memory, default_center_position).with_plugin(
                     geo_points_visualizer.plugin(ctx, query.space_view_id, &mut picked_instance),
                 ),
             );
+            let map_rect = map_response.rect;
 
             if let Some(picked_instance) = picked_instance {
                 map_response = map_response.on_hover_ui_at_pointer(|ui| {
@@ -268,7 +269,6 @@ Displays geospatial primitives on a map.
                 }
             }
 
-            let map_rect = map_response.rect;
             map_overlays::zoom_buttons_overlay(ui, &map_rect, map_memory);
             map_overlays::acknowledgement_overlay(ui, &map_rect, &tiles.attribution());
         });

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -226,7 +226,7 @@ Displays geospatial primitives on a map.
             );
 
             if let Some(picked_instance) = picked_instance {
-                map_response.clone().on_hover_ui_at_pointer(|ui| {
+                map_response = map_response.on_hover_ui_at_pointer(|ui| {
                     list_item::list_item_scope(ui, "map_hover", |ui| {
                         item_ui::instance_path_button(
                             ctx,

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -1,3 +1,5 @@
+use re_entity_db::{InstancePath, InstancePathHash};
+use re_log_types::{EntityPathHash, Instance};
 use re_space_view::{DataResultQuery as _, RangeResultsExt as _};
 use re_types::{
     archetypes::GeoPoints,
@@ -5,12 +7,12 @@ use re_types::{
     Loggable as _,
 };
 use re_viewer_context::{
-    auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,
-    TypedComponentFallbackProvider, ViewContext, ViewContextCollection, ViewQuery,
-    VisualizerQueryInfo, VisualizerSystem,
+    auto_color_for_entity_path, IdentifiedViewSystem, Item, QueryContext, SpaceViewId,
+    SpaceViewSystemExecutionError, TypedComponentFallbackProvider, ViewContext,
+    ViewContextCollection, ViewQuery, ViewerContext, VisualizerQueryInfo, VisualizerSystem,
 };
 
-// ---
+use crate::visualizers::{update_picked_instance, PickedInstance};
 
 #[derive(Debug, Clone)]
 struct GeoPointEntry {
@@ -23,12 +25,22 @@ struct GeoPointEntry {
 
     /// Color.
     color: egui::Color32,
+
+    /// The instance corresponding to this entry.
+    instance_path: InstancePath,
 }
 
-/// A map scene, with entries on the map to render.
+/// Visualizer for [`GeoPoints`].
 #[derive(Default)]
 pub struct GeoPointsVisualizer {
+    /// Objects to render.
     map_entries: Vec<GeoPointEntry>,
+
+    /// Indices into `map_entries` corresponding to a given entity.
+    entities: ahash::HashMap<EntityPathHash, Vec<usize>>,
+
+    /// Indices into `map_entries` corresponding to specific instances.
+    instances: ahash::HashMap<InstancePathHash, usize>,
 }
 
 impl IdentifiedViewSystem for GeoPointsVisualizer {
@@ -81,12 +93,14 @@ impl VisualizerSystem for GeoPointsVisualizer {
                 let last_radii = radii.last().copied().unwrap_or(fallback_radius);
 
                 // iterate over all instances
-                for (position, color, radius) in itertools::izip!(
+                for (instance_index, (position, color, radius)) in itertools::izip!(
                     positions,
                     colors.iter().chain(std::iter::repeat(&last_color)),
                     radii.iter().chain(std::iter::repeat(&last_radii)),
-                ) {
-                    self.map_entries.push(GeoPointEntry {
+                )
+                .enumerate()
+                {
+                    let entry = GeoPointEntry {
                         position: walkers::Position::from_lat_lon(
                             position.latitude(),
                             position.longitude(),
@@ -94,7 +108,20 @@ impl VisualizerSystem for GeoPointsVisualizer {
                         //TODO(#7872): support for radius in meter
                         radius: radius.0.abs(),
                         color: color.0.into(),
-                    });
+                        instance_path: InstancePath::instance(
+                            data_result.entity_path.clone(),
+                            (instance_index as u64).into(),
+                        ),
+                    };
+
+                    let next_idx = self.map_entries.len();
+                    self.instances.insert(entry.instance_path.hash(), next_idx);
+                    self.entities
+                        .entry(data_result.entity_path.hash())
+                        .or_default()
+                        .push(next_idx);
+
+                    self.map_entries.push(entry);
                 }
             }
         }
@@ -113,9 +140,17 @@ impl VisualizerSystem for GeoPointsVisualizer {
 
 impl GeoPointsVisualizer {
     /// Return a [`walkers::Plugin`] for this visualizer.
-    pub fn plugin(&self) -> impl walkers::Plugin + '_ {
+    pub fn plugin<'a>(
+        &'a self,
+        ctx: &'a ViewerContext<'a>,
+        view_id: SpaceViewId,
+        picked_instance: &'a mut Option<PickedInstance>,
+    ) -> impl walkers::Plugin + 'a {
         GeoPointsPlugin {
-            map_entries: &self.map_entries,
+            visualizer: self,
+            viewer_ctx: ctx,
+            view_id,
+            picked_instance,
         }
     }
 
@@ -126,6 +161,21 @@ impl GeoPointsVisualizer {
                 .iter()
                 .map(|entry| (entry.position.lat(), entry.position.lon())),
         )
+    }
+
+    /// Returns a slice of entry indices matching the provided instance path.
+    fn indices_for_instance(&self, instance_path: &InstancePath) -> &[usize] {
+        let indices = if instance_path.instance.is_all() {
+            self.entities
+                .get(&instance_path.entity_path.hash())
+                .map(|indices| indices.as_slice())
+        } else {
+            self.instances
+                .get(&instance_path.hash())
+                .map(|idx| std::slice::from_ref(idx))
+        };
+
+        indices.unwrap_or_default()
     }
 }
 
@@ -144,21 +194,102 @@ impl TypedComponentFallbackProvider<Radius> for GeoPointsVisualizer {
 re_viewer_context::impl_component_fallback_provider!(GeoPointsVisualizer => [Color, Radius]);
 
 struct GeoPointsPlugin<'a> {
-    map_entries: &'a Vec<GeoPointEntry>,
+    visualizer: &'a GeoPointsVisualizer,
+    viewer_ctx: &'a ViewerContext<'a>,
+    view_id: SpaceViewId,
+    picked_instance: &'a mut Option<PickedInstance>,
 }
 
 impl walkers::Plugin for GeoPointsPlugin<'_> {
     fn run(
         self: Box<Self>,
         ui: &mut egui::Ui,
-        _response: &egui::Response,
+        response: &egui::Response,
         projector: &walkers::Projector,
     ) {
-        for entry in self.map_entries {
-            // Project it into the position on the screen.
-            let position = projector.project(entry.position).to_pos2();
-            ui.painter()
-                .circle_filled(position, entry.radius, entry.color);
+        let painter = ui.painter();
+
+        // let's avoid computing that twice
+        let projected_position = self
+            .visualizer
+            .map_entries
+            .iter()
+            .map(|entry| projector.project(entry.position).to_pos2())
+            .collect::<Vec<_>>();
+
+        //
+        // First pass: draw everything without any highlight
+        //
+
+        let hover_position = response.hover_pos();
+        for (entry, position) in self
+            .visualizer
+            .map_entries
+            .iter()
+            .zip(projected_position.iter())
+        {
+            if let Some(hover_position) = hover_position {
+                let pixel_distance = hover_position.distance(*position);
+                if pixel_distance < entry.radius {
+                    update_picked_instance(
+                        self.picked_instance,
+                        Some(PickedInstance {
+                            instance: entry.instance_path.clone(),
+                            pixel_distance,
+                        }),
+                    );
+                }
+            }
+
+            painter.circle_filled(*position, entry.radius, entry.color);
+        }
+
+        //
+        // Find the indices of all entries that are part of the current selection.
+        //
+
+        let selected_entries_indices = self
+            .viewer_ctx
+            .selection()
+            .iter()
+            .map(|(item, _)| {
+                if let Item::DataResult(view_id, instance_path) = item {
+                    if *view_id == self.view_id {
+                        return self.visualizer.indices_for_instance(instance_path);
+                    }
+                }
+
+                // empty slice
+                Default::default()
+            })
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        //
+        // Second pass: draw highlights for everything that is selected
+        //
+
+        for index in &selected_entries_indices {
+            let entry = &self.visualizer.map_entries[*index];
+            let position = projected_position[*index];
+
+            painter.circle_stroke(
+                position,
+                entry.radius,
+                egui::Stroke::new(2.0, ui.style().visuals.selection.bg_fill),
+            );
+        }
+
+        //
+        // Third pass: draw the selected entries again on top of the selection highlight
+        //
+
+        for index in selected_entries_indices {
+            let entry = &self.visualizer.map_entries[index];
+            let position = projected_position[index];
+
+            painter.circle_filled(position, entry.radius, entry.color);
         }
     }
 }

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -304,6 +304,9 @@ impl walkers::Plugin for GeoPointsPlugin<'_> {
         // Forth pass: draw the hovered entries
         //
 
+        // Note: usually, there only ever is a single hovered item, so we don't use the two-pass
+        // approach here.
+
         let hovered_entries_indices = self
             .visualizer
             .indices_for_item_collection(self.viewer_ctx.hovered(), self.view_id);

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -19,7 +19,7 @@ struct GeoPointEntry {
     /// Position.
     position: walkers::Position,
 
-    /// Display radius in pixels
+    /// Display radius in ui points
     //TODO(#7872): support for radius in meter
     radius: f32,
 
@@ -229,6 +229,8 @@ impl walkers::Plugin for GeoPointsPlugin<'_> {
         response: &egui::Response,
         projector: &walkers::Projector,
     ) {
+        re_tracing::profile_function!();
+
         let painter = ui.painter();
 
         // let's avoid computing that twice
@@ -251,13 +253,13 @@ impl walkers::Plugin for GeoPointsPlugin<'_> {
             .zip(projected_position.iter())
         {
             if let Some(hover_position) = hover_position {
-                let pixel_distance = hover_position.distance(*position);
-                if pixel_distance < entry.radius {
+                let ui_point_distance = hover_position.distance(*position);
+                if ui_point_distance < entry.radius {
                     update_picked_instance(
                         self.picked_instance,
                         Some(PickedInstance {
                             instance_path: entry.instance_path.clone(),
-                            pixel_distance,
+                            ui_point_distance,
                         }),
                     );
                 }

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -172,7 +172,7 @@ impl GeoPointsVisualizer {
         } else {
             self.instances
                 .get(&instance_path.hash())
-                .map(|idx| std::slice::from_ref(idx))
+                .map(std::slice::from_ref)
         };
 
         indices.unwrap_or_default()
@@ -186,7 +186,7 @@ impl GeoPointsVisualizer {
     ) -> Vec<usize> {
         item_collection
             .iter()
-            .map(|(item, _)| {
+            .flat_map(|(item, _)| {
                 if let Item::DataResult(item_view_id, instance_path) = item {
                     if *item_view_id == view_id {
                         return self.indices_for_instance(instance_path);
@@ -196,8 +196,7 @@ impl GeoPointsVisualizer {
                 // empty slice
                 Default::default()
             })
-            .flatten()
-            .cloned()
+            .copied()
             .collect::<Vec<_>>()
     }
 }

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -37,7 +37,7 @@ pub struct GeoPointsVisualizer {
     map_entries: Vec<GeoPointEntry>,
 
     /// Indices into `map_entries` corresponding to a given entity.
-    entities: ahash::HashMap<EntityPathHash, Vec<usize>>,
+    entities: nohash_hasher::IntMap<EntityPathHash, Vec<usize>>,
 
     /// Indices into `map_entries` corresponding to specific instances.
     instances: ahash::HashMap<InstancePathHash, usize>,

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -1,3 +1,5 @@
+use re_entity_db::InstancePath;
+
 pub mod geo_points;
 
 /// Helper to track an area span in latitude and longitude.
@@ -70,6 +72,28 @@ impl GeoSpan {
 
         // Use the minimum zoom level to ensure the entire range fits
         Some(zoom_x.min(zoom_y))
+    }
+}
+
+/// A picked instance.
+#[derive(Debug, Clone)]
+pub struct PickedInstance {
+    pub instance: InstancePath,
+
+    /// Keep track of the mouse distance from the object's center, so we can arbitrate.
+    pixel_distance: f32,
+}
+
+/// Keep the closest instance.
+pub fn update_picked_instance(first: &mut Option<PickedInstance>, second: Option<PickedInstance>) {
+    if let Some(second) = second {
+        if let Some(first) = first {
+            if second.pixel_distance < first.pixel_distance {
+                *first = second;
+            }
+        } else {
+            *first = Some(second);
+        }
     }
 }
 

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -80,15 +80,15 @@ impl GeoSpan {
 pub struct PickedInstance {
     pub instance_path: InstancePath,
 
-    /// Keep track of the mouse distance from the object's center, so we can arbitrate.
-    pixel_distance: f32,
+    /// Keep track of the mouse distance from the object's center in ui points, so we can arbitrate.
+    ui_point_distance: f32,
 }
 
 /// Update a picked instance with another one if it's closer.
 pub fn update_picked_instance(first: &mut Option<PickedInstance>, second: Option<PickedInstance>) {
     if let Some(second) = second {
         if let Some(first) = first {
-            if second.pixel_distance < first.pixel_distance {
+            if second.ui_point_distance < first.ui_point_distance {
                 *first = second;
             }
         } else {

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -84,7 +84,7 @@ pub struct PickedInstance {
     pixel_distance: f32,
 }
 
-/// Keep the closest instance.
+/// Update a picked instance with another one if it's closer.
 pub fn update_picked_instance(first: &mut Option<PickedInstance>, second: Option<PickedInstance>) {
     if let Some(second) = second {
         if let Some(first) = first {

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -78,7 +78,7 @@ impl GeoSpan {
 /// A picked instance.
 #[derive(Debug, Clone)]
 pub struct PickedInstance {
-    pub instance: InstancePath,
+    pub instance_path: InstancePath,
 
     /// Keep track of the mouse distance from the object's center, so we can arbitrate.
     pixel_distance: f32,


### PR DESCRIPTION
### What

This PR adds the "usual" UI interactions to the map view, including:
- hover highlight
- click to select instance
- cmd-click to add instance to selection
- double-click to select entire entity
- click anywhere else in the map view to select the view
- hover tooltip for the instances

Note: the rendering of the selection/hover silhouette requires a whole bunch of draw passes, which clearly highlights (pun not intended) the need to eventually transit to using `re_renderer`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7938?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7938?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7938)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.