### PR TITLE
Better error & download url if ffmpeg is missing

### DIFF
--- a/crates/store/re_video/src/decode/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg.rs
@@ -66,7 +66,11 @@ pub enum Error {
 
 impl From<Error> for super::Error {
     fn from(err: Error) -> Self {
-        Self::Ffmpeg(std::sync::Arc::new(err))
+        if let Error::FfmpegNotInstalled { download_url } = err {
+            Self::FfmpegNotInstalled { download_url }
+        } else {
+            Self::Ffmpeg(std::sync::Arc::new(err))
+        }
     }
 }
 

--- a/crates/store/re_video/src/decode/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg.rs
@@ -19,7 +19,7 @@ use super::{AsyncDecoder, Chunk, Frame, OutputCallback};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Requires an install of FFmpeg, none has been found in PATH.")]
+    #[error("Couldn't find an installation of the FFmpeg executable.")]
     FfmpegNotInstalled {
         /// Download URL for the latest version of `FFmpeg` on the current platform.
         /// None if the platform is not supported.

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -81,14 +81,16 @@
 mod async_decoder_wrapper;
 #[cfg(with_dav1d)]
 mod av1;
+
 #[cfg(with_ffmpeg)]
 mod ffmpeg;
+#[cfg(with_ffmpeg)]
+pub use ffmpeg::Error as FfmpegError;
+
 #[cfg(target_arch = "wasm32")]
 mod webcodecs;
 
 use crate::Time;
-
-pub use ffmpeg::Error as FfmpegError;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -88,6 +88,8 @@ mod webcodecs;
 
 use crate::Time;
 
+pub use ffmpeg::Error as FfmpegError;
+
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
     #[error("Unsupported codec: {0}")]
@@ -115,7 +117,7 @@ pub enum Error {
 
     #[cfg(with_ffmpeg)]
     #[error(transparent)]
-    Ffmpeg(std::sync::Arc<ffmpeg::Error>),
+    Ffmpeg(std::sync::Arc<FfmpegError>),
 
     #[error("Unsupported bits per component: {0}")]
     BadBitsPerComponent(usize),

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -84,8 +84,6 @@ mod av1;
 
 #[cfg(with_ffmpeg)]
 mod ffmpeg;
-#[cfg(with_ffmpeg)]
-pub use ffmpeg::Error as FfmpegError;
 
 #[cfg(target_arch = "wasm32")]
 mod webcodecs;
@@ -119,7 +117,16 @@ pub enum Error {
 
     #[cfg(with_ffmpeg)]
     #[error(transparent)]
-    Ffmpeg(std::sync::Arc<FfmpegError>),
+    Ffmpeg(std::sync::Arc<ffmpeg::Error>),
+
+    // We need to check for this one and don't want to infect more crates with the feature requirement.
+    #[error("Couldn't find an installation of the FFmpeg executable.")]
+    FfmpegNotInstalled {
+        /// Download URL for the latest version of `FFmpeg` on the current platform.
+        /// None if the platform is not supported.
+        // TODO(andreas): as of writing, ffmpeg-sidecar doesn't define a download URL for linux arm.
+        download_url: Option<&'static str>,
+    },
 
     #[error("Unsupported bits per component: {0}")]
     BadBitsPerComponent(usize),

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -154,6 +154,18 @@ pub fn show_video_blob_info(
 
                         Err(err) => {
                             ui.error_label_long(&err.to_string());
+
+                            if let re_renderer::video::VideoPlayerError::Decoding(
+                                re_video::decode::Error::Ffmpeg(ffmpeg),
+                            ) = err
+                            {
+                                if let re_video::decode::FfmpegError::FfmpegNotInstalled {
+                                    download_url: Some(url),
+                                } = ffmpeg.as_ref()
+                                {
+                                    ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
+                                }
+                            }
                         }
                     }
                 }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -156,15 +156,12 @@ pub fn show_video_blob_info(
                             ui.error_label_long(&err.to_string());
 
                             if let re_renderer::video::VideoPlayerError::Decoding(
-                                re_video::decode::Error::Ffmpeg(ffmpeg),
+                                re_video::decode::Error::FfmpegNotInstalled {
+                                    download_url: Some(url),
+                                },
                             ) = err
                             {
-                                if let re_video::decode::FfmpegError::FfmpegNotInstalled {
-                                    download_url: Some(url),
-                                } = ffmpeg.as_ref()
-                                {
-                                    ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
-                                }
+                                ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
                             }
                         }
                     }


### PR DESCRIPTION
### What

* part of #7607 

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/317d2d07-d544-4743-86ef-c1ae51168b16">


Future work:
* download for you in the viewer to a location we manage
* have location be an application setting

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7991?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7991?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7991)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.