### PR TITLE
C++ SDK: add unreachable `default` cases in switch statements

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -992,6 +992,9 @@ impl QuotedObject {
                 ~#pascal_case_ident() {
                     switch (this->_tag) {
                         #(#destructor_match_arms)*
+
+                        default:
+                            assert(false && "unreachable");
                     }
                 }
             }
@@ -1054,6 +1057,9 @@ impl QuotedObject {
                             case detail::#tag_typename::None: {
                                 // there is nothing to copy
                             } break;
+
+                            default:
+                                assert(false && "unreachable");
                         }
                     }
                 }
@@ -1073,6 +1079,9 @@ impl QuotedObject {
                             case detail::#tag_typename::None: {
                                 // there is nothing to copy
                             } break;
+
+                            default:
+                                assert(false && "unreachable");
                         }
                     }
                 }
@@ -1841,7 +1850,11 @@ fn quote_fill_arrow_array_builder(
                             case TagType::None: {
                                 ARROW_RETURN_NOT_OK(variant_builder_untyped->AppendNull());
                             } break;
+
                             #(#tag_cases)*
+
+                            default:
+                                assert(false && "unreachable");
                         }
                     }
                 }

--- a/rerun_cpp/src/rerun/collection.hpp
+++ b/rerun_cpp/src/rerun/collection.hpp
@@ -95,6 +95,9 @@ namespace rerun {
                     new (&storage.vector_owned) std::vector<TElement>(other.storage.vector_owned);
                     break;
                 }
+
+                default:
+                    assert(false && "unreachable");
             }
         }
 
@@ -236,6 +239,9 @@ namespace rerun {
                             other.storage.borrowed = this_borrowed_data_old;
                             break;
                         }
+
+                        default:
+                            assert(false && "unreachable");
                     }
                     break;
                 }
@@ -253,9 +259,15 @@ namespace rerun {
                         case CollectionOwnership::VectorOwned:
                             std::swap(storage.vector_owned, other.storage.vector_owned);
                             break;
+
+                        default:
+                            assert(false && "unreachable");
                     }
                     break;
                 }
+
+                default:
+                    assert(false && "unreachable");
             }
 
             std::swap(ownership, other.ownership);
@@ -265,9 +277,13 @@ namespace rerun {
             switch (ownership) {
                 case CollectionOwnership::Borrowed:
                     break; // nothing to do.
+
                 case CollectionOwnership::VectorOwned:
                     storage.vector_owned.~vector(); // Deallocate the vector!
                     break;
+
+                default:
+                    assert(false && "unreachable");
             }
         }
 
@@ -276,8 +292,12 @@ namespace rerun {
             switch (ownership) {
                 case CollectionOwnership::Borrowed:
                     return storage.borrowed.num_instances;
+
                 case CollectionOwnership::VectorOwned:
                     return storage.vector_owned.size();
+
+                default:
+                    assert(false && "unreachable");
             }
             return 0;
         }
@@ -287,8 +307,12 @@ namespace rerun {
             switch (ownership) {
                 case CollectionOwnership::Borrowed:
                     return storage.borrowed.num_instances == 0;
+
                 case CollectionOwnership::VectorOwned:
                     return storage.vector_owned.empty();
+
+                default:
+                    assert(false && "unreachable");
             }
             return 0;
         }
@@ -304,8 +328,12 @@ namespace rerun {
             switch (ownership) {
                 case CollectionOwnership::Borrowed:
                     return storage.borrowed.data;
+
                 case CollectionOwnership::VectorOwned:
                     return storage.vector_owned.data();
+
+                default:
+                    assert(false && "unreachable");
             }
 
             // We need to return something to avoid compiler warnings.
@@ -359,9 +387,13 @@ namespace rerun {
                     result.insert(result.end(), begin(), end());
                     return result;
                 }
+
                 case CollectionOwnership::VectorOwned: {
                     return std::move(storage.vector_owned);
                 }
+
+                default:
+                    assert(false && "unreachable");
             }
             return std::vector<TElement>();
         }
@@ -375,6 +407,7 @@ namespace rerun {
                         size() * sizeof(TElement)
                     );
                 }
+
                 case CollectionOwnership::VectorOwned: {
                     auto ptr = reinterpret_cast<const uint8_t*>(data());
                     auto num_bytes = size() * sizeof(TElement);
@@ -382,6 +415,9 @@ namespace rerun {
                         std::vector<uint8_t>(ptr, ptr + num_bytes)
                     );
                 }
