### PR TITLE
Add support for scene units in the map view

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
@@ -25,6 +25,9 @@ table GeoLineStrings (
   // --- Recommended ---
 
   /// Optional radii for the line strings.
+  ///
+  /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+  /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
   radii: [rerun.components.Radius] ("attr.rerun.component_recommended", nullable, order: 2000);
 
   /// Optional colors for the line strings.

--- a/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
@@ -26,7 +26,7 @@ table GeoLineStrings (
 
   /// Optional radii for the line strings.
   ///
-  /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+  /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
   /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
   radii: [rerun.components.Radius] ("attr.rerun.component_recommended", nullable, order: 2000);
 

--- a/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
@@ -21,6 +21,8 @@ table GeoPoints (
   // --- Recommended ---
 
   /// Optional radii for the points, effectively turning them into circles.
+  ///
+  /// *Note*: scene units radiii are interpreted as meters.
   radii: [rerun.components.Radius] ("attr.rerun.component_recommended", nullable, order: 2000);
 
   /// Optional colors for the points.

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -54,7 +54,7 @@ pub struct GeoLineStrings {
 
     /// Optional radii for the line strings.
     ///
-    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
     /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
     pub radii: Option<Vec<crate::components::Radius>>,
 
@@ -241,7 +241,7 @@ impl GeoLineStrings {
 
     /// Optional radii for the line strings.
     ///
-    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
     /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
     #[inline]
     pub fn with_radii(

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -53,6 +53,9 @@ pub struct GeoLineStrings {
     pub line_strings: Vec<crate::components::GeoLineString>,
 
     /// Optional radii for the line strings.
+    ///
+    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
     pub radii: Option<Vec<crate::components::Radius>>,
 
     /// Optional colors for the line strings.
@@ -237,6 +240,9 @@ impl GeoLineStrings {
     }
 
     /// Optional radii for the line strings.
+    ///
+    /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
     #[inline]
     pub fn with_radii(
         mut self,

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -54,6 +54,8 @@ pub struct GeoPoints {
     pub positions: Vec<crate::components::LatLon>,
 
     /// Optional radii for the points, effectively turning them into circles.
+    ///
+    /// *Note*: scene units radiii are interpreted as meters.
     pub radii: Option<Vec<crate::components::Radius>>,
 
     /// Optional colors for the points.
@@ -238,6 +240,8 @@ impl GeoPoints {
     }
 
     /// Optional radii for the points, effectively turning them into circles.
+    ///
+    /// *Note*: scene units radiii are interpreted as meters.
     #[inline]
     pub fn with_radii(
         mut self,

--- a/crates/viewer/re_space_view_map/src/visualizers/mod.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/mod.rs
@@ -92,6 +92,23 @@ pub fn update_span(span: &mut Option<GeoSpan>, other: Option<GeoSpan>) {
     }
 }
 
+/// Convert a [`re_types::components::Radius`] to a [`re_renderer::Size`], considering scene units
+/// as meters.
+#[inline]
+pub fn radius_to_size(
+    radius: re_types::components::Radius,
+    projector: &walkers::Projector,
+    position: walkers::Position,
+) -> re_renderer::Size {
+    re_renderer::Size(
+        radius
+            .scene_units()
+            .map(|radius_meter| projector.scale_pixel_per_meter(position) * radius_meter)
+            .or(radius.ui_points())
+            .unwrap_or_default(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/viewer/re_viewer/src/reflection/mod.rs
+++ b/crates/viewer/re_viewer/src/reflection/mod.rs
@@ -1256,7 +1256,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : true, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Radius".into(), display_name : "Radii",
                     docstring_md :
-                    "Optional radii for the line strings.\n\n*Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of\nthe first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).",
+                    "Optional radii for the line strings.\n\n*Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of\nthe first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).",
                     is_required : false, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Color".into(), display_name : "Colors",
                     docstring_md : "Optional colors for the line strings.", is_required :

--- a/crates/viewer/re_viewer/src/reflection/mod.rs
+++ b/crates/viewer/re_viewer/src/reflection/mod.rs
@@ -1255,8 +1255,9 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     "The line strings, expressed in [EPSG:4326](https://epsg.io/4326) coordinates (North/East-positive degrees).",
                     is_required : true, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Radius".into(), display_name : "Radii",
-                    docstring_md : "Optional radii for the line strings.", is_required :
-                    false, }, ArchetypeFieldReflection { component_name :
+                    docstring_md :
+                    "Optional radii for the line strings.\n\n*Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of\nthe first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).",
+                    is_required : false, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Color".into(), display_name : "Colors",
                     docstring_md : "Optional colors for the line strings.", is_required :
                     false, },
@@ -1274,7 +1275,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     is_required : true, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Radius".into(), display_name : "Radii",
                     docstring_md :
-                    "Optional radii for the points, effectively turning them into circles.",
+                    "Optional radii for the points, effectively turning them into circles.\n\n*Note*: scene units radiii are interpreted as meters.",
                     is_required : false, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.Color".into(), display_name : "Colors",
                     docstring_md : "Optional colors for the points.", is_required :

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -55,6 +55,9 @@ namespace rerun::archetypes {
         Collection<rerun::components::GeoLineString> line_strings;
 
         /// Optional radii for the line strings.
+        ///
+        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+        /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
         std::optional<Collection<rerun::components::Radius>> radii;
 
         /// Optional colors for the line strings.
@@ -75,6 +78,9 @@ namespace rerun::archetypes {
             : line_strings(std::move(_line_strings)) {}
 
         /// Optional radii for the line strings.
+        ///
+        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+        /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
         GeoLineStrings with_radii(Collection<rerun::components::Radius> _radii) && {
             radii = std::move(_radii);
             // See: https://github.com/rerun-io/rerun/issues/4027

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -56,7 +56,7 @@ namespace rerun::archetypes {
 
         /// Optional radii for the line strings.
         ///
-        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
         /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
         std::optional<Collection<rerun::components::Radius>> radii;
 
@@ -79,7 +79,7 @@ namespace rerun::archetypes {
 
         /// Optional radii for the line strings.
         ///
-        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+        /// *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
         /// the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
         GeoLineStrings with_radii(Collection<rerun::components::Radius> _radii) && {
             radii = std::move(_radii);

--- a/rerun_cpp/src/rerun/archetypes/geo_points.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_points.hpp
@@ -47,6 +47,8 @@ namespace rerun::archetypes {
         Collection<rerun::components::LatLon> positions;
 
         /// Optional radii for the points, effectively turning them into circles.
+        ///
+        /// *Note*: scene units radiii are interpreted as meters.
         std::optional<Collection<rerun::components::Radius>> radii;
 
         /// Optional colors for the points.
@@ -77,6 +79,8 @@ namespace rerun::archetypes {
             : positions(std::move(_positions)) {}
 
         /// Optional radii for the points, effectively turning them into circles.
+        ///
+        /// *Note*: scene units radiii are interpreted as meters.
         GeoPoints with_radii(Collection<rerun::components::Radius> _radii) && {
             radii = std::move(_radii);
             // See: https://github.com/rerun-io/rerun/issues/4027

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -83,7 +83,7 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
     )
     # Optional radii for the line strings.
     #
-    # *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    # *Note*: scene units radiii are interpreted as meters. Currently, the display scale only considers the latitude of
     # the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
     #
     # (Docstring intentionally commented out to hide this field from the docs)

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -83,6 +83,9 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
     )
     # Optional radii for the line strings.
     #
+    # *Note*: scene units radiii are interpreted as meters. Currently, the display scale only consideres the latitude of
+    # the first vertex of each line string (see [this issue](https://github.com/rerun-io/rerun/issues/8013)).
+    #
     # (Docstring intentionally commented out to hide this field from the docs)
 
     colors: components.ColorBatch | None = field(

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_points.py
@@ -84,6 +84,8 @@ class GeoPoints(GeoPointsExt, Archetype):
     )
     # Optional radii for the points, effectively turning them into circles.
     #
+    # *Note*: scene units radiii are interpreted as meters.
+    #
     # (Docstring intentionally commented out to hide this field from the docs)
 
     colors: components.ColorBatch | None = field(


### PR DESCRIPTION
### What

- Fixes #7872 
- Limitation: #8013

Add support for scene units (aka meter)  in the map view.

https://github.com/user-attachments/assets/012c86d7-70cd-4144-9e54-414570ca286e


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8015?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8015?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8015)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.