### PR TITLE
Disable `MapProvider` variant when not available

### DIFF
--- a/crates/store/re_types/definitions/rerun/blueprint/components/map_provider.fbs
+++ b/crates/store/re_types/definitions/rerun/blueprint/components/map_provider.fbs
@@ -13,17 +13,11 @@ enum MapProvider: ubyte (
     OpenStreetMap (default),
 
     /// Mapbox Streets is a minimalistic map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxStreets,
 
     /// Mapbox Dark is a dark-themed map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxDark,
 
     /// Mapbox Satellite is a satellite map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxSatellite,
 }

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -28,18 +28,12 @@ pub enum MapProvider {
     OpenStreetMap = 1,
 
     /// Mapbox Streets is a minimalistic map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxStreets = 2,
 
     /// Mapbox Dark is a dark-themed map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxDark = 3,
 
     /// Mapbox Satellite is a satellite map designed by Mapbox.
-    ///
-    /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     MapboxSatellite = 4,
 }
 
@@ -58,15 +52,9 @@ impl ::re_types_core::reflection::Enum for MapProvider {
     fn docstring_md(self) -> &'static str {
         match self {
             Self::OpenStreetMap => "`OpenStreetMap` is the default map provider.",
-            Self::MapboxStreets => {
-                "Mapbox Streets is a minimalistic map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
-            }
-            Self::MapboxDark => {
-                "Mapbox Dark is a dark-themed map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
-            }
-            Self::MapboxSatellite => {
-                "Mapbox Satellite is a satellite map designed by Mapbox.\n\n**Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
-            }
+            Self::MapboxStreets => "Mapbox Streets is a minimalistic map designed by Mapbox.",
+            Self::MapboxDark => "Mapbox Dark is a dark-themed map designed by Mapbox.",
+            Self::MapboxSatellite => "Mapbox Satellite is a satellite map designed by Mapbox.",
         }
     }
 }

--- a/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
@@ -11,7 +11,7 @@ pub enum VariantAvailable {
 
     /// The variant is not available.
     No {
-        /// The reason why the variant is not available, markdown formated.
+        /// The reason why the variant is not available, markdown formatted.
         reason_markdown: String,
     },
 }

--- a/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/enum_combobox.rs
@@ -3,16 +3,70 @@ use re_viewer_context::{MaybeMutRef, ViewerContext};
 
 use crate::response_utils::response_with_changes_of_inner;
 