+
+                default:
+                    assert(false && "unreachable");
             }
             return Collection<uint8_t>();
         }

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.cpp
@@ -197,6 +197,8 @@ namespace rerun {
                         static_cast<int64_t>(union_instance.get_union_data().f64.size())
                     ));
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
+++ b/rerun_cpp/src/rerun/datatypes/tensor_buffer.hpp
@@ -147,6 +147,8 @@ namespace rerun::datatypes {
                 } break;
                 case detail::TensorBufferTag::None: {
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 
@@ -214,6 +216,8 @@ namespace rerun::datatypes {
                     using TypeAlias = rerun::Collection<double>;
                     _data.f64.~TypeAlias();
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/src/rerun/datatypes/time_range_boundary.cpp
+++ b/rerun_cpp/src/rerun/datatypes/time_range_boundary.cpp
@@ -97,6 +97,8 @@ namespace rerun {
                         static_cast<arrow::NullBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->AppendNull());
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/src/rerun/image_utils.hpp
+++ b/rerun_cpp/src/rerun/image_utils.hpp
@@ -5,6 +5,7 @@
 #include "datatypes/pixel_format.hpp"
 #include "half.hpp"
 
+#include <cassert>
 #include <cstdint>
 
 namespace rerun {
@@ -52,6 +53,8 @@ namespace rerun {
             case datatypes::ChannelDatatype::F64: {
                 return 64;
             }
+            default:
+                assert(false && "unreachable");
         }
         return 0;
     }
@@ -143,6 +146,8 @@ namespace rerun {
             case datatypes::ColorModel::BGRA:
             case datatypes::ColorModel::RGBA:
                 return 4;
+            default:
+                assert(false && "unreachable");
         }
         return 0;
     }
@@ -173,6 +178,9 @@ namespace rerun {
             case datatypes::PixelFormat::Y8_LimitedRange:
             case datatypes::PixelFormat::Y8_FullRange:
                 return num_pixels;
+
+            default:
+                assert(false && "unreachable");
         }
         return 0;
     }

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.cpp
@@ -112,6 +112,8 @@ namespace rerun {
                         static_cast<arrow::NullBuilder*>(variant_builder_untyped);
                     ARROW_RETURN_NOT_OK(variant_builder->AppendNull());
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer3.hpp
@@ -77,6 +77,8 @@ namespace rerun::datatypes {
                 } break;
                 case detail::AffixFuzzer3Tag::None: {
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 
@@ -113,6 +115,8 @@ namespace rerun::datatypes {
                 case detail::AffixFuzzer3Tag::empty_variant: {
                     // has a trivial destructor
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.cpp
@@ -100,6 +100,8 @@ namespace rerun {
                         "Failed to serialize AffixFuzzer4::many_required: objects (Object(\"rerun.testing.datatypes.AffixFuzzer3\")) in unions not yet implemented"
                     );
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 

--- a/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
+++ b/rerun_cpp/tests/generated/datatypes/affix_fuzzer4.hpp
@@ -69,6 +69,8 @@ namespace rerun::datatypes {
                 } break;
                 case detail::AffixFuzzer4Tag::None: {
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 
@@ -100,6 +102,8 @@ namespace rerun::datatypes {
                     using TypeAlias = rerun::Collection<rerun::datatypes::AffixFuzzer3>;
                     _data.many_required.~TypeAlias();
                 } break;
+                default:
+                    assert(false && "unreachable");
             }
         }
 


### PR DESCRIPTION
Whenever I work on the C++ SDK, I get several hundreds warnings of that nature every time I compile (clang18, gcc14):
```
/home/cmc/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/../collection.hpp:304:13: warning: 'switch' missing 'default' label [-Wswitch-default]
  304 |             switch (ownership) {
      |             ^
/home/cmc/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/../component_batch.hpp:47:59: note: in instantiation of member function 'rerun::Collection<rerun::components::IndicatorComponent<rerun::archetypes::EncodedImage::IndicatorComponentName>>::data' requested here
   47 |             auto array = Loggable<T>::to_arrow(components.data(), components.size());
      |                                                           ^
/home/cmc/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/../component_batch.hpp:63:20: note: in instantiation of function template specialization 'rerun::ComponentBatch::from_loggable<rerun::components::IndicatorComponent<rerun::archetypes::EncodedImage::IndicatorComponentName>>' requested here
   63 |             return from_loggable(collection);
      |                    ^
/home/cmc/dev/rerun-io/rerun/rerun_cpp/src/rerun/archetypes/encoded_image.cpp:41:43: note: in instantiation of function template specialization 'rerun::ComponentBatch::from_loggable<rerun::components::IndicatorComponent<rerun::archetypes::EncodedImage::IndicatorComponentName>>' requested here
   41 |             auto result = ComponentBatch::from_loggable(indicator);
```
Not only is it annoying but I would also tend to agree with it?

This PR simply adds an unreachable `default` case everywhere:
```cpp
default:
    assert(false && "unreachable");
```
which might or might not be the right approach, I don't know.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8057?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8057?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8057)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.