### PR TITLE
Line strips are no longer a disconnected series of quads

### DIFF
--- a/crates/viewer/re_renderer/shader/composite.wgsl
+++ b/crates/viewer/re_renderer/shader/composite.wgsl
@@ -7,6 +7,7 @@ struct CompositeUniformBuffer {
     outline_color_layer_a: vec4f,
     outline_color_layer_b: vec4f,
     outline_radius_pixel: f32,
+    blend_with_background: u32,
 };
 @group(1) @binding(0)
 var<uniform> uniforms: CompositeUniformBuffer;
@@ -27,11 +28,17 @@ fn main(in: FragmentInput) -> @location(0) vec4f {
     // but are about the location of the texel in the target texture.
     var color = textureSample(color_texture, nearest_sampler, in.texcoord);
 
+
     // TODO(andreas): We assume that the color from the texture does *not* have pre-multiplied alpha.
     // This is a brittle workaround for the alpha-to-coverage issue described in `ViewBuilder::MAIN_TARGET_ALPHA_TO_COVERAGE_COLOR_STATE`:
     // We need this because otherwise the feathered edges of alpha-to-coverage would be overly bright, as after
     // MSAA-resolve they end up with an unusually low alpha value relative to the color value.
-    color = vec4f(color.rgb * color.a, color.a);
+    if uniforms.blend_with_background == 0 {
+        // To not apply this hack needlessly and account for alpha from alpha to coverage, we have to ignore alpha values if blending is disabled.
+        color = vec4f(color.rgb, 1.0);
+    } else {
+        color = vec4f(color.rgb * color.a, color.a);
+    }
 
     // Outlines
     {

--- a/crates/viewer/re_renderer/shader/lines.wgsl
+++ b/crates/viewer/re_renderer/shader/lines.wgsl
@@ -288,9 +288,10 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
     }
 
     // Extend the line for rendering smooth joints, as well as round start/end caps.
-    if !is_cap_triangle &&
-        ((!is_at_quad_end && (!is_first_quad_after_cap || has_any_flag(strip_data.flags, FLAG_CAP_START_ROUND))) ||
-         (is_at_quad_end && (!is_last_quad_before_cap || has_any_flag(strip_data.flags, FLAG_CAP_END_ROUND)))) {
+    let is_at_inner_joint = !is_cap_triangle && !is_first_quad_after_cap && !is_last_quad_before_cap;
+    let is_at_quad_with_round_capped_start = !is_at_quad_end && is_first_quad_after_cap && has_any_flag(strip_data.flags, FLAG_CAP_START_ROUND);
+    let is_at_quad_with_round_capped_end = is_at_quad_end && is_last_quad_before_cap && has_any_flag(strip_data.flags, FLAG_CAP_END_ROUND);
+    if is_at_inner_joint || is_at_quad_with_round_capped_start || is_at_quad_with_round_capped_end {
         let left_right_offset = quad_dir * strip_radius * select(-1.0, 1.0, is_at_quad_end);
         pos += left_right_offset;
     }

--- a/crates/viewer/re_renderer/shader/lines.wgsl
+++ b/crates/viewer/re_renderer/shader/lines.wgsl
@@ -311,10 +311,10 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 }
 
 fn distance_to_line_sq(pos: vec3f, line_a: vec3f, line_b: vec3f) -> f32 {
-    let pa = pos - line_a;
-    let ba = line_b - line_a;
-    let h = clamp(dot(pa, ba) / dot(ba, ba), 0.0, 1.0);
-    let to_line = pa - ba*h;
+    let a_to_pos = pos - line_a;
+    let a_to_b = line_b - line_a;
+    let h = clamp(dot(a_to_pos, a_to_b) / dot(a_to_b, a_to_b), 0.0, 1.0);
+    let to_line = a_to_pos - a_to_b * h;
     return dot(to_line, to_line);
 }
 

--- a/crates/viewer/re_renderer/shader/lines.wgsl
+++ b/crates/viewer/re_renderer/shader/lines.wgsl
@@ -266,7 +266,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
         center_position += quad_dir * (size_boost * select(-1.0, 1.0, is_at_quad_end));
     }
 
