### PR TITLE
ChunkStore: fix row-id computation when removing dangling static chunks

### DIFF
--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -67,7 +67,7 @@ impl ChunkStore {
                     continue;
                 }
 
-                let Some((_row_id_min, row_id_max)) =
+                let Some((_row_id_min_for_component, row_id_max_for_component)) =
                     row_id_range_per_component.get(&component_name)
                 else {
                     continue;
@@ -81,24 +81,40 @@ impl ChunkStore {
                         // NOTE: When attempting to overwrite static data, the chunk with the most
                         // recent data within -- according to RowId -- wins.
 
-                        let (cur_row_id_min, cur_row_id_max) = self
+                        let cur_row_id_max_for_component = self
                             .chunks_per_chunk_id
                             .get(cur_chunk_id)
-                            .map_or((RowId::ZERO, RowId::ZERO), |chunk| {
+                            .map_or(RowId::ZERO, |chunk| {
                                 chunk
                                     .row_id_range_per_component()
                                     .get(&component_name)
-                                    .map_or(
-                                        (RowId::ZERO, RowId::ZERO),
-                                        |(row_id_min, row_id_max)| (*row_id_min, *row_id_max),
-                                    )
+                                    .map_or(RowId::ZERO, |(_, row_id_max)| *row_id_max)
                             });
-                        if *row_id_max > cur_row_id_max {
+
+                        if *row_id_max_for_component > cur_row_id_max_for_component {
                             // We are about to overwrite the existing chunk with the new one, at
                             // least for this one specific component.
                             // Keep track of the overwritten ChunkId: we'll need it further down in
                             // order to check whether that chunk is now dangling.
-                            overwritten_chunk_ids.insert(*cur_chunk_id, cur_row_id_min);
+
+                            // NOTE: The chunks themselves are indexed using the smallest RowId in
+                            // the chunk _as a whole_, as opposed to the smallest RowId of one
+                            // specific component in that chunk.
+                            let cur_row_id_min_for_chunk = self
+                                .chunks_per_chunk_id
+                                .get(cur_chunk_id)
+                                .and_then(|chunk| {
+                                    chunk.row_id_range().map(|(row_id_min, _)| row_id_min)
+                                });
+
+                            debug_assert!(
+                                cur_row_id_min_for_chunk.is_some(),
+                                "This condition cannot fail, we just want to avoid unwrapping",
+                            );
+                            if let Some(cur_row_id_min_for_chunk) = cur_row_id_min_for_chunk {
+                                overwritten_chunk_ids
+                                    .insert(*cur_chunk_id, cur_row_id_min_for_chunk);
+                            }
 
                             *cur_chunk_id = chunk.id();
                         }

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -113,9 +113,13 @@ impl ChunkStore {
                 None,                /* compacted */
             )];
 
-            // NOTE(1): Our chunks can only cover a single entity path at a time, therefore we know we
+            // NOTE: Our chunks can only cover a single entity path at a time, therefore we know we
             // only have to check that one entity for complete overwrite.
-            // NOTE(2): This condition cannot fail, we just want to avoid unwrapping.
+            debug_assert!(
+                self.static_chunk_ids_per_entity
+                    .contains_key(chunk.entity_path()),
+                "This condition cannot fail, we just want to avoid unwrapping",
+            );
             if let Some(per_component) = self.static_chunk_ids_per_entity.get(chunk.entity_path()) {
                 re_tracing::profile_scope!("static dangling checks");
 


### PR DESCRIPTION
The assertion was correct :partying_face::balloon:.

There was a real memleak in there when dealing with partially dangling static chunks (simplifying a bit: those are static chunks being overwritten for some components but not all, which is a very niche use case, thus why we've never hit it until now).

* Fixes #7992 

cc @grtlr 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8020?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8020?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8020)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.