### PR TITLE
Introducing Rerun Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/rerun-io/rerun/blob/main/LICENSE-MIT">    <img alt="MIT"            src="https://img.shields.io/badge/license-MIT-blue.svg">                        </a>
   <a href="https://github.com/rerun-io/rerun/blob/main/LICENSE-APACHE"> <img alt="Apache"         src="https://img.shields.io/badge/license-Apache-blue.svg">                     </a>
   <a href="https://discord.gg/Gcm8BbTaAj">                              <img alt="Rerun Discord"  src="https://img.shields.io/discord/1062300748202921994?label=Rerun%20Discord"> </a>
+  <a href="https://gurubase.io/g/rerun">                                <img alt="Gurubase"       src="https://img.shields.io/badge/Gurubase-Ask%20Rerun%20Guru-006BFF">           </a>
 </h1>
 
 # Time-aware multimodal data stack and visualizations


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Rerun Guru](https://gurubase.io/g/rerun) to Gurubase. Rerun Guru uses the data from this repo and data from the [docs](https://rerun.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Rerun Guru", which highlights that Rerun now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Rerun Guru in Gurubase, just let me know that's totally fine.