-    // Filtered list of flats that the fragment shader is interested in.
+    // Filtered list of flags that the fragment shader is interested in.
     var fragment_flags = strip_data.flags & FLAG_COLOR_GRADIENT;
 
     // If this is a triangle cap, we blow up our ("virtual") quad by a given factor.
@@ -313,7 +313,7 @@ fn vs_main(@builtin(vertex_index) vertex_idx: u32) -> VertexOut {
 fn distance_to_line_sq(pos: vec3f, line_a: vec3f, line_b: vec3f) -> f32 {
     let a_to_pos = pos - line_a;
     let a_to_b = line_b - line_a;
-    let h = clamp(dot(a_to_pos, a_to_b) / dot(a_to_b, a_to_b), 0.0, 1.0);
+    let h = saturate(dot(a_to_pos, a_to_b) / dot(a_to_b, a_to_b));
     let to_line = a_to_pos - a_to_b * h;
     return dot(to_line, to_line);
 }

--- a/crates/viewer/re_renderer/src/line_drawable_builder.rs
+++ b/crates/viewer/re_renderer/src/line_drawable_builder.rs
@@ -89,10 +89,7 @@ impl<'ctx> LineDrawableBuilder<'ctx> {
     }
 
     pub fn default_box_flags() -> LineStripFlags {
-        LineStripFlags::FLAG_CAP_END_ROUND
-            | LineStripFlags::FLAG_CAP_START_ROUND
-            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS
-            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
+        LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS
     }
 }
 

--- a/crates/viewer/re_renderer/src/line_drawable_builder.rs
+++ b/crates/viewer/re_renderer/src/line_drawable_builder.rs
@@ -307,7 +307,6 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
 
     /// Add box outlines from a unit cube transformed by `transform`.
     ///
-    /// Internally adds 12 line segments with rounded line heads.
     /// Disables color gradient since we don't support gradients in this setup yet (i.e. enabling them does not look good)
     #[inline]
     pub fn add_box_outline_from_transform(
@@ -324,36 +323,15 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
             transform.transform_point3(glam::vec3(0.5, 0.5, -0.5)),
             transform.transform_point3(glam::vec3(0.5, 0.5, 0.5)),
         ];
-        self.add_segments(
-            [
-                // bottom:
-                (corners[0b000], corners[0b001]),
-                (corners[0b000], corners[0b010]),
-                (corners[0b011], corners[0b001]),
-                (corners[0b011], corners[0b010]),
-                // top:
-                (corners[0b100], corners[0b101]),
-                (corners[0b100], corners[0b110]),
-                (corners[0b111], corners[0b101]),
-                (corners[0b111], corners[0b110]),
-                // sides:
-                (corners[0b000], corners[0b100]),
-                (corners[0b001], corners[0b101]),
-                (corners[0b010], corners[0b110]),
-                (corners[0b011], corners[0b111]),
-            ]
-            .into_iter(),
-        )
-        .flags(LineDrawableBuilder::default_box_flags())
+        self.add_box_from_corners(corners)
     }
 
     /// Add box outlines.
     ///
-    /// Internally adds 12 line segments with rounded line heads.
+    /// Internally a single closed line strip.
     /// Disables color gradient since we don't support gradients in this setup yet (i.e. enabling them does not look good)
     ///
     /// Returns None for empty and non-finite boxes.
-    #[inline]
     pub fn add_box_outline(
         &mut self,
         bbox: &re_math::BoundingBox,
@@ -362,35 +340,54 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
             return None;
         }
 
