### PR TITLE
Drag-n-drop: always use open semantics for rrd files

### DIFF
--- a/crates/store/re_data_loader/src/loader_rrd.rs
+++ b/crates/store/re_data_loader/src/loader_rrd.rs
@@ -87,14 +87,11 @@ impl crate::DataLoader for RrdLoader {
                     .name(format!("decode_and_stream({filepath:?})"))
                     .spawn({
                         let filepath = filepath.clone();
-                        let settings = settings.clone();
                         move || {
                             decode_and_stream(
-                                &filepath,
-                                &tx,
-                                decoder,
-                                settings.opened_application_id.as_ref(),
-                                settings.opened_store_id.as_ref(),
+                                &filepath, &tx, decoder,
+                                // Never use import semantics for .rrd files
+                                None, None,
                             );
                         }
                     })


### PR DESCRIPTION
Always use open semantics, as opposed to import semantics, for .rrd files. I.e. .rrd files will always be opened in their own recording, even with drag-n-drop.

Just reverting to the existing behavior basically.

cc @nikolausWest 

* [x] yes