### PR TITLE
Document arrow datatypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,6 +6242,7 @@ name = "re_types_builder"
 version = "0.20.0-alpha.1+dev"
 dependencies = [
  "anyhow",
+ "arrow",
  "camino",
  "clang-format",
  "flatbuffers",

--- a/crates/build/re_types_builder/Cargo.toml
+++ b/crates/build/re_types_builder/Cargo.toml
@@ -34,7 +34,8 @@ re_tracing.workspace = true
 
 # External
 anyhow.workspace = true
-arrow2.workspace = true
+arrow.workspace = true
+arrow2 = { workspace = true, features = ["arrow"] }
 camino.workspace = true
 clang-format.workspace = true
 flatbuffers.workspace = true

--- a/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
@@ -26,33 +26,17 @@ pub fn arrow_datatype_docs(page: &mut String, indent: usize, datatype: &DataType
         DataType::Float16 => page.push_str("float16"),
         DataType::Float32 => page.push_str("float32"),
         DataType::Float64 => page.push_str("float64"),
-        // DataType::Timestamp(time_unit, arc) => todo!(),
-        // DataType::Date32 => todo!(),
-        // DataType::Date64 => todo!(),
-        // DataType::Time32(time_unit) => todo!(),
-        // DataType::Time64(time_unit) => todo!(),
-        // DataType::Duration(time_unit) => todo!(),
-        // DataType::Interval(interval_unit) => todo!(),
-        // DataType::Binary => todo!(),
-        // DataType::FixedSizeBinary(_) => todo!(),
-        // DataType::LargeBinary => todo!(),
-        // DataType::BinaryView => todo!(),
         DataType::Utf8 => page.push_str("utf8"),
-        // DataType::LargeUtf8 => todo!(),
-        // DataType::Utf8View => todo!(),
         DataType::List(inner) => {
             page.push_str("List<");
             arrow_datatype_docs(page, indent + 1, inner.data_type());
             page.push('>');
         }
-        // DataType::ListView(arc) => todo!(),
         DataType::FixedSizeList(inner, length) => {
             page.push_str(&format!("FixedSizeList<{length}, "));
             arrow_datatype_docs(page, indent + 1, inner.data_type());
             page.push('>');
         }
-        // DataType::LargeList(arc) => todo!(),
-        // DataType::LargeListView(arc) => todo!(),
         DataType::Struct(fields) => {
             page.push_str("Struct {\n");
             for field in fields {
@@ -81,13 +65,11 @@ pub fn arrow_datatype_docs(page: &mut String, indent: usize, datatype: &DataType
             }
             page.push_indented(indent, "}", 0);
         }
-        // DataType::Dictionary(data_type, data_type1) => todo!(),
-        // DataType::Decimal128(_, _) => todo!(),
-        // DataType::Decimal256(_, _) => todo!(),
-        // DataType::Map(arc, _) => todo!(),
-        // DataType::RunEndEncoded(arc, arc1) => todo!(),
         _ => {
-            unimplemented!("Docs-formatting of arrow datatype {:#?}", datatype);
+            unimplemented!(
+                "For the docs, you need to implement formatting of arrow datatype {:#?}",
+                datatype
+            );
         }
     }
 }

--- a/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
@@ -1,0 +1,93 @@
+//! Document an Arrow datatype as human-readable markdown.
+//!
+//! Note that we use the `arrow` library in this module,
+//! with just a thin `arrow2` wrapper around it.
+
+use arrow::datatypes::DataType;
+
+use crate::codegen::StringExt as _;
+
+pub fn arrow2_datatype_docs(page: &mut String, datatype: &arrow2::datatypes::DataType) {
+    arrow_datatype_docs(page, 0, &DataType::from(datatype.clone()));
+}
+
+pub fn arrow_datatype_docs(page: &mut String, indent: usize, datatype: &DataType) {
+    match datatype {
+        DataType::Null => page.push_str("null"),
+        DataType::Boolean => page.push_str("boolean"),
+        DataType::Int8 => page.push_str("int8"),
+        DataType::Int16 => page.push_str("int16"),
+        DataType::Int32 => page.push_str("int32"),
+        DataType::Int64 => page.push_str("int64"),
+        DataType::UInt8 => page.push_str("uint8"),
+        DataType::UInt16 => page.push_str("uint16"),
+        DataType::UInt32 => page.push_str("uint32"),
+        DataType::UInt64 => page.push_str("uint64"),
+        DataType::Float16 => page.push_str("float16"),
+        DataType::Float32 => page.push_str("float32"),
+        DataType::Float64 => page.push_str("float64"),
+        // DataType::Timestamp(time_unit, arc) => todo!(),
+        // DataType::Date32 => todo!(),
+        // DataType::Date64 => todo!(),
+        // DataType::Time32(time_unit) => todo!(),
+        // DataType::Time64(time_unit) => todo!(),
+        // DataType::Duration(time_unit) => todo!(),
+        // DataType::Interval(interval_unit) => todo!(),
+        // DataType::Binary => todo!(),
+        // DataType::FixedSizeBinary(_) => todo!(),
+        // DataType::LargeBinary => todo!(),
+        // DataType::BinaryView => todo!(),
+        DataType::Utf8 => page.push_str("utf8"),
+        // DataType::LargeUtf8 => todo!(),
+        // DataType::Utf8View => todo!(),
+        DataType::List(inner) => {
+            page.push_str("List<");
+            arrow_datatype_docs(page, indent + 1, inner.data_type());
+            page.push('>');
+        }
+        // DataType::ListView(arc) => todo!(),
+        DataType::FixedSizeList(inner, length) => {
+            page.push_str("FixedSizeList<");
+            arrow_datatype_docs(page, indent + 1, inner.data_type());
+            page.push_str(&format!(", {length}>"));
+        }
+        // DataType::LargeList(arc) => todo!(),
+        // DataType::LargeListView(arc) => todo!(),
+        DataType::Struct(fields) => {
+            page.push_str("Struct {\n");
+            for field in fields {
+                page.push_indented(indent + 1, field.name(), 0);
+                page.push_str(": ");
+                if field.is_nullable() {
+                    page.push_str("nullable ");
+                }
+                arrow_datatype_docs(page, indent + 1, field.data_type());
+                page.push('\n');
+            }
+            page.push_indented(indent, "}", 0);
+        }
+        DataType::Union(union_fields, union_mode) => {
+            match union_mode {
+                arrow::datatypes::UnionMode::Sparse => page.push_str("SparseUnion {\n"),
+                arrow::datatypes::UnionMode::Dense => page.push_str("DenseUnion {\n"),
+            }
+            for (index, field) in union_fields.iter() {
+                page.push_indented(indent + 1, &format!("{index} = {:?}: ", field.name()), 0);
+                if field.is_nullable() {
+                    page.push_str("nullable ");
+                }
+                arrow_datatype_docs(page, indent + 1, field.data_type());
+                page.push('\n');
+            }
+            page.push_indented(indent, "}", 0);
+        }
+        // DataType::Dictionary(data_type, data_type1) => todo!(),
+        // DataType::Decimal128(_, _) => todo!(),
+        // DataType::Decimal256(_, _) => todo!(),
+        // DataType::Map(arc, _) => todo!(),
+        // DataType::RunEndEncoded(arc, arc1) => todo!(),
+        _ => {
+            unimplemented!("Docs-formatting of arrow datatype {:#?}", datatype);
+        }
+    }
+}

--- a/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/arrow_datatype.rs
@@ -47,9 +47,9 @@ pub fn arrow_datatype_docs(page: &mut String, indent: usize, datatype: &DataType
         }
         // DataType::ListView(arc) => todo!(),
         DataType::FixedSizeList(inner, length) => {
-            page.push_str("FixedSizeList<");
+            page.push_str(&format!("FixedSizeList<{length}, "));
             arrow_datatype_docs(page, indent + 1, inner.data_type());
-            page.push_str(&format!(", {length}>"));
+            page.push('>');
         }
         // DataType::LargeList(arc) => todo!(),
         // DataType::LargeListView(arc) => todo!(),

--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -455,6 +455,12 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
         }
     }
 
+    if object.is_arrow_transparent() {
+        debug_assert!(object.is_struct());
+        debug_assert_eq!(object.fields.len(), 1);
+        return; // This is just a wrapper type, so don't show the "Fields" section
+    }
+
     let mut fields = Vec::new();
     for field in &object.fields {
         let mut field_string = format!("* `{}`", field.name);

--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -488,9 +488,10 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
         if let Some(enum_value) = field.enum_value {
             field_string.push_str(&format!(" = {enum_value}"));
         }
+        field_string.push('\n');
 
         if !object.is_enum() {
-            field_string.push_str(": ");
+            field_string.push_str("Type: ");
             if field.typ == Type::Unit {
                 field_string.push_str("`null`");
             } else {
@@ -499,9 +500,10 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
                 }
                 field_string.push_str(&type_info(objects, &field.typ));
             }
+            field_string.push('\n');
+            field_string.push('\n');
         }
 
-        field_string.push('\n');
         for line in field.docs.lines_for(objects, Target::WebDocsMarkdown) {
             field_string.push_str(&line);
             field_string.push('\n');

--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -483,7 +483,7 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
 
     let mut fields = Vec::new();
     for field in &object.fields {
-        let mut field_string = format!("* `{}`", field.name);
+        let mut field_string = format!("#### `{}`", field.name);
 
         if let Some(enum_value) = field.enum_value {
             field_string.push_str(&format!(" = {enum_value}"));
@@ -500,6 +500,13 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
                 field_string.push_str(&type_info(objects, &field.typ));
             }
         }
+
+        field_string.push('\n');
+        for line in field.docs.lines_for(objects, Target::WebDocsMarkdown) {
+            field_string.push_str(&line);
+            field_string.push('\n');
+        }
+
         fields.push(field_string);
     }
 

--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -302,7 +302,7 @@ fn object_page(
         }
     }
 
-    if object.kind == ObjectKind::Datatype {
+    if matches!(object.kind, ObjectKind::Datatype | ObjectKind::Component) {
         let datatype = &arrow_registry.get(&object.fqname);
         putln!(page);
         putln!(page, "## Arrow datatype");

--- a/docs/content/reference/types/components/aggregation_policy.md
+++ b/docs/content/reference/types/components/aggregation_policy.md
@@ -10,12 +10,26 @@ i.e. a single pixel covers more than one tick worth of data. It can greatly impr
 (and readability) in such situations as it prevents overdraw.
 
 ## Variants
-* `Off` = 1
-* `Average` = 2
-* `Max` = 3
-* `Min` = 4
-* `MinMax` = 5
-* `MinMaxAverage` = 6
+#### `Off` = 1
+No aggregation.
+
+#### `Average` = 2
+Average all points in the range together.
+
+#### `Max` = 3
+Keep only the maximum values in the range.
+
+#### `Min` = 4
+Keep only the minimum values in the range.
+
+#### `MinMax` = 5
+Keep both the minimum and maximum values in the range.
+
+This will yield two aggregated points instead of one, effectively creating a vertical line.
+
+#### `MinMaxAverage` = 6
+Find both the minimum and maximum values in the range, then use the average of those.
+
 
 ## API reference links
  * 🌊 [C++ API docs for `AggregationPolicy`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/aggregation_policy.md
+++ b/docs/content/reference/types/components/aggregation_policy.md
@@ -10,13 +10,12 @@ i.e. a single pixel covers more than one tick worth of data. It can greatly impr
 (and readability) in such situations as it prevents overdraw.
 
 ## Variants
-
-* Off
-* Average
-* Max
-* Min
-* MinMax
-* MinMaxAverage
+* `Off` = 1
+* `Average` = 2
+* `Max` = 3
+* `Min` = 4
+* `MinMax` = 5
+* `MinMaxAverage` = 6
 
 ## API reference links
  * 🌊 [C++ API docs for `AggregationPolicy`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/aggregation_policy.md
+++ b/docs/content/reference/types/components/aggregation_policy.md
@@ -31,6 +31,11 @@ This will yield two aggregated points instead of one, effectively creating a ver
 Find both the minimum and maximum values in the range, then use the average of those.
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `AggregationPolicy`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `AggregationPolicy`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AggregationPolicy)

--- a/docs/content/reference/types/components/albedo_factor.md
+++ b/docs/content/reference/types/components/albedo_factor.md
@@ -6,6 +6,11 @@ title: "AlbedoFactor"
 A color multiplier, usually applied to a whole entity, e.g. a mesh.
 
 
+## Arrow datatype
+```
+uint32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `AlbedoFactor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AlbedoFactor.html)
  * 🐍 [Python API docs for `AlbedoFactor`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AlbedoFactor)

--- a/docs/content/reference/types/components/albedo_factor.md
+++ b/docs/content/reference/types/components/albedo_factor.md
@@ -5,9 +5,6 @@ title: "AlbedoFactor"
 
 A color multiplier, usually applied to a whole entity, e.g. a mesh.
 
-## Fields
-
-* albedo_factor: [`Rgba32`](../datatypes/rgba32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `AlbedoFactor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AlbedoFactor.html)

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -11,9 +11,6 @@ annotation context. We use the *first* annotation context we find in the
 path-hierarchy when searching up through the ancestors of a given entity
 path.
 
-## Fields
-
-* class_map: list of [`ClassDescriptionMapElem`](../datatypes/class_description_map_elem.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html)

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -12,6 +12,29 @@ path-hierarchy when searching up through the ancestors of a given entity
 path.
 
 
+## Arrow datatype
+```
+List<Struct {
+        class_id: uint16
+        class_description: Struct {
+            info: Struct {
+                id: uint16
+                label: nullable utf8
+                color: nullable uint32
+            }
+            keypoint_annotations: List<Struct {
+                    id: uint16
+                    label: nullable utf8
+                    color: nullable uint32
+                }>
+            keypoint_connections: List<Struct {
+                    keypoint0: uint16
+                    keypoint1: uint16
+                }>
+        }
+    }>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html)
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)

--- a/docs/content/reference/types/components/axis_length.md
+++ b/docs/content/reference/types/components/axis_length.md
@@ -6,6 +6,11 @@ title: "AxisLength"
 The length of an axis in local units of the space.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `AxisLength`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AxisLength.html)
  * 🐍 [Python API docs for `AxisLength`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AxisLength)

