### PR TITLE
Add warning for using an old version of ffmpeg, be accomodating for log quirks of older versions

### DIFF
--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -887,7 +887,7 @@ fn should_ignore_log_msg(msg: &str) -> bool {
 /// Strips out buffer addresses from `FFmpeg` log messages so that we can use it with the log-once family of methods.
 fn sanitize_ffmpeg_log_message(msg: &str) -> String {
     // Make warn_once work on `[swscaler @ 0x148db8000]` style warnings even if the address is different every time.
-    // In older versions of FFmpeg this may happen several times in the same message (happend in 5.1, did not happen in 7.1).
+    // In older versions of FFmpeg this may happen several times in the same message (happens in 5.1, did not happen in 7.1).
     let mut msg = msg.to_owned();
     while let Some(start_pos) = msg.find("[swscaler @ 0x") {
         if let Some(end_offset) = msg[start_pos..].find(']') {

--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -907,6 +907,8 @@ fn sanitize_ffmpeg_log_message(msg: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::sanitize_ffmpeg_log_message;
+
     #[test]
     fn test_sanitize_ffmpeg_log_message() {
         assert_eq!(

--- a/crates/store/re_video/src/decode/ffmpeg_h264/nalu.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/nalu.rs
@@ -86,6 +86,7 @@ impl NalHeader {
     }
 
     /// Ref idc is a value from 0-3 that tells us how "important" the frame/sample is.
+    #[allow(dead_code)]
     pub fn ref_idc(self) -> u8 {
         (self.0 >> 5) & 0b11
     }


### PR DESCRIPTION
### What

* part of https://github.com/rerun-io/rerun/issues/7607

Most replacing randomness with warnings. I haven't deep dived on which version will work but 5.1 went fine with my test data minus a bit of log spam which I fixed here.

I considered adding a check for coded availability, but this seems a bit cumbersome given that any off-the-shelf ffmpeg install comes with h264: the problem is that while we get a full string of compile options that ffmpeg was built with, we can't really infer the decoders from this since any given library may fulfill various roles. Instead we'd need to parse the output of `ffmpeg -codecs`. We should eventually! But doesn't seem urgent right now.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8005?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8005?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8005)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.