### PR TITLE
Replace the "Options" submenu with a settings screen

### DIFF
--- a/crates/store/re_types/definitions/rerun/blueprint/components/map_provider.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/map_provider.fbs
@@ -14,16 +14,16 @@ enum MapProvider: ubyte (
 
     /// Mapbox Streets is a minimalistic map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxStreets,
 
     /// Mapbox Dark is a dark-themed map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxDark,
 
     /// Mapbox Satellite is a satellite map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxSatellite,
 }

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -29,17 +29,17 @@ pub enum MapProvider {
 
     /// Mapbox Streets is a minimalistic map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxStreets = 2,
 
     /// Mapbox Dark is a dark-themed map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxDark = 3,
 
     /// Mapbox Satellite is a satellite map designed by Mapbox.
     ///
-    /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxSatellite = 4,
 }
 
@@ -59,13 +59,13 @@ impl ::re_types_core::reflection::Enum for MapProvider {
         match self {
             Self::OpenStreetMap => "`OpenStreetMap` is the default map provider.",
             Self::MapboxStreets => {
-                "Mapbox Streets is a minimalistic map designed by Mapbox.\n\n**Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
+                "Mapbox Streets is a minimalistic map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
             }
             Self::MapboxDark => {
-                "Mapbox Dark is a dark-themed map designed by Mapbox.\n\n**Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
+                "Mapbox Dark is a dark-themed map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
             }
             Self::MapboxSatellite => {
-                "Mapbox Satellite is a satellite map designed by Mapbox.\n\n**Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
+                "Mapbox Satellite is a satellite map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
             }
         }
     }

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -41,10 +41,11 @@ impl MapSpaceViewState {
     // This method ensures that tiles is initialized and returns mutable references to tiles and map_memory.
     pub fn ensure_and_get_mut_refs(
         &mut self,
-        ctx: &egui::Context,
+        ctx: &ViewerContext<'_>,
+        egui_ctx: &egui::Context,
     ) -> Result<(&mut HttpTiles, &mut MapMemory), SpaceViewSystemExecutionError> {
         if self.tiles.is_none() {
-            let tiles = get_tile_manager(self.selected_provider, ctx);
+            let tiles = get_tile_manager(ctx, self.selected_provider, egui_ctx);
             self.tiles = Some(tiles);
         }
 
@@ -217,7 +218,7 @@ Displays geospatial primitives on a map.
         // Map UI
         //
 
-        let (tiles, map_memory) = match state.ensure_and_get_mut_refs(ui.ctx()) {
+        let (tiles, map_memory) = match state.ensure_and_get_mut_refs(ctx, ui.ctx()) {
             Ok(refs) => refs,
             Err(err) => return Err(err),
         };
@@ -446,8 +447,12 @@ fn handle_ui_interactions(
     }
 }
 
-fn get_tile_manager(provider: MapProvider, egui_ctx: &Context) -> HttpTiles {
-    let mapbox_access_token = std::env::var("RERUN_MAPBOX_ACCESS_TOKEN").unwrap_or_default();
+fn get_tile_manager(
+    ctx: &ViewerContext<'_>,
+    provider: MapProvider,
+    egui_ctx: &Context,
+) -> HttpTiles {
+    let mapbox_access_token = ctx.app_options.mapbox_access_token().unwrap_or_default();
 
     match provider {
         MapProvider::OpenStreetMap => {

--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -40,6 +40,7 @@ pub enum UICommand {
     ToggleSelectionPanel,
     ToggleTimePanel,
     ToggleChunkStoreBrowser,
+    Settings,
 
     #[cfg(debug_assertions)]
     ToggleBlueprintInspectionPanel,
@@ -155,6 +156,7 @@ impl UICommand {
             Self::ToggleSelectionPanel => ("Toggle selection panel", "Toggle the right panel"),
             Self::ToggleTimePanel => ("Toggle time panel", "Toggle the bottom panel"),
             Self::ToggleChunkStoreBrowser => ("Toggle chunk store browser", "Toggle the chunk store browser"),
+            Self::Settings => ("Settings…", "Show the settings screen"),
 
             #[cfg(debug_assertions)]
             Self::ToggleBlueprintInspectionPanel => (
@@ -308,6 +310,7 @@ impl UICommand {
             Self::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
             Self::ToggleTimePanel => Some(ctrl_shift(Key::T)),
             Self::ToggleChunkStoreBrowser => Some(ctrl_shift(Key::D)),
+            Self::Settings => None,
 
             #[cfg(debug_assertions)]
             Self::ToggleBlueprintInspectionPanel => Some(ctrl_shift(Key::I)),

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -750,6 +750,10 @@ impl App {
                 self.toggle_fullscreen();
             }
 
+            UICommand::Settings => {
+                self.state.show_settings_ui = true;
+            }
+
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::ZoomIn => {
                 let mut zoom_factor = egui_ctx.zoom_factor();

--- a/crates/viewer/re_viewer/src/ui/mod.rs
+++ b/crates/viewer/re_viewer/src/ui/mod.rs
@@ -5,11 +5,12 @@ mod top_panel;
 mod welcome_screen;
 
 pub(crate) mod memory_panel;
+mod settings_screen;
 
 pub use recordings_panel::recordings_panel_ui;
 // ----
 
 pub(crate) use {
     self::mobile_warning_ui::mobile_warning_ui, self::top_panel::top_panel,
-    self::welcome_screen::WelcomeScreen,
+    self::welcome_screen::WelcomeScreen, settings_screen::settings_screen_ui,
 };

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -83,7 +83,7 @@ impl App {
             UICommand::Settings.menu_button_ui(ui, &self.command_sender);
 
             #[cfg(target_arch = "wasm32")]
-            backend_menu_ui(&self.command_sender, ui, frame, &mut self.state.app_options);
+            backend_menu_ui(&self.command_sender, ui, frame);
 
             #[cfg(debug_assertions)]
             ui.menu_button("Debug", |ui| {

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -2,7 +2,7 @@
 
 use egui::NumExt as _;
 
-use re_ui::{UICommand, UiExt as _};
+use re_ui::UICommand;
 use re_viewer_context::StoreContext;
 
 use crate::App;
@@ -324,6 +324,8 @@ fn backend_menu_ui(
 
 #[cfg(debug_assertions)]
 fn egui_debug_options_ui(ui: &mut egui::Ui) {
+    use re_ui::UiExt as _;
+
     let mut debug = ui.style().debug;
     let mut any_clicked = false;
 
@@ -366,6 +368,8 @@ fn debug_menu_options_ui(
     app_options: &mut re_viewer_context::AppOptions,
     command_sender: &CommandSender,
 ) {
+    use re_ui::UiExt as _;
+
     #[cfg(not(target_arch = "wasm32"))]
     {
         if ui.button("Mobile size").clicked() {

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -2,7 +2,6 @@
 
 use egui::NumExt as _;
 
-use re_log_types::TimeZone;
 use re_ui::{UICommand, UiExt as _};
 use re_viewer_context::StoreContext;
 
@@ -81,10 +80,10 @@ impl App {
 
             ui.add_space(SPACING);
 
-            ui.menu_button("Options", |ui| {
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
-                options_menu_ui(&self.command_sender, ui, frame, &mut self.state.app_options);
-            });
+            UICommand::Settings.menu_button_ui(ui, &self.command_sender);
+
+            #[cfg(target_arch = "wasm32")]
+            backend_menu_ui(&self.command_sender, ui, frame, &mut self.state.app_options);
 
             #[cfg(debug_assertions)]
             ui.menu_button("Debug", |ui| {
@@ -302,99 +301,25 @@ fn render_state_ui(ui: &mut egui::Ui, render_state: &egui_wgpu::RenderState) {
     });
 }
 
-fn options_menu_ui(
-    _command_sender: &re_viewer_context::CommandSender,
+/// Adapter switching UI.
+// Only implemented for web so far. For native it's less well defined since the application may be
+// embedded in another application that reads arguments differently.
+#[cfg(target_arch = "wasm32")]
+fn backend_menu_ui(
+    command_sender: &re_viewer_context::CommandSender,
     ui: &mut egui::Ui,
     frame: &eframe::Frame,
-    app_options: &mut re_viewer_context::AppOptions,
 ) {
-    ui.re_checkbox(&mut app_options.show_metrics, "Show performance metrics")
-        .on_hover_text("Show metrics for milliseconds/frame and RAM usage in the top bar");
-
-    ui.horizontal(|ui| {
-        ui.label("Timezone:");
-    });
-    ui.horizontal(|ui| {
-        ui.re_radio_value(&mut app_options.time_zone, TimeZone::Utc, "UTC")
-            .on_hover_text("Display timestamps in UTC");
-        ui.re_radio_value(&mut app_options.time_zone, TimeZone::Local, "Local")
-            .on_hover_text("Display timestamps in the local timezone");
-        ui.re_radio_value(
-            &mut app_options.time_zone,
-            TimeZone::UnixEpoch,
-            "Unix epoch",
-        )
-        .on_hover_text("Display timestamps in seconds since unix epoch");
-    });
-
-    ui.re_checkbox(
-        &mut app_options.include_welcome_screen_button_in_recordings_panel,
-        "Show 'Welcome screen' button",
-    );
-
-    {
-        use re_video::decode::DecodeHardwareAcceleration;
-
-        let hardware_acceleration = &mut app_options.video_decoder_hw_acceleration;
-
-        ui.horizontal(|ui| {
-            ui.label("Video Decoder:");
-            egui::ComboBox::from_id_salt("video_decoder_hw_acceleration")
-                .selected_text(hardware_acceleration.to_string())
-                .show_ui(ui, |ui| {
-                    ui.selectable_value(
-                        hardware_acceleration,
-                        DecodeHardwareAcceleration::Auto,
-                        DecodeHardwareAcceleration::Auto.to_string(),
-                    ) | ui.selectable_value(
-                        hardware_acceleration,
-                        DecodeHardwareAcceleration::PreferSoftware,
-                        DecodeHardwareAcceleration::PreferSoftware.to_string(),
-                    ) | ui.selectable_value(
-                        hardware_acceleration,
-                        DecodeHardwareAcceleration::PreferHardware,
-                        DecodeHardwareAcceleration::PreferHardware.to_string(),
-                    )
-                });
-            // Note that the setting is part of the video's cache key, so if it changes the cache entries outdate automatically.
-        });
-    }
-
-    // Currently, the wasm target does not have any experimental features. Remove this conditional
-    // compilation directive if/when this changes.
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        ui.add_space(SPACING);
-        ui.label("Experimental features:");
-        experimental_feature_ui(ui, app_options);
-    }
-
-    if let Some(_backend) = frame
+    if let Some(backend) = frame
         .wgpu_render_state()
         .map(|state| state.adapter.get_info().backend)
     {
-        // Adapter switching only implemented for web so far.
-        // For native it's less well defined since the application may be embedded in another application that reads arguments differently.
-        #[cfg(target_arch = "wasm32")]
-        {
-            ui.add_space(SPACING);
-            if _backend == wgpu::Backend::BrowserWebGpu {
-                UICommand::RestartWithWebGl.menu_button_ui(ui, _command_sender);
-            } else {
-                UICommand::RestartWithWebGpu.menu_button_ui(ui, _command_sender);
-            }
+        if backend == wgpu::Backend::BrowserWebGpu {
+            UICommand::RestartWithWebGl.menu_button_ui(ui, command_sender);
+        } else {
+            UICommand::RestartWithWebGpu.menu_button_ui(ui, command_sender);
         }
     }
-}
-
-// IMPORTANT: if/when adding wasm-compatible experimental features, move this conditional
-// compilation directive to `space_view_screenshot` and remove the one above the call size of this
-// function!!
-#[cfg(not(target_arch = "wasm32"))]
-fn experimental_feature_ui(ui: &mut egui::Ui, app_options: &mut re_viewer_context::AppOptions) {
-    ui
-        .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
-        .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
 }
 
 #[cfg(debug_assertions)]

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -1,0 +1,143 @@
+use egui::NumExt as _;
+
+use re_log_types::TimeZone;
+use re_ui::UiExt as _;
+use re_video::decode::DecodeHardwareAcceleration;
+use re_viewer_context::AppOptions;
+
+pub fn settings_screen_ui(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_open: &mut bool) {
+    egui::Frame {
+        inner_margin: egui::Margin::same(5.0),
+        ..Default::default()
+    }
+    .show(ui, |ui| {
+        let min_width = 500.0;
+        let centering_margin = ((ui.available_width() - min_width) / 2.0).at_least(0.0);
+
+        let max_rect = ui.max_rect().expand2(-centering_margin * egui::Vec2::X);
+        let horizontal_scroll = max_rect.width() < 300.0;
+
+        let mut child_ui = ui.new_child(egui::UiBuilder::new().max_rect(max_rect));
+
+        egui::ScrollArea::new([horizontal_scroll, true])
+            .auto_shrink(false)
+            .show(&mut child_ui, |ui| {
+                settings_screen_ui_impl(ui, app_options, keep_open);
+            });
+
+        if ui.input_mut(|ui| ui.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
+            *keep_open = false;
+        }
+    });
+}
+
+fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_open: &mut bool) {
+    ui.add_space(40.0);
+
+    ui.horizontal(|ui| {
+        ui.add(egui::Label::new(
+            egui::RichText::new("Settings")
+                .strong()
+                .line_height(Some(32.0))
+                .text_style(re_ui::DesignTokens::welcome_screen_h2()),
+        ));
+
+        ui.allocate_ui_with_layout(
+            egui::Vec2::X * ui.available_width(),
+            egui::Layout::right_to_left(egui::Align::Center),
+            |ui| {
+                if ui.small_icon_button(&re_ui::icons::CLOSE).clicked() {
+                    *keep_open = false;
+                }
+            },
+        )
+    });
+
+    separator_with_some_space(ui);
+
+    ui.strong("General");
+
+    ui.re_checkbox(
+        &mut app_options.include_welcome_screen_button_in_recordings_panel,
+        "Show 'Welcome screen' button",
+    );
+
+    ui.re_checkbox(&mut app_options.show_metrics, "Show performance metrics")
+        .on_hover_text("Show metrics for milliseconds/frame and RAM usage in the top bar");
+
+    separator_with_some_space(ui);
+
+    ui.strong("Timezone");
+    ui.re_radio_value(&mut app_options.time_zone, TimeZone::Utc, "UTC")
+        .on_hover_text("Display timestamps in UTC");
+    ui.re_radio_value(&mut app_options.time_zone, TimeZone::Local, "Local")
+        .on_hover_text("Display timestamps in the local timezone");
+    ui.re_radio_value(
+        &mut app_options.time_zone,
+        TimeZone::UnixEpoch,
+        "Unix epoch",
+    )
+    .on_hover_text("Display timestamps in seconds since unix epoch");
+
+    separator_with_some_space(ui);
+
+    ui.strong("Map view");
+
+    ui.horizontal(|ui| {
+        ui.label("Mapbox access token:").on_hover_ui(|ui| {
+            ui.markdown_ui(
+                "This token is used toe enable Mapbox-based map view backgrounds.\n\n\
+                Note that the token will be saved in clear text in the configuration file. \
+                The token can also be set using the `RERUN_MAPBOX_ACCESS_TOKEN` environment \
+                variable.",
+            );
+        });
+
+        ui.add(egui::TextEdit::singleline(&mut app_options.mapbox_access_token).password(true));
+    });
+
+    separator_with_some_space(ui);
+
+    ui.strong("Video");
+
+    let hardware_acceleration = &mut app_options.video_decoder_hw_acceleration;
+    ui.horizontal(|ui| {
+        ui.label("Decoder:");
+        egui::ComboBox::from_id_salt("video_decoder_hw_acceleration")
+            .selected_text(hardware_acceleration.to_string())
+            .show_ui(ui, |ui| {
+                ui.selectable_value(
+                    hardware_acceleration,
+                    DecodeHardwareAcceleration::Auto,
+                    DecodeHardwareAcceleration::Auto.to_string(),
+                ) | ui.selectable_value(
+                    hardware_acceleration,
+                    DecodeHardwareAcceleration::PreferSoftware,
+                    DecodeHardwareAcceleration::PreferSoftware.to_string(),
+                ) | ui.selectable_value(
+                    hardware_acceleration,
+                    DecodeHardwareAcceleration::PreferHardware,
+                    DecodeHardwareAcceleration::PreferHardware.to_string(),
+                )
+            });
+        // Note that the setting is part of the video's cache key, so, if it changes, the cache
+        // entries outdate automatically.
+    });
+
+    // Currently, the wasm target does not have any experimental features. If/when that changes,
+    // move the conditional compilation flag to the respective checkbox code.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        separator_with_some_space(ui);
+        ui.label("Experimental features:");
+        ui
+            .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
+            .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");
+    }
+}
+
+fn separator_with_some_space(ui: &mut egui::Ui) {
+    ui.add_space(10.0);
+    ui.separator();
+    ui.add_space(10.0);
+}

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -11,17 +11,17 @@ pub fn settings_screen_ui(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_
         ..Default::default()
     }
     .show(ui, |ui| {
-        let min_width = 500.0;
-        let centering_margin = ((ui.available_width() - min_width) / 2.0).at_least(0.0);
+        const MAX_WIDTH: f32 = 600.0;
+        const MIN_WIDTH: f32 = 300.0;
 
+        let centering_margin = ((ui.available_width() - MAX_WIDTH) / 2.0).at_least(0.0);
         let max_rect = ui.max_rect().expand2(-centering_margin * egui::Vec2::X);
-        let horizontal_scroll = max_rect.width() < 300.0;
-
         let mut child_ui = ui.new_child(egui::UiBuilder::new().max_rect(max_rect));
 
-        egui::ScrollArea::new([horizontal_scroll, true])
+        egui::ScrollArea::both()
             .auto_shrink(false)
             .show(&mut child_ui, |ui| {
+                ui.set_min_width(MIN_WIDTH);
                 settings_screen_ui_impl(ui, app_options, keep_open);
             });
 
@@ -32,6 +32,10 @@ pub fn settings_screen_ui(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_
 }
 
 fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep_open: &mut bool) {
+    //
+    // Title
+    //
+
     ui.add_space(40.0);
 
     ui.horizontal(|ui| {
@@ -53,6 +57,10 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
         )
     });
 
+    //
+    // General
+    //
+
     separator_with_some_space(ui);
 
     ui.strong("General");
@@ -64,6 +72,10 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
 
     ui.re_checkbox(&mut app_options.show_metrics, "Show performance metrics")
         .on_hover_text("Show metrics for milliseconds/frame and RAM usage in the top bar");
+
+    //
+    // Timezone
+    //
 
     separator_with_some_space(ui);
 
@@ -78,6 +90,10 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
         "Unix epoch",
     )
     .on_hover_text("Display timestamps in seconds since unix epoch");
+
+    //
+    // Map view
+    //
 
     separator_with_some_space(ui);
 
@@ -95,6 +111,10 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
 
         ui.add(egui::TextEdit::singleline(&mut app_options.mapbox_access_token).password(true));
     });
+
+    //
+    // Video
+    //
 
     separator_with_some_space(ui);
 
@@ -124,12 +144,16 @@ fn settings_screen_ui_impl(ui: &mut egui::Ui, app_options: &mut AppOptions, keep
         // entries outdate automatically.
     });
 
+    //
+    // Experimental features
+    //
+
     // Currently, the wasm target does not have any experimental features. If/when that changes,
     // move the conditional compilation flag to the respective checkbox code.
     #[cfg(not(target_arch = "wasm32"))]
     {
         separator_with_some_space(ui);
-        ui.label("Experimental features:");
+        ui.strong("Experimental features");
         ui
             .re_checkbox(&mut app_options.experimental_space_view_screenshots, "Space view screenshots")
             .on_hover_text("Allow taking screenshots of 2D and 3D space views via their context menu. Does not contain labels.");

--- a/crates/viewer/re_viewer_context/src/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/app_options.rs
@@ -1,5 +1,7 @@
 use re_log_types::TimeZone;
 
+const MAPBOX_ACCESS_TOKEN_ENV_VAR: &str = "RERUN_MAPBOX_ACCESS_TOKEN";
+
 /// Global options for the viewer.
 #[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(default)]
@@ -32,6 +34,11 @@ pub struct AppOptions {
 
     /// Hardware acceleration settings for video decoding.
     pub video_decoder_hw_acceleration: re_video::decode::DecodeHardwareAcceleration,
+
+    /// Mapbox API key (used to enable Mapbox-based map view backgrounds).
+    ///
+    /// Can also be set using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    pub mapbox_access_token: String,
 }
 
 impl Default for AppOptions {
@@ -56,6 +63,18 @@ impl Default for AppOptions {
             time_zone: TimeZone::Utc,
 
             video_decoder_hw_acceleration: Default::default(),
+
+            mapbox_access_token: String::new(),
+        }
+    }
+}
+
+impl AppOptions {
+    pub fn mapbox_access_token(&self) -> Option<String> {
+        if self.mapbox_access_token.is_empty() {
+            std::env::var(MAPBOX_ACCESS_TOKEN_ENV_VAR).ok()
+        } else {
+            Some(self.mapbox_access_token.clone())
         }
     }
 }

--- a/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
@@ -28,17 +28,17 @@ namespace rerun::blueprint::components {
 
         /// Mapbox Streets is a minimalistic map designed by Mapbox.
         ///
-        /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxStreets = 2,
 
         /// Mapbox Dark is a dark-themed map designed by Mapbox.
         ///
-        /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxDark = 3,
 
         /// Mapbox Satellite is a satellite map designed by Mapbox.
         ///
-        /// **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxSatellite = 4,
     };
 } // namespace rerun::blueprint::components

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
@@ -31,21 +31,21 @@ class MapProvider(Enum):
     """
     Mapbox Streets is a minimalistic map designed by Mapbox.
 
-    **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     """
 
     MapboxDark = 3
     """
     Mapbox Dark is a dark-themed map designed by Mapbox.
 
-    **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     """
 
     MapboxSatellite = 4
     """
     Mapbox Satellite is a satellite map designed by Mapbox.
 
-    **Note**: Requires a Mapbox API key in the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
+    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     """
 
     @classmethod


### PR DESCRIPTION
### What

This PR:
- removes the `Options` submenu and replace it with a full-window "Settings" screen
- moves the `Restart with WebGPU/WebGL` menu item to the top-level in the rerun menu (wasm only)
- add a field for the Mapbox access token in the settings
- fixes #7849



<img width="1265" alt="image" src="https://github.com/user-attachments/assets/f55ce903-d1e9-4cb1-b229-512c8958a5e5">

<br/><br/>

Web viewer:

<img width="246" alt="image" src="https://github.com/user-attachments/assets/c7d53cf0-00d2-41de-8ddd-9a19b7143834">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8001?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8001?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8001)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.