+/// Is a particular variant of an enum available for selection? If not, why?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VariantAvailable {
+    /// The variant is available
+    Yes,
+
+    /// The variant is not available.
+    No {
+        /// The reason why the variant is not available, markdown formated.
+        reason_markdown: String,
+    },
+}
+
+/// Trait for a type that can provide information about whether a particular variant of an enum is
+/// available for selection.
+pub trait VariantAvailableProvider<EnumT: re_types_core::reflection::Enum> {
+    fn is_variant_enabled(ctx: &ViewerContext<'_>, variant: EnumT) -> VariantAvailable;
+}
+
+/// A variant available provider that makes all variants available.
+struct AllEnumVariantAvailable<EnumT: re_types_core::reflection::Enum> {
+    _phantom: std::marker::PhantomData<EnumT>,
+}
+
+impl<EnumT: re_types_core::reflection::Enum> VariantAvailableProvider<EnumT>
+    for AllEnumVariantAvailable<EnumT>
+{
+    fn is_variant_enabled(_ctx: &ViewerContext<'_>, _variant: EnumT) -> VariantAvailable {
+        VariantAvailable::Yes
+    }
+}
+
+/// Edit or view an enum value using a combobox. All variants are available.
 pub fn edit_view_enum<EnumT: re_types_core::reflection::Enum + re_types_core::Component>(
-    _ctx: &ViewerContext<'_>,
+    ctx: &ViewerContext<'_>,
+    ui: &mut egui::Ui,
+    current_value: &mut MaybeMutRef<'_, EnumT>,
+) -> egui::Response {
+    edit_view_enum_with_variant_available::<EnumT, AllEnumVariantAvailable<EnumT>>(
+        ctx,
+        ui,
+        current_value,
+    )
+}
+
+/// Edit or view an enum value using a combobox. The availability of each variant is determined by
+/// the provided `VariantAvailableProvider` type.
+pub fn edit_view_enum_with_variant_available<
+    EnumT: re_types_core::reflection::Enum + re_types_core::Component,
+    VariantAvailT: VariantAvailableProvider<EnumT>,
+>(
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     current_value: &mut MaybeMutRef<'_, EnumT>,
 ) -> egui::Response {
     let id_salt = EnumT::name().full_name();
-    edit_view_enum_impl(ui, id_salt, current_value)
+    edit_view_enum_impl::<_, VariantAvailT>(ctx, ui, id_salt, current_value)
 }
 
-fn edit_view_enum_impl<EnumT: re_types_core::reflection::Enum>(
+fn edit_view_enum_impl<
+    EnumT: re_types_core::reflection::Enum,
+    VariantAvailT: VariantAvailableProvider<EnumT>,
+>(
+    ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     id_salt: &str,
     current_value: &mut MaybeMutRef<'_, EnumT>,
@@ -32,9 +86,19 @@ fn edit_view_enum_impl<EnumT: re_types_core::reflection::Enum>(
                     return ui.label("<no variants>");
                 };
 
-                let mut response = variant_ui(ui, current_value, first);
+                let mut response = crate::datatype_uis::enum_combobox::variant_ui(
+                    ui,
+                    current_value,
+                    first,
+                    VariantAvailT::is_variant_enabled(ctx, first),
+                );
                 for variant in iter {
-                    response |= variant_ui(ui, current_value, variant);
+                    response |= variant_ui(
+                        ui,
+                        current_value,
+                        variant,
+                        VariantAvailT::is_variant_enabled(ctx, variant),
+                    );
                 }
                 response
             });
@@ -53,9 +117,24 @@ fn variant_ui<EnumT: re_types_core::reflection::Enum>(
     ui: &mut egui::Ui,
     current_value: &mut EnumT,
     variant: EnumT,
+    variant_available: VariantAvailable,
 ) -> egui::Response {
-    ui.selectable_value(current_value, variant, variant.to_string())
-        .on_hover_ui(|ui| {
-            ui.markdown_ui(variant.docstring_md());
-        })
+    match variant_available {
+        VariantAvailable::Yes => ui
+            .selectable_value(current_value, variant, variant.to_string())
+            .on_hover_ui(|ui| {
+                ui.markdown_ui(variant.docstring_md());
+            }),
+        VariantAvailable::No {
+            reason_markdown: reason,
+        } => {
+            ui.add_enabled_ui(false, |ui| {
+                ui.selectable_value(current_value, variant, variant.to_string())
+                    .on_disabled_hover_ui(|ui| {
+                        ui.markdown_ui(&format!("{}\n\n{}", variant.docstring_md(), reason));
+                    })
+            })
+            .inner
+        }
+    }
 }

--- a/crates/viewer/re_component_ui/src/datatype_uis/mod.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/mod.rs
@@ -7,7 +7,10 @@ mod vec;
 mod view_id;
 
 pub use bool_toggle::edit_bool;
-pub use enum_combobox::edit_view_enum;
+pub use enum_combobox::{
+    edit_view_enum, edit_view_enum_with_variant_available, VariantAvailable,
+    VariantAvailableProvider,
+};
 pub use float_drag::{
     edit_f32_min_to_max_float, edit_f32_zero_to_max, edit_f32_zero_to_one,
     edit_f64_float_raw_with_speed_impl,

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -9,6 +9,7 @@ mod entity_path;
 mod fallback_ui;
 mod image_format;
 mod line_strip;
+mod map_provider;
 mod marker_shape;
 mod pinhole;
 mod radius;
@@ -27,6 +28,7 @@ use datatype_uis::{
     edit_view_enum, edit_view_range1d, view_view_id,
 };
 
+use crate::datatype_uis::edit_view_enum_with_variant_available;
 use re_types::{
     blueprint::components::{
         BackgroundKind, Corner2D, LockRangeDuringZoom, MapProvider, ViewFit, Visible, ZoomLevel,
@@ -94,7 +96,12 @@ pub fn create_component_ui_registry() -> re_viewer_context::ComponentUiRegistry 
     registry.add_singleline_edit_or_view::<Corner2D>(edit_view_enum);
     registry.add_singleline_edit_or_view::<FillMode>(edit_view_enum);
     registry.add_singleline_edit_or_view::<MagnificationFilter>(edit_view_enum);
-    registry.add_singleline_edit_or_view::<MapProvider>(edit_view_enum);
+    registry.add_singleline_edit_or_view::<MapProvider>(
+        edit_view_enum_with_variant_available::<
+            MapProvider,
+            crate::map_provider::MapProviderVariantAvailable,
+        >,
+    );
     registry.add_singleline_edit_or_view::<TransformRelation>(edit_view_enum);
     registry.add_singleline_edit_or_view::<ViewFit>(edit_view_enum);
 

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -25,10 +25,9 @@ mod zoom_level;
 use datatype_uis::{
     display_name_ui, display_text_ui, edit_bool, edit_f32_min_to_max_float, edit_f32_zero_to_max,
     edit_f32_zero_to_one, edit_multiline_string, edit_or_view_vec3d, edit_singleline_string,
-    edit_view_enum, edit_view_range1d, view_view_id,
+    edit_view_enum, edit_view_enum_with_variant_available, edit_view_range1d, view_view_id,
 };
 
-use crate::datatype_uis::edit_view_enum_with_variant_available;
 use re_types::{
     blueprint::components::{
         BackgroundKind, Corner2D, LockRangeDuringZoom, MapProvider, ViewFit, Visible, ZoomLevel,

--- a/crates/viewer/re_component_ui/src/map_provider.rs
+++ b/crates/viewer/re_component_ui/src/map_provider.rs
@@ -1,0 +1,30 @@
+use re_types::blueprint::components::MapProvider;
+use re_viewer_context::ViewerContext;
+
+use crate::datatype_uis::{VariantAvailable, VariantAvailableProvider};
+
+pub struct MapProviderVariantAvailable;
+
+impl VariantAvailableProvider<MapProvider> for MapProviderVariantAvailable {
+    fn is_variant_enabled(ctx: &ViewerContext<'_>, variant: MapProvider) -> VariantAvailable {
+        let map_box_available = if ctx
+            .app_options
+            .mapbox_access_token()
+            .is_some_and(|token| !token.is_empty())
+        {
+            VariantAvailable::Yes
+        } else {
+            VariantAvailable::No {
+                reason_markdown: "Mapbox access token is not set. ".to_owned(),
+            }
+        };
+
+        match variant {
+            MapProvider::OpenStreetMap => VariantAvailable::Yes,
+
+            MapProvider::MapboxStreets | MapProvider::MapboxDark | MapProvider::MapboxSatellite => {
+                map_box_available
+            }
+        }
+    }
+}

--- a/crates/viewer/re_component_ui/src/map_provider.rs
+++ b/crates/viewer/re_component_ui/src/map_provider.rs
@@ -15,7 +15,9 @@ impl VariantAvailableProvider<MapProvider> for MapProviderVariantAvailable {
             VariantAvailable::Yes
         } else {
             VariantAvailable::No {
-                reason_markdown: "Mapbox access token is not set. ".to_owned(),
+                reason_markdown: "A Mapbox access token is not available. You can set it in the \
+                settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable."
+                    .to_owned(),
             }
         };
 

--- a/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
+++ b/rerun_cpp/src/rerun/blueprint/components/map_provider.hpp
@@ -27,18 +27,12 @@ namespace rerun::blueprint::components {
         OpenStreetMap = 1,
 
         /// Mapbox Streets is a minimalistic map designed by Mapbox.
-        ///
-        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxStreets = 2,
 
         /// Mapbox Dark is a dark-themed map designed by Mapbox.
-        ///
-        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxDark = 3,
 
         /// Mapbox Satellite is a satellite map designed by Mapbox.
-        ///
-        /// **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
         MapboxSatellite = 4,
     };
 } // namespace rerun::blueprint::components

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
@@ -28,25 +28,13 @@ class MapProvider(Enum):
     """`OpenStreetMap` is the default map provider."""
 
     MapboxStreets = 2
-    """
-    Mapbox Streets is a minimalistic map designed by Mapbox.
-
-    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
-    """
+    """Mapbox Streets is a minimalistic map designed by Mapbox."""
 
     MapboxDark = 3
-    """
-    Mapbox Dark is a dark-themed map designed by Mapbox.
-
-    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
-    """
+    """Mapbox Dark is a dark-themed map designed by Mapbox."""
 
     MapboxSatellite = 4
-    """
-    Mapbox Satellite is a satellite map designed by Mapbox.
-
-    **Note**: Requires a Mapbox access token in the settings or using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
-    """
+    """Mapbox Satellite is a satellite map designed by Mapbox."""
 
     @classmethod
     def auto(cls, val: str | int | MapProvider) -> MapProvider:


### PR DESCRIPTION
### What

This PR introduces a possibly over-engineered generic mechanism to control the availability of individual view property variant, and uses it to disable mapbox-based map background when the API key isn't properly set.

<img width="743" alt="image" src="https://github.com/user-attachments/assets/17c3aaf4-ce66-4335-9b21-543cb8730a9c">


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8006?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8006?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8006)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.