### PR TITLE
Enable `map_view` feature for web viewer

### DIFF
--- a/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
@@ -74,6 +74,7 @@ pub fn build(
     debug_symbols: bool,
     target: Target,
     build_dir: &Utf8Path,
+    features: &String,
 ) -> anyhow::Result<()> {
     std::env::set_current_dir(workspace_root())?;
 
@@ -113,24 +114,19 @@ pub fn build(
         cmd.args([
             "build",
             "--quiet",
-            "--package",
-            crate_name,
+            &format!("--package={crate_name}"),
             "--lib",
-            "--target",
-            "wasm32-unknown-unknown",
-            "--target-dir",
-            target_wasm_dir.as_str(),
+            "--target=wasm32-unknown-unknown",
+            &format!("--target-dir={}", target_wasm_dir.as_str()),
             "--no-default-features",
-            "--features=analytics",
+            &format!("--features={features}"),
         ]);
         if profile == Profile::Release {
             cmd.arg("--release");
         }
 
-        // This is required to enable the web_sys clipboard API which egui_web uses
-        // https://rustwasm.github.io/wasm-bindgen/api/web_sys/struct.Clipboard.html
+        // This is required for unstable WebGPU apis to work
         // https://rustwasm.github.io/docs/wasm-bindgen/web-sys/unstable-apis.html
-        // Furthermore, it's necessary for unstable WebGPU apis to work.
         cmd.env("RUSTFLAGS", "--cfg=web_sys_unstable_apis");
 
         // When executing this script from a Rust build script, do _not_, under any circumstances,

--- a/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
@@ -34,6 +34,14 @@ pub struct Args {
     /// set the output directory. This is a path relative to the cargo workspace root.
     #[argh(option, short = 'o', long = "out")]
     build_dir: Option<Utf8PathBuf>,
+
+    /// comma-separated list of features to pass on to `re_viewer`
+    #[argh(option, short = 'F', long = "features", default = "default_features()")]
+    features: String,
+}
+
+fn default_features() -> String {
+    "analytics".to_owned()
 }
 
 pub fn main(args: Args) -> anyhow::Result<()> {
@@ -49,5 +57,11 @@ pub fn main(args: Args) -> anyhow::Result<()> {
 
     let build_dir = args.build_dir.unwrap_or_else(default_build_dir);
 
-    build(profile, args.debug_symbols, args.target, &build_dir)
+    build(
+        profile,
+        args.debug_symbols,
+        args.target,
+        &build_dir,
+        &args.features,
+    )
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -173,13 +173,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -195,7 +195,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends_on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.


### PR DESCRIPTION
### What
Enable the `map_view` feature when running `pixi run rerun-web`, and the PR preview web-viewer.
Also makes it easier to change exactly what features are enabled.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7947?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7947?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7947)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.