--- a/docs/content/reference/types/components/axis_length.md
+++ b/docs/content/reference/types/components/axis_length.md
@@ -5,9 +5,6 @@ title: "AxisLength"
 
 The length of an axis in local units of the space.
 
-## Fields
-
-* length: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `AxisLength`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AxisLength.html)

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -5,9 +5,6 @@ title: "Blob"
 
 A binary blob of data.
 
-## Fields
-
-* data: [`Blob`](../datatypes/blob.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html)

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -6,6 +6,11 @@ title: "Blob"
 A binary blob of data.
 
 
+## Arrow datatype
+```
+List<uint8>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html)
  * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -5,9 +5,6 @@ title: "ClassId"
 
 A 16-bit ID representing a type of semantic class.
 
-## Fields
-
-* id: [`ClassId`](../datatypes/class_id.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html)

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -6,6 +6,11 @@ title: "ClassId"
 A 16-bit ID representing a type of semantic class.
 
 
+## Arrow datatype
+```
+uint16
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html)
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -5,9 +5,6 @@ title: "ClearIsRecursive"
 
 Configures how a clear operation should behave - recursive or not.
 
-## Fields
-
-* recursive: [`Bool`](../datatypes/bool.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html)

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -6,6 +6,11 @@ title: "ClearIsRecursive"
 Configures how a clear operation should behave - recursive or not.
 
 
+## Arrow datatype
+```
+boolean
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html)
  * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -8,9 +8,6 @@ An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear 
 The color is stored as a 32-bit integer, where the most significant
 byte is `R` and the least significant byte is `A`.
 
-## Fields
-
-* rgba: [`Rgba32`](../datatypes/rgba32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html)

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -9,6 +9,11 @@ The color is stored as a 32-bit integer, where the most significant
 byte is `R` and the least significant byte is `A`.
 
 
+## Arrow datatype
+```
+uint32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html)
  * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)

--- a/docs/content/reference/types/components/colormap.md
+++ b/docs/content/reference/types/components/colormap.md
@@ -10,13 +10,50 @@ In the future, the Rerun Viewer will allow users to define their own colormaps,
 but currently the Viewer is limited to the types defined here.
 
 ## Variants
-* `Grayscale` = 1
-* `Inferno` = 2
-* `Magma` = 3
-* `Plasma` = 4
-* `Turbo` = 5
-* `Viridis` = 6
-* `CyanToYellow` = 7
+#### `Grayscale` = 1
+A simple black to white gradient.
+
+This is a sRGB gray gradient which is perceptually uniform.
+
+#### `Inferno` = 2
+The Inferno colormap from Matplotlib.
+
+This is a perceptually uniform colormap.
+It interpolates from black to red to bright yellow.
+
+#### `Magma` = 3
+The Magma colormap from Matplotlib.
+
+This is a perceptually uniform colormap.
+It interpolates from black to purple to white.
+
+#### `Plasma` = 4
+The Plasma colormap from Matplotlib.
+
+This is a perceptually uniform colormap.
+It interpolates from dark blue to purple to yellow.
+
+#### `Turbo` = 5
+Google's Turbo colormap map.
+
+This is a perceptually non-uniform rainbow colormap addressing many issues of
+more traditional rainbow colormaps like Jet.
+It is more perceptually uniform without sharp transitions and is more colorblind-friendly.
+Details: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>
+
+#### `Viridis` = 6
+The Viridis colormap from Matplotlib
+
+This is a perceptually uniform colormap which is robust to color blindness.
+It interpolates from dark purple to green to yellow.
+
+#### `CyanToYellow` = 7
+Rasmusgo's Cyan to Yellow colormap
+
+This is a perceptually uniform colormap which is robust to color blindness.
+It is especially suited for visualizing signed values.
+It interpolates from cyan to blue to dark gray to brass to yellow.
+
 
 ## API reference links
  * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/colormap.md
+++ b/docs/content/reference/types/components/colormap.md
@@ -55,6 +55,11 @@ It is especially suited for visualizing signed values.
 It interpolates from cyan to blue to dark gray to brass to yellow.
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `Colormap`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Colormap)

--- a/docs/content/reference/types/components/colormap.md
+++ b/docs/content/reference/types/components/colormap.md
@@ -10,14 +10,13 @@ In the future, the Rerun Viewer will allow users to define their own colormaps,
 but currently the Viewer is limited to the types defined here.
 
 ## Variants
-
-* Grayscale
-* Inferno
-* Magma
-* Plasma
-* Turbo
-* Viridis
-* CyanToYellow
+* `Grayscale` = 1
+* `Inferno` = 2
+* `Magma` = 3
+* `Plasma` = 4
+* `Turbo` = 5
+* `Viridis` = 6
+* `CyanToYellow` = 7
 
 ## API reference links
  * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -12,9 +12,6 @@ this value would be `1000`.
 Note that the only effect on 2D views is the physical depth values shown when hovering the image.
 In 3D views on the other hand, this affects where the points of the point cloud are placed.
 
-## Fields
-
-* value: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html)

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -13,6 +13,11 @@ Note that the only effect on 2D views is the physical depth values shown when ho
 In 3D views on the other hand, this affects where the points of the point cloud are placed.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html)
  * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -10,9 +10,6 @@ making it impossible to transform the entity path into its parent's space and vi
 It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
 
-## Fields
-
-* is_disconnected: [`Bool`](../datatypes/bool.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html)

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -11,6 +11,11 @@ It *only* applies to space views that work with spatial transformations, i.e. 2D
 This is useful for specifying that a subgraph is independent of the rest of the scene.
 
 
+## Arrow datatype
+```
+boolean
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html)
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -11,6 +11,11 @@ Within an entity draw order is governed by the order of the components.
 Draw order for entities with the same draw order is generally undefined.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html)
  * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -10,9 +10,6 @@ Within an entity draw order is governed by the order of the components.
 
 Draw order for entities with the same draw order is generally undefined.
 
-## Fields
-
-* value: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html)

--- a/docs/content/reference/types/components/entity_path.md
+++ b/docs/content/reference/types/components/entity_path.md
@@ -6,6 +6,11 @@ title: "EntityPath"
 A path to an entity, usually to reference some data that is part of the target entity.
 
 
+## Arrow datatype
+```
+utf8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1EntityPath.html)
  * 🐍 [Python API docs for `EntityPath`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.EntityPath)

--- a/docs/content/reference/types/components/entity_path.md
+++ b/docs/content/reference/types/components/entity_path.md
@@ -5,9 +5,6 @@ title: "EntityPath"
 
 A path to an entity, usually to reference some data that is part of the target entity.
 
-## Fields
-
-* value: [`EntityPath`](../datatypes/entity_path.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1EntityPath.html)

--- a/docs/content/reference/types/components/fill_mode.md
+++ b/docs/content/reference/types/components/fill_mode.md
@@ -6,10 +6,9 @@ title: "FillMode"
 How a geometric shape is drawn and colored.
 
 ## Variants
-
-* MajorWireframe
-* DenseWireframe
-* Solid
+* `MajorWireframe` = 1
+* `DenseWireframe` = 2
+* `Solid` = 3
 
 ## API reference links
  * 🌊 [C++ API docs for `FillMode`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/fill_mode.md
+++ b/docs/content/reference/types/components/fill_mode.md
@@ -28,6 +28,11 @@ Examples of what this means:
 The surface of the shape is filled in with a solid color. No lines are drawn.
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `FillMode`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `FillMode`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.FillMode)

--- a/docs/content/reference/types/components/fill_mode.md
+++ b/docs/content/reference/types/components/fill_mode.md
@@ -6,9 +6,27 @@ title: "FillMode"
 How a geometric shape is drawn and colored.
 
 ## Variants
-* `MajorWireframe` = 1
-* `DenseWireframe` = 2
-* `Solid` = 3
+#### `MajorWireframe` = 1
+Lines are drawn around the parts of the shape which directly correspond to the logged data.
+
+Examples of what this means:
+
+* An [`archetypes.Ellipsoids3D`](https://rerun.io/docs/reference/types/archetypes/ellipsoids3d) will draw three axis-aligned ellipses that are cross-sections
+  of each ellipsoid, each of which displays two out of three of the sizes of the ellipsoid.
+* For [`archetypes.Boxes3D`](https://rerun.io/docs/reference/types/archetypes/boxes3d), it is the edges of the box, identical to `DenseWireframe`.
+
+#### `DenseWireframe` = 2
+Many lines are drawn to represent the surface of the shape in a see-through fashion.
+
+Examples of what this means:
+
+* An [`archetypes.Ellipsoids3D`](https://rerun.io/docs/reference/types/archetypes/ellipsoids3d) will draw a wireframe triangle mesh that approximates each
+  ellipsoid.
+* For [`archetypes.Boxes3D`](https://rerun.io/docs/reference/types/archetypes/boxes3d), it is the edges of the box, identical to `MajorWireframe`.
+
+#### `Solid` = 3
+The surface of the shape is filled in with a solid color. No lines are drawn.
+
 
 ## API reference links
  * 🌊 [C++ API docs for `FillMode`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/fill_ratio.md
+++ b/docs/content/reference/types/components/fill_ratio.md
@@ -11,6 +11,11 @@ Valid range is from 0 to max float although typically values above 1.0 are not u
 Defaults to 1.0.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `FillRatio`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1FillRatio.html)
  * 🐍 [Python API docs for `FillRatio`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.FillRatio)

--- a/docs/content/reference/types/components/fill_ratio.md
+++ b/docs/content/reference/types/components/fill_ratio.md
@@ -10,9 +10,6 @@ Valid range is from 0 to max float although typically values above 1.0 are not u
 
 Defaults to 1.0.
 
-## Fields
-
-* value: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `FillRatio`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1FillRatio.html)

--- a/docs/content/reference/types/components/gamma_correction.md
+++ b/docs/content/reference/types/components/gamma_correction.md
@@ -12,6 +12,11 @@ Valid range is from 0 (excluding) to max float.
 Defaults to 1.0 unless otherwise specified.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `GammaCorrection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1GammaCorrection.html)
  * 🐍 [Python API docs for `GammaCorrection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.GammaCorrection)

--- a/docs/content/reference/types/components/gamma_correction.md
+++ b/docs/content/reference/types/components/gamma_correction.md
@@ -11,9 +11,6 @@ Used to adjust the gamma of a color or scalar value between 0 and 1 before rende
 Valid range is from 0 (excluding) to max float.
 Defaults to 1.0 unless otherwise specified.
 
-## Fields
-
-* gamma: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `GammaCorrection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1GammaCorrection.html)

--- a/docs/content/reference/types/components/half_size2d.md
+++ b/docs/content/reference/types/components/half_size2d.md
@@ -10,9 +10,6 @@ Measured in its local coordinate system.
 The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
-## Fields
-
-* xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize2D.html)

--- a/docs/content/reference/types/components/half_size2d.md
+++ b/docs/content/reference/types/components/half_size2d.md
@@ -11,6 +11,11 @@ The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize2D.html)
  * 🐍 [Python API docs for `HalfSize2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSize2D)

--- a/docs/content/reference/types/components/half_size3d.md
+++ b/docs/content/reference/types/components/half_size3d.md
@@ -11,6 +11,11 @@ The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize3D.html)
  * 🐍 [Python API docs for `HalfSize3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSize3D)

--- a/docs/content/reference/types/components/half_size3d.md
+++ b/docs/content/reference/types/components/half_size3d.md
@@ -10,9 +10,6 @@ Measured in its local coordinate system.
 The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
-## Fields
-
-* xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize3D.html)

--- a/docs/content/reference/types/components/image_buffer.md
+++ b/docs/content/reference/types/components/image_buffer.md
@@ -7,9 +7,6 @@ A buffer that is known to store image data.
 
 To interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).
 
-## Fields
-
-* buffer: [`Blob`](../datatypes/blob.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ImageBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageBuffer.html)

--- a/docs/content/reference/types/components/image_buffer.md
+++ b/docs/content/reference/types/components/image_buffer.md
@@ -8,6 +8,11 @@ A buffer that is known to store image data.
 To interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).
 
 
+## Arrow datatype
+```
+List<uint8>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ImageBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageBuffer.html)
  * 🐍 [Python API docs for `ImageBuffer`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImageBuffer)

--- a/docs/content/reference/types/components/image_format.md
+++ b/docs/content/reference/types/components/image_format.md
@@ -5,9 +5,6 @@ title: "ImageFormat"
 
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
-## Fields
-
-* image_format: [`ImageFormat`](../datatypes/image_format.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ImageFormat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageFormat.html)

--- a/docs/content/reference/types/components/image_format.md
+++ b/docs/content/reference/types/components/image_format.md
@@ -6,6 +6,17 @@ title: "ImageFormat"
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
 
+## Arrow datatype
+```
+Struct {
+    width: uint32
+    height: uint32
+    pixel_format: nullable uint8
+    color_model: nullable uint8
+    channel_datatype: nullable uint8
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ImageFormat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageFormat.html)
  * 🐍 [Python API docs for `ImageFormat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImageFormat)

--- a/docs/content/reference/types/components/image_plane_distance.md
+++ b/docs/content/reference/types/components/image_plane_distance.md
@@ -7,9 +7,6 @@ The distance from the camera origin to the image plane when the projection is sh
 
 This is only used for visualization purposes, and does not affect the projection itself.
 
-## Fields
-
-* image_from_camera: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImagePlaneDistance.html)

