### PR TITLE
Lower a bunch of `debug` log levels to `trace`

### DIFF
--- a/crates/store/re_entity_db/src/store_bundle.rs
+++ b/crates/store/re_entity_db/src/store_bundle.rs
@@ -78,7 +78,7 @@ impl StoreBundle {
     /// One is created if it doesn't already exist.
     pub fn entry(&mut self, id: &StoreId) -> &mut EntityDb {
         self.entity_dbs.entry(id.clone()).or_insert_with(|| {
-            re_log::debug!("Creating new store: {id}");
+            re_log::trace!("Creating new store: '{id}'");
             EntityDb::new(id.clone())
         })
     }
@@ -96,7 +96,7 @@ impl StoreBundle {
 
             let mut blueprint_db = EntityDb::new(id.clone());
 
-            re_log::debug!("Creating a new blueprint {id}");
+            re_log::trace!("Creating a new blueprint '{id}'");
 
             blueprint_db.set_store_info(re_log_types::SetStoreInfo {
                 row_id: *re_chunk::RowId::new(),

--- a/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
+++ b/crates/viewer/re_renderer/src/allocator/gpu_readback_belt.rs
@@ -274,8 +274,7 @@ impl GpuReadbackBelt {
             } else {
                 // Allocation might be bigger than a chunk!
                 let buffer_size = self.chunk_size.max(size_in_bytes);
-                // Happens relatively rarely, this is a noteworthy event!
-                re_log::debug!(
+                re_log::trace!(
                     "Allocating new GpuReadbackBelt chunk of size {:.1} MiB",
                     buffer_size as f32 / (1024.0 * 1024.0)
                 );

--- a/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
@@ -63,7 +63,7 @@ impl MeshCache {
             .or_default()
             .entry(key)
             .or_insert_with(|| {
-                re_log::debug!("Loading CPU mesh {name:?}…");
+                re_log::trace!("Loading CPU mesh {name:?}…");
 
                 let result = LoadedMesh::load(name.to_owned(), mesh, render_ctx);
 

--- a/crates/viewer/re_space_view_spatial/src/proc_mesh.rs
+++ b/crates/viewer/re_space_view_spatial/src/proc_mesh.rs
@@ -164,7 +164,7 @@ impl WireframeCache {
             .or_insert_with(|| {
                 re_tracing::profile_scope!("proc_mesh::WireframeCache(miss)", format!("{key:?}"));
 
-                re_log::debug!("Generating wireframe mesh {key:?}…");
+                re_log::trace!("Generating wireframe mesh {key:?}…");
 
                 match generate_wireframe(&key, render_ctx) {
                     Ok(mesh) => Some(Arc::new(mesh)),
@@ -311,7 +311,7 @@ impl SolidCache {
             .or_insert_with(|| {
                 re_tracing::profile_scope!("proc_mesh::SolidCache(miss)", format!("{key:?}"));
 
-                re_log::debug!("Generating solid mesh {key:?}…");
+                re_log::trace!("Generating solid mesh {key:?}…");
 
                 match generate_solid(&key, render_ctx) {
                     Ok(mesh) => Some(mesh),

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1178,7 +1178,7 @@ impl App {
                     // updates the app-id when changing the recording.
                     match store_id.kind {
                         StoreKind::Recording => {
-                            re_log::debug!("Opening a new recording: {store_id}");
+                            re_log::trace!("Opening a new recording: '{store_id}'");
                             store_hub.set_active_recording_id(store_id.clone());
 
                             // Also select the new recording:
@@ -1214,7 +1214,7 @@ impl App {
                     }
                     StoreKind::Blueprint => {
                         if let Some(info) = entity_db.store_info() {
-                            re_log::debug!(
+                            re_log::trace!(
                                 "Activating blueprint that was loaded from {channel_source}"
                             );
                             let app_id = info.application_id.clone();

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -252,7 +252,7 @@ pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
                     break;
                 }
             }
-            re_log::debug!("Shutting down ui_waker thread");
+            re_log::trace!("Shutting down ui_waker thread");
         })
         .unwrap();
     new_rx

--- a/crates/viewer/re_viewer_context/src/store_hub.rs
+++ b/crates/viewer/re_viewer_context/src/store_hub.rs
@@ -487,7 +487,7 @@ impl StoreHub {
             }
         }
 
-        re_log::debug!("Switching default blueprint for {app_id} to {blueprint_id}");
+        re_log::trace!("Switching default blueprint for '{app_id}' to '{blueprint_id}'");
         self.default_blueprint_by_app_id
             .insert(app_id.clone(), blueprint_id.clone());
 
@@ -532,8 +532,8 @@ impl StoreHub {
     ) -> anyhow::Result<()> {
         let new_id = StoreId::random(StoreKind::Blueprint);
 
-        re_log::debug!(
-            "Cloning {blueprint_id} as {new_id} the active blueprint for {app_id} to {blueprint_id}"
+        re_log::trace!(
+            "Cloning '{blueprint_id}' as '{new_id}' the active blueprint for '{app_id}' to '{blueprint_id}'"
         );
 
         let blueprint = self


### PR DESCRIPTION
Just to keep the output of our debug build cleaner

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7979?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7979?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7979)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.