### PR TITLE
Add datatype to component reflection and use it (preferred) for placeholders 

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/reflection.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/reflection.rs
@@ -142,8 +142,8 @@ fn generate_component_reflection(
         let quoted_reflection = quote! {
             ComponentReflection {
                 docstring_md: #docstring_md,
-
                 custom_placeholder: #custom_placeholder,
+                datatype: #type_name::arrow_datatype(),
             }
         };
         quoted_pairs.push(quote! { (#quoted_name, #quoted_reflection) });

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -91,14 +91,6 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
 ///
 /// Any [`Loggable`] with a [`Loggable::Name`] set to [`ComponentName`] automatically implements
 /// [`Component`].
-///
-/// All built-in components should implement the [`Default`] trait, so that the Viewer has a placeholder
-/// value that it can display for ui editors in absence of a value.
-/// In absence of an obvious default value, they should be implemented such that they are versatile
-/// and informative for the user when using the viewer.
-///
-/// This is not enforced via a trait bound, since it's only necessary for components known to the Rerun Viewer.
-/// It is not a hard requirement for custom components that are only used on the SDK side.
 pub trait Component: Loggable<Name = ComponentName> {}
 
 impl<L: Loggable<Name = ComponentName>> Component for L {}

--- a/crates/store/re_types_core/src/reflection.rs
+++ b/crates/store/re_types_core/src/reflection.rs
@@ -219,6 +219,9 @@ pub struct ComponentReflection {
     /// Typically, this is only used when `FallbackProvider`s are not available.
     /// If there's no custom placeholder, a placeholder can be derived from the arrow datatype.
     pub custom_placeholder: Option<Box<dyn arrow2::array::Array>>,
+
+    /// Datatype of the component.
+    pub datatype: arrow2::datatypes::DataType,
 }
 
 /// Runtime reflection about archetypes.

--- a/crates/viewer/re_viewer/src/reflection/mod.rs
+++ b/crates/viewer/re_viewer/src/reflection/mod.rs
@@ -39,6 +39,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The active tab in a tabbed container.",
                 custom_placeholder: Some(ActiveTab::default().to_arrow()?),
+                datatype: ActiveTab::arrow_datatype(),
             },
         ),
         (
@@ -46,6 +47,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether empty cells in a dataframe should be filled with a latest-at query.",
                 custom_placeholder: Some(ApplyLatestAt::default().to_arrow()?),
+                datatype: ApplyLatestAt::arrow_datatype(),
             },
         ),
         (
@@ -53,6 +55,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether the viewport layout is determined automatically.",
                 custom_placeholder: Some(AutoLayout::default().to_arrow()?),
+                datatype: AutoLayout::arrow_datatype(),
             },
         ),
         (
@@ -60,6 +63,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether or not space views should be created automatically.",
                 custom_placeholder: Some(AutoSpaceViews::default().to_arrow()?),
+                datatype: AutoSpaceViews::arrow_datatype(),
             },
         ),
         (
@@ -67,6 +71,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The type of the background in a view.",
                 custom_placeholder: Some(BackgroundKind::default().to_arrow()?),
+                datatype: BackgroundKind::arrow_datatype(),
             },
         ),
         (
@@ -74,6 +79,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The layout share of a column in the container.",
                 custom_placeholder: Some(ColumnShare::default().to_arrow()?),
+                datatype: ColumnShare::arrow_datatype(),
             },
         ),
         (
@@ -81,6 +87,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(ComponentColumnSelector::default().to_arrow()?),
+                datatype: ComponentColumnSelector::arrow_datatype(),
             },
         ),
         (
@@ -88,6 +95,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The kind of a blueprint container (tabs, grid, …).",
                 custom_placeholder: Some(ContainerKind::default().to_arrow()?),
+                datatype: ContainerKind::arrow_datatype(),
             },
         ),
         (
@@ -95,6 +103,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "One of four 2D corners, typically used to align objects.",
                 custom_placeholder: Some(Corner2D::default().to_arrow()?),
+                datatype: Corner2D::arrow_datatype(),
             },
         ),
         (
@@ -102,6 +111,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Configuration for a filter-by-range feature of the dataframe view.",
                 custom_placeholder: Some(FilterByRange::default().to_arrow()?),
+                datatype: FilterByRange::arrow_datatype(),
             },
         ),
         (
@@ -109,6 +119,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Configuration for the filter is not null feature of the dataframe view.",
                 custom_placeholder: Some(FilterIsNotNull::default().to_arrow()?),
+                datatype: FilterIsNotNull::arrow_datatype(),
             },
         ),
         (
@@ -116,6 +127,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "How many columns a grid container should have.",
                 custom_placeholder: Some(GridColumns::default().to_arrow()?),
+                datatype: GridColumns::arrow_datatype(),
             },
         ),
         (
@@ -123,6 +135,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "All the contents in the container.",
                 custom_placeholder: Some(IncludedContent::default().to_arrow()?),
+                datatype: IncludedContent::arrow_datatype(),
             },
         ),
         (
@@ -130,6 +143,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The unique id of a space view, used to refer to views in containers.",
                 custom_placeholder: Some(IncludedSpaceView::default().to_arrow()?),
+                datatype: IncludedSpaceView::arrow_datatype(),
             },
         ),
         (
@@ -137,6 +151,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether the entity can be interacted with.\n\nNon interactive components are still visible, but mouse interactions in the view are disabled.",
                 custom_placeholder: Some(Interactive::default().to_arrow()?),
+                datatype: Interactive::arrow_datatype(),
             },
         ),
         (
@@ -144,6 +159,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Indicate whether the range should be locked when zooming in on the data.\n\nDefault is `false`, i.e. zoom will change the visualized range.",
                 custom_placeholder: Some(LockRangeDuringZoom::default().to_arrow()?),
+                datatype: LockRangeDuringZoom::arrow_datatype(),
             },
         ),
         (
@@ -151,6 +167,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Name of the map provider to be used in Map views.",
                 custom_placeholder: Some(MapProvider::default().to_arrow()?),
+                datatype: MapProvider::arrow_datatype(),
             },
         ),
         (
@@ -158,6 +175,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Tri-state for panel controls.",
                 custom_placeholder: Some(PanelState::default().to_arrow()?),
+                datatype: PanelState::arrow_datatype(),
             },
         ),
         (
@@ -165,6 +183,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "An individual query expression used to filter a set of [`datatypes.EntityPath`](https://rerun.io/docs/reference/types/datatypes/entity_path)s.\n\nEach expression is either an inclusion or an exclusion expression.\nInclusions start with an optional `+` and exclusions must start with a `-`.\n\nMultiple expressions are combined together as part of `SpaceViewContents`.\n\nThe `/**` suffix matches the whole subtree, i.e. self and any child, recursively\n(`/world/**` matches both `/world` and `/world/car/driver`).\nOther uses of `*` are not (yet) supported.",
                 custom_placeholder: Some(QueryExpression::default().to_arrow()?),
+                datatype: QueryExpression::arrow_datatype(),
             },
         ),
         (
@@ -172,6 +191,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The container that sits at the root of a viewport.",
                 custom_placeholder: Some(RootContainer::default().to_arrow()?),
+                datatype: RootContainer::arrow_datatype(),
             },
         ),
         (
@@ -179,6 +199,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The layout share of a row in the container.",
                 custom_placeholder: Some(RowShare::default().to_arrow()?),
+                datatype: RowShare::arrow_datatype(),
             },
         ),
         (
@@ -186,6 +207,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(SelectedColumns::default().to_arrow()?),
+                datatype: SelectedColumns::arrow_datatype(),
             },
         ),
         (
@@ -193,6 +215,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The class identifier of view, e.g. `\"2D\"`, `\"TextLog\"`, ….",
                 custom_placeholder: Some(SpaceViewClass::default().to_arrow()?),
+                datatype: SpaceViewClass::arrow_datatype(),
             },
         ),
         (
@@ -200,6 +223,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether a space view is maximized.",
                 custom_placeholder: Some(SpaceViewMaximized::default().to_arrow()?),
+                datatype: SpaceViewMaximized::arrow_datatype(),
             },
         ),
         (
@@ -207,6 +231,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The origin of a `SpaceView`.",
                 custom_placeholder: Some(SpaceViewOrigin::default().to_arrow()?),
+                datatype: SpaceViewOrigin::arrow_datatype(),
             },
         ),
         (
@@ -216,6 +241,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 custom_placeholder: Some(
                     TensorDimensionIndexSlider::default().to_arrow()?,
                 ),
+                datatype: TensorDimensionIndexSlider::arrow_datatype(),
             },
         ),
         (
@@ -223,6 +249,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A timeline identified by its name.",
                 custom_placeholder: Some(TimelineName::default().to_arrow()?),
+                datatype: TimelineName::arrow_datatype(),
             },
         ),
         (
@@ -230,13 +257,17 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Determines whether an image or texture should be scaled to fit the viewport.",
                 custom_placeholder: Some(ViewFit::default().to_arrow()?),
+                datatype: ViewFit::arrow_datatype(),
             },
         ),
         (
             <ViewerRecommendationHash as Loggable>::name(),
             ComponentReflection {
                 docstring_md: "Hash of a viewer recommendation.\n\nThe formation of this hash is considered an internal implementation detail of the viewer.",
-                custom_placeholder: Some(ViewerRecommendationHash::default().to_arrow()?),
+                custom_placeholder: Some(
+                    ViewerRecommendationHash::default().to_arrow()?,
+                ),
+                datatype: ViewerRecommendationHash::arrow_datatype(),
             },
         ),
         (
@@ -244,6 +275,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether the container, view, entity or instance is currently visible.",
                 custom_placeholder: Some(Visible::default().to_arrow()?),
+                datatype: Visible::arrow_datatype(),
             },
         ),
         (
@@ -251,6 +283,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The range of values on a given timeline that will be included in a view's query.\n\nRefer to `VisibleTimeRanges` archetype for more information.",
                 custom_placeholder: Some(VisibleTimeRange::default().to_arrow()?),
+                datatype: VisibleTimeRange::arrow_datatype(),
             },
         ),
         (
@@ -258,6 +291,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Visual bounds in 2D space used for `Spatial2DView`.",
                 custom_placeholder: Some(VisualBounds2D::default().to_arrow()?),
+                datatype: VisualBounds2D::arrow_datatype(),
             },
         ),
         (
@@ -265,6 +299,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Override the visualizers for an entity.\n\nThis component is a stop-gap mechanism based on the current implementation details\nof the visualizer system. It is not intended to be a long-term solution, but provides\nenough utility to be useful in the short term.\n\nThe long-term solution is likely to be based off: <https://github.com/rerun-io/rerun/issues/6626>\n\nThis can only be used as part of blueprints. It will have no effect if used\nin a regular entity.",
                 custom_placeholder: Some(VisualizerOverrides::default().to_arrow()?),
+                datatype: VisualizerOverrides::arrow_datatype(),
             },
         ),
         (
@@ -272,6 +307,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A zoom level determines how much of the world is visible on a map.",
                 custom_placeholder: Some(ZoomLevel::default().to_arrow()?),
+                datatype: ZoomLevel::arrow_datatype(),
             },
         ),
         (
@@ -279,6 +315,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Policy for aggregation of multiple scalar plot values.\n\nThis is used for lines in plots when the X axis distance of individual points goes below a single pixel,\ni.e. a single pixel covers more than one tick worth of data. It can greatly improve performance\n(and readability) in such situations as it prevents overdraw.",
                 custom_placeholder: Some(AggregationPolicy::default().to_arrow()?),
+                datatype: AggregationPolicy::arrow_datatype(),
             },
         ),
         (
@@ -286,6 +323,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A color multiplier, usually applied to a whole entity, e.g. a mesh.",
                 custom_placeholder: Some(AlbedoFactor::default().to_arrow()?),
+                datatype: AlbedoFactor::arrow_datatype(),
             },
         ),
         (
@@ -293,6 +331,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The annotation context provides additional information on how to display entities.\n\nEntities can use [`datatypes.ClassId`](https://rerun.io/docs/reference/types/datatypes/class_id)s and [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s to provide annotations, and\nthe labels and colors will be looked up in the appropriate\nannotation context. We use the *first* annotation context we find in the\npath-hierarchy when searching up through the ancestors of a given entity\npath.",
                 custom_placeholder: Some(AnnotationContext::default().to_arrow()?),
+                datatype: AnnotationContext::arrow_datatype(),
             },
         ),
         (
@@ -300,6 +339,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The length of an axis in local units of the space.",
                 custom_placeholder: Some(AxisLength::default().to_arrow()?),
+                datatype: AxisLength::arrow_datatype(),
             },
         ),
         (
@@ -307,6 +347,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A binary blob of data.",
                 custom_placeholder: None,
+                datatype: Blob::arrow_datatype(),
             },
         ),
         (
@@ -314,6 +355,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 16-bit ID representing a type of semantic class.",
                 custom_placeholder: Some(ClassId::default().to_arrow()?),
+                datatype: ClassId::arrow_datatype(),
             },
         ),
         (
@@ -321,6 +363,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Configures how a clear operation should behave - recursive or not.",
                 custom_placeholder: Some(ClearIsRecursive::default().to_arrow()?),
+                datatype: ClearIsRecursive::arrow_datatype(),
             },
         ),
         (
@@ -328,6 +371,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.\n\nThe color is stored as a 32-bit integer, where the most significant\nbyte is `R` and the least significant byte is `A`.",
                 custom_placeholder: Some(Color::default().to_arrow()?),
+                datatype: Color::arrow_datatype(),
             },
         ),
         (
@@ -335,6 +379,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Colormap for mapping scalar values within a given range to a color.\n\nThis provides a number of popular pre-defined colormaps.\nIn the future, the Rerun Viewer will allow users to define their own colormaps,\nbut currently the Viewer is limited to the types defined here.",
                 custom_placeholder: Some(Colormap::default().to_arrow()?),
+                datatype: Colormap::arrow_datatype(),
             },
         ),
         (
@@ -342,6 +387,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the only effect on 2D views is the physical depth values shown when hovering the image.\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
                 custom_placeholder: Some(DepthMeter::default().to_arrow()?),
+                datatype: DepthMeter::arrow_datatype(),
             },
         ),
         (
@@ -349,6 +395,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Spatially disconnect this entity from its parent.\n\nSpecifies that the entity path at which this is logged is spatially disconnected from its parent,\nmaking it impossible to transform the entity path into its parent's space and vice versa.\nIt *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.\nThis is useful for specifying that a subgraph is independent of the rest of the scene.",
                 custom_placeholder: Some(DisconnectedSpace::default().to_arrow()?),
+                datatype: DisconnectedSpace::arrow_datatype(),
             },
         ),
         (
@@ -356,6 +403,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Draw order of 2D elements. Higher values are drawn on top of lower values.\n\nAn entity can have only a single draw order component.\nWithin an entity draw order is governed by the order of the components.\n\nDraw order for entities with the same draw order is generally undefined.",
                 custom_placeholder: Some(DrawOrder::default().to_arrow()?),
+                datatype: DrawOrder::arrow_datatype(),
             },
         ),
         (
@@ -363,6 +411,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A path to an entity, usually to reference some data that is part of the target entity.",
                 custom_placeholder: Some(EntityPath::default().to_arrow()?),
+                datatype: EntityPath::arrow_datatype(),
             },
         ),
         (
@@ -370,6 +419,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "How a geometric shape is drawn and colored.",
                 custom_placeholder: Some(FillMode::default().to_arrow()?),
+                datatype: FillMode::arrow_datatype(),
             },
         ),
         (
@@ -377,6 +427,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "How much a primitive fills out the available space.\n\nUsed for instance to scale the points of the point cloud created from [`archetypes.DepthImage`](https://rerun.io/docs/reference/types/archetypes/depth_image) projection in 3D views.\nValid range is from 0 to max float although typically values above 1.0 are not useful.\n\nDefaults to 1.0.",
                 custom_placeholder: Some(FillRatio::default().to_arrow()?),
+                datatype: FillRatio::arrow_datatype(),
             },
         ),
         (
@@ -384,6 +435,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A gamma correction value to be used with a scalar value or color.\n\nUsed to adjust the gamma of a color or scalar value between 0 and 1 before rendering.\n`new_value = old_value ^ gamma`\n\nValid range is from 0 (excluding) to max float.\nDefaults to 1.0 unless otherwise specified.",
                 custom_placeholder: Some(GammaCorrection::default().to_arrow()?),
+                datatype: GammaCorrection::arrow_datatype(),
             },
         ),
         (
@@ -391,6 +443,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Half-size (radius) of a 2D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize2D::default().to_arrow()?),
+                datatype: HalfSize2D::arrow_datatype(),
             },
         ),
         (
@@ -398,6 +451,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Half-size (radius) of a 3D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize3D::default().to_arrow()?),
+                datatype: HalfSize3D::arrow_datatype(),
             },
         ),
         (
@@ -405,6 +459,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A buffer that is known to store image data.\n\nTo interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).",
                 custom_placeholder: None,