--- a/docs/content/reference/types/components/image_plane_distance.md
+++ b/docs/content/reference/types/components/image_plane_distance.md
@@ -8,6 +8,11 @@ The distance from the camera origin to the image plane when the projection is sh
 This is only used for visualization purposes, and does not affect the projection itself.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImagePlaneDistance.html)
  * 🐍 [Python API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImagePlaneDistance)

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -5,9 +5,6 @@ title: "KeypointId"
 
 A 16-bit ID representing a type of semantic keypoint within a class.
 
-## Fields
-
-* id: [`KeypointId`](../datatypes/keypoint_id.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html)

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -6,6 +6,11 @@ title: "KeypointId"
 A 16-bit ID representing a type of semantic keypoint within a class.
 
 
+## Arrow datatype
+```
+uint16
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html)
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)

--- a/docs/content/reference/types/components/lat_lon.md
+++ b/docs/content/reference/types/components/lat_lon.md
@@ -5,9 +5,6 @@ title: "LatLon"
 
 A geographical position expressed in EPSG:4326 latitude and longitude.
 
-## Fields
-
-* lat_lon: [`DVec2D`](../datatypes/dvec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `LatLon`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LatLon.html?speculative-link)

--- a/docs/content/reference/types/components/lat_lon.md
+++ b/docs/content/reference/types/components/lat_lon.md
@@ -6,6 +6,11 @@ title: "LatLon"
 A geographical position expressed in EPSG:4326 latitude and longitude.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float64>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `LatLon`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LatLon.html?speculative-link)
  * 🐍 [Python API docs for `LatLon`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.LatLon)

--- a/docs/content/reference/types/components/length.md
+++ b/docs/content/reference/types/components/length.md
@@ -8,9 +8,6 @@ Length, or one-dimensional size.
 Measured in its local coordinate system; consult the archetype in use to determine which
 axis or part of the entity this is the length of.
 
-## Fields
-
-* length: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Length`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Length.html?speculative-link)

--- a/docs/content/reference/types/components/length.md
+++ b/docs/content/reference/types/components/length.md
@@ -9,6 +9,11 @@ Measured in its local coordinate system; consult the archetype in use to determi
 axis or part of the entity this is the length of.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Length`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Length.html?speculative-link)
  * 🐍 [Python API docs for `Length`](https://ref.rerun.io/docs/python/stable/common/components?speculative-link#rerun.components.Length)

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -16,9 +16,6 @@ The points will be connected in order, like so:
                  4
 ```
 
-## Fields
-
-* points: list of [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html)

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -17,6 +17,11 @@ The points will be connected in order, like so:
 ```
 
 
+## Arrow datatype
+```
+List<FixedSizeList<2, float32>>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html)
  * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -17,6 +17,11 @@ The points will be connected in order, like so:
 ```
 
 
+## Arrow datatype
+```
+List<FixedSizeList<3, float32>>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html)
  * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -16,9 +16,6 @@ The points will be connected in order, like so:
                  4
 ```
 
-## Fields
-
-* points: list of [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html)

--- a/docs/content/reference/types/components/magnification_filter.md
+++ b/docs/content/reference/types/components/magnification_filter.md
@@ -18,6 +18,11 @@ Linearly interpolate the nearest neighbors, creating a smoother look when zoomin
 Used as default for mesh rendering.
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `MagnificationFilter`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `MagnificationFilter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MagnificationFilter)

--- a/docs/content/reference/types/components/magnification_filter.md
+++ b/docs/content/reference/types/components/magnification_filter.md
@@ -6,8 +6,17 @@ title: "MagnificationFilter"
 Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.
 
 ## Variants
-* `Nearest` = 1
-* `Linear` = 2
+#### `Nearest` = 1
+Show the nearest pixel value.
+
+This will give a blocky appearance when zooming in.
+Used as default when rendering 2D images.
+
+#### `Linear` = 2
+Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.
+
+Used as default for mesh rendering.
+
 
 ## API reference links
  * 🌊 [C++ API docs for `MagnificationFilter`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/magnification_filter.md
+++ b/docs/content/reference/types/components/magnification_filter.md
@@ -6,9 +6,8 @@ title: "MagnificationFilter"
 Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.
 
 ## Variants
-
-* Nearest
-* Linear
+* `Nearest` = 1
+* `Linear` = 2
 
 ## API reference links
  * 🌊 [C++ API docs for `MagnificationFilter`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -6,17 +6,16 @@ title: "MarkerShape"
 The visual appearance of a point in e.g. a 2D plot.
 
 ## Variants
-
-* Circle
-* Diamond
-* Square
-* Cross
-* Plus
-* Up
-* Down
-* Left
-* Right
-* Asterisk
+* `Circle` = 1
+* `Diamond` = 2
+* `Square` = 3
+* `Cross` = 4
+* `Plus` = 5
+* `Up` = 6
+* `Down` = 7
+* `Left` = 8
+* `Right` = 9
+* `Asterisk` = 10
 
 ## API reference links
  * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -6,16 +6,36 @@ title: "MarkerShape"
 The visual appearance of a point in e.g. a 2D plot.
 
 ## Variants
-* `Circle` = 1
-* `Diamond` = 2
-* `Square` = 3
-* `Cross` = 4
-* `Plus` = 5
-* `Up` = 6
-* `Down` = 7
-* `Left` = 8
-* `Right` = 9
-* `Asterisk` = 10
+#### `Circle` = 1
+`⏺`
+
+#### `Diamond` = 2
+`◆`
+
+#### `Square` = 3
+`◼️`
+
+#### `Cross` = 4
+`x`
+
+#### `Plus` = 5
+`+`
+
+#### `Up` = 6
+`▲`
+
+#### `Down` = 7
+`▼`
+
+#### `Left` = 8
+`◀`
+
+#### `Right` = 9
+`▶`
+
+#### `Asterisk` = 10
+`*`
+
 
 ## API reference links
  * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -37,6 +37,11 @@ The visual appearance of a point in e.g. a 2D plot.
 `*`
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `MarkerShape`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerShape)

--- a/docs/content/reference/types/components/marker_size.md
+++ b/docs/content/reference/types/components/marker_size.md
@@ -5,9 +5,6 @@ title: "MarkerSize"
 
 Radius of a marker of a point in e.g. a 2D plot, measured in UI points.
 
-## Fields
-
-* value: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `MarkerSize`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerSize.html)

--- a/docs/content/reference/types/components/marker_size.md
+++ b/docs/content/reference/types/components/marker_size.md
@@ -6,6 +6,11 @@ title: "MarkerSize"
 Radius of a marker of a point in e.g. a 2D plot, measured in UI points.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `MarkerSize`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerSize.html)
  * 🐍 [Python API docs for `MarkerSize`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerSize)

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -8,9 +8,6 @@ A standardized media type (RFC2046, formerly known as MIME types), encoded as a 
 The complete reference of officially registered media types is maintained by the IANA and can be
 consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 
-## Fields
-
-* value: [`Utf8`](../datatypes/utf8.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html)

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -9,6 +9,11 @@ The complete reference of officially registered media types is maintained by the
 consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 
 
+## Arrow datatype
+```
+utf8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html)
  * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)

--- a/docs/content/reference/types/components/name.md
+++ b/docs/content/reference/types/components/name.md
@@ -5,9 +5,6 @@ title: "Name"
 
 A display name, typically for an entity or a item like a plot series.
 
-## Fields
-
-* value: [`Utf8`](../datatypes/utf8.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Name`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Name.html)

--- a/docs/content/reference/types/components/name.md
+++ b/docs/content/reference/types/components/name.md
@@ -6,6 +6,11 @@ title: "Name"
 A display name, typically for an entity or a item like a plot series.
 
 
+## Arrow datatype
+```
+utf8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Name`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Name.html)
  * 🐍 [Python API docs for `Name`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Name)

--- a/docs/content/reference/types/components/opacity.md
+++ b/docs/content/reference/types/components/opacity.md
@@ -8,9 +8,6 @@ Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque
 The final opacity value may be a result of multiplication with alpha values as specified by other color sources.
 Unless otherwise specified, the default value is 1.
 
-## Fields
-
-* opacity: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Opacity`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Opacity.html)

--- a/docs/content/reference/types/components/opacity.md
+++ b/docs/content/reference/types/components/opacity.md
@@ -9,6 +9,11 @@ The final opacity value may be a result of multiplication with alpha values as s
 Unless otherwise specified, the default value is 1.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Opacity`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Opacity.html)
  * 🐍 [Python API docs for `Opacity`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Opacity)

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -16,6 +16,11 @@ Example:
 ```
 
 
+## Arrow datatype
+```
+FixedSizeList<9, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html)
  * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -15,9 +15,6 @@ Example:
    0.0     0.0    1.0
 ```
 
-## Fields
-
-* image_from_camera: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html)

--- a/docs/content/reference/types/components/pose_rotation_axis_angle.md
+++ b/docs/content/reference/types/components/pose_rotation_axis_angle.md
@@ -6,6 +6,14 @@ title: "PoseRotationAxisAngle"
 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 
 
+## Arrow datatype
+```
+Struct {
+    axis: FixedSizeList<3, float32>
+    angle: float32
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationAxisAngle.html)
  * 🐍 [Python API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseRotationAxisAngle)

--- a/docs/content/reference/types/components/pose_rotation_axis_angle.md
+++ b/docs/content/reference/types/components/pose_rotation_axis_angle.md
@@ -5,9 +5,6 @@ title: "PoseRotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 
-## Fields
-
-* rotation: [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationAxisAngle.html)

--- a/docs/content/reference/types/components/pose_rotation_quat.md
+++ b/docs/content/reference/types/components/pose_rotation_quat.md
@@ -9,6 +9,11 @@ Note: although the x,y,z,w components of the quaternion will be passed through t
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
 
+## Arrow datatype
+```
+FixedSizeList<4, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationQuat.html)
  * 🐍 [Python API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseRotationQuat)

--- a/docs/content/reference/types/components/pose_rotation_quat.md
+++ b/docs/content/reference/types/components/pose_rotation_quat.md
@@ -8,9 +8,6 @@ A 3D rotation expressed as a quaternion that doesn't propagate in the transform 
 Note: although the x,y,z,w components of the quaternion will be passed through to the
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
-## Fields
-
-* quaternion: [`Quaternion`](../datatypes/quaternion.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationQuat.html)

--- a/docs/content/reference/types/components/pose_scale3d.md
+++ b/docs/content/reference/types/components/pose_scale3d.md
@@ -10,6 +10,11 @@ A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PoseScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseScale3D.html)
  * 🐍 [Python API docs for `PoseScale3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseScale3D)

--- a/docs/content/reference/types/components/pose_scale3d.md
+++ b/docs/content/reference/types/components/pose_scale3d.md
@@ -9,9 +9,6 @@ A scale of 1.0 means no scaling.
 A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
-## Fields
-
-* scale: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PoseScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseScale3D.html)

--- a/docs/content/reference/types/components/pose_transform_mat3x3.md
+++ b/docs/content/reference/types/components/pose_transform_mat3x3.md
@@ -18,6 +18,11 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
 
+## Arrow datatype
+```
+FixedSizeList<9, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTransformMat3x3.html)
  * 🐍 [Python API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseTransformMat3x3)

--- a/docs/content/reference/types/components/pose_transform_mat3x3.md
+++ b/docs/content/reference/types/components/pose_transform_mat3x3.md
@@ -17,9 +17,6 @@ row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
 row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
-## Fields
-
-* matrix: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTransformMat3x3.html)

--- a/docs/content/reference/types/components/pose_translation3d.md
+++ b/docs/content/reference/types/components/pose_translation3d.md
@@ -5,9 +5,6 @@ title: "PoseTranslation3D"
 
 A translation vector in 3D space that doesn't propagate in the transform hierarchy.
 
-## Fields
-
-* vector: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTranslation3D.html)

--- a/docs/content/reference/types/components/pose_translation3d.md
+++ b/docs/content/reference/types/components/pose_translation3d.md
@@ -6,6 +6,11 @@ title: "PoseTranslation3D"
 A translation vector in 3D space that doesn't propagate in the transform hierarchy.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTranslation3D.html)
  * 🐍 [Python API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseTranslation3D)

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -6,6 +6,11 @@ title: "Position2D"
 A position in 2D space.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html)
  * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -5,9 +5,6 @@ title: "Position2D"
 
 A position in 2D space.
 
-## Fields
-
-* xy: [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html)

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -5,9 +5,6 @@ title: "Position3D"
 
 A position in 3D space.
 
-## Fields
-
-* xyz: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html)

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -6,6 +6,11 @@ title: "Position3D"
 A position in 3D space.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html)
  * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -12,9 +12,6 @@ UI points are independent of zooming in Views, but are sensitive to the applicat
 at 100% UI scaling, UI points are equal to pixels
 The Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.
 
-## Fields
-
-* value: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html)

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -13,6 +13,11 @@ at 100% UI scaling, UI points are equal to pixels
 The Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html)
  * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)

--- a/docs/content/reference/types/components/range1d.md
+++ b/docs/content/reference/types/components/range1d.md
@@ -6,6 +6,11 @@ title: "Range1D"
 A 1D range, specifying a lower and upper bound.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float64>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Range1D.html)
  * 🐍 [Python API docs for `Range1D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Range1D)

--- a/docs/content/reference/types/components/range1d.md
+++ b/docs/content/reference/types/components/range1d.md
@@ -5,9 +5,6 @@ title: "Range1D"
 
 A 1D range, specifying a lower and upper bound.
 
-## Fields
-
-* range: [`Range1D`](../datatypes/range1d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Range1D.html)

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -8,6 +8,11 @@ Pixel resolution width & height, e.g. of a camera sensor.
 Typically in integer units, but for some use cases floating point may be used.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html)
  * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -7,9 +7,6 @@ Pixel resolution width & height, e.g. of a camera sensor.
 
 Typically in integer units, but for some use cases floating point may be used.
 
-## Fields
-
-* resolution: [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html)

