### PR TITLE
Fix video docs incorrectly advertising vp8 support

### DIFF
--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -46,10 +46,13 @@ Codec support varies in the web & native viewer:
 | AV1        | ✅       | ✅      |
 | H.264/avc  | ✅       | ✅      |
 | H.265/hevc | 🔳       | ❌      |
-| VP8        | ✅       | ❌      |
 | VP9        | ✅       | ❌      |
 
-<!-- for web codecs see https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry -->
+<!--
+for web codecs see https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry
+VP8 is only not in the list because VP9 doesn't support MP4 as a container and that's
+today the only container we take.
+-->
 
 Details see below.
 


### PR DESCRIPTION
### What

VP8 can't be stored in MP4 -> we don't support it

Note that this table hasn't shipped in 0.19.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8071?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8071?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8071)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.