-        let corners = bbox.corners();
-        Some(
-            self.add_segments(
-                [
-                    // bottom:
-                    (corners[0b000], corners[0b001]),
-                    (corners[0b000], corners[0b010]),
-                    (corners[0b011], corners[0b001]),
-                    (corners[0b011], corners[0b010]),
-                    // top:
-                    (corners[0b100], corners[0b101]),
-                    (corners[0b100], corners[0b110]),
-                    (corners[0b111], corners[0b101]),
-                    (corners[0b111], corners[0b110]),
-                    // sides:
-                    (corners[0b000], corners[0b100]),
-                    (corners[0b001], corners[0b101]),
-                    (corners[0b010], corners[0b110]),
-                    (corners[0b011], corners[0b111]),
-                ]
-                .into_iter(),
-            )
-            .flags(LineDrawableBuilder::default_box_flags()),
+        Some(self.add_box_from_corners(bbox.corners()))
+    }
+
+    fn add_box_from_corners(&mut self, corners: [glam::Vec3; 8]) -> LineStripBuilder<'_, 'ctx> {
+        let mut strip_index = self.0.strips_buffer.len() as u32;
+
+        // Bottom plus connection to top.
+        self.add_vertices(
+            [
+                // bottom loop
+                corners[0b000],
+                corners[0b001],
+                corners[0b011],
+                corners[0b010],
+                corners[0b000],
+                // joined to top loop
+                corners[0b100],
+                corners[0b101],
+                corners[0b111],
+                corners[0b110],
+                corners[0b100],
+            ]
+            .into_iter(),
+            strip_index,
         )
+        .ok_or_log_error_once();
+        strip_index += 1;
+
+        // remaining side edges.
+        for line in [
+            [corners[0b001], corners[0b101]],
+            [corners[0b010], corners[0b110]],
+            [corners[0b011], corners[0b111]],
+        ] {
+            self.add_vertices(line.into_iter(), strip_index)
+                .ok_or_log_error_once();
+            strip_index += 1;
+        }
+
+        let num_strips_added = 4;
+        let num_vertices_added = 10 + 3 * 2;
+        self.create_strip_builder(num_strips_added, num_vertices_added)
+            .flags(LineDrawableBuilder::default_box_flags())
     }
 
     /// Add rectangle outlines.
     ///