--- a/docs/content/reference/types/components/rotation_axis_angle.md
+++ b/docs/content/reference/types/components/rotation_axis_angle.md
@@ -5,9 +5,6 @@ title: "RotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis.
 
-## Fields
-
-* rotation: [`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationAxisAngle.html)

--- a/docs/content/reference/types/components/rotation_axis_angle.md
+++ b/docs/content/reference/types/components/rotation_axis_angle.md
@@ -6,6 +6,14 @@ title: "RotationAxisAngle"
 3D rotation represented by a rotation around a given axis.
 
 
+## Arrow datatype
+```
+Struct {
+    axis: FixedSizeList<3, float32>
+    angle: float32
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationAxisAngle.html)
  * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.RotationAxisAngle)

--- a/docs/content/reference/types/components/rotation_quat.md
+++ b/docs/content/reference/types/components/rotation_quat.md
@@ -8,9 +8,6 @@ A 3D rotation expressed as a quaternion.
 Note: although the x,y,z,w components of the quaternion will be passed through to the
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
-## Fields
-
-* quaternion: [`Quaternion`](../datatypes/quaternion.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `RotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationQuat.html)

--- a/docs/content/reference/types/components/rotation_quat.md
+++ b/docs/content/reference/types/components/rotation_quat.md
@@ -9,6 +9,11 @@ Note: although the x,y,z,w components of the quaternion will be passed through t
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
 
+## Arrow datatype
+```
+FixedSizeList<4, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `RotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationQuat.html)
  * 🐍 [Python API docs for `RotationQuat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.RotationQuat)

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -7,9 +7,6 @@ A scalar value, encoded as a 64-bit floating point.
 
 Used for time series plots.
 
-## Fields
-
-* value: [`Float64`](../datatypes/float64.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html)

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -8,6 +8,11 @@ A scalar value, encoded as a 64-bit floating point.
 Used for time series plots.
 
 
+## Arrow datatype
+```
+float64
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html)
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)

--- a/docs/content/reference/types/components/scale3d.md
+++ b/docs/content/reference/types/components/scale3d.md
@@ -9,9 +9,6 @@ A scale of 1.0 means no scaling.
 A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
-## Fields
-
-* scale: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scale3D.html)

--- a/docs/content/reference/types/components/scale3d.md
+++ b/docs/content/reference/types/components/scale3d.md
@@ -10,6 +10,11 @@ A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scale3D.html)
  * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scale3D)

--- a/docs/content/reference/types/components/show_labels.md
+++ b/docs/content/reference/types/components/show_labels.md
@@ -9,9 +9,6 @@ The main purpose of this component existing separately from the labels themselve
 is to be overridden when desired, to allow hiding and showing from the viewer and
 blueprints.
 
-## Fields
-
-* show_labels: [`Bool`](../datatypes/bool.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ShowLabels`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ShowLabels.html)

--- a/docs/content/reference/types/components/show_labels.md
+++ b/docs/content/reference/types/components/show_labels.md
@@ -10,6 +10,11 @@ is to be overridden when desired, to allow hiding and showing from the viewer an
 blueprints.
 
 
+## Arrow datatype
+```
+boolean
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ShowLabels`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ShowLabels.html)
  * 🐍 [Python API docs for `ShowLabels`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ShowLabels)

--- a/docs/content/reference/types/components/stroke_width.md
+++ b/docs/content/reference/types/components/stroke_width.md
@@ -5,9 +5,6 @@ title: "StrokeWidth"
 
 The width of a stroke specified in UI points.
 
-## Fields
-
-* width: [`Float32`](../datatypes/float32.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `StrokeWidth`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1StrokeWidth.html)

--- a/docs/content/reference/types/components/stroke_width.md
+++ b/docs/content/reference/types/components/stroke_width.md
@@ -6,6 +6,11 @@ title: "StrokeWidth"
 The width of a stroke specified in UI points.
 
 
+## Arrow datatype
+```
+float32
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `StrokeWidth`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1StrokeWidth.html)
  * 🐍 [Python API docs for `StrokeWidth`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.StrokeWidth)

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -12,9 +12,6 @@ a 2D RGB Image, the shape would be `[height, width, channel]`.
 These dimensions are combined with an index to look up values from the `buffer` field,
 which stores a contiguous array of typed values.
 
-## Fields
-
-* data: [`TensorData`](../datatypes/tensor_data.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html)

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -13,6 +13,30 @@ These dimensions are combined with an index to look up values from the `buffer` 
 which stores a contiguous array of typed values.
 
 
+## Arrow datatype
+```
+Struct {
+    shape: List<Struct {
+            size: uint64
+            name: nullable utf8
+        }>
+    buffer: DenseUnion {
+        0 = "_null_markers": nullable null
+        1 = "U8": List<uint8>
+        2 = "U16": List<uint16>
+        3 = "U32": List<uint32>
+        4 = "U64": List<uint64>
+        5 = "I8": List<int8>
+        6 = "I16": List<int16>
+        7 = "I32": List<int32>
+        8 = "I64": List<int64>
+        9 = "F16": List<float16>
+        10 = "F32": List<float32>
+        11 = "F64": List<float64>
+    }
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html)
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)

--- a/docs/content/reference/types/components/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/components/tensor_dimension_index_selection.md
@@ -6,6 +6,14 @@ title: "TensorDimensionIndexSelection"
 Specifies a concrete index on a tensor dimension.
 
 
+## Arrow datatype
+```
+Struct {
+    dimension: uint32
+    index: uint64
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorDimensionIndexSelection.html)
  * 🐍 [Python API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorDimensionIndexSelection)

--- a/docs/content/reference/types/components/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/components/tensor_dimension_index_selection.md
@@ -5,9 +5,6 @@ title: "TensorDimensionIndexSelection"
 
 Specifies a concrete index on a tensor dimension.
 
-## Fields
-
-* selection: [`TensorDimensionIndexSelection`](../datatypes/tensor_dimension_index_selection.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorDimensionIndexSelection.html)

--- a/docs/content/reference/types/components/tensor_height_dimension.md
+++ b/docs/content/reference/types/components/tensor_height_dimension.md
@@ -6,6 +6,14 @@ title: "TensorHeightDimension"
 Specifies which dimension to use for height.
 
 
+## Arrow datatype
+```
+Struct {
+    dimension: uint32
+    invert: boolean
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorHeightDimension.html)
  * 🐍 [Python API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorHeightDimension)

--- a/docs/content/reference/types/components/tensor_height_dimension.md
+++ b/docs/content/reference/types/components/tensor_height_dimension.md
@@ -5,9 +5,6 @@ title: "TensorHeightDimension"
 
 Specifies which dimension to use for height.
 
-## Fields
-
-* dimension: [`TensorDimensionSelection`](../datatypes/tensor_dimension_selection.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorHeightDimension.html)

--- a/docs/content/reference/types/components/tensor_width_dimension.md
+++ b/docs/content/reference/types/components/tensor_width_dimension.md
@@ -6,6 +6,14 @@ title: "TensorWidthDimension"
 Specifies which dimension to use for width.
 
 
+## Arrow datatype
+```
+Struct {
+    dimension: uint32
+    invert: boolean
+}
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorWidthDimension.html)
  * 🐍 [Python API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorWidthDimension)

--- a/docs/content/reference/types/components/tensor_width_dimension.md
+++ b/docs/content/reference/types/components/tensor_width_dimension.md
@@ -5,9 +5,6 @@ title: "TensorWidthDimension"
 
 Specifies which dimension to use for width.
 
-## Fields
-
-* dimension: [`TensorDimensionSelection`](../datatypes/tensor_dimension_selection.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorWidthDimension.html)

--- a/docs/content/reference/types/components/texcoord2d.md
+++ b/docs/content/reference/types/components/texcoord2d.md
@@ -20,9 +20,6 @@ V |           .
 This is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenGL,
 which places the origin at the bottom-left.
 
-## Fields
-
-* uv: [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Texcoord2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Texcoord2D.html)

--- a/docs/content/reference/types/components/texcoord2d.md
+++ b/docs/content/reference/types/components/texcoord2d.md
@@ -21,6 +21,11 @@ This is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenG
 which places the origin at the bottom-left.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Texcoord2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Texcoord2D.html)
  * 🐍 [Python API docs for `Texcoord2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Texcoord2D)

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -5,9 +5,6 @@ title: "Text"
 
 A string of text, e.g. for labels and text documents.
 
-## Fields
-
-* value: [`Utf8`](../datatypes/utf8.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html)

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -6,6 +6,11 @@ title: "Text"
 A string of text, e.g. for labels and text documents.
 
 
+## Arrow datatype
+```
+utf8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html)
  * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -13,9 +13,6 @@ Recommended to be one of:
 * `"DEBUG"`
 * `"TRACE"`
 
-## Fields
-
-* value: [`Utf8`](../datatypes/utf8.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html)

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -14,6 +14,11 @@ Recommended to be one of:
 * `"TRACE"`
 
 
+## Arrow datatype
+```
+utf8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html)
  * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)

--- a/docs/content/reference/types/components/transform_mat3x3.md
+++ b/docs/content/reference/types/components/transform_mat3x3.md
@@ -17,9 +17,6 @@ row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
 row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
-## Fields
-
-* matrix: [`Mat3x3`](../datatypes/mat3x3.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TransformMat3x3.html)

--- a/docs/content/reference/types/components/transform_mat3x3.md
+++ b/docs/content/reference/types/components/transform_mat3x3.md
@@ -18,6 +18,11 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
 
+## Arrow datatype
+```
+FixedSizeList<9, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TransformMat3x3.html)
  * 🐍 [Python API docs for `TransformMat3x3`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TransformMat3x3)

--- a/docs/content/reference/types/components/transform_relation.md
+++ b/docs/content/reference/types/components/transform_relation.md
@@ -21,6 +21,11 @@ that from the point of view of `parent`, `parent/child` is translated -1 unit al
 From perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis.
 
 
+## Arrow datatype
+```
+uint8
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TransformRelation`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `TransformRelation`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TransformRelation)

--- a/docs/content/reference/types/components/transform_relation.md
+++ b/docs/content/reference/types/components/transform_relation.md
@@ -6,9 +6,8 @@ title: "TransformRelation"
 Specifies relation a spatial transform describes.
 
 ## Variants
-
-* ParentFromChild
-* ChildFromParent
+* `ParentFromChild` = 1
+* `ChildFromParent` = 2
 
 ## API reference links
  * 🌊 [C++ API docs for `TransformRelation`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/transform_relation.md
+++ b/docs/content/reference/types/components/transform_relation.md
@@ -6,8 +6,20 @@ title: "TransformRelation"
 Specifies relation a spatial transform describes.
 
 ## Variants
-* `ParentFromChild` = 1
-* `ChildFromParent` = 2
+#### `ParentFromChild` = 1
+The transform describes how to transform into the parent entity's space.
+
+E.g. a translation of (0, 1, 0) with this [`components.TransformRelation`](https://rerun.io/docs/reference/types/components/transform_relation) logged at `parent/child` means
+that from the point of view of `parent`, `parent/child` is translated 1 unit along `parent`'s Y axis.
+From perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis.
+
+#### `ChildFromParent` = 2
+The transform describes how to transform into the child entity's space.
+
+E.g. a translation of (0, 1, 0) with this [`components.TransformRelation`](https://rerun.io/docs/reference/types/components/transform_relation) logged at `parent/child` means
+that from the point of view of `parent`, `parent/child` is translated -1 unit along `parent`'s Y axis.
+From perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis.
+
 
 ## API reference links
  * 🌊 [C++ API docs for `TransformRelation`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)

--- a/docs/content/reference/types/components/translation3d.md
+++ b/docs/content/reference/types/components/translation3d.md
@@ -5,9 +5,6 @@ title: "Translation3D"
 
 A translation vector in 3D space.
 
-## Fields
-
-* vector: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Translation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Translation3D.html)

--- a/docs/content/reference/types/components/translation3d.md
+++ b/docs/content/reference/types/components/translation3d.md
@@ -6,6 +6,11 @@ title: "Translation3D"
 A translation vector in 3D space.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Translation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Translation3D.html)
  * 🐍 [Python API docs for `Translation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Translation3D)

--- a/docs/content/reference/types/components/triangle_indices.md
+++ b/docs/content/reference/types/components/triangle_indices.md
@@ -5,9 +5,6 @@ title: "TriangleIndices"
 
 The three indices of a triangle in a triangle mesh.
 
-## Fields
-
-* indices: [`UVec3D`](../datatypes/uvec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `TriangleIndices`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TriangleIndices.html)

--- a/docs/content/reference/types/components/triangle_indices.md
+++ b/docs/content/reference/types/components/triangle_indices.md
@@ -6,6 +6,11 @@ title: "TriangleIndices"
 The three indices of a triangle in a triangle mesh.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, uint32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `TriangleIndices`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TriangleIndices.html)
  * 🐍 [Python API docs for `TriangleIndices`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TriangleIndices)

--- a/docs/content/reference/types/components/value_range.md
+++ b/docs/content/reference/types/components/value_range.md
@@ -6,6 +6,11 @@ title: "ValueRange"
 Range of expected or valid values, specifying a lower and upper bound.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float64>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ValueRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ValueRange.html)
  * 🐍 [Python API docs for `ValueRange`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ValueRange)

--- a/docs/content/reference/types/components/value_range.md
+++ b/docs/content/reference/types/components/value_range.md
@@ -5,9 +5,6 @@ title: "ValueRange"
 
 Range of expected or valid values, specifying a lower and upper bound.
 
-## Fields
-
-* range: [`Range1D`](../datatypes/range1d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ValueRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ValueRange.html)

--- a/docs/content/reference/types/components/vector2d.md
+++ b/docs/content/reference/types/components/vector2d.md
@@ -5,9 +5,6 @@ title: "Vector2D"
 
 A vector in 2D space.
 
-## Fields
-
-* vector: [`Vec2D`](../datatypes/vec2d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Vector2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector2D.html)

