### PR TITLE
Enable local http cache for the map view (native only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6144,6 +6144,7 @@ dependencies = [
 name = "re_space_view_map"
 version = "0.20.0-alpha.1+dev"
 dependencies = [
+ "directories",
  "egui",
  "glam",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6144,7 +6144,6 @@ dependencies = [
 name = "re_space_view_map"
 version = "0.20.0-alpha.1+dev"
 dependencies = [
- "directories",
  "egui",
  "glam",
  "itertools 0.13.0",
@@ -6587,6 +6586,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.6.0",
  "bytemuck",
+ "directories",
  "egui",
  "egui-wgpu",
  "egui_extras",

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -33,7 +33,6 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
-directories.workspace = true
 egui.workspace = true
 glam.workspace = true
 itertools.workspace = true

--- a/crates/viewer/re_space_view_map/Cargo.toml
+++ b/crates/viewer/re_space_view_map/Cargo.toml
@@ -33,6 +33,7 @@ re_ui.workspace = true
 re_viewer_context.workspace = true
 re_viewport_blueprint.workspace = true
 
+directories.workspace = true
 egui.workspace = true
 glam.workspace = true
 itertools.workspace = true

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -291,12 +291,12 @@ pub fn reset_viewer_persistence() -> anyhow::Result<()> {
         // Clear the default cache directory if it exists
         //TODO(#8064): should clear the _actual_ cache directory, not the default one
         if let Some(cache_dir) = re_viewer_context::AppOptions::default_cache_directory() {
-            if cache_dir.exists() {
-                if let Err(err) = std::fs::remove_dir_all(&cache_dir) {
+            if let Err(err) = std::fs::remove_dir_all(&cache_dir) {
+                if err.kind() != std::io::ErrorKind::NotFound {
                     anyhow::bail!("Failed to remove {cache_dir:?}: {err}");
-                } else {
-                    re_log::info!("Cleared {cache_dir:?}.");
                 }
+            } else {
+                re_log::info!("Cleared {cache_dir:?}.");
             }
         }
     }

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -287,6 +287,18 @@ pub fn reset_viewer_persistence() -> anyhow::Result<()> {
         } else {
             re_log::info!("Rerun state was already cleared.");
         }
+
+        // Clear the default cache directory if it exists
+        //TODO(#8064): should clear the _actual_ cache directory, not the default one
+        if let Some(cache_dir) = re_viewer_context::AppOptions::default_cache_directory() {
+            if cache_dir.exists() {
+                if let Err(err) = std::fs::remove_dir_all(&cache_dir) {
+                    anyhow::bail!("Failed to remove {cache_dir:?}: {err}");
+                } else {
+                    re_log::info!("Cleared {cache_dir:?}.");
+                }
+            }
+        }
     }
     #[cfg(target_arch = "wasm32")]
     {

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -42,6 +42,7 @@ anyhow.workspace = true
 bit-vec.workspace = true
 bitflags.workspace = true
 bytemuck.workspace = true
+directories.workspace = true
 egui_extras.workspace = true
 egui_tiles.workspace = true
 egui-wgpu.workspace = true

--- a/crates/viewer/re_viewer_context/src/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/app_options.rs
@@ -46,7 +46,7 @@ pub struct AppOptions {
     /// to [`directories::ProjectDirs::cache_dir`].
     ///
     /// *NOTE*: subsystems making use of the cache directory should use a unique sub-directory name,
-    /// see [`cache_subdirectory`].
+    /// see [`AppOptions::cache_subdirectory`].
     #[cfg(not(target_arch = "wasm32"))]
     pub cache_directory: Option<std::path::PathBuf>,
 }

--- a/crates/viewer/re_viewer_context/src/app_options.rs
+++ b/crates/viewer/re_viewer_context/src/app_options.rs
@@ -39,6 +39,16 @@ pub struct AppOptions {
     ///
     /// Can also be set using the `RERUN_MAPBOX_ACCESS_TOKEN` environment variable.
     pub mapbox_access_token: String,
+
+    /// Path to the directory suitable for storing cache data.
+    ///
+    /// By cache data, we mean data that is safe to be garbage collected by the OS. Defaults to
+    /// to [`directories::ProjectDirs::cache_dir`].
+    ///
+    /// *NOTE*: subsystems making use of the cache directory should use a unique sub-directory name,
+    /// see [`cache_subdirectory`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub cache_directory: Option<std::path::PathBuf>,
 }
 
 impl Default for AppOptions {
@@ -65,6 +75,9 @@ impl Default for AppOptions {
             video_decoder_hw_acceleration: Default::default(),
 
             mapbox_access_token: String::new(),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            cache_directory: Self::default_cache_directory(),
         }
     }
 }
@@ -76,5 +89,21 @@ impl AppOptions {
         } else {
             Some(self.mapbox_access_token.clone())
         }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn cache_subdirectory(
+        &self,
+        sub_dir: impl AsRef<std::path::Path>,
+    ) -> Option<std::path::PathBuf> {
+        self.cache_directory
+            .as_ref()
+            .map(|cache_dir| cache_dir.join(sub_dir))
+    }
+
+    /// Default cache directory
+    pub fn default_cache_directory() -> Option<std::path::PathBuf> {
+        directories::ProjectDirs::from("io", "rerun", "Rerun")
+            .map(|dirs| dirs.cache_dir().to_owned())
     }
 }


### PR DESCRIPTION
### What

☝🏻 

This pr introduce a cache directory in `re_viewer_context::AppOptions`, which is cleared by `rerun reset`. With some caveat, see:
- https://github.com/rerun-io/rerun/issues/8064

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8060?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8060?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8060)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.