-    /// Internally adds 4 line segments with rounded line heads.
+    /// Internally adds a single linestrip with 5 vertices.
     /// Disables color gradient since we don't support gradients in this setup yet (i.e. enabling them does not look good)
     #[inline]
     pub fn add_rectangle_outline(
@@ -399,18 +396,13 @@ impl<'a, 'ctx> LineBatchBuilder<'a, 'ctx> {
         extent_u: glam::Vec3,
         extent_v: glam::Vec3,
     ) -> LineStripBuilder<'_, 'ctx> {
-        self.add_segments(
+        self.add_strip(
             [
-                (top_left_corner, top_left_corner + extent_u),
-                (
-                    top_left_corner + extent_u,
-                    top_left_corner + extent_u + extent_v,
-                ),
-                (
-                    top_left_corner + extent_u + extent_v,
-                    top_left_corner + extent_v,
-                ),
-                (top_left_corner + extent_v, top_left_corner),
+                top_left_corner,
+                top_left_corner + extent_u,
+                top_left_corner + extent_u + extent_v,
+                top_left_corner + extent_v,
+                top_left_corner,
             ]
             .into_iter(),
         )

--- a/crates/viewer/re_renderer/src/renderer/compositor.rs
+++ b/crates/viewer/re_renderer/src/renderer/compositor.rs
@@ -24,7 +24,9 @@ mod gpu_data {
     pub struct CompositeUniformBuffer {
         pub outline_color_layer_a: wgpu_buffer_types::Vec4,
         pub outline_color_layer_b: wgpu_buffer_types::Vec4,
-        pub outline_radius_pixel: wgpu_buffer_types::F32RowPadded,
+        pub outline_radius_pixel: f32,
+        pub blend_with_background: u32,
+        pub padding: [u32; 2],
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 3],
     }
 }
@@ -72,7 +74,9 @@ impl CompositorDrawData {
             gpu_data::CompositeUniformBuffer {
                 outline_color_layer_a: outline_config.color_layer_a.into(),
                 outline_color_layer_b: outline_config.color_layer_b.into(),
-                outline_radius_pixel: outline_config.outline_radius_pixel.into(),
+                outline_radius_pixel: outline_config.outline_radius_pixel,
+                blend_with_background: enable_blending as u32,
+                padding: Default::default(),
                 end_padding: Default::default(),
             },
         );

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -236,6 +236,13 @@ bitflags! {
         ///
         /// TODO(andreas): Could be moved to per batch flags.
         const FLAG_FORCE_ORTHO_SPANNING = 0b1000_0000;
+
+        /// Combination of flags to extend lines outwards with round caps.
+        const FLAGS_OUTWARD_EXTENDING_ROUND_CAPS =
+            LineStripFlags::FLAG_CAP_START_ROUND.bits() |
+            LineStripFlags::FLAG_CAP_END_ROUND.bits() |
+            LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS.bits() |
+            LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS.bits();
     }
 }
 

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -39,6 +39,8 @@
 //! Why not a triangle *strip* instead if *list*?
 //! -----------------------------------------------
 //!
+//! TODO: rewrite this chapter
+//!
 //! As long as we're not able to restart the strip (requires indices!), we can't discard a quad in a triangle strip setup.
 //! However, this could be solved with an index buffer which has the ability to restart triangle strips (something we haven't tried yet).
 //!

--- a/crates/viewer/re_renderer/src/renderer/lines.rs
+++ b/crates/viewer/re_renderer/src/renderer/lines.rs
@@ -39,12 +39,10 @@
 //! Why not a triangle *strip* instead if *list*?
 //! -----------------------------------------------
 //!
-//! TODO: rewrite this chapter
-//!
 //! As long as we're not able to restart the strip (requires indices!), we can't discard a quad in a triangle strip setup.
 //! However, this could be solved with an index buffer which has the ability to restart triangle strips (something we haven't tried yet).
 //!
-//! Another much more tricky issue is handling of line miters:
+//! Another much more tricky issue is handling of line joints:
 //! Let's have a look at a corner between two line positions (line positions marked with `X`)
 //! ```raw
 //! o--------------------------o
@@ -55,36 +53,10 @@
 //!          /     //      /
 //!         o      X      o
 //! ```
-//! If we want to keep the line along its skeleton with constant radius, the top right corner
-//! would move further and further outward as we decrease the angle of the joint. Eventually it reaches infinity!
-//! (i.e. not great to fix it up with discard in the fragment shader either)
+//! The problem is that the top right corner would move further and further outward as we decrease the angle of the joint.
+//! Instead, we generate overlapping, detached quads and handle line joints as cut-outs in the fragment shader.
 //!
-//! To prevent this we need to generate this shape:
-//! ```raw
-//! a-------------------b
-//!                       \
-//! X=================X    \
-//!                  //     \
-//! c---------d     //      e
-//!          /     //      /
-//!         f      X      g
-//! ```
-//!
-//! To achieve this we need to do one of:
-//! 1) generating a new triangle at `[d,b,e]`
-//!     * can't do that without significant preprocessing, makes the entire pipeline much more complicated
-//! 2) twist one of the quads, making both quads overlap in the area of `[d,b,e]` (doesn't add any new vertices)
-//!    * unless (!) we duplicate vertices at one of the quads, the twist would need to continue for the rest of the strip!
-//! 3) make one quad stop before the joint by forming `[a,b,d,c]`, the other one taking over the joint by forming `[b,e,g,f]`
-//!    * implies breaking up the quads (point d would be part of one quad but not the other)
-//!
-//! (2) and (3) can be implemented relatively easy if we're using a triangle strip!
-//! (2) can be implemented in theory with a triangle list, but means that any joint has ripple effects on the rest of the list.
-//!
-//! TODO(andreas): Implement (3). Right now we don't implement line caps at all.
-//!
-//!
-//! Line start/end caps (arrows/rounded/etc.)
+//! Line start/end caps (arrows/etc.)
 //! -----------------------------------------------
 //! Yet another place where our triangle *strip* comes in handy is that we can take triangles from superfluous quads to form pointy arrows.
 //! Again, we keep all the geometry calculating logic in the vertex shader.
@@ -95,7 +67,6 @@
 //!             \ |  … n strip quads …  | \ | … m strip quads … | \
 //!              \|_____________________|__\|___________________|__\
 //! (start cap triangle only)         (start+end triangle)              (end triangle only)
-//!
 //!
 //!
 //! Things we might try in the future

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
@@ -174,12 +174,7 @@ impl GeoLineStringsVisualizer {
                             .unwrap_or(walkers::Position::from_lat_lon(0.0, 0.0)),
                     ))
                     // Looped lines should be connected with rounded corners, so we always add outward extending caps.