--- a/docs/content/reference/types/components/vector2d.md
+++ b/docs/content/reference/types/components/vector2d.md
@@ -6,6 +6,11 @@ title: "Vector2D"
 A vector in 2D space.
 
 
+## Arrow datatype
+```
+FixedSizeList<2, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Vector2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector2D.html)
  * 🐍 [Python API docs for `Vector2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector2D)

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -6,6 +6,11 @@ title: "Vector3D"
 A vector in 3D space.
 
 
+## Arrow datatype
+```
+FixedSizeList<3, float32>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html)
  * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -5,9 +5,6 @@ title: "Vector3D"
 
 A vector in 3D space.
 
-## Fields
-
-* vector: [`Vec3D`](../datatypes/vec3d.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html)

--- a/docs/content/reference/types/components/video_timestamp.md
+++ b/docs/content/reference/types/components/video_timestamp.md
@@ -6,6 +6,11 @@ title: "VideoTimestamp"
 Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).
 
 
+## Arrow datatype
+```
+int64
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `VideoTimestamp`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1VideoTimestamp.html)
  * 🐍 [Python API docs for `VideoTimestamp`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.VideoTimestamp)

--- a/docs/content/reference/types/components/video_timestamp.md
+++ b/docs/content/reference/types/components/video_timestamp.md
@@ -5,9 +5,6 @@ title: "VideoTimestamp"
 
 Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).
 
-## Fields
-
-* timestamp: [`VideoTimestamp`](../datatypes/video_timestamp.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `VideoTimestamp`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1VideoTimestamp.html)

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -23,6 +23,11 @@ The following constants are used to represent the different directions:
  * Back = 6
 
 
+## Arrow datatype
+```
+FixedSizeList<3, uint8>
+```
+
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -22,9 +22,6 @@ The following constants are used to represent the different directions:
  * Forward = 5
  * Back = 6
 
-## Fields
-
-* coordinates: [`ViewCoordinates`](../datatypes/view_coordinates.md)
 
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html)

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -5,9 +5,11 @@ title: "Angle"
 
 Angle in radians.
 
-## Fields
 
-* radians: `f32`
+## Arrow datatype
+```
+float32
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Angle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Angle.html)

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -9,10 +9,18 @@ Color and label will be used to annotate entities/keypoints which reference the 
 The id refers either to a class or key-point id
 
 ## Fields
+* `id`: `uint16`
+* `label`: nullable [`Utf8`](../datatypes/utf8.md)
+* `color`: nullable [`Rgba32`](../datatypes/rgba32.md)
 
-* id: `u16`
-* label: [`Utf8`](../datatypes/utf8.md)
-* color: [`Rgba32`](../datatypes/rgba32.md)
+## Arrow datatype
+```
+Struct {
+    id: uint16
+    label: nullable utf8
+    color: nullable uint32
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationInfo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1AnnotationInfo.html)

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -9,9 +9,15 @@ Color and label will be used to annotate entities/keypoints which reference the 
 The id refers either to a class or key-point id
 
 ## Fields