+                datatype: ImageBuffer::arrow_datatype(),
             },
         ),
         (
@@ -412,6 +467,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).",
                 custom_placeholder: Some(ImageFormat::default().to_arrow()?),
+                datatype: ImageFormat::arrow_datatype(),
             },
         ),
         (
@@ -419,6 +475,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.\n\nThis is only used for visualization purposes, and does not affect the projection itself.",
                 custom_placeholder: Some(ImagePlaneDistance::default().to_arrow()?),
+                datatype: ImagePlaneDistance::arrow_datatype(),
             },
         ),
         (
@@ -426,6 +483,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 16-bit ID representing a type of semantic keypoint within a class.",
                 custom_placeholder: Some(KeypointId::default().to_arrow()?),
+                datatype: KeypointId::arrow_datatype(),
             },
         ),
         (
@@ -433,6 +491,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A geographical position expressed in EPSG:4326 latitude and longitude.",
                 custom_placeholder: Some(LatLon::default().to_arrow()?),
+                datatype: LatLon::arrow_datatype(),
             },
         ),
         (
@@ -440,6 +499,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Length, or one-dimensional size.\n\nMeasured in its local coordinate system; consult the archetype in use to determine which\naxis or part of the entity this is the length of.",
                 custom_placeholder: Some(Length::default().to_arrow()?),
+                datatype: Length::arrow_datatype(),
             },
         ),
         (
@@ -447,6 +507,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A line strip in 2D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip2D::default().to_arrow()?),
+                datatype: LineStrip2D::arrow_datatype(),
             },
         ),
         (
@@ -454,6 +515,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A line strip in 3D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip3D::default().to_arrow()?),
+                datatype: LineStrip3D::arrow_datatype(),
             },
         ),
         (
@@ -461,6 +523,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.",
                 custom_placeholder: Some(MagnificationFilter::default().to_arrow()?),
+                datatype: MagnificationFilter::arrow_datatype(),
             },
         ),
         (
@@ -468,6 +531,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The visual appearance of a point in e.g. a 2D plot.",
                 custom_placeholder: Some(MarkerShape::default().to_arrow()?),
+                datatype: MarkerShape::arrow_datatype(),
             },
         ),
         (
@@ -475,6 +539,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Radius of a marker of a point in e.g. a 2D plot, measured in UI points.",
                 custom_placeholder: Some(MarkerSize::default().to_arrow()?),
+                datatype: MarkerSize::arrow_datatype(),
             },
         ),
         (
@@ -482,6 +547,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A standardized media type (RFC2046, formerly known as MIME types), encoded as a string.\n\nThe complete reference of officially registered media types is maintained by the IANA and can be\nconsulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.",
                 custom_placeholder: Some(MediaType::default().to_arrow()?),
+                datatype: MediaType::arrow_datatype(),
             },
         ),
         (
@@ -489,6 +555,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A display name, typically for an entity or a item like a plot series.",
                 custom_placeholder: Some(Name::default().to_arrow()?),
+                datatype: Name::arrow_datatype(),
             },
         ),
         (
@@ -496,6 +563,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque).\n\nThe final opacity value may be a result of multiplication with alpha values as specified by other color sources.\nUnless otherwise specified, the default value is 1.",
                 custom_placeholder: Some(Opacity::default().to_arrow()?),
