### PR TITLE
Support version strings with commit hashes

### DIFF
--- a/crates/build/re_build_info/src/build_info.rs
+++ b/crates/build/re_build_info/src/build_info.rs
@@ -142,7 +142,10 @@ impl CrateVersion {
     /// <name> <semver> [<rust_info>] <target> <branch> <commit> <build_date>
     /// ```
     pub fn try_parse_from_build_info_string(s: impl AsRef<str>) -> Result<Self, String> {
-        let s = Box::leak(s.as_ref().to_owned().into_boxed_str()); // We leak it here to get a 'static str, so it can be parsed by the same const function. Yes, this is ugly.
+        // `CrateVersion::try_parse` is `const` (for good reasons), and needs a `&'static str`.
+        // In order to accomplish this, we need to leak the string here.
+        let s = Box::leak(s.as_ref().to_owned().into_boxed_str());
+
         let parts = s.split_whitespace().collect::<Vec<_>>();
         if parts.len() < 2 {
             return Err(format!("{s:?} is not a valid BuildInfo string"));

--- a/crates/build/re_build_info/src/build_info.rs
+++ b/crates/build/re_build_info/src/build_info.rs
@@ -142,7 +142,7 @@ impl CrateVersion {
     /// <name> <semver> [<rust_info>] <target> <branch> <commit> <build_date>
     /// ```
     pub fn try_parse_from_build_info_string(s: impl AsRef<str>) -> Result<Self, String> {
-        let s = s.as_ref();
+        let s = Box::leak(s.as_ref().to_owned().into_boxed_str()); // We leak it here to get a 'static str, so it can be parsed by the same const function. Yes, this is ugly.
         let parts = s.split_whitespace().collect::<Vec<_>>();
         if parts.len() < 2 {
             return Err(format!("{s:?} is not a valid BuildInfo string"));
@@ -160,7 +160,10 @@ fn crate_version_from_build_info_string() {
             major: 0,
             minor: 10,
             patch: 0,
-            meta: Some(crate::crate_version::Meta::DevAlpha(7)),
+            meta: Some(crate::crate_version::Meta::DevAlpha {
+                alpha: 7,
+                commit: None,
+            }),
         },
         rustc_version: "1.76.0 (d5c2e9c34 2023-09-13)",
         llvm_version: "16.0.5",

--- a/crates/build/re_build_info/src/build_info.rs
+++ b/crates/build/re_build_info/src/build_info.rs
@@ -175,8 +175,12 @@ fn crate_version_from_build_info_string() {
 
     {
         let expected_crate_version = build_info.version;
-        let crate_version = CrateVersion::try_parse_from_build_info_string(build_info_str);
+        let crate_version = CrateVersion::try_parse_from_build_info_string(&build_info_str);
 
-        assert_eq!(Ok(expected_crate_version), crate_version);
+        assert_eq!(
+            crate_version,
+            Ok(expected_crate_version),
+            "Failed to parse {build_info_str:?}"
+        );
     }
 }

--- a/crates/build/re_build_info/src/crate_version.rs
+++ b/crates/build/re_build_info/src/crate_version.rs
@@ -94,13 +94,13 @@ pub enum Meta {
 }
 
 impl Meta {
-    pub const fn to_byte(&self) -> u8 {
+    pub const fn to_byte(self) -> u8 {
         match self {
-            Self::Rc(value) => *value | meta::RC,
-            Self::Alpha(value) => *value | meta::ALPHA,
+            Self::Rc(value) => value | meta::RC,
+            Self::Alpha(value) => value | meta::ALPHA,
 
             // We ignore the commit hash, if any
-            Self::DevAlpha { alpha, .. } => *alpha | meta::DEV_ALPHA,
+            Self::DevAlpha { alpha, .. } => alpha | meta::DEV_ALPHA,
         }
     }
 
@@ -240,7 +240,7 @@ impl CrateVersion {
             self.major,
             self.minor,
             self.patch,
-            self.meta.as_ref().map(Meta::to_byte).unwrap_or_default(),
+            self.meta.map(Meta::to_byte).unwrap_or_default(),
         ]
     }
 


### PR DESCRIPTION
### What
We want to include the commit hash in the version string when we publish wheel builds off of main (i.e. not actual releases), so that we get unique version strings.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8041?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8041?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8041)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.