-* `id`: `uint16`
-* `label`: nullable [`Utf8`](../datatypes/utf8.md)
-* `color`: nullable [`Rgba32`](../datatypes/rgba32.md)
+#### `id`: `uint16`
+[`datatypes.ClassId`](https://rerun.io/docs/reference/types/datatypes/class_id) or [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id) to which this annotation info belongs.
+
+#### `label`: nullable [`Utf8`](../datatypes/utf8.md)
+The label that will be shown in the UI.
+
+#### `color`: nullable [`Rgba32`](../datatypes/rgba32.md)
+The color that will be applied to the annotated entity.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -9,13 +9,19 @@ Color and label will be used to annotate entities/keypoints which reference the 
 The id refers either to a class or key-point id
 
 ## Fields
-#### `id`: `uint16`
+#### `id`
+Type: `uint16`
+
 [`datatypes.ClassId`](https://rerun.io/docs/reference/types/datatypes/class_id) or [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id) to which this annotation info belongs.
 
-#### `label`: nullable [`Utf8`](../datatypes/utf8.md)
+#### `label`
+Type: nullable [`Utf8`](../datatypes/utf8.md)
+
 The label that will be shown in the UI.
 
-#### `color`: nullable [`Rgba32`](../datatypes/rgba32.md)
+#### `color`
+Type: nullable [`Rgba32`](../datatypes/rgba32.md)
+
 The color that will be applied to the annotated entity.
 
 

--- a/docs/content/reference/types/datatypes/blob.md
+++ b/docs/content/reference/types/datatypes/blob.md
@@ -5,9 +5,11 @@ title: "Blob"
 
 A binary blob of data.
 
-## Fields
 
-* data: list of `u8`
+## Arrow datatype
+```
+List<uint8>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Blob.html)

--- a/docs/content/reference/types/datatypes/bool.md
+++ b/docs/content/reference/types/datatypes/bool.md
@@ -5,9 +5,11 @@ title: "Bool"
 
 A single boolean.
 
-## Fields
 
-* value: `bool`
+## Arrow datatype
+```
+boolean
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Bool`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Bool.html)

--- a/docs/content/reference/types/datatypes/channel_datatype.md
+++ b/docs/content/reference/types/datatypes/channel_datatype.md
@@ -8,17 +8,39 @@ The innermost datatype of an image.
 How individual color channel components are encoded.
 
 ## Variants
-* `U8` = 6
-* `I8` = 7
-* `U16` = 8
-* `I16` = 9
-* `U32` = 10
-* `I32` = 11
-* `U64` = 12
-* `I64` = 13
-* `F16` = 33
-* `F32` = 34
-* `F64` = 35
+#### `U8` = 6
+8-bit unsigned integer.
+
+#### `I8` = 7
+8-bit signed integer.
+
+#### `U16` = 8
+16-bit unsigned integer.
+
+#### `I16` = 9
+16-bit signed integer.
+
+#### `U32` = 10
+32-bit unsigned integer.
+
+#### `I32` = 11
+32-bit signed integer.
+
+#### `U64` = 12
+64-bit unsigned integer.
+
+#### `I64` = 13
+64-bit signed integer.
+
+#### `F16` = 33
+16-bit IEEE-754 floating point, also known as `half`.
+
+#### `F32` = 34
+32-bit IEEE-754 floating point, also known as `float` or `single`.
+
+#### `F64` = 35
+64-bit IEEE-754 floating point, also known as `double`.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/channel_datatype.md
+++ b/docs/content/reference/types/datatypes/channel_datatype.md
@@ -8,18 +8,22 @@ The innermost datatype of an image.
 How individual color channel components are encoded.
 
 ## Variants
+* `U8` = 6
+* `I8` = 7
+* `U16` = 8
+* `I16` = 9
+* `U32` = 10
+* `I32` = 11
+* `U64` = 12
+* `I64` = 13
+* `F16` = 33
+* `F32` = 34
+* `F64` = 35
 
-* U8
-* I8
-* U16
-* I16
-* U32
-* I32
-* U64
-* I64
-* F16
-* F32
-* F64
+## Arrow datatype
+```
+uint8
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ChannelDatatype`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -19,13 +19,19 @@ keypoints should be connected with an edge. The edge should be labeled and
 colored as described by the class's [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info).
 
 ## Fields
-#### `info`: [`AnnotationInfo`](../datatypes/annotation_info.md)
+#### `info`
+Type: [`AnnotationInfo`](../datatypes/annotation_info.md)
+
 The [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info) for the class.
 
-#### `keypoint_annotations`: List of [`AnnotationInfo`](../datatypes/annotation_info.md)
+#### `keypoint_annotations`
+Type: List of [`AnnotationInfo`](../datatypes/annotation_info.md)
+
 The [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info) for all of the keypoints.
 
-#### `keypoint_connections`: List of [`KeypointPair`](../datatypes/keypoint_pair.md)
+#### `keypoint_connections`
+Type: List of [`KeypointPair`](../datatypes/keypoint_pair.md)
+
 The connections between keypoints.
 
 

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -19,10 +19,29 @@ keypoints should be connected with an edge. The edge should be labeled and
 colored as described by the class's [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info).
 
 ## Fields
+* `info`: [`AnnotationInfo`](../datatypes/annotation_info.md)
+* `keypoint_annotations`: List of [`AnnotationInfo`](../datatypes/annotation_info.md)
+* `keypoint_connections`: List of [`KeypointPair`](../datatypes/keypoint_pair.md)
 
-* info: [`AnnotationInfo`](../datatypes/annotation_info.md)
-* keypoint_annotations: list of [`AnnotationInfo`](../datatypes/annotation_info.md)
-* keypoint_connections: list of [`KeypointPair`](../datatypes/keypoint_pair.md)
+## Arrow datatype
+```
+Struct {
+    info: Struct {
+        id: uint16
+        label: nullable utf8
+        color: nullable uint32
+    }
+    keypoint_annotations: List<Struct {
+            id: uint16
+            label: nullable utf8
+            color: nullable uint32
+        }>
+    keypoint_connections: List<Struct {
+            keypoint0: uint16
+            keypoint1: uint16
+        }>
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ClassDescription`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescription.html)

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -19,9 +19,15 @@ keypoints should be connected with an edge. The edge should be labeled and
 colored as described by the class's [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info).
 
 ## Fields
-* `info`: [`AnnotationInfo`](../datatypes/annotation_info.md)
-* `keypoint_annotations`: List of [`AnnotationInfo`](../datatypes/annotation_info.md)
-* `keypoint_connections`: List of [`KeypointPair`](../datatypes/keypoint_pair.md)
+#### `info`: [`AnnotationInfo`](../datatypes/annotation_info.md)
+The [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info) for the class.
+
+#### `keypoint_annotations`: List of [`AnnotationInfo`](../datatypes/annotation_info.md)
+The [`datatypes.AnnotationInfo`](https://rerun.io/docs/reference/types/datatypes/annotation_info) for all of the keypoints.
+
+#### `keypoint_connections`: List of [`KeypointPair`](../datatypes/keypoint_pair.md)
+The connections between keypoints.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -8,8 +8,12 @@ A helper type for mapping [`datatypes.ClassId`](https://rerun.io/docs/reference/
 This is internal to [`components.AnnotationContext`](https://rerun.io/docs/reference/types/components/annotation_context).
 
 ## Fields
-* `class_id`: [`ClassId`](../datatypes/class_id.md)
-* `class_description`: [`ClassDescription`](../datatypes/class_description.md)
+#### `class_id`: [`ClassId`](../datatypes/class_id.md)
+The key: the [`components.ClassId`](https://rerun.io/docs/reference/types/components/class_id).
+
+#### `class_description`: [`ClassDescription`](../datatypes/class_description.md)
+The value: class name, color, etc.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -8,9 +8,31 @@ A helper type for mapping [`datatypes.ClassId`](https://rerun.io/docs/reference/
 This is internal to [`components.AnnotationContext`](https://rerun.io/docs/reference/types/components/annotation_context).
 
 ## Fields
+* `class_id`: [`ClassId`](../datatypes/class_id.md)
+* `class_description`: [`ClassDescription`](../datatypes/class_description.md)
 
-* class_id: [`ClassId`](../datatypes/class_id.md)
-* class_description: [`ClassDescription`](../datatypes/class_description.md)
+## Arrow datatype
+```
+Struct {
+    class_id: uint16
+    class_description: Struct {
+        info: Struct {
+            id: uint16
+            label: nullable utf8
+            color: nullable uint32
+        }
+        keypoint_annotations: List<Struct {
+                id: uint16
+                label: nullable utf8
+                color: nullable uint32
+            }>
+        keypoint_connections: List<Struct {
+                keypoint0: uint16
+                keypoint1: uint16
+            }>
+    }
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescriptionMapElem.html)

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -8,10 +8,14 @@ A helper type for mapping [`datatypes.ClassId`](https://rerun.io/docs/reference/
 This is internal to [`components.AnnotationContext`](https://rerun.io/docs/reference/types/components/annotation_context).
 
 ## Fields
-#### `class_id`: [`ClassId`](../datatypes/class_id.md)
+#### `class_id`
+Type: [`ClassId`](../datatypes/class_id.md)
+
 The key: the [`components.ClassId`](https://rerun.io/docs/reference/types/components/class_id).
 
-#### `class_description`: [`ClassDescription`](../datatypes/class_description.md)
+#### `class_description`
+Type: [`ClassDescription`](../datatypes/class_description.md)
+
 The value: class name, color, etc.
 
 

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -5,9 +5,11 @@ title: "ClassId"
 
 A 16-bit ID representing a type of semantic class.
 
-## Fields
 
-* id: `u16`
+## Arrow datatype
+```
+uint16
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassId.html)

--- a/docs/content/reference/types/datatypes/color_model.md
+++ b/docs/content/reference/types/datatypes/color_model.md
@@ -8,12 +8,16 @@ Specified what color components are present in an [`archetypes.Image`](https://r
 This combined with [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) determines the pixel format of an image.
 
 ## Variants
+* `L` = 1
+* `RGB` = 2
+* `RGBA` = 3
+* `BGR` = 4
+* `BGRA` = 5
 
-* L
-* RGB
-* RGBA
-* BGR
-* BGRA
+## Arrow datatype
+```
+uint8
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ColorModel`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)

--- a/docs/content/reference/types/datatypes/color_model.md
+++ b/docs/content/reference/types/datatypes/color_model.md
@@ -8,11 +8,21 @@ Specified what color components are present in an [`archetypes.Image`](https://r
 This combined with [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) determines the pixel format of an image.
 
 ## Variants
-* `L` = 1
-* `RGB` = 2
-* `RGBA` = 3
-* `BGR` = 4
-* `BGRA` = 5
+#### `L` = 1
+Grayscale luminance intencity/brightness/value, sometimes called `Y`
+
+#### `RGB` = 2
+Red, Green, Blue
+
+#### `RGBA` = 3
+Red, Green, Blue, Alpha
+
+#### `BGR` = 4
+Blue, Green, Red
+
+#### `BGRA` = 5
+Blue, Green, Red, Alpha
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/dvec2d.md
+++ b/docs/content/reference/types/datatypes/dvec2d.md
@@ -5,9 +5,11 @@ title: "DVec2D"
 
 A double-precision vector in 2D space.
 
-## Fields
 
-* xy: 2x `f64`
+## Arrow datatype
+```
+FixedSizeList<float64, 2>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `DVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1DVec2D.html?speculative-link)

--- a/docs/content/reference/types/datatypes/dvec2d.md
+++ b/docs/content/reference/types/datatypes/dvec2d.md
@@ -8,7 +8,7 @@ A double-precision vector in 2D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<float64, 2>
+FixedSizeList<2, float64>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/entity_path.md
+++ b/docs/content/reference/types/datatypes/entity_path.md
@@ -5,9 +5,11 @@ title: "EntityPath"
 
 A path to an entity in the `ChunkStore`.
 
-## Fields
 
-* path: `string`
+## Arrow datatype
+```
+utf8
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1EntityPath.html)

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -5,9 +5,11 @@ title: "Float32"
 
 A single-precision 32-bit IEEE 754 floating point number.
 
-## Fields
 
-* value: `f32`
+## Arrow datatype
+```
+float32
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Float32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float32.html)

--- a/docs/content/reference/types/datatypes/float64.md
+++ b/docs/content/reference/types/datatypes/float64.md
@@ -5,9 +5,11 @@ title: "Float64"
 
 A double-precision 64-bit IEEE 754 floating point number.
 
-## Fields
 
-* value: `f64`
+## Arrow datatype
+```
+float64
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Float64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float64.html)

--- a/docs/content/reference/types/datatypes/image_format.md
+++ b/docs/content/reference/types/datatypes/image_format.md
@@ -6,23 +6,33 @@ title: "ImageFormat"
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
 ## Fields
-#### `width`: `uint32`
+#### `width`
+Type: `uint32`
+
 The width of the image in pixels.
 
-#### `height`: `uint32`
+#### `height`
+Type: `uint32`
+
 The height of the image in pixels.
 
-#### `pixel_format`: nullable [`PixelFormat`](../datatypes/pixel_format.md)
+#### `pixel_format`
+Type: nullable [`PixelFormat`](../datatypes/pixel_format.md)
+
 Used mainly for chroma downsampled formats and differing number of bits per channel.
 
 If specified, this takes precedence over both [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model) and [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) (which are ignored).
 
-#### `color_model`: nullable [`ColorModel`](../datatypes/color_model.md)
+#### `color_model`
+Type: nullable [`ColorModel`](../datatypes/color_model.md)
+
 L, RGB, RGBA, …
 
 Also requires a [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) to fully specify the pixel format.
 
-#### `channel_datatype`: nullable [`ChannelDatatype`](../datatypes/channel_datatype.md)
+#### `channel_datatype`
+Type: nullable [`ChannelDatatype`](../datatypes/channel_datatype.md)
+
 The data type of each channel (e.g. the red channel) of the image data (U8, F16, …).
 
 Also requires a [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model) to fully specify the pixel format.

--- a/docs/content/reference/types/datatypes/image_format.md
+++ b/docs/content/reference/types/datatypes/image_format.md
@@ -6,12 +6,22 @@ title: "ImageFormat"
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
 ## Fields
+* `width`: `uint32`
+* `height`: `uint32`
+* `pixel_format`: nullable [`PixelFormat`](../datatypes/pixel_format.md)
+* `color_model`: nullable [`ColorModel`](../datatypes/color_model.md)
+* `channel_datatype`: nullable [`ChannelDatatype`](../datatypes/channel_datatype.md)
 
-* width: `u32`
-* height: `u32`
-* pixel_format: [`PixelFormat`](../datatypes/pixel_format.md)
-* color_model: [`ColorModel`](../datatypes/color_model.md)
-* channel_datatype: [`ChannelDatatype`](../datatypes/channel_datatype.md)
+## Arrow datatype
+```
+Struct {
+    width: uint32
+    height: uint32
+    pixel_format: nullable uint8
+    color_model: nullable uint8
+    channel_datatype: nullable uint8
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ImageFormat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ImageFormat.html)

--- a/docs/content/reference/types/datatypes/image_format.md
+++ b/docs/content/reference/types/datatypes/image_format.md
@@ -6,11 +6,27 @@ title: "ImageFormat"
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
 ## Fields
-* `width`: `uint32`
-* `height`: `uint32`
-* `pixel_format`: nullable [`PixelFormat`](../datatypes/pixel_format.md)
-* `color_model`: nullable [`ColorModel`](../datatypes/color_model.md)
-* `channel_datatype`: nullable [`ChannelDatatype`](../datatypes/channel_datatype.md)
+#### `width`: `uint32`
+The width of the image in pixels.
+
+#### `height`: `uint32`
+The height of the image in pixels.
+
+#### `pixel_format`: nullable [`PixelFormat`](../datatypes/pixel_format.md)
+Used mainly for chroma downsampled formats and differing number of bits per channel.
+
+If specified, this takes precedence over both [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model) and [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) (which are ignored).
+
+#### `color_model`: nullable [`ColorModel`](../datatypes/color_model.md)
+L, RGB, RGBA, …
+
+Also requires a [`datatypes.ChannelDatatype`](https://rerun.io/docs/reference/types/datatypes/channel_datatype) to fully specify the pixel format.
+
+#### `channel_datatype`: nullable [`ChannelDatatype`](../datatypes/channel_datatype.md)
+The data type of each channel (e.g. the red channel) of the image data (U8, F16, …).
+
+Also requires a [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model) to fully specify the pixel format.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -5,9 +5,11 @@ title: "KeypointId"
 
 A 16-bit ID representing a type of semantic keypoint within a class.
 
-## Fields
 
-* id: `u16`
+## Arrow datatype
+```
+uint16
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointId.html)

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -6,9 +6,16 @@ title: "KeypointPair"
 A connection between two [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s.
 
 ## Fields
+* `keypoint0`: [`KeypointId`](../datatypes/keypoint_id.md)
+* `keypoint1`: [`KeypointId`](../datatypes/keypoint_id.md)
 
-* keypoint0: [`KeypointId`](../datatypes/keypoint_id.md)
-* keypoint1: [`KeypointId`](../datatypes/keypoint_id.md)
+## Arrow datatype
+```
+Struct {
+    keypoint0: uint16
+    keypoint1: uint16
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `KeypointPair`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointPair.html)

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -6,10 +6,14 @@ title: "KeypointPair"
 A connection between two [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s.
 
 ## Fields
-#### `keypoint0`: [`KeypointId`](../datatypes/keypoint_id.md)
+#### `keypoint0`
+Type: [`KeypointId`](../datatypes/keypoint_id.md)
+
 The first point of the pair.
 
-#### `keypoint1`: [`KeypointId`](../datatypes/keypoint_id.md)
+#### `keypoint1`
+Type: [`KeypointId`](../datatypes/keypoint_id.md)
+
 The second point of the pair.
 
 

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -6,8 +6,12 @@ title: "KeypointPair"
 A connection between two [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s.
 
 ## Fields
-* `keypoint0`: [`KeypointId`](../datatypes/keypoint_id.md)
-* `keypoint1`: [`KeypointId`](../datatypes/keypoint_id.md)
+#### `keypoint0`: [`KeypointId`](../datatypes/keypoint_id.md)
+The first point of the pair.
+
+#### `keypoint1`: [`KeypointId`](../datatypes/keypoint_id.md)
+The second point of the pair.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -17,7 +17,7 @@ row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 9>
+FixedSizeList<9, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -14,9 +14,11 @@ row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
 row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
-## Fields
 
-* flat_columns: 9x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 9>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Mat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat3x3.html)

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -18,7 +18,7 @@ row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 16>
+FixedSizeList<16, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -15,9 +15,11 @@ row 2 | flat_columns[2]  flat_columns[6]  flat_columns[10] flat_columns[14]
 row 3 | flat_columns[3]  flat_columns[7]  flat_columns[11] flat_columns[15]
 ```
 
-## Fields
 
-* flat_columns: 16x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 16>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Mat4x4`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat4x4.html)

--- a/docs/content/reference/types/datatypes/pixel_format.md
+++ b/docs/content/reference/types/datatypes/pixel_format.md
@@ -16,16 +16,86 @@ All these formats support random access.
 For more compressed image formats, see [`archetypes.EncodedImage`](https://rerun.io/docs/reference/types/archetypes/encoded_image).
 
 ## Variants
-* `Y_U_V12_LimitedRange` = 20
-* `NV12` = 26
-* `YUY2` = 27
-* `Y8_FullRange` = 30
-* `Y_U_V24_LimitedRange` = 39
-* `Y_U_V24_FullRange` = 40
-* `Y8_LimitedRange` = 41
-* `Y_U_V12_FullRange` = 44
-* `Y_U_V16_LimitedRange` = 49
-* `Y_U_V16_FullRange` = 50
+#### `Y_U_V12_LimitedRange` = 20
+`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].
+
+First comes entire image in Y in one plane, followed by the U and V planes, which each only have half
+the resolution of the Y plane.
+
+#### `NV12` = 26
+`NV12` (aka `Y_UV12`) is a YUV 4:2:0 chroma downsampled form at with 12 bits per pixel and 8 bits per channel.
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].
+
+First comes entire image in Y in one plane,
+followed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc.
+
+#### `YUY2` = 27
+`YUY2` (aka `YUYV`, `YUYV16` or `NV21`), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].
+
+The order of the channels is Y0, U0, Y1, V0, all in the same plane.
+
+#### `Y8_FullRange` = 30
+Monochrome Y plane only, essentially a YUV 4:0:0 planar format.
+
+Also known as just "gray". This is virtually identical to a 8bit luminance/grayscale (see [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model)).
+
+This uses entire range YUV, i.e. Y is expected to be within [0, 255].
+(as opposed to "limited range" YUV as used e.g. in NV12).
+
+#### `Y_U_V24_LimitedRange` = 39
+`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].
+
+First comes entire image in Y in one plane, followed by the U and V planes.
+
+#### `Y_U_V24_FullRange` = 40
+`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.
+
+This uses full range YUV with all components ranging from 0 to 255
+(as opposed to "limited range" YUV as used e.g. in NV12).
+
+First comes entire image in Y in one plane, followed by the U and V planes.
+
+#### `Y8_LimitedRange` = 41
+Monochrome Y plane only, essentially a YUV 4:0:0 planar format.
+
+Also known as just "gray".
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235].
+If not for this range limitation/remapping, this is almost identical to 8bit luminace/grayscale (see [`datatypes.ColorModel`](https://rerun.io/docs/reference/types/datatypes/color_model)).
+
+#### `Y_U_V12_FullRange` = 44
+`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.
+
+This uses full range YUV with all components ranging from 0 to 255
+(as opposed to "limited range" YUV as used e.g. in NV12).
+
+First comes entire image in Y in one plane, followed by the U and V planes, which each only have half
+the resolution of the Y plane.
+
+#### `Y_U_V16_LimitedRange` = 49
+`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.
+
+This uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].
+
+First comes entire image in Y in one plane, followed by the U and V planes, which each only have half
+the horizontal resolution of the Y plane.
+
+#### `Y_U_V16_FullRange` = 50
+`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.
+
+This uses full range YUV with all components ranging from 0 to 255
+(as opposed to "limited range" YUV as used e.g. in NV12).
+
+First comes entire image in Y in one plane, followed by the U and V planes, which each only have half
+the horizontal resolution of the Y plane.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/pixel_format.md
+++ b/docs/content/reference/types/datatypes/pixel_format.md
@@ -16,17 +16,21 @@ All these formats support random access.
 For more compressed image formats, see [`archetypes.EncodedImage`](https://rerun.io/docs/reference/types/archetypes/encoded_image).
 
 ## Variants
+* `Y_U_V12_LimitedRange` = 20
+* `NV12` = 26
+* `YUY2` = 27
+* `Y8_FullRange` = 30
+* `Y_U_V24_LimitedRange` = 39
+* `Y_U_V24_FullRange` = 40
+* `Y8_LimitedRange` = 41
+* `Y_U_V12_FullRange` = 44
+* `Y_U_V16_LimitedRange` = 49
+* `Y_U_V16_FullRange` = 50
 
-* Y_U_V12_LimitedRange
-* NV12
-* YUY2
-* Y8_FullRange
-* Y_U_V24_LimitedRange
-* Y_U_V24_FullRange
-* Y8_LimitedRange
-* Y_U_V12_FullRange
-* Y_U_V16_LimitedRange
-* Y_U_V16_FullRange
+## Arrow datatype
+```
+uint8
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `PixelFormat`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -11,7 +11,7 @@ datastore as provided, when used in the Viewer Quaternions will always be normal
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 4>
+FixedSizeList<4, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -8,9 +8,11 @@ A Quaternion represented by 4 real numbers.
 Note: although the x,y,z,w components of the quaternion will be passed through to the
 datastore as provided, when used in the Viewer Quaternions will always be normalized.
 
-## Fields
 
-* xyzw: 4x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 4>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Quaternion`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Quaternion.html)

--- a/docs/content/reference/types/datatypes/range1d.md
+++ b/docs/content/reference/types/datatypes/range1d.md
@@ -5,9 +5,11 @@ title: "Range1D"
 
 A 1D range, specifying a lower and upper bound.
 
-## Fields
 
-* range: 2x `f64`
+## Arrow datatype
+```
+FixedSizeList<float64, 2>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range1D.html)