+                datatype: Opacity::arrow_datatype(),
             },
         ),
         (
@@ -503,6 +571,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Camera projection, from image coordinates to view coordinates.\n\nChild from parent.\nImage coordinates from camera view coordinates.\n\nExample:\n```text\n1496.1     0.0  980.5\n   0.0  1496.1  744.5\n   0.0     0.0    1.0\n```",
                 custom_placeholder: Some(PinholeProjection::default().to_arrow()?),
+                datatype: PinholeProjection::arrow_datatype(),
             },
         ),
         (
@@ -510,6 +579,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.",
                 custom_placeholder: Some(PoseRotationAxisAngle::default().to_arrow()?),
+                datatype: PoseRotationAxisAngle::arrow_datatype(),
             },
         ),
         (
@@ -517,6 +587,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3D rotation expressed as a quaternion that doesn't propagate in the transform hierarchy.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.",
                 custom_placeholder: Some(PoseRotationQuat::default().to_arrow()?),
+                datatype: PoseRotationQuat::arrow_datatype(),
             },
         ),
         (
@@ -524,6 +595,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3D scale factor that doesn't propagate in the transform hierarchy.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(PoseScale3D::default().to_arrow()?),
+                datatype: PoseScale3D::arrow_datatype(),
             },
         ),
         (
@@ -531,6 +603,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3x3 transformation matrix Matrix that doesn't propagate in the transform hierarchy.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(PoseTransformMat3x3::default().to_arrow()?),
+                datatype: PoseTransformMat3x3::arrow_datatype(),
             },
         ),
         (
@@ -538,6 +611,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A translation vector in 3D space that doesn't propagate in the transform hierarchy.",
                 custom_placeholder: Some(PoseTranslation3D::default().to_arrow()?),
+                datatype: PoseTranslation3D::arrow_datatype(),
             },
         ),
         (
@@ -545,6 +619,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A position in 2D space.",
                 custom_placeholder: Some(Position2D::default().to_arrow()?),
+                datatype: Position2D::arrow_datatype(),
             },
         ),
         (
@@ -552,6 +627,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A position in 3D space.",
                 custom_placeholder: Some(Position3D::default().to_arrow()?),
+                datatype: Position3D::arrow_datatype(),
             },
         ),
         (
@@ -559,6 +635,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The radius of something, e.g. a point.\n\nInternally, positive values indicate scene units, whereas negative values\nare interpreted as UI points.\n\nUI points are independent of zooming in Views, but are sensitive to the application UI scaling.\nat 100% UI scaling, UI points are equal to pixels\nThe Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.",
                 custom_placeholder: Some(Radius::default().to_arrow()?),
+                datatype: Radius::arrow_datatype(),
             },
         ),
         (
@@ -566,6 +643,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 1D range, specifying a lower and upper bound.",
                 custom_placeholder: Some(Range1D::default().to_arrow()?),
+                datatype: Range1D::arrow_datatype(),
             },
         ),
         (
@@ -573,6 +651,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Pixel resolution width & height, e.g. of a camera sensor.\n\nTypically in integer units, but for some use cases floating point may be used.",
                 custom_placeholder: Some(Resolution::default().to_arrow()?),
+                datatype: Resolution::arrow_datatype(),
             },
         ),
         (
@@ -580,6 +659,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "3D rotation represented by a rotation around a given axis.",
                 custom_placeholder: Some(RotationAxisAngle::default().to_arrow()?),
+                datatype: RotationAxisAngle::arrow_datatype(),
             },
         ),
         (
@@ -587,6 +667,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3D rotation expressed as a quaternion.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.",
                 custom_placeholder: Some(RotationQuat::default().to_arrow()?),
+                datatype: RotationQuat::arrow_datatype(),
             },
         ),
         (
@@ -594,6 +675,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A scalar value, encoded as a 64-bit floating point.\n\nUsed for time series plots.",
                 custom_placeholder: Some(Scalar::default().to_arrow()?),
+                datatype: Scalar::arrow_datatype(),
             },
         ),
         (
@@ -601,6 +683,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3D scale factor.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(Scale3D::default().to_arrow()?),
+                datatype: Scale3D::arrow_datatype(),
             },
         ),
         (
@@ -608,6 +691,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Whether the entity's [`components.Text`](https://rerun.io/docs/reference/types/components/text) label is shown.\n\nThe main purpose of this component existing separately from the labels themselves\nis to be overridden when desired, to allow hiding and showing from the viewer and\nblueprints.",
                 custom_placeholder: None,
+                datatype: ShowLabels::arrow_datatype(),
             },
         ),
         (
@@ -615,6 +699,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The width of a stroke specified in UI points.",
                 custom_placeholder: Some(StrokeWidth::default().to_arrow()?),
+                datatype: StrokeWidth::arrow_datatype(),
             },
         ),
         (
@@ -622,6 +707,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "An N-dimensional array of numbers.\n\nThe number of dimensions and their respective lengths is specified by the `shape` field.\nThe dimensions are ordered from outermost to innermost. For example, in the common case of\na 2D RGB Image, the shape would be `[height, width, channel]`.\n\nThese dimensions are combined with an index to look up values from the `buffer` field,\nwhich stores a contiguous array of typed values.",
                 custom_placeholder: Some(TensorData::default().to_arrow()?),
+                datatype: TensorData::arrow_datatype(),
             },
         ),
         (
@@ -631,6 +717,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
                 custom_placeholder: Some(
                     TensorDimensionIndexSelection::default().to_arrow()?,
                 ),
+                datatype: TensorDimensionIndexSelection::arrow_datatype(),
             },
         ),
         (
@@ -638,6 +725,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Specifies which dimension to use for height.",
                 custom_placeholder: Some(TensorHeightDimension::default().to_arrow()?),
+                datatype: TensorHeightDimension::arrow_datatype(),
             },
         ),
         (
@@ -645,6 +733,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Specifies which dimension to use for width.",
                 custom_placeholder: Some(TensorWidthDimension::default().to_arrow()?),
+                datatype: TensorWidthDimension::arrow_datatype(),
             },
         ),
         (
@@ -652,6 +741,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 2D texture UV coordinate.\n\nTexture coordinates specify a position on a 2D texture.\nA range from 0-1 covers the entire texture in the respective dimension.\nUnless configured otherwise, the texture repeats outside of this range.\nRerun uses top-left as the origin for UV coordinates.\n\n  0     U     1\n0 + --------- →\n  |           .\nV |           .\n  |           .\n1 ↓ . . . . . .\n\nThis is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenGL,\nwhich places the origin at the bottom-left.",
                 custom_placeholder: Some(Texcoord2D::default().to_arrow()?),
+                datatype: Texcoord2D::arrow_datatype(),
             },
         ),
         (
@@ -659,6 +749,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A string of text, e.g. for labels and text documents.",
                 custom_placeholder: Some(Text::default().to_arrow()?),
+                datatype: Text::arrow_datatype(),
             },
         ),
         (
@@ -666,6 +757,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The severity level of a text log message.\n\nRecommended to be one of:\n* `\"CRITICAL\"`\n* `\"ERROR\"`\n* `\"WARN\"`\n* `\"INFO\"`\n* `\"DEBUG\"`\n* `\"TRACE\"`",
                 custom_placeholder: Some(TextLogLevel::default().to_arrow()?),
+                datatype: TextLogLevel::arrow_datatype(),
             },
         ),
         (
@@ -673,6 +765,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A 3x3 transformation matrix Matrix.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(TransformMat3x3::default().to_arrow()?),
+                datatype: TransformMat3x3::arrow_datatype(),
             },
         ),
         (
@@ -680,6 +773,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Specifies relation a spatial transform describes.",
                 custom_placeholder: Some(TransformRelation::default().to_arrow()?),
+                datatype: TransformRelation::arrow_datatype(),
             },
         ),
         (
@@ -687,6 +781,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A translation vector in 3D space.",
                 custom_placeholder: Some(Translation3D::default().to_arrow()?),
+                datatype: Translation3D::arrow_datatype(),
             },
         ),
         (
@@ -694,6 +789,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "The three indices of a triangle in a triangle mesh.",
                 custom_placeholder: Some(TriangleIndices::default().to_arrow()?),
+                datatype: TriangleIndices::arrow_datatype(),
             },
         ),
         (
@@ -701,6 +797,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Range of expected or valid values, specifying a lower and upper bound.",
                 custom_placeholder: Some(ValueRange::default().to_arrow()?),
+                datatype: ValueRange::arrow_datatype(),
             },
         ),
         (
@@ -708,6 +805,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A vector in 2D space.",
                 custom_placeholder: Some(Vector2D::default().to_arrow()?),
+                datatype: Vector2D::arrow_datatype(),
             },
         ),
         (
@@ -715,6 +813,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "A vector in 3D space.",
                 custom_placeholder: Some(Vector3D::default().to_arrow()?),
+                datatype: Vector3D::arrow_datatype(),
             },
         ),
         (
@@ -722,6 +821,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).",
                 custom_placeholder: Some(VideoTimestamp::default().to_arrow()?),
+                datatype: VideoTimestamp::arrow_datatype(),
             },
         ),
         (
@@ -729,6 +829,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             ComponentReflection {
                 docstring_md: "How we interpret the coordinate system of an entity/space.\n\nFor instance: What is \"up\"? What does the Z axis mean?\n\nThe three coordinates are always ordered as [x, y, z].\n\nFor example [Right, Down, Forward] means that the X axis points to the right, the Y axis points\ndown, and the Z axis points forward.\n\n⚠ [Rerun does not yet support left-handed coordinate systems](https://github.com/rerun-io/rerun/issues/5032).\n\nThe following constants are used to represent the different directions:\n * Up = 1\n * Down = 2\n * Right = 3\n * Left = 4\n * Forward = 5\n * Back = 6",
                 custom_placeholder: Some(ViewCoordinates::default().to_arrow()?),
+                datatype: ViewCoordinates::arrow_datatype(),
             },
         ),
     ];


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/7940

Tested by removing the fallback provider for `ShowLabels` from points which prior to this fix exhibits the same issue as above

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7944?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7944?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7944)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.