### PR TITLE
Component docs: link to the rerun datatype the component wraps

### DIFF
--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -476,8 +476,16 @@ fn write_fields(objects: &Objects, o: &mut String, object: &Object) {
     }
 
     if object.is_arrow_transparent() {
-        debug_assert!(object.is_struct());
-        debug_assert_eq!(object.fields.len(), 1);
+        assert!(object.is_struct());
+        assert_eq!(object.fields.len(), 1);
+        let field_type = &object.fields[0].typ;
+        if object.kind == ObjectKind::Component && matches!(field_type, Type::Object(_)) {
+            putln!(o, "## Rerun datatype");
+            putln!(o, "{}", type_info(objects, field_type));
+            putln!(o);
+        } else {
+            // The arrow datatype section covers it
+        }
         return; // This is just a wrapper type, so don't show the "Fields" section
     }
 

--- a/docs/content/reference/types/components/albedo_factor.md
+++ b/docs/content/reference/types/components/albedo_factor.md
@@ -5,6 +5,9 @@ title: "AlbedoFactor"
 
 A color multiplier, usually applied to a whole entity, e.g. a mesh.
 
+## Rerun datatype
+[`Rgba32`](../datatypes/rgba32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/axis_length.md
+++ b/docs/content/reference/types/components/axis_length.md
@@ -5,6 +5,9 @@ title: "AxisLength"
 
 The length of an axis in local units of the space.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -5,6 +5,9 @@ title: "Blob"
 
 A binary blob of data.
 
+## Rerun datatype
+[`Blob`](../datatypes/blob.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -5,6 +5,9 @@ title: "ClassId"
 
 A 16-bit ID representing a type of semantic class.
 
+## Rerun datatype
+[`ClassId`](../datatypes/class_id.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -5,6 +5,9 @@ title: "ClearIsRecursive"
 
 Configures how a clear operation should behave - recursive or not.
 
+## Rerun datatype
+[`Bool`](../datatypes/bool.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -8,6 +8,9 @@ An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear 
 The color is stored as a 32-bit integer, where the most significant
 byte is `R` and the least significant byte is `A`.
 
+## Rerun datatype
+[`Rgba32`](../datatypes/rgba32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -12,6 +12,9 @@ this value would be `1000`.
 Note that the only effect on 2D views is the physical depth values shown when hovering the image.
 In 3D views on the other hand, this affects where the points of the point cloud are placed.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -10,6 +10,9 @@ making it impossible to transform the entity path into its parent's space and vi
 It *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.
 This is useful for specifying that a subgraph is independent of the rest of the scene.
 
+## Rerun datatype
+[`Bool`](../datatypes/bool.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -10,6 +10,9 @@ Within an entity draw order is governed by the order of the components.
 
 Draw order for entities with the same draw order is generally undefined.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/entity_path.md
+++ b/docs/content/reference/types/components/entity_path.md
@@ -5,6 +5,9 @@ title: "EntityPath"
 
 A path to an entity, usually to reference some data that is part of the target entity.
 
+## Rerun datatype
+[`EntityPath`](../datatypes/entity_path.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/fill_ratio.md
+++ b/docs/content/reference/types/components/fill_ratio.md
@@ -10,6 +10,9 @@ Valid range is from 0 to max float although typically values above 1.0 are not u
 
 Defaults to 1.0.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/gamma_correction.md
+++ b/docs/content/reference/types/components/gamma_correction.md
@@ -11,6 +11,9 @@ Used to adjust the gamma of a color or scalar value between 0 and 1 before rende
 Valid range is from 0 (excluding) to max float.
 Defaults to 1.0 unless otherwise specified.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/half_size2d.md
+++ b/docs/content/reference/types/components/half_size2d.md
@@ -10,6 +10,9 @@ Measured in its local coordinate system.
 The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
+## Rerun datatype
+[`Vec2D`](../datatypes/vec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/half_size3d.md
+++ b/docs/content/reference/types/components/half_size3d.md
@@ -10,6 +10,9 @@ Measured in its local coordinate system.
 The box extends both in negative and positive direction along each axis.
 Negative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/image_buffer.md
+++ b/docs/content/reference/types/components/image_buffer.md
@@ -7,6 +7,9 @@ A buffer that is known to store image data.
 
 To interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).
 
+## Rerun datatype
+[`Blob`](../datatypes/blob.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/image_format.md
+++ b/docs/content/reference/types/components/image_format.md
@@ -5,6 +5,9 @@ title: "ImageFormat"
 
 The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).
 
+## Rerun datatype
+[`ImageFormat`](../datatypes/image_format.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/image_plane_distance.md
+++ b/docs/content/reference/types/components/image_plane_distance.md
@@ -7,6 +7,9 @@ The distance from the camera origin to the image plane when the projection is sh
 
 This is only used for visualization purposes, and does not affect the projection itself.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -5,6 +5,9 @@ title: "KeypointId"
 
 A 16-bit ID representing a type of semantic keypoint within a class.
 
+## Rerun datatype
+[`KeypointId`](../datatypes/keypoint_id.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/lat_lon.md
+++ b/docs/content/reference/types/components/lat_lon.md
@@ -5,6 +5,9 @@ title: "LatLon"
 
 A geographical position expressed in EPSG:4326 latitude and longitude.
 
+## Rerun datatype
+[`DVec2D`](../datatypes/dvec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/length.md
+++ b/docs/content/reference/types/components/length.md
@@ -8,6 +8,9 @@ Length, or one-dimensional size.
 Measured in its local coordinate system; consult the archetype in use to determine which
 axis or part of the entity this is the length of.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/marker_size.md
+++ b/docs/content/reference/types/components/marker_size.md
@@ -5,6 +5,9 @@ title: "MarkerSize"
 
 Radius of a marker of a point in e.g. a 2D plot, measured in UI points.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -8,6 +8,9 @@ A standardized media type (RFC2046, formerly known as MIME types), encoded as a 
 The complete reference of officially registered media types is maintained by the IANA and can be
 consulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.
 
+## Rerun datatype
+[`Utf8`](../datatypes/utf8.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/name.md
+++ b/docs/content/reference/types/components/name.md
@@ -5,6 +5,9 @@ title: "Name"
 
 A display name, typically for an entity or a item like a plot series.
 
+## Rerun datatype
+[`Utf8`](../datatypes/utf8.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/opacity.md
+++ b/docs/content/reference/types/components/opacity.md
@@ -8,6 +8,9 @@ Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque
 The final opacity value may be a result of multiplication with alpha values as specified by other color sources.
 Unless otherwise specified, the default value is 1.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -15,6 +15,9 @@ Example:
    0.0     0.0    1.0
 ```
 
+## Rerun datatype
+[`Mat3x3`](../datatypes/mat3x3.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pose_rotation_axis_angle.md
+++ b/docs/content/reference/types/components/pose_rotation_axis_angle.md
@@ -5,6 +5,9 @@ title: "PoseRotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
 
+## Rerun datatype
+[`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pose_rotation_quat.md
+++ b/docs/content/reference/types/components/pose_rotation_quat.md
@@ -8,6 +8,9 @@ A 3D rotation expressed as a quaternion that doesn't propagate in the transform 
 Note: although the x,y,z,w components of the quaternion will be passed through to the
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
+## Rerun datatype
+[`Quaternion`](../datatypes/quaternion.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pose_scale3d.md
+++ b/docs/content/reference/types/components/pose_scale3d.md
@@ -9,6 +9,9 @@ A scale of 1.0 means no scaling.
 A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pose_transform_mat3x3.md
+++ b/docs/content/reference/types/components/pose_transform_mat3x3.md
@@ -17,6 +17,9 @@ row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
 row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
+## Rerun datatype
+[`Mat3x3`](../datatypes/mat3x3.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/pose_translation3d.md
+++ b/docs/content/reference/types/components/pose_translation3d.md
@@ -5,6 +5,9 @@ title: "PoseTranslation3D"
 
 A translation vector in 3D space that doesn't propagate in the transform hierarchy.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -5,6 +5,9 @@ title: "Position2D"
 
 A position in 2D space.
 
+## Rerun datatype
+[`Vec2D`](../datatypes/vec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -5,6 +5,9 @@ title: "Position3D"
 
 A position in 3D space.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -12,6 +12,9 @@ UI points are independent of zooming in Views, but are sensitive to the applicat
 at 100% UI scaling, UI points are equal to pixels
 The Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/range1d.md
+++ b/docs/content/reference/types/components/range1d.md
@@ -5,6 +5,9 @@ title: "Range1D"
 
 A 1D range, specifying a lower and upper bound.
 
+## Rerun datatype
+[`Range1D`](../datatypes/range1d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -7,6 +7,9 @@ Pixel resolution width & height, e.g. of a camera sensor.
 
 Typically in integer units, but for some use cases floating point may be used.
 
+## Rerun datatype
+[`Vec2D`](../datatypes/vec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/rotation_axis_angle.md
+++ b/docs/content/reference/types/components/rotation_axis_angle.md
@@ -5,6 +5,9 @@ title: "RotationAxisAngle"
 
 3D rotation represented by a rotation around a given axis.
 
+## Rerun datatype
+[`RotationAxisAngle`](../datatypes/rotation_axis_angle.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/rotation_quat.md
+++ b/docs/content/reference/types/components/rotation_quat.md
@@ -8,6 +8,9 @@ A 3D rotation expressed as a quaternion.
 Note: although the x,y,z,w components of the quaternion will be passed through to the
 datastore as provided, when used in the Viewer, quaternions will always be normalized.
 
+## Rerun datatype
+[`Quaternion`](../datatypes/quaternion.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -7,6 +7,9 @@ A scalar value, encoded as a 64-bit floating point.
 
 Used for time series plots.
 
+## Rerun datatype
+[`Float64`](../datatypes/float64.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/scale3d.md
+++ b/docs/content/reference/types/components/scale3d.md
@@ -9,6 +9,9 @@ A scale of 1.0 means no scaling.
 A scale of 2.0 means doubling the size.
 Each component scales along the corresponding axis.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/show_labels.md
+++ b/docs/content/reference/types/components/show_labels.md
@@ -9,6 +9,9 @@ The main purpose of this component existing separately from the labels themselve
 is to be overridden when desired, to allow hiding and showing from the viewer and
 blueprints.
 
+## Rerun datatype
+[`Bool`](../datatypes/bool.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/stroke_width.md
+++ b/docs/content/reference/types/components/stroke_width.md
@@ -5,6 +5,9 @@ title: "StrokeWidth"
 
 The width of a stroke specified in UI points.
 
+## Rerun datatype
+[`Float32`](../datatypes/float32.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -12,6 +12,9 @@ a 2D RGB Image, the shape would be `[height, width, channel]`.
 These dimensions are combined with an index to look up values from the `buffer` field,
 which stores a contiguous array of typed values.
 
+## Rerun datatype
+[`TensorData`](../datatypes/tensor_data.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/components/tensor_dimension_index_selection.md
@@ -5,6 +5,9 @@ title: "TensorDimensionIndexSelection"
 
 Specifies a concrete index on a tensor dimension.
 
+## Rerun datatype
+[`TensorDimensionIndexSelection`](../datatypes/tensor_dimension_index_selection.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/tensor_height_dimension.md
+++ b/docs/content/reference/types/components/tensor_height_dimension.md
@@ -5,6 +5,9 @@ title: "TensorHeightDimension"
 
 Specifies which dimension to use for height.
 
+## Rerun datatype
+[`TensorDimensionSelection`](../datatypes/tensor_dimension_selection.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/tensor_width_dimension.md
+++ b/docs/content/reference/types/components/tensor_width_dimension.md
@@ -5,6 +5,9 @@ title: "TensorWidthDimension"
 
 Specifies which dimension to use for width.
 
+## Rerun datatype
+[`TensorDimensionSelection`](../datatypes/tensor_dimension_selection.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/texcoord2d.md
+++ b/docs/content/reference/types/components/texcoord2d.md
@@ -20,6 +20,9 @@ V |           .
 This is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenGL,
 which places the origin at the bottom-left.
 
+## Rerun datatype
+[`Vec2D`](../datatypes/vec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -5,6 +5,9 @@ title: "Text"
 
 A string of text, e.g. for labels and text documents.
 
+## Rerun datatype
+[`Utf8`](../datatypes/utf8.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -13,6 +13,9 @@ Recommended to be one of:
 * `"DEBUG"`
 * `"TRACE"`
 
+## Rerun datatype
+[`Utf8`](../datatypes/utf8.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/transform_mat3x3.md
+++ b/docs/content/reference/types/components/transform_mat3x3.md
@@ -17,6 +17,9 @@ row 1 | flat_columns[1] flat_columns[4] flat_columns[7]
 row 2 | flat_columns[2] flat_columns[5] flat_columns[8]
 ```
 
+## Rerun datatype
+[`Mat3x3`](../datatypes/mat3x3.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/translation3d.md
+++ b/docs/content/reference/types/components/translation3d.md
@@ -5,6 +5,9 @@ title: "Translation3D"
 
 A translation vector in 3D space.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/triangle_indices.md
+++ b/docs/content/reference/types/components/triangle_indices.md
@@ -5,6 +5,9 @@ title: "TriangleIndices"
 
 The three indices of a triangle in a triangle mesh.
 
+## Rerun datatype
+[`UVec3D`](../datatypes/uvec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/value_range.md
+++ b/docs/content/reference/types/components/value_range.md
@@ -5,6 +5,9 @@ title: "ValueRange"
 
 Range of expected or valid values, specifying a lower and upper bound.
 
+## Rerun datatype
+[`Range1D`](../datatypes/range1d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/vector2d.md
+++ b/docs/content/reference/types/components/vector2d.md
@@ -5,6 +5,9 @@ title: "Vector2D"
 
 A vector in 2D space.
 
+## Rerun datatype
+[`Vec2D`](../datatypes/vec2d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -5,6 +5,9 @@ title: "Vector3D"
 
 A vector in 3D space.
 
+## Rerun datatype
+[`Vec3D`](../datatypes/vec3d.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/video_timestamp.md
+++ b/docs/content/reference/types/components/video_timestamp.md
@@ -5,6 +5,9 @@ title: "VideoTimestamp"
 
 Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).
 
+## Rerun datatype
+[`VideoTimestamp`](../datatypes/video_timestamp.md)
+
 
 ## Arrow datatype
 ```

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -22,6 +22,9 @@ The following constants are used to represent the different directions:
  * Forward = 5
  * Back = 6
 
+## Rerun datatype
+[`ViewCoordinates`](../datatypes/view_coordinates.md)
+
 
 ## Arrow datatype
 ```

--- a/examples/python/differentiable_blocks_world/README.md
+++ b/examples/python/differentiable_blocks_world/README.md
@@ -40,6 +40,4 @@ To stabilize the optimization and avoid local minima, a 3-stage optimization is 
 
 https://vimeo.com/865329177?autoplay=1&loop=1&autopause=0&background=1&muted=1&ratio=10000:8845
 
-Check out the [project page](https://www.tmonnier.com/DBW/), which also contains examples of physical simulation and scene editing enabled by this kind of scene decomposition.
-
-Also make sure to read the [paper](https://arxiv.org/abs/2307.05473) by Tom Monnier, Jake Austin, Angjoo Kanazawa, Alexei A. Efros, Mathieu Aubry. Interesting study of how to approach such a difficult optimization problem.
+Make sure to read the [paper](https://arxiv.org/abs/2307.05473) by Tom Monnier, Jake Austin, Angjoo Kanazawa, Alexei A. Efros, Mathieu Aubry. Interesting study of how to approach such a difficult optimization problem.


### PR DESCRIPTION
### What
* Follow-up to https://github.com/rerun-io/rerun/pull/7986

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7996?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/7996?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/7996)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.