--- a/docs/content/reference/types/datatypes/range1d.md
+++ b/docs/content/reference/types/datatypes/range1d.md
@@ -8,7 +8,7 @@ A 1D range, specifying a lower and upper bound.
 
 ## Arrow datatype
 ```
-FixedSizeList<float64, 2>
+FixedSizeList<2, float64>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -6,10 +6,14 @@ title: "Range2D"
 An Axis-Aligned Bounding Box in 2D space, implemented as the minimum and maximum corners.
 
 ## Fields
-#### `x_range`: [`Range1D`](../datatypes/range1d.md)
+#### `x_range`
+Type: [`Range1D`](../datatypes/range1d.md)
+
 The range of the X-axis (usually left and right bounds).
 
-#### `y_range`: [`Range1D`](../datatypes/range1d.md)
+#### `y_range`
+Type: [`Range1D`](../datatypes/range1d.md)
+
 The range of the Y-axis (usually top and bottom bounds).
 
 

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -16,8 +16,8 @@ The range of the Y-axis (usually top and bottom bounds).
 ## Arrow datatype
 ```
 Struct {
-    x_range: FixedSizeList<float64, 2>
-    y_range: FixedSizeList<float64, 2>
+    x_range: FixedSizeList<2, float64>
+    y_range: FixedSizeList<2, float64>
 }
 ```
 

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -6,9 +6,16 @@ title: "Range2D"
 An Axis-Aligned Bounding Box in 2D space, implemented as the minimum and maximum corners.
 
 ## Fields
+* `x_range`: [`Range1D`](../datatypes/range1d.md)
+* `y_range`: [`Range1D`](../datatypes/range1d.md)
 
-* x_range: [`Range1D`](../datatypes/range1d.md)
-* y_range: [`Range1D`](../datatypes/range1d.md)
+## Arrow datatype
+```
+Struct {
+    x_range: FixedSizeList<float64, 2>
+    y_range: FixedSizeList<float64, 2>
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Range2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range2D.html)

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -6,8 +6,12 @@ title: "Range2D"
 An Axis-Aligned Bounding Box in 2D space, implemented as the minimum and maximum corners.
 
 ## Fields
-* `x_range`: [`Range1D`](../datatypes/range1d.md)
-* `y_range`: [`Range1D`](../datatypes/range1d.md)
+#### `x_range`: [`Range1D`](../datatypes/range1d.md)
+The range of the X-axis (usually left and right bounds).
+
+#### `y_range`: [`Range1D`](../datatypes/range1d.md)
+The range of the Y-axis (usually top and bottom bounds).
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -8,9 +8,11 @@ An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear 
 The color is stored as a 32-bit integer, where the most significant
 byte is `R` and the least significant byte is `A`.
 
-## Fields
 
-* rgba: `u32`
+## Arrow datatype
+```
+uint32
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Rgba32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rgba32.html)

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -6,9 +6,16 @@ title: "RotationAxisAngle"
 3D rotation represented by a rotation around a given axis.
 
 ## Fields
+* `axis`: [`Vec3D`](../datatypes/vec3d.md)
+* `angle`: [`Angle`](../datatypes/angle.md)
 
-* axis: [`Vec3D`](../datatypes/vec3d.md)
-* angle: [`Angle`](../datatypes/angle.md)
+## Arrow datatype
+```
+Struct {
+    axis: FixedSizeList<float32, 3>
+    angle: float32
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1RotationAxisAngle.html)

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -6,14 +6,18 @@ title: "RotationAxisAngle"
 3D rotation represented by a rotation around a given axis.
 
 ## Fields
-#### `axis`: [`Vec3D`](../datatypes/vec3d.md)
+#### `axis`
+Type: [`Vec3D`](../datatypes/vec3d.md)
+
 Axis to rotate around.
 
 This is not required to be normalized.
 If normalization fails (typically because the vector is length zero), the rotation is silently
 ignored.
 
-#### `angle`: [`Angle`](../datatypes/angle.md)
+#### `angle`
+Type: [`Angle`](../datatypes/angle.md)
+
 How much to rotate around the axis.
 
 

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -20,7 +20,7 @@ How much to rotate around the axis.
 ## Arrow datatype
 ```
 Struct {
-    axis: FixedSizeList<float32, 3>
+    axis: FixedSizeList<3, float32>
     angle: float32
 }
 ```

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -6,8 +6,16 @@ title: "RotationAxisAngle"
 3D rotation represented by a rotation around a given axis.
 
 ## Fields
-* `axis`: [`Vec3D`](../datatypes/vec3d.md)
-* `angle`: [`Angle`](../datatypes/angle.md)
+#### `axis`: [`Vec3D`](../datatypes/vec3d.md)
+Axis to rotate around.
+
+This is not required to be normalized.
+If normalization fails (typically because the vector is length zero), the rotation is silently
+ignored.
+
+#### `angle`: [`Angle`](../datatypes/angle.md)
+How much to rotate around the axis.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -8,37 +8,59 @@ The underlying storage for [`archetypes.Tensor`](https://rerun.io/docs/reference
 Tensor elements are stored in a contiguous buffer of a single type.
 
 ## Variants
-#### `U8` = 1: List of `uint8`
+#### `U8` = 1
+Type: List of `uint8`
+
 8bit unsigned integer.
 
-#### `U16` = 2: List of `uint16`
+#### `U16` = 2
+Type: List of `uint16`
+
 16bit unsigned integer.
 
-#### `U32` = 3: List of `uint32`
+#### `U32` = 3
+Type: List of `uint32`
+
 32bit unsigned integer.
 
-#### `U64` = 4: List of `uint64`
+#### `U64` = 4
+Type: List of `uint64`
+
 64bit unsigned integer.
 
-#### `I8` = 5: List of `int8`
+#### `I8` = 5
+Type: List of `int8`
+
 8bit signed integer.
 
-#### `I16` = 6: List of `int16`
+#### `I16` = 6
+Type: List of `int16`
+
 16bit signed integer.
 
-#### `I32` = 7: List of `int32`
+#### `I32` = 7
+Type: List of `int32`
+
 32bit signed integer.
 
-#### `I64` = 8: List of `int64`
+#### `I64` = 8
+Type: List of `int64`
+
 64bit signed integer.
 
-#### `F16` = 9: List of `float16`
+#### `F16` = 9
+Type: List of `float16`
+
 16bit IEEE-754 floating point, also known as `half`.
 
-#### `F32` = 10: List of `float32`
+#### `F32` = 10
+Type: List of `float32`
+
 32bit IEEE-754 floating point, also known as `float` or `single`.
 
-#### `F64` = 11: List of `float64`
+#### `F64` = 11
+Type: List of `float64`
+
 64bit IEEE-754 floating point, also known as `double`.
 
 

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -8,18 +8,35 @@ The underlying storage for [`archetypes.Tensor`](https://rerun.io/docs/reference
 Tensor elements are stored in a contiguous buffer of a single type.
 
 ## Variants
+* `U8` = 1: List of `uint8`
+* `U16` = 2: List of `uint16`
+* `U32` = 3: List of `uint32`
+* `U64` = 4: List of `uint64`
+* `I8` = 5: List of `int8`
+* `I16` = 6: List of `int16`
+* `I32` = 7: List of `int32`
+* `I64` = 8: List of `int64`
+* `F16` = 9: List of `float16`
+* `F32` = 10: List of `float32`
+* `F64` = 11: List of `float64`
 
-* U8: list of `u8`
-* U16: list of `u16`
-* U32: list of `u32`
-* U64: list of `u64`
-* I8: list of `i8`
-* I16: list of `i16`
-* I32: list of `i32`
-* I64: list of `i64`
-* F16: list of `f16`
-* F32: list of `f32`
-* F64: list of `f64`
+## Arrow datatype
+```
+DenseUnion {
+    0 = "_null_markers": nullable null
+    1 = "U8": List<uint8>
+    2 = "U16": List<uint16>
+    3 = "U32": List<uint32>
+    4 = "U64": List<uint64>
+    5 = "I8": List<int8>
+    6 = "I16": List<int16>
+    7 = "I32": List<int32>
+    8 = "I64": List<int64>
+    9 = "F16": List<float16>
+    10 = "F32": List<float32>
+    11 = "F64": List<float64>
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorBuffer.html)

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -8,17 +8,39 @@ The underlying storage for [`archetypes.Tensor`](https://rerun.io/docs/reference
 Tensor elements are stored in a contiguous buffer of a single type.
 
 ## Variants
-* `U8` = 1: List of `uint8`
-* `U16` = 2: List of `uint16`
-* `U32` = 3: List of `uint32`
-* `U64` = 4: List of `uint64`
-* `I8` = 5: List of `int8`
-* `I16` = 6: List of `int16`
-* `I32` = 7: List of `int32`
-* `I64` = 8: List of `int64`
-* `F16` = 9: List of `float16`
-* `F32` = 10: List of `float32`
-* `F64` = 11: List of `float64`
+#### `U8` = 1: List of `uint8`
+8bit unsigned integer.
+
+#### `U16` = 2: List of `uint16`
+16bit unsigned integer.
+
+#### `U32` = 3: List of `uint32`
+32bit unsigned integer.
+
+#### `U64` = 4: List of `uint64`
+64bit unsigned integer.
+
+#### `I8` = 5: List of `int8`
+8bit signed integer.
+
+#### `I16` = 6: List of `int16`
+16bit signed integer.
+
+#### `I32` = 7: List of `int32`
+32bit signed integer.
+
+#### `I64` = 8: List of `int64`
+64bit signed integer.
+
+#### `F16` = 9: List of `float16`
+16bit IEEE-754 floating point, also known as `half`.
+
+#### `F32` = 10: List of `float32`
+32bit IEEE-754 floating point, also known as `float` or `single`.
+
+#### `F64` = 11: List of `float64`
+64bit IEEE-754 floating point, also known as `double`.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -13,10 +13,14 @@ These dimensions are combined with an index to look up values from the `buffer` 
 which stores a contiguous array of typed values.
 
 ## Fields
-#### `shape`: List of [`TensorDimension`](../datatypes/tensor_dimension.md)
+#### `shape`
+Type: List of [`TensorDimension`](../datatypes/tensor_dimension.md)
+
 The shape of the tensor, including optional names for each dimension.
 
-#### `buffer`: [`TensorBuffer`](../datatypes/tensor_buffer.md)
+#### `buffer`
+Type: [`TensorBuffer`](../datatypes/tensor_buffer.md)
+
 The content/data.
 
 

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -13,9 +13,32 @@ These dimensions are combined with an index to look up values from the `buffer` 
 which stores a contiguous array of typed values.
 
 ## Fields
+* `shape`: List of [`TensorDimension`](../datatypes/tensor_dimension.md)
+* `buffer`: [`TensorBuffer`](../datatypes/tensor_buffer.md)
 
-* shape: list of [`TensorDimension`](../datatypes/tensor_dimension.md)
-* buffer: [`TensorBuffer`](../datatypes/tensor_buffer.md)
+## Arrow datatype
+```
+Struct {
+    shape: List<Struct {
+            size: uint64
+            name: nullable utf8
+        }>
+    buffer: DenseUnion {
+        0 = "_null_markers": nullable null
+        1 = "U8": List<uint8>
+        2 = "U16": List<uint16>
+        3 = "U32": List<uint32>
+        4 = "U64": List<uint64>
+        5 = "I8": List<int8>
+        6 = "I16": List<int16>
+        7 = "I32": List<int32>
+        8 = "I64": List<int64>
+        9 = "F16": List<float16>
+        10 = "F32": List<float32>
+        11 = "F64": List<float64>
+    }
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorData.html)

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -13,8 +13,12 @@ These dimensions are combined with an index to look up values from the `buffer` 
 which stores a contiguous array of typed values.
 
 ## Fields
-* `shape`: List of [`TensorDimension`](../datatypes/tensor_dimension.md)
-* `buffer`: [`TensorBuffer`](../datatypes/tensor_buffer.md)
+#### `shape`: List of [`TensorDimension`](../datatypes/tensor_dimension.md)
+The shape of the tensor, including optional names for each dimension.
+
+#### `buffer`: [`TensorBuffer`](../datatypes/tensor_buffer.md)
+The content/data.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -6,9 +6,16 @@ title: "TensorDimension"
 A single dimension within a multi-dimensional tensor.
 
 ## Fields
+* `size`: `uint64`
+* `name`: nullable `utf8`
 
-* size: `u64`
-* name: `string`
+## Arrow datatype
+```
+Struct {
+    size: uint64
+    name: nullable utf8
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimension.html)

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -6,10 +6,14 @@ title: "TensorDimension"
 A single dimension within a multi-dimensional tensor.
 
 ## Fields
-#### `size`: `uint64`
+#### `size`
+Type: `uint64`
+
 The length of this dimension.
 
-#### `name`: nullable `utf8`
+#### `name`
+Type: nullable `utf8`
+
 The name of this dimension, e.g. "width", "height", "channel", "batch', ….
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -6,8 +6,12 @@ title: "TensorDimension"
 A single dimension within a multi-dimensional tensor.
 
 ## Fields
-* `size`: `uint64`
-* `name`: nullable `utf8`
+#### `size`: `uint64`
+The length of this dimension.
+
+#### `name`: nullable `utf8`
+The name of this dimension, e.g. "width", "height", "channel", "batch', ….
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
@@ -8,9 +8,16 @@ Indexing a specific tensor dimension.
 Selecting `dimension=2` and `index=42` is similar to doing `tensor[:, :, 42, :, :, …]` in numpy.
 
 ## Fields
+* `dimension`: `uint32`
+* `index`: `uint64`
 
-* dimension: `u32`
-* index: `u64`
+## Arrow datatype
+```
+Struct {
+    dimension: uint32
+    index: uint64
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimensionIndexSelection.html)

--- a/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
@@ -8,10 +8,14 @@ Indexing a specific tensor dimension.
 Selecting `dimension=2` and `index=42` is similar to doing `tensor[:, :, 42, :, :, …]` in numpy.
 
 ## Fields
-#### `dimension`: `uint32`
+#### `dimension`
+Type: `uint32`
+
 The dimension number to select.
 
-#### `index`: `uint64`
+#### `index`
+Type: `uint64`
+
 The index along the dimension to use.
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
@@ -8,8 +8,12 @@ Indexing a specific tensor dimension.
 Selecting `dimension=2` and `index=42` is similar to doing `tensor[:, :, 42, :, :, …]` in numpy.
 
 ## Fields
-* `dimension`: `uint32`
-* `index`: `uint64`
+#### `dimension`: `uint32`
+The dimension number to select.
+
+#### `index`: `uint64`
+The index along the dimension to use.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/tensor_dimension_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_selection.md
@@ -6,9 +6,16 @@ title: "TensorDimensionSelection"
 Selection of a single tensor dimension.
 
 ## Fields
+* `dimension`: `uint32`
+* `invert`: `boolean`
 
-* dimension: `u32`
-* invert: `bool`
+## Arrow datatype
+```
+Struct {
+    dimension: uint32
+    invert: boolean
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimensionSelection.html)

--- a/docs/content/reference/types/datatypes/tensor_dimension_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_selection.md
@@ -6,10 +6,14 @@ title: "TensorDimensionSelection"
 Selection of a single tensor dimension.
 
 ## Fields
-#### `dimension`: `uint32`
+#### `dimension`
+Type: `uint32`
+
 The dimension number to select.
 
-#### `invert`: `boolean`
+#### `invert`
+Type: `boolean`
+
 Invert the direction of the dimension.
 
 

--- a/docs/content/reference/types/datatypes/tensor_dimension_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_selection.md
@@ -6,8 +6,12 @@ title: "TensorDimensionSelection"
 Selection of a single tensor dimension.
 
 ## Fields
-* `dimension`: `uint32`
-* `invert`: `boolean`
+#### `dimension`: `uint32`
+The dimension number to select.
+
+#### `invert`: `boolean`
+Invert the direction of the dimension.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/time_int.md
+++ b/docs/content/reference/types/datatypes/time_int.md
@@ -5,9 +5,11 @@ title: "TimeInt"
 
 A 64-bit number describing either nanoseconds OR sequence numbers.
 
-## Fields
 
-* value: `i64`
+## Arrow datatype
+```
+int64
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TimeInt`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeInt.html)

--- a/docs/content/reference/types/datatypes/time_range.md
+++ b/docs/content/reference/types/datatypes/time_range.md
@@ -6,10 +6,14 @@ title: "TimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
-#### `start`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+#### `start`
+Type: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+
 Low time boundary for sequence timeline.
 
-#### `end`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+#### `end`
+Type: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+
 High time boundary for sequence timeline.
 
 

--- a/docs/content/reference/types/datatypes/time_range.md
+++ b/docs/content/reference/types/datatypes/time_range.md
@@ -6,9 +6,26 @@ title: "TimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
+* `start`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+* `end`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
 
-* start: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
-* end: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+## Arrow datatype
+```
+Struct {
+    start: DenseUnion {
+        0 = "_null_markers": nullable null
+        1 = "CursorRelative": int64
+        2 = "Absolute": int64
+        3 = "Infinite": nullable null
+    }
+    end: DenseUnion {
+        0 = "_null_markers": nullable null
+        1 = "CursorRelative": int64
+        2 = "Absolute": int64
+        3 = "Infinite": nullable null
+    }
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRange.html)

--- a/docs/content/reference/types/datatypes/time_range.md
+++ b/docs/content/reference/types/datatypes/time_range.md
@@ -6,8 +6,12 @@ title: "TimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
-* `start`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
-* `end`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+#### `start`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+Low time boundary for sequence timeline.
+
+#### `end`: [`TimeRangeBoundary`](../datatypes/time_range_boundary.md)
+High time boundary for sequence timeline.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/time_range_boundary.md
+++ b/docs/content/reference/types/datatypes/time_range_boundary.md
@@ -6,10 +6,19 @@ title: "TimeRangeBoundary"
 Left or right boundary of a time range.
 
 ## Variants
+* `CursorRelative` = 1: [`TimeInt`](../datatypes/time_int.md)
+* `Absolute` = 2: [`TimeInt`](../datatypes/time_int.md)
+* `Infinite` = 3: `null`
 
-* CursorRelative: [`TimeInt`](../datatypes/time_int.md)
-* Absolute: [`TimeInt`](../datatypes/time_int.md)
-* Infinite
+## Arrow datatype
+```
+DenseUnion {
+    0 = "_null_markers": nullable null
+    1 = "CursorRelative": int64
+    2 = "Absolute": int64
+    3 = "Infinite": nullable null
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRangeBoundary.html)

--- a/docs/content/reference/types/datatypes/time_range_boundary.md
+++ b/docs/content/reference/types/datatypes/time_range_boundary.md
@@ -6,13 +6,19 @@ title: "TimeRangeBoundary"
 Left or right boundary of a time range.
 
 ## Variants
-#### `CursorRelative` = 1: [`TimeInt`](../datatypes/time_int.md)
+#### `CursorRelative` = 1
+Type: [`TimeInt`](../datatypes/time_int.md)
+
 Boundary is a value relative to the time cursor.
 
-#### `Absolute` = 2: [`TimeInt`](../datatypes/time_int.md)
+#### `Absolute` = 2
+Type: [`TimeInt`](../datatypes/time_int.md)
+
 Boundary is an absolute value.
 
-#### `Infinite` = 3: `null`
+#### `Infinite` = 3
+Type: `null`
+
 The boundary extends to infinity.
 
 

--- a/docs/content/reference/types/datatypes/time_range_boundary.md
+++ b/docs/content/reference/types/datatypes/time_range_boundary.md
@@ -6,9 +6,15 @@ title: "TimeRangeBoundary"
 Left or right boundary of a time range.
 
 ## Variants
-* `CursorRelative` = 1: [`TimeInt`](../datatypes/time_int.md)
-* `Absolute` = 2: [`TimeInt`](../datatypes/time_int.md)
-* `Infinite` = 3: `null`
+#### `CursorRelative` = 1: [`TimeInt`](../datatypes/time_int.md)
+Boundary is a value relative to the time cursor.
+
+#### `Absolute` = 2: [`TimeInt`](../datatypes/time_int.md)
+Boundary is an absolute value.
+
+#### `Infinite` = 3: `null`
+The boundary extends to infinity.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/uint16.md
+++ b/docs/content/reference/types/datatypes/uint16.md
@@ -5,9 +5,11 @@ title: "UInt16"
 
 A 16bit unsigned integer.
 
-## Fields
 
-* value: `u16`
+## Arrow datatype
+```
+uint16
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UInt16`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt16.html)

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -5,9 +5,11 @@ title: "UInt32"
 
 A 32bit unsigned integer.
 
-## Fields
 
-* value: `u32`
+## Arrow datatype
+```
+uint32
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UInt32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt32.html)

--- a/docs/content/reference/types/datatypes/uint64.md
+++ b/docs/content/reference/types/datatypes/uint64.md
@@ -5,9 +5,11 @@ title: "UInt64"
 
 A 64bit unsigned integer.
 
-## Fields
 
-* value: `u64`
+## Arrow datatype
+```
+uint64
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UInt64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt64.html)

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -5,9 +5,11 @@ title: "Utf8"
 
 A string of text, encoded as UTF-8.
 
-## Fields
 
-* value: `string`
+## Arrow datatype
+```
+utf8
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Utf8`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Utf8.html)

--- a/docs/content/reference/types/datatypes/uuid.md
+++ b/docs/content/reference/types/datatypes/uuid.md
@@ -8,7 +8,7 @@ A 16-byte UUID.
 
 ## Arrow datatype
 ```
-FixedSizeList<uint8, 16>
+FixedSizeList<16, uint8>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/uuid.md
+++ b/docs/content/reference/types/datatypes/uuid.md
@@ -5,9 +5,11 @@ title: "Uuid"
 
 A 16-byte UUID.
 
-## Fields
 
-* bytes: 16x `u8`
+## Arrow datatype
+```
+FixedSizeList<uint8, 16>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Uuid`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Uuid.html)

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -5,9 +5,11 @@ title: "UVec2D"
 
 A uint32 vector in 2D space.
 
