### PR TITLE
Expose basic information about group of pictures in video data in the selection panel

### DIFF
--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -50,7 +50,7 @@ impl VideoData {
                     let start = samples[gop_sample_start_index].decode_timestamp;
                     let sample_range = gop_sample_start_index as u32..samples.len() as u32;
                     gops.push(GroupOfPictures {
-                        start,
+                        decode_start_time: start,
                         sample_range,
                     });
                     gop_sample_start_index = samples.len();
@@ -78,7 +78,7 @@ impl VideoData {
             let start = samples[gop_sample_start_index].decode_timestamp;
             let sample_range = gop_sample_start_index as u32..samples.len() as u32;
             gops.push(GroupOfPictures {
-                start,
+                decode_start_time: start,
                 sample_range,
             });
         }

--- a/crates/viewer/re_chunk_store_ui/src/arrow_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/arrow_ui.rs
@@ -43,9 +43,9 @@ pub(crate) fn arrow_ui(ui: &mut egui::Ui, array: &dyn arrow2::array::Array) {
                 let mut string = String::new();
                 match display(&mut string, 0) {
                     Ok(_) => ui.monospace(&string),
-                    Err(err) => ui.error_label("error").on_hover_ui(|ui| {
+                    Err(err) => ui.error_with_details_on_hover("error").on_hover_ui(|ui| {
                         ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
-                        ui.error_label(&format!("{err}"));
+                        ui.error_with_details_on_hover(&format!("{err}"));
                     }),
                 };
                 return;

--- a/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
+++ b/crates/viewer/re_chunk_store_ui/src/chunk_ui.rs
@@ -146,7 +146,7 @@ impl ChunkUi {
                             crate::arrow_ui::arrow_ui(ui, &*data);
                         }
                         Some(Err(err)) => {
-                            ui.error_label("error").on_hover_ui(|ui| {
+                            ui.error_with_details_on_hover("error").on_hover_ui(|ui| {
                                 ui.label(format!("{err}"));
                             });
                         }
@@ -284,7 +284,9 @@ impl ChunkUi {
                     });
                 }
                 Err(err) => {
-                    ui.error_label(&format!("Failed to convert to tqransport: {err}"));
+                    ui.error_with_details_on_hover(&format!(
+                        "Failed to convert to tqransport: {err}"
+                    ));
                 }
             }
         });

--- a/crates/viewer/re_component_ui/src/datatype_uis/singleline_string.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/singleline_string.rs
@@ -89,7 +89,7 @@ pub fn display_text_ui(
     let text = match Text::from_arrow(data) {
         Ok(text) => text.first().cloned(),
         Err(err) => {
-            ui.error_label("failed to deserialize")
+            ui.error_with_details_on_hover("failed to deserialize")
                 .on_hover_text(err.to_string());
             return;
         }
@@ -118,7 +118,7 @@ pub fn display_name_ui(
     let name = match Name::from_arrow(data) {
         Ok(name) => name.first().cloned(),
         Err(err) => {
-            ui.error_label("failed to deserialize")
+            ui.error_with_details_on_hover("failed to deserialize")
                 .on_hover_text(err.to_string());
             return;
         }

--- a/crates/viewer/re_data_ui/src/component_ui_registry.rs
+++ b/crates/viewer/re_data_ui/src/component_ui_registry.rs
@@ -46,7 +46,7 @@ pub fn add_to_registry<C: EntityDataUi + re_types::Component>(registry: &mut Com
                     }
                 },
                 Err(err) => {
-                    ui.error_label("(failed to deserialize)")
+                    ui.error_with_details_on_hover("(failed to deserialize)")
                         .on_hover_text(err.to_string());
                 }
             },

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -117,9 +117,9 @@ pub fn show_video_blob_info(
         }
         Err(err) => {
             if ui_layout.is_single_line() {
-                ui.error_label(&format!("Failed to load video: {err}"));
+                ui.error_with_details_on_hover(&format!("Failed to load video: {err}"));
             } else {
-                ui.error_label_long(&format!("Failed to load video: {err}"));
+                ui.error_label(&format!("Failed to load video: {err}"));
             }
         }
     }
@@ -198,7 +198,7 @@ pub fn show_decoded_frame_info(
         }
 
         Err(err) => {
-            ui.error_label_long(&err.to_string());
+            ui.error_label(&err.to_string());
 
             if let re_renderer::video::VideoPlayerError::Decoding(
                 re_video::decode::Error::FfmpegNotInstalled {

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -92,6 +92,13 @@ pub fn show_video_blob_info(
                         "More video statistics",
                         false,
                         |ui| {
+                            ui.list_item_flat_noninteractive(
+                                PropertyContent::new("Number of GOPs")
+                                    .value_text(data.gops.len().to_string()),
+                            )
+                            .on_hover_text(
+                                "The total number of Group of Pictures (GOPs) in the video.",
+                            );
                             samples_statistics_ui(ui, &data.samples_statistics);
                         },
                     );
@@ -260,6 +267,37 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
     )
     .on_hover_text("Raw presentation timestamp prior to applying the timescale.\n\
                     This specifies the time at which the frame should be shown relative to the start of a video stream.");
+
+    // Information about the current group of pictures this frame is part of.
+    // Lookup via decode timestamp is faster, but it may not always be available.
+    if let Some(gop_index) =
+        video_data.gop_index_containing_presentation_timestamp(frame_info.presentation_timestamp)
+    {
+        ui.list_item_flat_noninteractive(
+            PropertyContent::new("GOP index").value_text(gop_index.to_string()),
+        )
+        .on_hover_text("The index of the group of picture (GOP) that this sample belongs to.");
+
+        if let Some(gop) = video_data.gops.get(gop_index) {
+            let first_sample = video_data.samples.get(gop.sample_range.start as usize);
+            let last_sample = video_data
+                .samples
+                .get((gop.sample_range.end as usize).saturating_sub(1));
+
+            if let (Some(first_sample), Some(last_sample)) = (first_sample, last_sample) {
+                ui.list_item_flat_noninteractive(PropertyContent::new("GOP DTS range").value_text(
+                    format!("{} - {}", first_sample.decode_timestamp.0, last_sample.decode_timestamp.0)
+                ))
+                .on_hover_text(
+                    "The range of decode timestamps in the currently active group of picture (GOP).",
+                );
+            } else {
+                ui.error_label("GOP has invalid sample range"); // Should never happen.
+            }
+        } else {
+            ui.error_label("Invalid GOP index"); // Should never happen.
+        }
+    }
 }
 
 fn source_image_data_format_ui(ui: &mut egui::Ui, format: &SourceImageDataFormat) {

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use crate::{
     resource_managers::SourceImageDataFormat,
     video::{
-        player::{latest_at_idx, TimedDecodingError, VideoTexture},
+        player::{TimedDecodingError, VideoTexture},
         VideoPlayerError,
     },
     wgpu_resources::GpuTexture,
@@ -101,7 +101,7 @@ impl VideoChunkDecoder {
         let mut decoder_output = self.decoder_output.lock();
         let frames = &mut decoder_output.frames;
 
-        let Some(frame_idx) = latest_at_idx(
+        let Some(frame_idx) = re_video::demux::latest_at_idx(
             frames,
             |frame| frame.info.presentation_timestamp,
             &presentation_timestamp,

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -204,19 +204,18 @@ impl VideoPlayer {
         // In the presence of b-frames this order may be different!
 
         // Find sample which when decoded will be presented at the timestamp the user requested.
-        let Some(requested_sample_idx) = self
+        let requested_sample_idx = self
             .data
             .latest_sample_index_at_presentation_timestamp(presentation_timestamp)
-        else {
-            return Err(VideoPlayerError::EmptyVideo);
-        };
+            .ok_or(VideoPlayerError::EmptyVideo)?;
 
         // Find the GOP that contains the sample.
-        let Some(requested_gop_idx) = self.data.gop_index_containing_decode_timestamp(
-            self.data.samples[requested_sample_idx].decode_timestamp,
-        ) else {
-            return Err(VideoPlayerError::EmptyVideo);
-        };
+        let requested_gop_idx = self
+            .data
+            .gop_index_containing_decode_timestamp(
+                self.data.samples[requested_sample_idx].decode_timestamp,
+            )
+            .ok_or(VideoPlayerError::EmptyVideo)?;
 
         // Enqueue GOPs as needed.
 

--- a/crates/viewer/re_selection_panel/src/visualizer_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visualizer_ui.rs
@@ -26,7 +26,7 @@ pub fn visualizer_ui(
         .lookup_result_by_path(entity_path)
         .cloned()
     else {
-        ui.error_label("Entity not found in view.");
+        ui.error_with_details_on_hover("Entity not found in view.");
         return;
     };
     let active_visualizers: Vec<_> = data_result.visualizers.iter().sorted().copied().collect();

--- a/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_space_view_dataframe/src/dataframe_ui.rs
@@ -628,7 +628,7 @@ fn column_groups_for_entity(
 
 fn error_ui(ui: &mut egui::Ui, error: impl AsRef<str>) {
     let error = error.as_ref();
-    ui.error_label(error);
+    ui.error_with_details_on_hover(error);
     re_log::warn_once!("{error}");
 }
 

--- a/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
+++ b/crates/viewer/re_space_view_dataframe/src/display_record_batch.rs
@@ -254,7 +254,7 @@ impl DisplayColumn {
                             ui.label(timeline.typ().format(timestamp, ctx.app_options.time_zone));
                         }
                         Err(err) => {
-                            ui.error_label(&format!("{err}"));
+                            ui.error_with_details_on_hover(&format!("{err}"));
                         }
                     }
                 } else {

--- a/crates/viewer/re_space_view_spatial/src/picking_ui_pixel.rs
+++ b/crates/viewer/re_space_view_spatial/src/picking_ui_pixel.rs
@@ -179,7 +179,7 @@ pub fn show_zoomed_image_region(
         interaction_id,
         center_texel,
     ) {
-        ui.error_label(&err.to_string());
+        ui.error_with_details_on_hover(&err.to_string());
     }
 }
 

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -25,7 +25,7 @@ pub trait UiExt {
     }
 
     /// Shows a small error label with the given text on hover and copies the text to the clipboard on click.
-    fn error_label(&mut self, error_text: &str) -> egui::Response {
+    fn error_with_details_on_hover(&mut self, error_text: &str) -> egui::Response {
         let label = egui::Label::new(self.ui().ctx().error_text("Error"))
             .selectable(false)
             .sense(egui::Sense::click());
@@ -39,7 +39,7 @@ pub trait UiExt {
     /// Shows an error label with the entire error text and copies the text to the clipboard on click.
     ///
     /// Use this only if you have a lot of space to spare.
-    fn error_label_long(&mut self, error_text: &str) -> egui::Response {
+    fn error_label(&mut self, error_text: &str) -> egui::Response {
         let label = egui::Label::new(self.ui().ctx().error_text(error_text))
             .selectable(true)
             .sense(egui::Sense::click());

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -411,7 +411,7 @@ impl ComponentUiRegistry {
         // Also, it allows us to slice the array without cloning any elements.
         let Some(array) = unit.component_batch_raw(&component_name) else {
             re_log::error_once!("Couldn't get {component_name}: missing");
-            ui.error_label(&format!("Couldn't get {component_name}: missing"));
+            ui.error_with_details_on_hover(&format!("Couldn't get {component_name}: missing"));
             return;
         };
 


### PR DESCRIPTION
### What

Added some more information to the selection panel while investigating https://github.com/rerun-io/rerun/issues/7956
Part of the hidden-by-default sections since this goes fairly deep and is full of scary TLAs.

my favorite h264 sample:
<img width="303" alt="image" src="https://github.com/user-attachments/assets/2b3faa39-e728-4b4f-8428-d32a87d270ab">

av1 sample:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/eaa9828e-edb5-4bd3-a066-5a7842b5d0d1">



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8043?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8043?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8043)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.