-                    .flags(
-                        LineStripFlags::FLAG_CAP_START_ROUND
-                            | LineStripFlags::FLAG_CAP_END_ROUND
-                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
-                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
-                    )
+                    .flags(LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS)
                     .color(*color)
                     .picking_instance_id(*instance)
                     .outline_mask_ids(

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
@@ -136,6 +136,9 @@ impl GeoLineStringsVisualizer {
         highlight: &SpaceViewHighlights,
     ) -> Result<(), LineDrawDataError> {
         let mut lines = re_renderer::LineDrawableBuilder::new(render_ctx);
+        lines.radius_boost_in_ui_points_for_outlines(
+            re_space_view::SIZE_BOOST_IN_POINTS_FOR_LINE_OUTLINES,
+        );
 
         for (entity_path, batch) in &self.batches {
             let outline = highlight.entity_outline_mask(entity_path.hash());

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
@@ -1,5 +1,8 @@
 use re_log_types::{EntityPath, Instance};
-use re_renderer::{renderer::LineDrawDataError, PickingLayerInstanceId};
+use re_renderer::{
+    renderer::{LineDrawDataError, LineStripFlags},
+    PickingLayerInstanceId,
+};
 use re_space_view::{DataResultQuery as _, RangeResultsExt as _};
 use re_types::{
     archetypes::GeoLineStrings,
@@ -170,6 +173,13 @@ impl GeoLineStringsVisualizer {
                             .copied()
                             .unwrap_or(walkers::Position::from_lat_lon(0.0, 0.0)),
                     ))
+                    // Looped lines should be connected with rounded corners, so we always add outward extending caps.
+                    .flags(
+                        LineStripFlags::FLAG_CAP_START_ROUND
+                            | LineStripFlags::FLAG_CAP_END_ROUND
+                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
+                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
+                    )
                     .color(*color)
                     .picking_instance_id(*instance)
                     .outline_mask_ids(

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -226,9 +226,9 @@ impl VisualizerSystem for Boxes2DVisualizer {
                     return Ok(());
                 }
 
-                // Each box consists of 4 independent lines of 2 vertices each.
-                line_builder.reserve_strips(num_boxes * 4)?;
-                line_builder.reserve_vertices(num_boxes * 4 * 2)?;
+                // Each box consists of one strip with a total of 5 vertices each.
+                line_builder.reserve_strips(num_boxes)?;
+                line_builder.reserve_vertices(num_boxes * 5)?;
 
                 let timeline = ctx.query.timeline();
                 let all_half_sizes_indexed = iter_primitive_array::<2, f32>(

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -169,9 +169,9 @@ impl VisualizerSystem for Boxes3DVisualizer {
 
                 match fill_mode {
                     FillMode::DenseWireframe | FillMode::MajorWireframe => {
-                        // Each box consists of 12 independent lines with 2 vertices each.
-                        builder.line_builder.reserve_strips(num_boxes * 12)?;
-                        builder.line_builder.reserve_vertices(num_boxes * 12 * 2)?;
+                        // Each box consists of 4 strips with a total of 16 vertices
+                        builder.line_builder.reserve_strips(num_boxes * 4)?;
+                        builder.line_builder.reserve_vertices(num_boxes * 16)?;
                     }
                     FillMode::Solid => {
                         // No lines.

--- a/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/cameras.rs
@@ -130,21 +130,31 @@ impl CamerasVisualizer {
 
         let strips = vec![
             // Frustum rectangle, connected with zero point.
-            vec![
-                corners[0],
-                corners[1],
-                glam::Vec3::ZERO,
-                corners[2],
-                corners[3],
-                glam::Vec3::ZERO,
-                corners[0],
-                corners[3],
-                glam::Vec3::ZERO,
-            ],
+            (
+                vec![
+                    corners[0],
+                    corners[1],
+                    glam::Vec3::ZERO,
+                    corners[2],
+                    corners[3],
+                    glam::Vec3::ZERO,
+                    corners[0],
+                    corners[3],
+                    glam::Vec3::ZERO,
+                ],
+                LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS,
+            ),
             // Missing piece of the rectangle at the far plane.
-            vec![corners[1], corners[2]],
-            // Triangle indicating up direction:
-            vec![up_triangle[0], up_triangle[1], up_triangle[2]],
+            (
+                vec![corners[1], corners[2]],
+                LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS,
+            ),
+            // Triangle indicating up direction.
+            // Don't extend round caps here, this would reach into the frustum otherwise.
+            (
+                vec![up_triangle[0], up_triangle[1], up_triangle[2]],
+                LineStripFlags::empty(),
+            ),
         ];
 
         let radius = re_renderer::Size::new_ui_points(1.0);
@@ -163,12 +173,12 @@ impl CamerasVisualizer {
             .outline_mask_ids(entity_highlight.overall)
             .picking_object_id(instance_layer_id.object);
 
-        for strip in strips {
+        for (strip, flags) in strips {
             let lines = batch
                 .add_strip(strip.into_iter())
                 .radius(radius)
                 .color(CAMERA_COLOR)
-                .flags(LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS)
+                .flags(flags)
                 .picking_instance_id(instance_layer_id.instance);
 
             if let Some(outline_mask_ids) = entity_highlight.instances.get(&instance) {

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -90,12 +90,7 @@ impl Lines2DVisualizer {
                     .color(color)
                     .radius(radius)
                     // Looped lines should be connected with rounded corners, so we always add outward extending caps.
-                    .flags(
-                        LineStripFlags::FLAG_CAP_START_ROUND
-                            | LineStripFlags::FLAG_CAP_END_ROUND
-                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
-                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
-                    )
+                    .flags(LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS)
                     .picking_instance_id(PickingLayerInstanceId(i as _));
 
                 if let Some(outline_mask_ids) = ent_context

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -1,5 +1,5 @@
 use re_log_types::Instance;
-use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId};
+use re_renderer::{renderer::LineStripFlags, LineDrawableBuilder, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips2D,
     components::{ClassId, Color, DrawOrder, KeypointId, LineStrip2D, Radius, ShowLabels, Text},
@@ -89,6 +89,13 @@ impl Lines2DVisualizer {
                     .add_strip_2d(strip.iter().copied().map(Into::into))
                     .color(color)
                     .radius(radius)
+                    // Looped lines should be connected with rounded corners, so we always add outward extending caps.
+                    .flags(
+                        LineStripFlags::FLAG_CAP_START_ROUND
+                            | LineStripFlags::FLAG_CAP_END_ROUND
+                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
+                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
+                    )
                     .picking_instance_id(PickingLayerInstanceId(i as _));
 
                 if let Some(outline_mask_ids) = ent_context

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -92,12 +92,7 @@ impl Lines3DVisualizer {
                 let lines = line_batch
                     .add_strip(strip.iter().copied().map(Into::into))
                     // Looped lines should be connected with rounded corners, so we always add outward extending caps.
-                    .flags(
-                        LineStripFlags::FLAG_CAP_START_ROUND
-                            | LineStripFlags::FLAG_CAP_END_ROUND
-                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
-                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
-                    )
+                    .flags(LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS)
                     .color(color)
                     .radius(radius)
                     .picking_instance_id(PickingLayerInstanceId(i as _));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -1,5 +1,5 @@
 use re_log_types::Instance;
-use re_renderer::PickingLayerInstanceId;
+use re_renderer::{renderer::LineStripFlags, PickingLayerInstanceId};
 use re_types::{
     archetypes::LineStrips3D,
     components::{ClassId, Color, KeypointId, LineStrip3D, Radius, ShowLabels, Text},
@@ -91,6 +91,13 @@ impl Lines3DVisualizer {
             {
                 let lines = line_batch
                     .add_strip(strip.iter().copied().map(Into::into))
+                    // Looped lines should be connected with rounded corners, so we always add outward extending caps.
+                    .flags(
+                        LineStripFlags::FLAG_CAP_START_ROUND
+                            | LineStripFlags::FLAG_CAP_END_ROUND
+                            | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
+                            | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
+                    )
                     .color(color)
                     .radius(radius)
                     .picking_instance_id(PickingLayerInstanceId(i as _));

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/proc_mesh_vis.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/proc_mesh_vis.rs
@@ -197,12 +197,7 @@ where
                             .radius(radius)
                             .picking_instance_id(PickingLayerInstanceId(instance_index as _))
                             // Looped lines should be connected with rounded corners.
-                            .flags(
-                                LineStripFlags::FLAG_CAP_START_ROUND
-                                    | LineStripFlags::FLAG_CAP_END_ROUND
-                                    | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
-                                    | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
-                            );
+                            .flags(LineStripFlags::FLAGS_OUTWARD_EXTENDING_ROUND_CAPS);
 
                         if let Some(outline_mask_ids) = ent_context
                             .highlight

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/proc_mesh_vis.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/proc_mesh_vis.rs
@@ -1,6 +1,6 @@
 use re_entity_db::InstancePathHash;
 use re_log_types::Instance;
-use re_renderer::renderer::GpuMeshInstance;
+use re_renderer::renderer::{GpuMeshInstance, LineStripFlags};
 use re_renderer::{LineDrawableBuilder, PickingLayerInstanceId, RenderContext};
 use re_types::components::{self, FillMode};
 use re_viewer_context::{
@@ -195,7 +195,14 @@ where
                             )
                             .color(color)
                             .radius(radius)
-                            .picking_instance_id(PickingLayerInstanceId(instance_index as _));
+                            .picking_instance_id(PickingLayerInstanceId(instance_index as _))
+                            // Looped lines should be connected with rounded corners.
+                            .flags(
+                                LineStripFlags::FLAG_CAP_START_ROUND
+                                    | LineStripFlags::FLAG_CAP_END_ROUND
+                                    | LineStripFlags::FLAG_CAP_START_EXTEND_OUTWARDS
+                                    | LineStripFlags::FLAG_CAP_END_EXTEND_OUTWARDS,
+                            );
 
                         if let Some(outline_mask_ids) = ent_context
                             .highlight


### PR DESCRIPTION
### What

* Fixes https://github.com/rerun-io/rerun/issues/829
* Fixes https://github.com/rerun-io/rerun/issues/7191

Fixes a long standing issue that the segments of a line have small gaps between them.

Other than originally planned, the solution employed here is entirely based on fragment shader discard + elongation of the line. This can cause some slight artifacts for 3D lines but it's quite hard to spot those issues. Otherwise the biggest drawback of this is that we have more overdraw which gonna be tricky to deal with once we add transparency. On the flip side this is fairly simple and can re-use some of the round cap handling code - round caps no longer use the "trailing triangle" we had for every strip internally, and instead use the quad extension, actually leading to better looking round caps.

⚠️  To allow loops to "just work", all line segments & line strips start and end now with extended round caps. I.e. if your line has a radius of 1 and goes from (0,0,0) to (100,0,0), then what's drawn goes from (-1,0,0) to (101,0,0). Before we didn't have caps on this, so we essentially drew a square starting at (0,0,0) whereas now it's more capsule like (it does not exactly behave like a capsule under perspective though).


Line loops on map view:
Before:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/6d19ef7b-ea8e-422d-8ad9-6eb18f567340">

After:
<img width="303" alt="image" src="https://github.com/user-attachments/assets/81ffb6a7-3216-4c96-84fd-3f4d9268300c">


RRT Star:
Before:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a72352e7-8a73-4507-9f3a-5b4c713f7fc0">

After:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/03040348-f275-49c5-ad89-36fafc9fc1e9">


3D line snippet snippet:
Before:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/000dfef6-5d03-45e6-95bf-03a5033cc7a3">

After:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/1e511ee3-6464-4d30-aa30-34dce358bd85">


Failure Example in #7191
Before - confusingly broken:
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/261fe4dd-1d21-46e9-8139-6444af4e8cdf">


After - pretty bad rendering performance due to quite massive overdraw of alpha tested geometry, but no longer broken.
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/1bbe8b0b-c90b-4164-bf14-6b2de1c6884b">

(After: setting the radius to something large, but sane)
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/5f02e388-80cf-472b-b99d-8f45dfb2e9f2">


re_renderer 2D demo. Left before, right after. Note that "shaded lines" look a lot better now as a sideffect, with shading of arrows slightly broken. Afaik we don't use this anywhere in Rerun today though. 
However, rounded caps are higher quality now in general.

<img width="999" alt="Screenshot 2024-11-11 at 11 10 29" src="https://github.com/user-attachments/assets/9404e2b1-218a-41c4-bc62-e711bdbcfe63">

----

Things that were several segments before can now be strips. No visual change there:

Rectangles:
<img width="364" alt="image" src="https://github.com/user-attachments/assets/85ef5d5d-da82-4e70-a828-54e802fdd447">

Frustum:
<img width="873" alt="image" src="https://github.com/user-attachments/assets/a58ec4d6-9500-40b0-9023-61b077a63920">

Box wireframes:

This fixes a regression! In 0.19 those boxes had disconnected lines, in 0.18 this still worked since they were separate segments with rounded corners.

Before (regression):
<img width="233" alt="image" src="https://github.com/user-attachments/assets/b2a2aade-7271-46cc-a0ff-aa82031638e4">

After:
<img width="233" alt="image" src="https://github.com/user-attachments/assets/727df4ea-9b63-43b1-ab48-64afdf508567">

----

Due to aforementioned always-round-caps, a list of segments can now look indistinguishable from a single strip:

<img width="438" alt="image" src="https://github.com/user-attachments/assets/ec0ca8da-201a-4d80-8e3e-c512c9fdb23b">


----

Under more extreme circumstances it is still (!) possible to have boxes exhibit some artifacts:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/fee28464-f0f8-4b5c-9cbe-2e049df92153">

This is due to the quasi-capsule nature of our line segments. Calculating a world position from ray-capsule intersection would yield the correct result. What's actually happening right now is that we interpolate the world position over the spanned quad (which is a lot cheaper).

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8065?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8065?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8065)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

### Testing
* [x] Tested on WebGL
* [x] Tested on WebGPU