### PR TITLE
Improve video doc page

### DIFF
--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -45,7 +45,7 @@ Codec support varies in the web & native viewer:
 | ---------- | ------- | ------ |
 | AV1        | ✅       | ✅      |
 | H.264/avc  | ✅       | ✅      |
-| H.265/hevc | 🚧       | ❌      |
+| H.265/hevc | 🔳       | ❌      |
 | VP8        | ✅       | ❌      |
 | VP9        | ✅       | ❌      |
 
@@ -56,7 +56,7 @@ Details see below.
 When choosing a codec, we recommend [AV1](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#av1),
 as it seems to have the best overall playback support while also having very high compression quality.
 
-Since AV1 can have very long encoding times, it is often not yet suitable for streaming.
+Since AV1 can have very long encoding times, it is often not suitable for streaming.
 In those cases where encoding time matters, we recommend H.264/avc.
 
 ### Native viewer

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -27,27 +27,46 @@ snippet: archetypes/video_auto_frames
 Video support is new in Rerun, and has a few limitations:
 
 * [#7354](https://github.com/rerun-io/rerun/issues/7354): Only the MP4 container format is supported
-* [#7298](https://github.com/rerun-io/rerun/issues/7298): On native, only the AV1 codec is supported
 * [#7755](https://github.com/rerun-io/rerun/issues/7755): No AV1 support on Linux ARM
 * [#5181](https://github.com/rerun-io/rerun/issues/5181): There is no audio support
 * [#7594](https://github.com/rerun-io/rerun/issues/7594): HDR video is not supported
 * There is no video encoder in the Rerun SDK, so you need to create the video file yourself
-* A limited sets of codecs are supported on web (see below)
 
 ## Streaming video
 Rerun does not yet support streaming video support. For scenarios where you don't need live video, you can work around this limitation by logging many small `AssetVideo`s to the same Entity Path. See [#7484](https://github.com/rerun-io/rerun/issues/7484) for more.
 
 ## Codec support
+
+### Overview
+
+Codec support varies in the web & native viewer:
+
+|            | Browser | Native |
+| ---------- | ------- | ------ |
+| AV1        | ✅       | ✅      |
+| H.264/avc  | ✅       | ✅      |
+| H.265/hevc | 🚧       | ❌      |
+| VP8        | ✅       | ❌      |
+| VP9        | ✅       | ❌      |
+
+<!-- for web codecs see https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry -->
+
+Details see below.
+
 When choosing a codec, we recommend [AV1](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#av1),
 as it seems to have the best overall playback support while also having very high compression quality.
-AV1 is also patent-free, and is the only codec we currently support in the native viewer (see [#7298](https://github.com/rerun-io/rerun/issues/7298)). H.264/avc is another popular choice, and native support for that is coming soon.
+
+Since AV1 can have very long encoding times, it is often not yet suitable for streaming.
+In those cases where encoding time matters, we recommend H.264/avc.
 
 ### Native viewer
-In the native viewer, AV1 is the only supported codec. H.264 is coming soon ([#7298](https://github.com/rerun-io/rerun/issues/7298)).
 
+* AV1 is supported out of the box using a software decoder paired with gpu based image conversion
+* H.264/avc is supported via a system installed `FFmpeg` binary
+  * When no binary is found, Rerun offers a download link to a build of `FFmpeg` for your platform in the selection panel upon selecting the failed video
 
 ### Web viewer
-Video playback in the Rerun Web Viewer is done using the browser's own video decoder, so the supported codecs depend on your browser.
+Video playback in the Rerun Web Viewer is done using the browser's own video decoder, so the exact supported codecs depend on your browser.
 
 Overall, we recommend using Chrome or another Chromium-based browser, as it seems to have the best video support as of writing.
 
@@ -55,34 +74,24 @@ For decoding video in the Web Viewer, we use the [WebCodecs API](https://develop
 This API enables us to take advantage of the browser's hardware accelerated video decoding capabilities.
 It is implemented by all modern browsers, but with varying levels of support for different codecs, and varying levels of quality.
 
-With that in mind, here are the browsers which we have tested and verified to generally work:
-
-|            | Linux | macOS | Windows |
-| ---------- | ----- | ----- | ------- |
-| Firefox    | ✅[^1] | ✅     | ✅       |
-| Chrome[^2] | ✅     | ✅     | ✅[^3]   |
-| Safari     |       | ✅     |         |
-
-[^1]: Firefox on Linux has been observed to [stutter when playing back H.264 video](https://github.com/rerun-io/rerun/issues/7532).
-[^2]: Any Chromium-based browser should work, but we don't test all of them.
-[^3]: Chrome on Windows has been observed to stutter on playback. It can be mitigated by [using software decoding](https://rerun.io/docs/getting-started/troubleshooting#video-stuttering), but this may lead to high memory usage. See [#7595](https://github.com/rerun-io/rerun/issues/7595).
-
 When it comes to codecs, we aim to support any codec which the browser supports, but
 we currently cannot guarantee that all of them will work. For more information about
 which codecs are supported by which browser, see [Video codecs on MDN](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs#codec_details).
 
-At the moment, we test the following codecs:
+We tested the following codecs in more detail:
 
-|            | Linux Firefox | Linux Chrome | macOS Firefox | macOS Chrome | macOS Safari | Windows Firefox | Windows Chrome |
-| ---------- | ------------- | ------------ | ------------- | ------------ | ------------ | --------------- | -------------- |
-| AV1        | ✅             | ✅            | ✅             | ✅            | 🚧[^4]        | ✅               | ✅              |
-| H.264/avc  | ✅             | ✅            | ✅             | ✅            | ✅            | ✅               | ✅              |
-| H.265/hevc | ❌             | ❌            | ❌             | ✅            | 🚧[^6]        | ❌               | 🚧[^7]          |
+|            | Linux Firefox | Linux Chrome[^2] | macOS Firefox | macOS Chrome | macOS Safari | Windows Firefox | Windows Chrome[^3] |
+| ---------- | ------------- | ---------------- | ------------- | ------------ | ------------ | --------------- | ------------------ |
+| AV1        | ✅             | ✅                | ✅             | ✅            | 🚧[^4]        | ✅               | ✅                  |
+| H.264/avc  | ✅[^4]         | ✅                | ✅             | ✅            | ✅            | ✅               | ✅                  |
+| H.265/hevc | ❌             | ❌                | ❌             | ✅            | 🚧[^6]        | ❌               | 🚧[^7]              |
 
+[^1]: Firefox on Linux has been observed to [stutter when playing back H.264 video](https://github.com/rerun-io/rerun/issues/7532).
+[^2]: Any Chromium-based browser should work, but we don't test all of them.
+[^3]: Chrome on Windows has been observed to stutter on playback. It can be mitigated by [using software decoding](https://rerun.io/docs/getting-started/troubleshooting#video-stuttering), but this may lead to high memory usage. See [#7595](https://github.com/rerun-io/rerun/issues/7595).
 [^4]: Safari/WebKit does not support AV1 decoding except on [Apple Silicon devices with hardware support](https://webkit.org/blog/14445/webkit-features-in-safari-17-0/).
-[^5]: Firefox does not support H.265 decoding on any platform.
-[^6]: Safari/WebKit has been observed suttering when playing `hvc1` but working fine with `hevc1`. Despite support being advertised Safari 16.5 has been observed not support H.265 decoding.
-[^7]: Only supported if hardware encoding is available. Therefore always affected by Windows stuttering issues, see above.
+[^5]: Safari/WebKit has been observed suttering when playing `hvc1` but working fine with `hevc1`. Despite support being advertised Safari 16.5 has been observed not support H.265 decoding.
+[^6]: Only supported if hardware encoding is available. Therefore always affected by Windows stuttering issues, see above.
 
 Beyond this, for best compatibility we recommend:
 * prefer YUV over RGB & monochrome formats


### PR DESCRIPTION
### What

Mostly for updating it about the fact that we have ffmpeg now in the native viewer, but some more general polish and revamp.

This is the last ship-blocker for ffmpeg based h264 decoding, so this
* closes https://github.com/rerun-io/rerun/issues/7607

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8007?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8007?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8007)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.