### PR TITLE
Add `VisualizerSystemError` and `SpaceViewClassError`

### DIFF
--- a/crates/viewer/re_viewer_context/src/space_view/mod.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/mod.rs
@@ -23,6 +23,7 @@ pub use highlights::{
     SpaceViewOutlineMasks,
 };
 pub use named_system::{IdentifiedViewSystem, PerSystemEntities, ViewSystemIdentifier};
+use re_types::SpaceViewClassIdentifier;
 pub use space_view_class::{
     SpaceViewClass, SpaceViewClassExt, SpaceViewClassLayoutPriority, SpaceViewState,
     SpaceViewStateExt, VisualizableFilterContext,
@@ -51,6 +52,18 @@ pub enum SpaceViewSystemExecutionError {
 
     #[error("View part system {0} not found")]
     VisualizerSystemNotFound(&'static str),
+
+    #[error("View part system {identifier} failed with error: {error}")]
+    VisualizerSystemError {
+        identifier: ViewSystemIdentifier,
+        error: Box<dyn std::error::Error>,
+    },
+
+    #[error("View class {identifier} failed with error: {error}")]
+    SpaceViewClassError {
+        identifier: SpaceViewClassIdentifier,
+        error: Box<dyn std::error::Error>,
+    },
 
     #[error(transparent)]
     QueryError2(#[from] re_query::QueryError),


### PR DESCRIPTION
<!--
Open the PR up as a draft until you feel it is ready for a proper review.

Do not make PR:s from your own `main` branch, as that makes it difficult for reviewers to add their own fixes.

Add any improvements to the branch as new commits to make it easier for reviewers to follow the progress. All commits will be squashed to a single commit once the PR is merged into `main`.

Make sure you mention any issues that this PR closes in the description, as well as any other related issues.

To get an auto-generated PR description you can put "copilot:summary" or "copilot:walkthrough" anywhere.
-->

### What

In some instances, visualizers and views can run into errors, because the data is not well-formed. As an example, consider a graph layout algorithm that was chosen by the user that only works on DAGs but a cyclic graph was provided. Other examples would be node fixed node positions, supplied by the user, that lead to a non-well defined layout configration .

While Rerun's data model should prevent most of these errors, there still can be places where an escape hatch might be required. A small discussion can be found here: https://github.com/rerun-io/rerun/pull/7500#discussion_r1816888067

This PR adds two variants, `VisualizerSystemError` and `SpaceViewClassError` to `SpaceViewSystemExecutionError`.

:warning: Open problem: these systems often run on every frame, leading to many errors, most of them are not going away until the user changes something in their logging or blueprint logic. This leads to overflowing error messages in the _toast_ notifications. Ideally we would have something like backing up, or retrial logic.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [ ] I've included a screenshot or gif (if applicable)
* [ ] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7942?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7942?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [ ] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [ ] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7942)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.