### PR TITLE
Update the Viewport reference page

### DIFF
--- a/docs/content/reference/viewer/viewport.md
+++ b/docs/content/reference/viewer/viewport.md
@@ -3,48 +3,31 @@ title: Viewport
 order: 4
 ---
 
-The viewport is a flexible area where you can arrange your Space Views:
-You can grab the title of any Space View to dock it to different parts of the viewport or to form tabs.
+The viewport is a flexible area where you can arrange your views:
+You can grab the title of any view to dock it to different parts of the viewport or to form tabs.
 
-View controls
--------------
+## View controls
 
 <picture>
   <img src="https://static.rerun.io/view-controls/e911cec51fcf840e014340b3cb135b7faeb2e8b6/full.png" alt="">
 </picture>
 
 
-Clicking on the title of a Space View has the same effect as selecting it in the [Blueprint view](blueprint.md)
-and will show additional information & settings in the [Selection view](selection.md) or other means.
+Clicking on the title of a view has the same effect as selecting it in the [blueprint panel](blueprint.md)
+and will show additional information and settings in the [selection panel](selection.md).
 
-For more information on how to navigate a specific Space View, hover its help icon at the top right corner.
+For more information on how to navigate within a specific view, hover its help icon in the top right corner.
 
-The maximize button makes a single Space View fill the entire viewport.
-Only one Space view can be maximized at a time.
+The maximize button makes a single view fill the entire viewport.
+Only one view can be maximized at a time.
 
 
-Space View Classes
----------------------------
-Rerun distinguishes various Space Views classes:
+## View classes
 
-* 2D
-  * General 2D content like images, lines, points, boxes, etc.
-* 3D
-  * 3D scene with cameras, meshes, points, lines etc.
-* Tensor
-  * Tensor view with support for arbitrary dimensionality.
-* Text log
-  * Text over time.
-* Text Document
-  * Shows a single markdown or raw text document.
-* Time series plot
-  * Scalars over time.
-* Bar chart
-  * Bar-chart lots made from 1D tensor data.
-* Dataframe
-  * Displays any data in a tabular form.
+Rerun includes multiple view classes, each dedicated to a specific type of visualization; for example, a 3D scene or a timeseries plot.
+See the [views reference page](../types/views.md) for a list of available view classes.
 
-Which class is used is determined upon creation of a Space View.
+The view class, which is specified upon creation, determines which entities it can display, how it displays them, and the way they can be interacted with.
+Views can be created both from viewer and from code (see [Configure the Viewer through code](../../howto/configure-viewer-through-code.md)).
 
-The Space View class determines which Entities it can display, how it displays them and the way they can be interacted with.
-To learn more about the _internals_ of how Space View classes work, check the [guide on Viewer extensions](../../howto/extend.md).
+To learn more about the _internals_ of how view classes work, check the [guide on implementing custom views](../../howto/extend/extend-ui.md).


### PR DESCRIPTION
### What

Much needed facelift.

- Updated to our current style
- "Space View" -> "view"
- Removed the list and linked to the codegen'd one instead
- Minor rewording here and there



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7972?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7972?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7972)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.