### PR TITLE
Ignore RUSTSEC-2024-0384 in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ all-features = true
 version = 2
 ignore = [
   "RUSTSEC-2023-0086", # TODO(#3741): Waiting for https://github.com/apache/arrow-rs/pull/6401
+  "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,6 @@ all-features = true
 [advisories]
 version = 2
 ignore = [
-  "RUSTSEC-2023-0086", # TODO(#3741): Waiting for https://github.com/apache/arrow-rs/pull/6401
   "RUSTSEC-2024-0384", # Waiting for https://github.com/console-rs/indicatif/pull/666
 ]
 


### PR DESCRIPTION
* Fixes red main
* Real fix coming in https://github.com/console-rs/indicatif/pull/666

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)