### PR TITLE
Better dev experience for JS generated file hashes

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -280,10 +280,14 @@ js-setup = "npm i -g yarn"
 js-install = { cmd = "yarn install --cwd rerun_js", depends_on = ["js-setup"] }
 
 # Build JS packages
-js-build-base = { cmd = "yarn --cwd rerun_js/web-viewer run build", depends_on = [
+js-build-base = { cmd = "yarn --cwd rerun_js/web-viewer run build:no-check", depends_on = [
   "js-install",
 ] }
-js-build-all = { cmd = "yarn --cwd rerun_js workspaces run build", depends_on = [
+js-build-all = { cmd = "yarn --cwd rerun_js workspaces run build:no-check", depends_on = [
+  "js-install",
+] }
+
+js-update-hashes = { cmd = "node rerun_js/web-viewer/build-wasm.mjs --update-hashes", depends_on = [
   "js-install",
 ] }
 

--- a/rerun_js/web-viewer-react/package.json
+++ b/rerun_js/web-viewer-react/package.json
@@ -12,7 +12,8 @@
   ],
   "scripts": {
     "build:types": "tsc --noEmit && dts-buddy",
-    "build": "npm run build:types"
+    "build": "npm run build:types",
+    "build:no-check": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/rerun_js/web-viewer/package.json
+++ b/rerun_js/web-viewer/package.json
@@ -14,6 +14,7 @@
     "build:wasm": "node build-wasm.mjs --mode release",
     "build:js": "tsc && node bundle.mjs",
     "build": "npm run build:wasm && npm run build:js",
+    "build:no-check": "npm run build:wasm -- --no-check && npm run build:js",
     "build:wasm:debug": "node build-wasm.mjs --mode debug",
     "build:debug": "npm run build:wasm:debug && npm run build:js"
   },


### PR DESCRIPTION
### What

- The hash check no longer runs during normal development (`pixi run js-build-*`, more generally appending `:no-check` to the npm `build` commands will do the same)
- Added more info to the error that is emitted when the hashes don't match
- Added a pixi task to update the hashes: `pixi run js-update-hashes`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7975?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7975?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7975)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.