### PR TITLE
Consistent open/import/log_file behaviors in all common scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5376,6 +5376,7 @@ dependencies = [
  "re_types",
  "tempfile",
  "thiserror",
+ "uuid",
  "walkdir",
 ]
 
@@ -6415,6 +6416,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/crates/store/re_data_loader/Cargo.toml
+++ b/crates/store/re_data_loader/Cargo.toml
@@ -43,6 +43,7 @@ once_cell.workspace = true
 parking_lot.workspace = true
 rayon.workspace = true
 thiserror.workspace = true
+uuid.workspace = true
 walkdir.workspace = true
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]

--- a/crates/store/re_data_loader/src/load_file.rs
+++ b/crates/store/re_data_loader/src/load_file.rs
@@ -320,7 +320,7 @@ pub(crate) fn send(
 
                 // Never try to send custom store info for RRDs and RBLs, they always have their own, and
                 // it's always right.
-                let should_force_store_info = !tracked.is_rrd_or_rbl && settings.force_store_info;
+                let should_force_store_info = settings.force_store_info && !tracked.is_rrd_or_rbl;
 
                 let should_send_new_store_info = should_force_store_info
                     || (!tracked.already_has_store_info && !is_a_preexisting_recording);

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -138,7 +138,7 @@ impl DataLoader for ArchetypeLoader {
             .clone()
             .unwrap_or_else(|| settings.store_id.clone());
         for row in rows {
-            let data = LoadedData::Chunk(store_id.clone(), row);
+            let data = LoadedData::Chunk(Self::name(&Self), store_id.clone(), row);
             if tx.send(data).is_err() {
                 break; // The other end has decided to hang up, not our problem.
             }

--- a/crates/store/re_data_loader/src/loader_external.rs
+++ b/crates/store/re_data_loader/src/loader_external.rs
@@ -6,7 +6,7 @@ use std::{
 use ahash::HashMap;
 use once_cell::sync::Lazy;
 
-use crate::LoadedData;
+use crate::{DataLoader, LoadedData};
 
 // ---
 
@@ -321,7 +321,7 @@ fn decode_and_stream<R: std::io::Read>(
             }
         };
 
-        let data = LoadedData::LogMsg(msg);
+        let data = LoadedData::LogMsg(ExternalLoader::name(&ExternalLoader), msg);
         if tx.send(data).is_err() {
             break; // The other end has decided to hang up, not our problem.
         }

--- a/crates/store/re_data_source/src/data_source.rs
+++ b/crates/store/re_data_source/src/data_source.rs
@@ -178,6 +178,7 @@ impl DataSource {
                 let settings = re_data_loader::DataLoaderSettings {
                     opened_application_id: file_source.recommended_application_id().cloned(),
                     opened_store_id: file_source.recommended_recording_id().cloned(),
+                    force_store_info: file_source.force_store_info(),
                     ..re_data_loader::DataLoaderSettings::recommended(shared_store_id)
                 };
                 re_data_loader::load_from_path(&settings, file_source, &path, &tx)
@@ -206,6 +207,7 @@ impl DataSource {
                 let settings = re_data_loader::DataLoaderSettings {
                     opened_application_id: file_source.recommended_application_id().cloned(),
                     opened_store_id: file_source.recommended_recording_id().cloned(),
+                    force_store_info: file_source.force_store_info(),
                     ..re_data_loader::DataLoaderSettings::recommended(shared_store_id)
                 };
                 re_data_loader::load_from_file_contents(
@@ -275,6 +277,7 @@ fn test_data_source_from_uri() {
     let file_source = FileSource::DragAndDrop {
         recommended_application_id: None,
         recommended_recording_id: None,
+        force_store_info: false,
     };
 
     for uri in file {

--- a/crates/store/re_log_types/src/lib.rs
+++ b/crates/store/re_log_types/src/lib.rs
@@ -413,21 +413,39 @@ pub enum FileSource {
     DragAndDrop {
         /// The [`ApplicationId`] that the viewer heuristically recommends should be used when loading
         /// this data source, based on the surrounding context.
+        #[cfg_attr(feature = "serde", serde(skip))]
         recommended_application_id: Option<ApplicationId>,
 
         /// The [`StoreId`] that the viewer heuristically recommends should be used when loading
         /// this data source, based on the surrounding context.
+        #[cfg_attr(feature = "serde", serde(skip))]
         recommended_recording_id: Option<StoreId>,
+
+        /// Whether `SetStoreInfo`s should be sent, regardless of the surrounding context.
+        ///
+        /// Only useful when creating a recording just-in-time directly in the viewer (which is what
+        /// happens when importing things into the welcome screen).
+        #[cfg_attr(feature = "serde", serde(skip))]
+        force_store_info: bool,
     },
 
     FileDialog {
         /// The [`ApplicationId`] that the viewer heuristically recommends should be used when loading
         /// this data source, based on the surrounding context.
+        #[cfg_attr(feature = "serde", serde(skip))]
         recommended_application_id: Option<ApplicationId>,
 
         /// The [`StoreId`] that the viewer heuristically recommends should be used when loading
         /// this data source, based on the surrounding context.
+        #[cfg_attr(feature = "serde", serde(skip))]
         recommended_recording_id: Option<StoreId>,
+
+        /// Whether `SetStoreInfo`s should be sent, regardless of the surrounding context.
+        ///
+        /// Only useful when creating a recording just-in-time directly in the viewer (which is what
+        /// happens when importing things into the welcome screen).
+        #[cfg_attr(feature = "serde", serde(skip))]
+        force_store_info: bool,
     },
 
     Sdk,
@@ -461,6 +479,19 @@ impl FileSource {
                 ..
             } => recommended_recording_id.as_ref(),
             Self::Cli | Self::Sdk => None,
+        }
+    }
+
+    #[inline]
+    pub fn force_store_info(&self) -> bool {
+        match self {
+            Self::FileDialog {
+                force_store_info, ..
+            }
+            | Self::DragAndDrop {
+                force_store_info, ..
+            } => *force_store_info,
+            Self::Cli | Self::Sdk => false,
         }
     }
 }

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -1259,6 +1259,7 @@ impl RecordingStream {
             opened_application_id: None,
             store_id: store_info.store_id.clone(),
             opened_store_id: None,
+            force_store_info: false,
             entity_path_prefix,
             timepoint: (!static_).then(|| {
                 self.with(|inner| {

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -120,6 +120,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde-wasm-bindgen.workspace = true
 thiserror.workspace = true
+uuid.workspace = true
 web-time.workspace = true
 wgpu.workspace = true
 

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -9,7 +9,7 @@
 use rerun::{
     external::{anyhow, re_build_info, re_data_loader, re_log},
     log::{Chunk, RowId},
-    EntityPath, LoadedData, TimePoint,
+    DataLoader as _, EntityPath, LoadedData, TimePoint,
 };
 
 fn main() -> anyhow::Result<std::process::ExitCode> {
@@ -81,7 +81,7 @@ fn hash_and_log(
         .opened_store_id
         .clone()
         .unwrap_or_else(|| settings.store_id.clone());
-    let data = LoadedData::Chunk(store_id, chunk);
+    let data = LoadedData::Chunk(HashLoader::name(&HashLoader), store_id, chunk);
     tx.send(data).ok();
 
     Ok(())


### PR DESCRIPTION
All the major data-loading paths now behave sanely and consistently on both native and web.

You can try and look at the matrix below for the specific behavior of each path, but really my advice would be to just play with it to get a sense of things.

One of these days we'll clearly need a bottom-up in-hindsight refactoring for all these things, it is _so_ complex.
But today is not that day.

* Fixes #7965 

---

Checklist:
* Native:
    * Open:
        * In welcome screen:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (2 new apps, 2 new recordings, all IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
        * In pre-existing recording:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (2 new apps, 2 new recordings, all IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
    * Import:
        * In welcome screen:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (single new app, single new recording, both IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
        * In pre-existing recording:
            * [x] Single file (imports into existing recording, no new app nor recording)
            * [x] Multiple files (imports into existing recording, no new app nor recording)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (updates blueprint for the current app)
* Web:
    * Open:
        * In welcome screen:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (2 new apps, 2 new recordings, all IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
        * In pre-existing recording:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (2 new apps, 2 new recordings, all IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
    * Import:
        * In welcome screen:
            * [x] Single file (new app, new recording, both IDs are generated UUIDs)
            * [x] Multiple files (single new app, single new recording, both IDs are generated UUIDs)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (new app with predefined ID)
        * In pre-existing recording:
            * [x] Single file (imports into existing recording, no new app nor recording)
            * [x] Multiple files (imports into existing recording, no new app nor recording)
            * [x] RRD w/ RBL (new app and recording with predefined IDs)
            * [x] RRD w/o RBL (new app and recording with predefined IDs)
            * [x] RBL (updates blueprint for the current app)
* SDK:
    * `log_file`:
        * [x] Single file (merges nicely into active recording)
        * [x] RRD w/ RBL (new app and recording with predefined IDs)
        * [x] RRD w/o RBL (new app and recording with predefined IDs)
        * [x] RBL (updates blueprint for the current app)

---

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7966?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7966?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7966)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.