### PR TITLE
enable using ``StoreId`` as recording unique identifier on the remote store side

### DIFF
--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -25,12 +25,29 @@ pub mod v0 {
 
     // ==== below are all necessary transforms from internal rerun types to protobuf types =====
 
-    use std::collections::BTreeSet;
+    use std::{collections::BTreeSet, sync::Arc};
 
     #[derive(Debug, thiserror::Error)]
     pub enum TypeConversionError {
         #[error("missing required field: {0}")]
         MissingField(&'static str),
+    }
+
+    impl From<RecordingId> for re_log_types::StoreId {
+        fn from(value: RecordingId) -> Self {
+            Self {
+                kind: re_log_types::StoreKind::Recording,
+                id: Arc::new(value.id),
+            }
+        }
+    }
+
+    impl From<re_log_types::StoreId> for RecordingId {
+        fn from(value: re_log_types::StoreId) -> Self {
+            Self {
+                id: value.id.to_string(),
+            }
+        }
     }
 
     impl From<re_log_types::ResolvedTimeRange> for TimeRange {

--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -34,6 +34,7 @@ pub mod v0 {
     }
 
     impl From<RecordingId> for re_log_types::StoreId {
+        #[inline]
         fn from(value: RecordingId) -> Self {
             Self {
                 kind: re_log_types::StoreKind::Recording,

--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -428,7 +428,7 @@ mod tests {
     #[test]
     fn test_recording_id_conversion() {
         let recording_id = RecordingId {
-            id: "recording_id".to_string(),
+            id: "recording_id".to_owned(),
         };
 
         let store_id: re_log_types::StoreId = recording_id.clone().into();

--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -349,8 +349,8 @@ mod tests {
     use crate::v0::{
         column_selector::SelectorType, ColumnSelection, ColumnSelector, Component,
         ComponentColumnSelector, ComponentsSet, EntityPath, IndexColumnSelector, IndexRange,
-        IndexValues, Query, SparseFillStrategy, TimeInt, TimeRange, Timeline, ViewContents,
-        ViewContentsPart,
+        IndexValues, Query, RecordingId, SparseFillStrategy, TimeInt, TimeRange, Timeline,
+        ViewContents, ViewContentsPart,
     };
 
     #[test]
@@ -421,5 +421,17 @@ mod tests {
         let grpc_query_after = query_expression_native.into();
 
         assert_eq!(grpc_query_before, grpc_query_after);
+    }
+
+    #[test]
+    fn test_recording_id_conversion() {
+        let recording_id = RecordingId {
+            id: "recording_id".to_string(),
+        };
+
+        let store_id: re_log_types::StoreId = recording_id.clone().into();
+        let recording_id_after: RecordingId = store_id.into();
+
+        assert_eq!(recording_id, recording_id_after);
     }
 }

--- a/crates/store/re_remote_store_types/src/lib.rs
+++ b/crates/store/re_remote_store_types/src/lib.rs
@@ -44,6 +44,7 @@ pub mod v0 {
     }
 
     impl From<re_log_types::StoreId> for RecordingId {
+        #[inline]
         fn from(value: re_log_types::StoreId) -> Self {
             Self {
                 id: value.id.to_string(),


### PR DESCRIPTION
### What

Few more type conversions in remote store types are needed so we can use ``StoreId`` as the unique recording id identifier.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7954?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7954?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7954)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.