### PR TITLE
Fix some videos having offseted (incorrect) timestamps

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/video_frame_reference.fbs
@@ -19,6 +19,10 @@ table VideoFrameReference (
     ///
     /// Note that this uses the closest video frame instead of the latest at this timestamp
     /// in order to be more forgiving of rounding errors for inprecise timestamp types.
+    ///
+    /// Timestamps are relative to the start of the video, i.e. a timestamp of 0 always corresponds to the first frame.
+    /// This is oftentimes equivalent to presentation timestamps (known as PTS), but in the presence of B-frames
+    /// (bidirectionally predicted frames) there may be an offset on the first presentation timestamp in the video.
     timestamp: rerun.components.VideoTimestamp ("attr.rerun.component_required", required, order: 1000);
 
     // --- Optional ---

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -128,6 +128,10 @@ pub struct VideoFrameReference {
     ///
     /// Note that this uses the closest video frame instead of the latest at this timestamp
     /// in order to be more forgiving of rounding errors for inprecise timestamp types.
+    ///
+    /// Timestamps are relative to the start of the video, i.e. a timestamp of 0 always corresponds to the first frame.
+    /// This is oftentimes equivalent to presentation timestamps (known as PTS), but in the presence of B-frames
+    /// (bidirectionally predicted frames) there may be an offset on the first presentation timestamp in the video.
     pub timestamp: crate::components::VideoTimestamp,
 
     /// Optional reference to an entity with a [`archetypes::AssetVideo`][crate::archetypes::AssetVideo].

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -167,8 +167,7 @@ pub fn new_decoder(
 
     #[cfg(target_arch = "wasm32")]
     return Ok(Box::new(webcodecs::WebVideoDecoder::new(
-        video.config.clone(),
-        video.timescale,
+        video,
         hw_acceleration,
         on_output,
     )?));

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -282,7 +282,7 @@ impl Default for FrameInfo {
 
 impl FrameInfo {
     /// Presentation timestamp range in which this frame is valid.
-    pub fn time_range(&self) -> std::ops::Range<Time> {
+    pub fn presentation_time_range(&self) -> std::ops::Range<Time> {
         self.presentation_timestamp..self.presentation_timestamp + self.duration
     }
 }

--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -10,7 +10,7 @@ use web_sys::{
 use super::{
     AsyncDecoder, Chunk, DecodeHardwareAcceleration, Frame, FrameInfo, OutputCallback, Result,
 };
-use crate::{Config, Time, Timescale};
+use crate::{Config, Time, Timescale, VideoData};
 
 #[derive(Clone)]
 #[repr(transparent)]
@@ -34,6 +34,7 @@ impl std::ops::Deref for WebVideoFrame {
 pub struct WebVideoDecoder {
     video_config: Config,
     timescale: Timescale,
+    minimum_presentation_timestamp: Time,
     decoder: web_sys::VideoDecoder,
     hw_acceleration: DecodeHardwareAcceleration,
     on_output: Arc<OutputCallback>,
@@ -102,17 +103,21 @@ impl Drop for WebVideoDecoder {
 
 impl WebVideoDecoder {
     pub fn new(
-        video_config: Config,
-        timescale: Timescale,
+        video: &VideoData,
         hw_acceleration: DecodeHardwareAcceleration,
         on_output: impl Fn(Result<Frame>) + Send + Sync + 'static,
     ) -> Result<Self, Error> {
         let on_output = Arc::new(on_output);
-        let decoder = init_video_decoder(on_output.clone(), timescale)?;
+        let decoder = init_video_decoder(
+            on_output.clone(),
+            video.timescale,
+            video.sample_statistics.minimum_presentation_timestamp,
+        )?;
 
         Ok(Self {
-            video_config,
-            timescale,
+            video_config: video.config.clone(),
+            timescale: video.timescale,
+            minimum_presentation_timestamp: video.sample_statistics.minimum_presentation_timestamp,
             decoder,
             hw_acceleration,
             on_output,
@@ -133,10 +138,10 @@ impl AsyncDecoder for WebVideoDecoder {
             &data,
             video_chunk
                 .presentation_timestamp
-                .into_micros(self.timescale),
+                .into_micros_since_start(self.timescale, self.minimum_presentation_timestamp),
             type_,
         );
-        web_chunk.set_duration(video_chunk.duration.into_micros(self.timescale));
+        web_chunk.set_duration(video_chunk.duration.duration(self.timescale).as_secs_f64() * 1e6); // as_millis_f64 is experimental Rust api and there's no as_micros_f64
         let web_chunk = EncodedVideoChunk::new(&web_chunk)
             .map_err(|err| Error::CreateChunk(js_error_to_string(&err)))?;
         self.decoder
@@ -154,7 +159,11 @@ impl AsyncDecoder for WebVideoDecoder {
             // At least on Firefox, it can happen that reset on a previous error fails.
             // In that case, start over completely and try again!
             re_log::debug!("Video decoder reset failed, recreating decoder.");
-            self.decoder = init_video_decoder(self.on_output.clone(), self.timescale)?;
+            self.decoder = init_video_decoder(
+                self.on_output.clone(),
+                self.timescale,
+                self.minimum_presentation_timestamp,
+            )?;
         };
 
         self.decoder
@@ -171,13 +180,23 @@ impl AsyncDecoder for WebVideoDecoder {
 fn init_video_decoder(
     on_output_callback: Arc<OutputCallback>,
     timescale: Timescale,
+    minimum_presentation_timestamp: Time,
 ) -> Result<web_sys::VideoDecoder, Error> {
     let on_output = {
         let on_output = on_output_callback.clone();
         Closure::wrap(Box::new(move |frame: web_sys::VideoFrame| {
-            let presentation_timestamp =
-                Time::from_micros(frame.timestamp().unwrap_or(0.0), timescale);
-            let duration = Time::from_micros(frame.duration().unwrap_or(0.0), timescale);
+            // We assume that the timestamp returned by the decoder is in time since start,
+            // and does not represent demuxed "raw" presentation timestamps.
+            let presentation_timestamp = Time::from_micros_since_start(
+                frame.timestamp().unwrap_or(0.0),
+                timescale,
+                minimum_presentation_timestamp,
+            );
+            let duration = Time::from_micros_since_start(
+                frame.duration().unwrap_or(0.0),
+                timescale,
+                minimum_presentation_timestamp,
+            );
 
             on_output(Ok(Frame {
                 content: WebVideoFrame(frame),

--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -141,7 +141,10 @@ impl AsyncDecoder for WebVideoDecoder {
                 .into_micros_since_start(self.timescale, self.minimum_presentation_timestamp),
             type_,
         );
-        web_chunk.set_duration(video_chunk.duration.duration(self.timescale).as_secs_f64() * 1e6); // as_millis_f64 is experimental Rust api and there's no as_micros_f64
+
+        let duration_millis =
+            1e-3 * video_chunk.duration.duration(self.timescale).as_nanos() as f64;
+        web_chunk.set_duration(duration_millis);
         let web_chunk = EncodedVideoChunk::new(&web_chunk)
             .map_err(|err| Error::CreateChunk(js_error_to_string(&err)))?;
         self.decoder

--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -111,13 +111,13 @@ impl WebVideoDecoder {
         let decoder = init_video_decoder(
             on_output.clone(),
             video.timescale,
-            video.sample_statistics.minimum_presentation_timestamp,
+            video.samples_statistics.minimum_presentation_timestamp,
         )?;
 
         Ok(Self {
             video_config: video.config.clone(),
             timescale: video.timescale,
-            minimum_presentation_timestamp: video.sample_statistics.minimum_presentation_timestamp,
+            minimum_presentation_timestamp: video.samples_statistics.minimum_presentation_timestamp,
             decoder,
             hw_acceleration,
             on_output,

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -61,7 +61,7 @@ pub struct VideoData {
     pub samples: Vec<Sample>,
 
     /// Meta information about the samples.
-    pub sample_statistics: SampleStatistics,
+    pub samples_statistics: SamplesStatistics,
 
     /// All the tracks in the mp4; not just the video track.
     ///
@@ -71,7 +71,7 @@ pub struct VideoData {
 
 /// Meta informationa about the video samples.
 #[derive(Clone, Debug)]
-pub struct SampleStatistics {
+pub struct SamplesStatistics {
     /// The smallest presentation timestamp observed in this video.
     ///
     /// This is typically 0, but in the presence of B-frames, it may be non-zero.
@@ -91,7 +91,7 @@ pub struct SampleStatistics {
     pub dts_always_equal_pts: bool,
 }
 
-impl SampleStatistics {
+impl SamplesStatistics {
     pub fn new(samples: &[Sample]) -> Self {
         re_tracing::profile_function!();
 
@@ -290,7 +290,7 @@ impl VideoData {
                 .map(|pts| {
                     pts.into_nanos_since_start(
                         self.timescale,
-                        self.sample_statistics.minimum_presentation_timestamp,
+                        self.samples_statistics.minimum_presentation_timestamp,
                     )
                 })
         })

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -280,8 +280,6 @@ impl VideoData {
     /// These are *not* necessarily the same as the presentation timestamps, as the returned timestamps are
     /// normalized respect to the start of the video, see [`SampleStatistics::minimum_presentation_timestamp`].
     pub fn frame_timestamps_ns(&self) -> impl Iterator<Item = i64> + '_ {
-        re_tracing::profile_function!();
-
         // Segments are guaranteed to be sorted among each other, but within a segment,
         // presentation timestamps may not be sorted since this is sorted by decode timestamps.
         self.gops.iter().flat_map(|seg| {

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -278,7 +278,7 @@ impl VideoData {
     ///
     /// Returned timestamps are in nanoseconds since start and are guaranteed to be monotonically increasing.
     /// These are *not* necessarily the same as the presentation timestamps, as the returned timestamps are
-    /// normalized respect to the start of the video, see [`SampleStatistics::minimum_presentation_timestamp`].
+    /// normalized respect to the start of the video, see [`SamplesStatistics::minimum_presentation_timestamp`].
     pub fn frame_timestamps_ns(&self) -> impl Iterator<Item = i64> + '_ {
         // Segments are guaranteed to be sorted among each other, but within a segment,
         // presentation timestamps may not be sorted since this is sorted by decode timestamps.

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -138,7 +138,7 @@ impl VideoData {
     /// Length of the video.
     #[inline]
     pub fn duration(&self) -> std::time::Duration {
-        std::time::Duration::from_nanos(self.duration.into_nanos(self.timescale) as _)
+        self.duration.duration(self.timescale)
     }
 
     /// Natural width and height of the video
@@ -288,8 +288,10 @@ impl VideoData {
                 .map(|sample| sample.presentation_timestamp)
                 .sorted()
                 .map(|pts| {
-                    (pts - self.sample_statistics.minimum_presentation_timestamp)
-                        .into_nanos(self.timescale)
+                    pts.into_nanos_since_start(
+                        self.timescale,
+                        self.sample_statistics.minimum_presentation_timestamp,
+                    )
                 })
         })
     }

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -278,7 +278,7 @@ impl VideoData {
     ///
     /// Returned timestamps are in nanoseconds since start and are guaranteed to be monotonically increasing.
     /// These are *not* necessarily the same as the presentation timestamps, as the returned timestamps are
-    /// normalized respect to the start of the video, see [`Self::minimum_presentation_timestamp`].
+    /// normalized respect to the start of the video, see [`SampleStatistics::minimum_presentation_timestamp`].
     pub fn frame_timestamps_ns(&self) -> impl Iterator<Item = i64> + '_ {
         re_tracing::profile_function!();
 

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -80,7 +80,7 @@ pub struct SampleStatistics {
     /// Note that timestamps in the [`Sample`]s are *not* automatically adjusted with this value.
     // This is roughly equivalent to FFmpeg's internal `min_corrected_pts`
     // https://github.com/FFmpeg/FFmpeg/blob/4047b887fc44b110bccb1da09bcb79d6e454b88b/libavformat/isom.h#L202
-    // (unlike us, this handles a bunch more edge cases but it fullfills the same role)
+    // (unlike us, this handles a bunch more edge cases but it fulfills the same role)
     // To learn more about this I recommend reading the patch that introduced this in FFmpeg:
     // https://patchwork.ffmpeg.org/project/ffmpeg/patch/20170606181601.25187-1-isasi@google.com/#12592
     pub minimum_presentation_timestamp: Time,

--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -2,7 +2,7 @@
 
 use super::{Config, GroupOfPictures, Sample, VideoData, VideoLoadError};
 
-use crate::{Time, Timescale};
+use crate::{demux::SampleStatistics, Time, Timescale};
 
 impl VideoData {
     pub fn load_mp4(bytes: &[u8]) -> Result<Self, VideoLoadError> {
@@ -83,17 +83,13 @@ impl VideoData {
             });
         }
 
-        let minimum_presentation_timestamp = samples
-            .iter()
-            .map(|s| s.presentation_timestamp)
-            .min()
-            .unwrap_or_default();
+        let sample_statistics = SampleStatistics::new(&samples);
 
         Ok(Self {
             config,
             timescale,
             duration,
-            minimum_presentation_timestamp,
+            sample_statistics,
             gops,
             samples,
             mp4_tracks,

--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -2,7 +2,7 @@
 
 use super::{Config, GroupOfPictures, Sample, VideoData, VideoLoadError};
 
-use crate::{demux::SampleStatistics, Time, Timescale};
+use crate::{demux::SamplesStatistics, Time, Timescale};
 
 impl VideoData {
     pub fn load_mp4(bytes: &[u8]) -> Result<Self, VideoLoadError> {
@@ -83,13 +83,13 @@ impl VideoData {
             });
         }
 
-        let sample_statistics = SampleStatistics::new(&samples);
+        let samples_statistics = SamplesStatistics::new(&samples);
 
         Ok(Self {
             config,
             timescale,
             duration,
-            sample_statistics,
+            samples_statistics,
             gops,
             samples,
             mp4_tracks,

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -9,7 +9,7 @@ pub use re_mp4::{TrackId, TrackKind};
 
 pub use self::{
     decode::{Chunk, Frame, PixelFormat},
-    demux::{Config, Sample, SampleStatistics, VideoData, VideoLoadError},
+    demux::{Config, Sample, SamplesStatistics, VideoData, VideoLoadError},
     time::{Time, Timescale},
 };
 

--- a/crates/store/re_video/src/lib.rs
+++ b/crates/store/re_video/src/lib.rs
@@ -9,7 +9,7 @@ pub use re_mp4::{TrackId, TrackKind};
 
 pub use self::{
     decode::{Chunk, Frame, PixelFormat},
-    demux::{Config, Sample, VideoData, VideoLoadError},
+    demux::{Config, Sample, SampleStatistics, VideoData, VideoLoadError},
     time::{Time, Timescale},
 };
 

--- a/crates/store/re_video/src/time.rs
+++ b/crates/store/re_video/src/time.rs
@@ -28,50 +28,67 @@ impl Time {
         Self(v)
     }
 
+    /// `time_base` specifies the
     #[inline]
-    pub fn from_secs(v: f64, timescale: Timescale) -> Self {
-        Self((v * timescale.0 as f64).round() as i64)
+    pub fn from_secs_since_start(
+        secs_since_start: f64,
+        timescale: Timescale,
+        start_time: Self,
+    ) -> Self {
+        Self((secs_since_start * timescale.0 as f64).round() as i64 + start_time.0)
     }
 
     #[inline]
-    pub fn from_millis(v: f64, timescale: Timescale) -> Self {
-        Self::from_secs(v / 1e3, timescale)
+    pub fn from_millis_since_start(
+        millis_since_start: f64,
+        timescale: Timescale,
+        start_time: Self,
+    ) -> Self {
+        Self::from_secs_since_start(millis_since_start / 1e3, timescale, start_time)
     }
 
     #[inline]
-    pub fn from_micros(v: f64, timescale: Timescale) -> Self {
-        Self::from_secs(v / 1e6, timescale)
+    pub fn from_micros_since_start(
+        micros_since_start: f64,
+        timescale: Timescale,
+        start_time: Self,
+    ) -> Self {
+        Self::from_secs_since_start(micros_since_start / 1e6, timescale, start_time)
     }
 
     #[inline]
-    pub fn from_nanos(v: i64, timescale: Timescale) -> Self {
-        Self::from_secs(v as f64 / 1e9, timescale)
+    pub fn from_nanos_since_start(
+        nanos_since_start: i64,
+        timescale: Timescale,
+        start_time: Self,
+    ) -> Self {
+        Self::from_secs_since_start(nanos_since_start as f64 / 1e9, timescale, start_time)
     }
 
     /// Convert to a duration
     #[inline]
     pub fn duration(self, timescale: Timescale) -> std::time::Duration {
-        std::time::Duration::from_nanos(self.into_nanos(timescale) as _)
+        std::time::Duration::from_nanos(self.into_nanos_since_start(timescale, Self(0)) as _)
     }
 
     #[inline]
-    pub fn into_secs(self, timescale: Timescale) -> f64 {
-        self.0 as f64 / timescale.0 as f64
+    pub fn into_secs_since_start(self, timescale: Timescale, start_time: Self) -> f64 {
+        (self.0 - start_time.0) as f64 / timescale.0 as f64
     }
 
     #[inline]
-    pub fn into_millis(self, timescale: Timescale) -> f64 {
-        self.into_secs(timescale) * 1e3
+    pub fn into_millis_since_start(self, timescale: Timescale, start_time: Self) -> f64 {
+        self.into_secs_since_start(timescale, start_time) * 1e3
     }
 
     #[inline]
-    pub fn into_micros(self, timescale: Timescale) -> f64 {
-        self.into_secs(timescale) * 1e6
+    pub fn into_micros_since_start(self, timescale: Timescale, start_time: Self) -> f64 {
+        self.into_secs_since_start(timescale, start_time) * 1e6
     }
 
     #[inline]
-    pub fn into_nanos(self, timescale: Timescale) -> i64 {
-        (self.into_secs(timescale) * 1e9).round() as i64
+    pub fn into_nanos_since_start(self, timescale: Timescale, start_time: Self) -> i64 {
+        (self.into_secs_since_start(timescale, start_time) * 1e9).round() as i64
     }
 }
 

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -103,6 +103,7 @@ pub fn blob_preview_and_save_ui(
     media_type: Option<&MediaType>,
     video_timestamp: Option<VideoTimestamp>,
 ) {
+    #[allow(unused_assignments)] // Not used when targeting web.
     let mut image = None;
     let mut video_result_for_frame_preview = None;
 

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -4,7 +4,7 @@ use re_renderer::{
 };
 use re_types::components::VideoTimestamp;
 use re_ui::{list_item::PropertyContent, UiExt};
-use re_video::{decode::FrameInfo, demux::SampleStatistics};
+use re_video::{decode::FrameInfo, demux::SamplesStatistics};
 use re_viewer_context::UiLayout;
 
 pub fn show_video_blob_info(
@@ -92,7 +92,7 @@ pub fn show_video_blob_info(
                         "More video statistics",
                         false,
                         |ui| {
-                            sample_statistics_ui(ui, &data.sample_statistics);
+                            sample_statistics_ui(ui, &data.samples_statistics);
                         },
                     );
                 }
@@ -205,7 +205,7 @@ pub fn show_decoded_frame_info(
     }
 }
 
-fn sample_statistics_ui(ui: &mut egui::Ui, sample_statistics: &SampleStatistics) {
+fn sample_statistics_ui(ui: &mut egui::Ui, sample_statistics: &SamplesStatistics) {
     ui.list_item_flat_noninteractive(
             PropertyContent::new("Minimum PTS").value_text(sample_statistics.minimum_presentation_timestamp.0.to_string())
         ).on_hover_text("The smallest presentation timestamp (PTS) observed in this video.\n\
@@ -223,11 +223,11 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
         "{} - {}",
         re_format::format_timestamp_seconds(time_range.start.into_secs_since_start(
             video_data.timescale,
-            video_data.sample_statistics.minimum_presentation_timestamp
+            video_data.samples_statistics.minimum_presentation_timestamp
         )),
         re_format::format_timestamp_seconds(time_range.end.into_secs_since_start(
             video_data.timescale,
-            video_data.sample_statistics.minimum_presentation_timestamp
+            video_data.samples_statistics.minimum_presentation_timestamp
         )),
     )))
     .on_hover_text("Time range in which this frame is valid.");
@@ -241,7 +241,7 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
                 .on_hover_text(re_format::format_timestamp_seconds(
                     time.into_secs_since_start(
                         video_data.timescale,
-                        video_data.sample_statistics.minimum_presentation_timestamp,
+                        video_data.samples_statistics.minimum_presentation_timestamp,
                     ),
                 ));
         }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -220,16 +220,16 @@ fn sample_statistics_ui(ui: &mut egui::Ui, sample_statistics: &SampleStatistics)
 fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_video::VideoData) {
     let time_range = frame_info.presentation_time_range();
     ui.list_item_flat_noninteractive(PropertyContent::new("Time range").value_text(format!(
-            "{} - {}",
-            re_format::format_timestamp_seconds(
-                (time_range.start - video_data.sample_statistics.minimum_presentation_timestamp)
-                    .into_secs(video_data.timescale)
-            ),
-            re_format::format_timestamp_seconds(
-                (time_range.end - video_data.sample_statistics.minimum_presentation_timestamp)
-                    .into_secs(video_data.timescale)
-            ),
-        )))
+        "{} - {}",
+        re_format::format_timestamp_seconds(time_range.start.into_secs_since_start(
+            video_data.timescale,
+            video_data.sample_statistics.minimum_presentation_timestamp
+        )),
+        re_format::format_timestamp_seconds(time_range.end.into_secs_since_start(
+            video_data.timescale,
+            video_data.sample_statistics.minimum_presentation_timestamp
+        )),
+    )))
     .on_hover_text("Time range in which this frame is valid.");
 
     fn value_fn_for_time(
@@ -239,8 +239,10 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
         move |ui, _| {
             ui.add(egui::Label::new(time.0.to_string()).truncate())
                 .on_hover_text(re_format::format_timestamp_seconds(
-                    (time - video_data.sample_statistics.minimum_presentation_timestamp)
-                        .into_secs(video_data.timescale),
+                    time.into_secs_since_start(
+                        video_data.timescale,
+                        video_data.sample_statistics.minimum_presentation_timestamp,
+                    ),
                 ));
         }
     }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -92,7 +92,7 @@ pub fn show_video_blob_info(
                         }
                     });
                     ui.list_item_collapsible_noninteractive_label(
-                        "Extended timing info",
+                        "More video statistics",
                         false,
                         |ui| {
                             sample_statistics_ui(ui, &data.sample_statistics);
@@ -117,6 +117,9 @@ pub fn show_video_blob_info(
                         ui.id().with("video_player").value(),
                     );
 
+                    ui.separator();
+                    ui.add_space(4.0);
+
                     match video.frame_at(
                         render_ctx,
                         player_stream_id,
@@ -130,6 +133,18 @@ pub fn show_video_blob_info(
                             frame_info,
                             source_pixel_format,
                         }) => {
+                            re_ui::list_item::list_item_scope(ui, "decoded_frame_ui", |ui| {
+                                let default_open = false;
+                                ui.list_item_collapsible_noninteractive_label(
+                                    "Current decoded frame",
+                                    default_open,
+                                    |ui| {
+                                        frame_info_ui(ui, &frame_info, video.data());
+                                        source_image_data_format_ui(ui, &source_pixel_format);
+                                    },
+                                );
+                            });
+
                             let response = crate::image::texture_preview_ui(
                                 render_ctx,
                                 ui,
@@ -150,8 +165,6 @@ pub fn show_video_blob_info(
                                 );
                                 egui::Spinner::new().paint_at(ui, smaller_rect);
                             }
-
-                            decoded_frame_ui(ui, &frame_info, video.data(), &source_pixel_format);
                         }
 
                         Err(err) => {
@@ -198,23 +211,8 @@ fn sample_statistics_ui(ui: &mut egui::Ui, sample_statistics: &SampleStatistics)
                                          Rerun will place the 0:00:00 time at this timestamp.");
     ui.list_item_flat_noninteractive(
             // `value_bool` doesn't look great for static values.
-            PropertyContent::new("PTS equivalent to DTS").value_text(sample_statistics.dts_always_equal_pts.to_string())
+            PropertyContent::new("All PTS equal DTS").value_text(sample_statistics.dts_always_equal_pts.to_string())
         ).on_hover_text("Whether all decode timestamps are equal to presentation timestamps. If true, the video typically has no B-frames.");
-}
-
-fn decoded_frame_ui(
-    ui: &mut egui::Ui,
-    frame_info: &FrameInfo,
-    video_data: &re_video::VideoData,
-    source_image_format: &SourceImageDataFormat,
-) {
-    re_ui::list_item::list_item_scope(ui, "decoded_frame_ui", |ui| {
-        let default_open = false;
-        ui.list_item_collapsible_noninteractive_label("Decoded frame info", default_open, |ui| {
-            frame_info_ui(ui, frame_info, video_data);
-            source_image_data_format_ui(ui, source_image_format);
-        });
-    });
 }
 
 fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_video::VideoData) {

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -92,7 +92,7 @@ pub fn show_video_blob_info(
                         "More video statistics",
                         false,
                         |ui| {
-                            sample_statistics_ui(ui, &data.samples_statistics);
+                            samples_statistics_ui(ui, &data.samples_statistics);
                         },
                     );
                 }
@@ -205,15 +205,15 @@ pub fn show_decoded_frame_info(
     }
 }
 
-fn sample_statistics_ui(ui: &mut egui::Ui, sample_statistics: &SamplesStatistics) {
+fn samples_statistics_ui(ui: &mut egui::Ui, samples_statistics: &SamplesStatistics) {
     ui.list_item_flat_noninteractive(
-            PropertyContent::new("Minimum PTS").value_text(sample_statistics.minimum_presentation_timestamp.0.to_string())
+            PropertyContent::new("Minimum PTS").value_text(samples_statistics.minimum_presentation_timestamp.0.to_string())
         ).on_hover_text("The smallest presentation timestamp (PTS) observed in this video.\n\
                                          A non-zero value indicates that there are B-frames in the video.\n\
                                          Rerun will place the 0:00:00 time at this timestamp.");
     ui.list_item_flat_noninteractive(
             // `value_bool` doesn't look great for static values.
-            PropertyContent::new("All PTS equal DTS").value_text(sample_statistics.dts_always_equal_pts.to_string())
+            PropertyContent::new("All PTS equal DTS").value_text(samples_statistics.dts_always_equal_pts.to_string())
         ).on_hover_text("Whether all decode timestamps are equal to presentation timestamps. If true, the video typically has no B-frames.");
 }
 

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -47,7 +47,10 @@ impl VideoChunkDecoder {
             let decoder_output = decoder_output.clone();
             move |frame: re_video::decode::Result<Frame>| match frame {
                 Ok(frame) => {
-                    re_log::trace!("Decoded frame at {:?}", frame.info.presentation_timestamp);
+                    re_log::trace!(
+                        "Decoded frame at PTS {:?}",
+                        frame.info.presentation_timestamp
+                    );
                     let mut output = decoder_output.lock();
                     output.frames.push(frame);
                     output.error = None; // We successfully decoded a frame, reset the error state.
@@ -114,10 +117,10 @@ impl VideoChunkDecoder {
         let frame_idx = 0;
         let frame = &frames[frame_idx];
 
-        let frame_time_range = frame.info.time_range();
+        let frame_time_range = frame.info.presentation_time_range();
 
         if frame_time_range.contains(&presentation_timestamp)
-            && video_texture.frame_info.time_range() != frame_time_range
+            && video_texture.frame_info.presentation_time_range() != frame_time_range
         {
             #[cfg(target_arch = "wasm32")]
             {

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -145,7 +145,7 @@ impl Video {
     ///
     /// The time is specified in seconds since the start of the video.
     /// This may not be equal to the presentation timestamp as it may have an offset applied,
-    /// see [`VideoData::minimum_presentation_timestamp`].
+    /// see [`re_video::SampleStatistics::minimum_presentation_timestamp`].
     pub fn frame_at(
         &self,
         render_context: &RenderContext,

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -145,7 +145,7 @@ impl Video {
     ///
     /// The time is specified in seconds since the start of the video.
     /// This may not be equal to the presentation timestamp as it may have an offset applied,
-    /// see [`re_video::SampleStatistics::minimum_presentation_timestamp`].
+    /// see [`re_video::SamplesStatistics::minimum_presentation_timestamp`].
     pub fn frame_at(
         &self,
         render_context: &RenderContext,

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -129,7 +129,7 @@ impl VideoPlayer {
         }
         let presentation_timestamp =
             Time::from_secs(time_since_video_start_in_seconds, self.data.timescale)
-                + self.data.minimum_presentation_timestamp;
+                + self.data.sample_statistics.minimum_presentation_timestamp;
         let presentation_timestamp = presentation_timestamp.min(self.data.duration); // Don't seek past the end of the video.
 
         let error_on_last_frame_at = self.last_error.is_some();

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -130,10 +130,10 @@ impl VideoPlayer {
         let presentation_timestamp = Time::from_secs_since_start(
             time_since_video_start_in_seconds,
             self.data.timescale,
-            self.data.sample_statistics.minimum_presentation_timestamp,
+            self.data.samples_statistics.minimum_presentation_timestamp,
         );
         let presentation_timestamp = presentation_timestamp
-            .min(self.data.duration + self.data.sample_statistics.minimum_presentation_timestamp); // Don't seek past the end of the video.
+            .min(self.data.duration + self.data.samples_statistics.minimum_presentation_timestamp); // Don't seek past the end of the video.
 
         let error_on_last_frame_at = self.last_error.is_some();
         let result = self.frame_at_internal(render_ctx, presentation_timestamp, video_data);

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -121,13 +121,15 @@ impl VideoPlayer {
     pub fn frame_at(
         &mut self,
         render_ctx: &RenderContext,
-        presentation_timestamp_s: f64,
+        time_since_video_start_in_seconds: f64,
         video_data: &[u8],
     ) -> Result<VideoFrameTexture, VideoPlayerError> {
-        if presentation_timestamp_s < 0.0 {
+        if time_since_video_start_in_seconds < 0.0 {
             return Err(VideoPlayerError::NegativeTimestamp);
         }
-        let presentation_timestamp = Time::from_secs(presentation_timestamp_s, self.data.timescale);
+        let presentation_timestamp =
+            Time::from_secs(time_since_video_start_in_seconds, self.data.timescale)
+                + self.data.minimum_presentation_timestamp;
         let presentation_timestamp = presentation_timestamp.min(self.data.duration); // Don't seek past the end of the video.
 
         let error_on_last_frame_at = self.last_error.is_some();
@@ -138,7 +140,7 @@ impl VideoPlayer {
                 let is_active_frame = self
                     .video_texture
                     .frame_info
-                    .time_range()
+                    .presentation_time_range()
                     .contains(&presentation_timestamp);
 
                 let is_pending = !is_active_frame;
@@ -151,7 +153,7 @@ impl VideoPlayer {
                     self.video_texture.frame_info = FrameInfo::default();
                 }
 
-                let time_range = self.video_texture.frame_info.time_range();
+                let time_range = self.video_texture.frame_info.presentation_time_range();
                 let show_spinner = if presentation_timestamp < time_range.start {
                     // We're seeking backwards and somehow forgot to reset.
                     true

--- a/crates/viewer/re_viewer/src/reflection/mod.rs
+++ b/crates/viewer/re_viewer/src/reflection/mod.rs
@@ -1678,7 +1678,7 @@ fn generate_archetype_reflection() -> ArchetypeReflectionMap {
                     ArchetypeFieldReflection { component_name :
                     "rerun.components.VideoTimestamp".into(), display_name : "Timestamp",
                     docstring_md :
-                    "References the closest video frame to this timestamp.\n\nNote that this uses the closest video frame instead of the latest at this timestamp\nin order to be more forgiving of rounding errors for inprecise timestamp types.",
+                    "References the closest video frame to this timestamp.\n\nNote that this uses the closest video frame instead of the latest at this timestamp\nin order to be more forgiving of rounding errors for inprecise timestamp types.\n\nTimestamps are relative to the start of the video, i.e. a timestamp of 0 always corresponds to the first frame.\nThis is oftentimes equivalent to presentation timestamps (known as PTS), but in the presence of B-frames\n(bidirectionally predicted frames) there may be an offset on the first presentation timestamp in the video.",
                     is_required : true, }, ArchetypeFieldReflection { component_name :
                     "rerun.components.EntityPath".into(), display_name :
                     "Video reference", docstring_md :

--- a/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
+++ b/rerun_cpp/src/rerun/archetypes/video_frame_reference.hpp
@@ -116,6 +116,10 @@ namespace rerun::archetypes {
         ///
         /// Note that this uses the closest video frame instead of the latest at this timestamp
         /// in order to be more forgiving of rounding errors for inprecise timestamp types.
+        ///
+        /// Timestamps are relative to the start of the video, i.e. a timestamp of 0 always corresponds to the first frame.
+        /// This is oftentimes equivalent to presentation timestamps (known as PTS), but in the presence of B-frames
+        /// (bidirectionally predicted frames) there may be an offset on the first presentation timestamp in the video.
         rerun::components::VideoTimestamp timestamp;
 
         /// Optional reference to an entity with a `archetypes::AssetVideo`.

--- a/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/video_frame_reference.py
@@ -135,6 +135,10 @@ class VideoFrameReference(VideoFrameReferenceExt, Archetype):
     # Note that this uses the closest video frame instead of the latest at this timestamp
     # in order to be more forgiving of rounding errors for inprecise timestamp types.
     #
+    # Timestamps are relative to the start of the video, i.e. a timestamp of 0 always corresponds to the first frame.
+    # This is oftentimes equivalent to presentation timestamps (known as PTS), but in the presence of B-frames
+    # (bidirectionally predicted frames) there may be an offset on the first presentation timestamp in the video.
+    #
     # (Docstring intentionally commented out to hide this field from the docs)
 
     video_reference: components.EntityPathBatch | None = field(


### PR DESCRIPTION
### What

* fixes https://github.com/rerun-io/rerun/issues/7960

.. and adds a few more "expert" information fields to video blob plus improving the selection panel view overall a bit

Before:
<img width="372" alt="image" src="https://github.com/user-attachments/assets/b80bdceb-b594-4864-8639-ecf3159c110a">

After:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/6948f24a-2ffd-40c2-8fbe-d81dda486df2">


-> note how the timestamp component and the timestamped etched into the video are now the same.


The problem is that in the presence of B-frames it can happen that presentation timestamps don't start at 0. This is because in MP4 (and other formats?) timestamps can't be negative and the first timestamp may have a decode timestamp of zero but a presentation timestamp some point later. Turns out this happens in a bunch of the example video material I'm using - not too surprising given that ffmpeg's default encoding settings on h264 tend to produce this!
From what I found (see links in comments) this is compensated by players. We do so now on the fly in key locations, preserving the internal PTS/DTS values of the samples. I tried to sharpen the docs where appropriate.

(on a personal note: I don't quite fully follow yet how this makes sense practically given that the first frame should be an IDR frame (it is, right?). But that's 100% what's happening and I found strong indication that players compensate for this just like we do here now)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8029?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8029?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8029)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.