### PR TITLE
Allow editing blueprint while inspecting it

### DIFF
--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -27,8 +27,8 @@ use re_log_types::{
 use re_types::blueprint::components::PanelState;
 use re_ui::{list_item, ContextExt as _, DesignTokens, UiExt as _};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, PlayState, RecordingConfig, TimeControl, TimeView,
-    UiLayout, ViewerContext,
+    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiLayout,
+    ViewerContext,
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
@@ -947,18 +947,6 @@ impl TimePanel {
             self.time_control_ui.playback_speed_ui(time_ctrl, ui);
             self.time_control_ui.fps_ui(time_ctrl, ui);
             current_time_ui(ctx, ui, time_ctrl);
-
-            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                help_button(ui);
-
-                if self.source == TimePanelSource::Blueprint
-                    && ctx.app_options.inspect_blueprint_timeline
-                    && time_ctrl.play_state() != PlayState::Following
-                {
-                    ui.label(ui.ctx().warning_text("Blueprint editing is disabled"))
-                        .on_hover_text("Enable follow-mode to allow editing");
-                }
-            });
         }
     }
 }

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -27,8 +27,8 @@ use re_log_types::{
 use re_types::blueprint::components::PanelState;
 use re_ui::{list_item, ContextExt as _, DesignTokens, UiExt as _};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiLayout,
-    ViewerContext,
+    CollapseScope, HoverHighlight, Item, PlayState, RecordingConfig, TimeControl, TimeView,
+    UiLayout, ViewerContext,
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
@@ -953,10 +953,10 @@ impl TimePanel {
 
                 if self.source == TimePanelSource::Blueprint
                     && ctx.app_options.inspect_blueprint_timeline
+                    && time_ctrl.play_state() != PlayState::Following
                 {
-                    // TODO(jleibs): Once we can edit blueprint while in follow mode, show
-                    // this conditionally.
-                    ui.label(ui.ctx().warning_text("Blueprint Editing is Disabled"));
+                    ui.label(ui.ctx().warning_text("Blueprint editing is disabled"))
+                        .on_hover_text("Enable follow-mode to allow editing");
                 }
             });
         }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -528,13 +528,6 @@ impl App {
                             re_chunk::TimeInt::MAX,
                         ),
                     );
-
-                    let times_per_timeline = blueprint_db.times_per_timeline();
-                    self.state
-                        .blueprint_cfg
-                        .time_ctrl
-                        .write()
-                        .set_play_state(times_per_timeline, PlayState::Following);
                 }
 
                 for chunk in updates {
@@ -545,6 +538,10 @@ impl App {
                         }
                     }
                 }
+
+                // If we inspect the timeline, make sure we show the latest state:
+                let mut time_ctrl = self.state.blueprint_cfg.time_ctrl.write();
+                time_ctrl.set_play_state(blueprint_db.times_per_timeline(), PlayState::Following);
             }
             SystemCommand::DropEntity(blueprint_id, entity_path) => {
                 let blueprint_db = store_hub.entity_db_mut(&blueprint_id);

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -514,15 +514,7 @@ impl App {
                 egui_ctx.request_repaint(); // Many changes take a frame delay to show up.
             }
             SystemCommand::UpdateBlueprint(blueprint_id, updates) => {
-                // We only want to update the blueprint if the "inspect blueprint timeline" mode is
-                // disabled. This is because the blueprint inspector allows you to change the
-                // blueprint query time, which in turn updates the displayed state of the UI itself.
-                // This means any updates we receive while in this mode may be relative to a historical
-                // blueprint state and would conflict with the current true blueprint state.
-
-                // TODO(jleibs): When the blueprint is in "follow-mode" we should actually be able
-                // to apply updates here, but this needs more validation and testing to be safe.
-                if !self.state.app_options.inspect_blueprint_timeline {
+                if self.state.blueprint_editing_enabled() {
                     let blueprint_db = store_hub.entity_db_mut(&blueprint_id);
                     for chunk in updates {
                         match blueprint_db.add_chunk(&Arc::new(chunk)) {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -518,6 +518,17 @@ impl AppState {
             LatestAtQuery::latest(blueprint_timeline())
         }
     }
+
+    pub fn blueprint_editing_enabled(&self) -> bool {
+        // If the "inspect blueprint timeline" mode allows the user to change the
+        // blueprint query time, which in turn updates the displayed state of the UI itself.
+        // This means any updates we receive while in this mode may be relative to a historical
+        // blueprint state and would conflict with the current true blueprint state.
+        // So we only allow edits if we're also in follow-mode, i.e. seeing the latest edits.
+        // An alternative would be to always allow edits, but throw away everything after the current time.
+        !self.app_options.inspect_blueprint_timeline
+            || self.blueprint_cfg.time_ctrl.read().play_state() == PlayState::Following
+    }
 }
 
 fn move_time(ctx: &ViewerContext<'_>, recording: &EntityDb, rx: &ReceiveSet<LogMsg>) {

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -191,7 +191,7 @@ impl ContainerBlueprint {
         }
 
         if let Some(chunk) = Chunk::builder(id.as_entity_path())
-            .with_archetype(RowId::new(), timepoint.clone(), &arch)
+            .with_archetype(RowId::new(), timepoint, &arch)
             .build()
             .warn_on_err_once("Failed to create container blueprint.")
         {


### PR DESCRIPTION
### What
This makes it easier to explore the blueprint live. You can roll back the time but still interact with your data. In effect, this acts like an undo!

I wanted/needed this to diagnose my undo work

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8031?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8031?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8031)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.