-## Fields
 
-* xy: 2x `u32`
+## Arrow datatype
+```
+FixedSizeList<uint32, 2>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec2D.html)

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -8,7 +8,7 @@ A uint32 vector in 2D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<uint32, 2>
+FixedSizeList<2, uint32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -5,9 +5,11 @@ title: "UVec3D"
 
 A uint32 vector in 3D space.
 
-## Fields
 
-* xyz: 3x `u32`
+## Arrow datatype
+```
+FixedSizeList<uint32, 3>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UVec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec3D.html)

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -8,7 +8,7 @@ A uint32 vector in 3D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<uint32, 3>
+FixedSizeList<3, uint32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -8,7 +8,7 @@ A uint vector in 4D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<uint32, 4>
+FixedSizeList<4, uint32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -5,9 +5,11 @@ title: "UVec4D"
 
 A uint vector in 4D space.
 
-## Fields
 
-* xyzw: 4x `u32`
+## Arrow datatype
+```
+FixedSizeList<uint32, 4>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `UVec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec4D.html)

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -8,7 +8,7 @@ A vector in 2D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 2>
+FixedSizeList<2, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -5,9 +5,11 @@ title: "Vec2D"
 
 A vector in 2D space.
 
-## Fields
 
-* xy: 2x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 2>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Vec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec2D.html)

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -5,9 +5,11 @@ title: "Vec3D"
 
 A vector in 3D space.
 
-## Fields
 
-* xyz: 3x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 3>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Vec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec3D.html)

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -8,7 +8,7 @@ A vector in 3D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 3>
+FixedSizeList<3, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -5,9 +5,11 @@ title: "Vec4D"
 
 A vector in 4D space.
 
-## Fields
 
-* xyzw: 4x `f32`
+## Arrow datatype
+```
+FixedSizeList<float32, 4>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `Vec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec4D.html)

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -8,7 +8,7 @@ A vector in 4D space.
 
 ## Arrow datatype
 ```
-FixedSizeList<float32, 4>
+FixedSizeList<4, float32>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/video_timestamp.md
+++ b/docs/content/reference/types/datatypes/video_timestamp.md
@@ -8,9 +8,11 @@ Presentation timestamp within a [`archetypes.AssetVideo`](https://rerun.io/docs/
 Specified in nanoseconds.
 Presentation timestamps are typically measured as time since video start.
 
-## Fields
 
-* timestamp_ns: `i64`
+## Arrow datatype
+```
+int64
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `VideoTimestamp`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1VideoTimestamp.html)

--- a/docs/content/reference/types/datatypes/view_coordinates.md
+++ b/docs/content/reference/types/datatypes/view_coordinates.md
@@ -25,7 +25,7 @@ The following constants are used to represent the different directions:
 
 ## Arrow datatype
 ```
-FixedSizeList<uint8, 3>
+FixedSizeList<3, uint8>
 ```
 
 ## API reference links

--- a/docs/content/reference/types/datatypes/view_coordinates.md
+++ b/docs/content/reference/types/datatypes/view_coordinates.md
@@ -22,9 +22,11 @@ The following constants are used to represent the different directions:
  * Forward = 5
  * Back = 6
 
-## Fields
 
-* coordinates: 3x `u8`
+## Arrow datatype
+```
+FixedSizeList<uint8, 3>
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ViewCoordinates.html)

--- a/docs/content/reference/types/datatypes/visible_time_range.md
+++ b/docs/content/reference/types/datatypes/visible_time_range.md
@@ -6,10 +6,14 @@ title: "VisibleTimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
-#### `timeline`: [`Utf8`](../datatypes/utf8.md)
+#### `timeline`
+Type: [`Utf8`](../datatypes/utf8.md)
+
 Name of the timeline this applies to.
 
-#### `range`: [`TimeRange`](../datatypes/time_range.md)
+#### `range`
+Type: [`TimeRange`](../datatypes/time_range.md)
+
 Time range to use for this timeline.
 
 

--- a/docs/content/reference/types/datatypes/visible_time_range.md
+++ b/docs/content/reference/types/datatypes/visible_time_range.md
@@ -6,8 +6,12 @@ title: "VisibleTimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
-* `timeline`: [`Utf8`](../datatypes/utf8.md)
-* `range`: [`TimeRange`](../datatypes/time_range.md)
+#### `timeline`: [`Utf8`](../datatypes/utf8.md)
+Name of the timeline this applies to.
+
+#### `range`: [`TimeRange`](../datatypes/time_range.md)
+Time range to use for this timeline.
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/datatypes/visible_time_range.md
+++ b/docs/content/reference/types/datatypes/visible_time_range.md
@@ -6,9 +6,29 @@ title: "VisibleTimeRange"
 Visible time range bounds for a specific timeline.
 
 ## Fields
+* `timeline`: [`Utf8`](../datatypes/utf8.md)
+* `range`: [`TimeRange`](../datatypes/time_range.md)
 
-* timeline: [`Utf8`](../datatypes/utf8.md)
-* range: [`TimeRange`](../datatypes/time_range.md)
+## Arrow datatype
+```
+Struct {
+    timeline: utf8
+    range: Struct {
+        start: DenseUnion {
+            0 = "_null_markers": nullable null
+            1 = "CursorRelative": int64
+            2 = "Absolute": int64
+            3 = "Infinite": nullable null
+        }
+        end: DenseUnion {
+            0 = "_null_markers": nullable null
+            1 = "CursorRelative": int64
+            2 = "Absolute": int64
+            3 = "Infinite": nullable null
+        }
+    }
+}
+```
 
 ## API reference links
  * 🌊 [C++ API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1VisibleTimeRange.html)


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/6818

Example output: https://github.com/rerun-io/rerun/blob/emilk/document-arrow-datatype/docs/content/reference/types/datatypes/image_format.md

The format of the arrow datatypes is far from perfect, but it is intelligible and explicit, so I think it is good enough for now.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7986?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7986?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7986)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.