### PR TITLE
Fix a bunch of broken feature flags

### DIFF
--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -359,9 +359,6 @@ impl UICommand {
             Self::RestartWithWebGl => None,
             #[cfg(target_arch = "wasm32")]
             Self::RestartWithWebGpu => None,
-
-            #[cfg(target_arch = "wasm32 ")]
-            Self::ViewportMode(_) => None,
         }
     }
 

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -230,7 +230,6 @@ pub fn customize_eframe_and_setup_renderer(
 // ---------------------------------------------------------------------------
 
 /// This wakes up the ui thread each time we receive a new message.
-#[cfg(not(feature = "web_viewer"))]
 #[cfg(not(target_arch = "wasm32"))]
 pub fn wake_up_ui_thread_on_each_msg<T: Send + 'static>(
     rx: re_smart_channel::Receiver<T>,

--- a/crates/viewer/re_viewer_context/src/image_info.rs
+++ b/crates/viewer/re_viewer_context/src/image_info.rs
@@ -164,7 +164,7 @@ impl ImageInfo {
             // But it can happen, e.g. when logging a `1x1xu8` image followed by a `1x1xf32` image
             // to the same entity path, and they are put in the same chunk.
 
-            if cfg!(debug_asserttions) {
+            if cfg!(debug_assertions) {
                 re_log::warn_once!(
                     "The image buffer was not aligned to the element type {}",
                     std::any::type_name::<T>()

--- a/crates/viewer/re_web_viewer_server/build.rs
+++ b/crates/viewer/re_web_viewer_server/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(disable_web_viewer_server)");
+}


### PR DESCRIPTION
Discovered them by temporarily upgrading to Rust 1.80, which landed the feature flag checker.

* [x] :fr: 