### PR TITLE
Add more video codecs to check_video checklist

### DIFF
--- a/tests/assets/download_test_assets.py
+++ b/tests/assets/download_test_assets.py
@@ -16,6 +16,9 @@ import tqdm
 
 test_assets = [
     "video/Big_Buck_Bunny_1080_10s_av1.mp4",
+    "video/Big_Buck_Bunny_1080_10s_h264.mp4",
+    "video/Big_Buck_Bunny_1080_10s_h265.mp4",
+    "video/Big_Buck_Bunny_1080_10s_vp9.mp4",
     "video/Sintel_1080_10s_av1.mp4",
 ]
 

--- a/tests/python/release_checklist/check_video.py
+++ b/tests/python/release_checklist/check_video.py
@@ -5,14 +5,20 @@ from argparse import Namespace
 from uuid import uuid4
 
 import rerun as rr
+import rerun.blueprint as rrb
 
 README = """\
 # Video support
-This test only works in the browser!
 
-The video should show up both in 2D, 3D, and in the selection panel.
+Make sure video plays on all views unless lack of support is mentioned:
 
-When moving the time cursor, a "loading" spinner should show briefly, while the video is seeking.
+* `AV1` is expected to work on web & release version native.
+(In debug native this should inform that it is not supported in debug.)
+* `AV1 frustum` should work if `AV1 video` works, showing a frustum with a video.
+* `H.264` should work on web & native. On native this may complain about missing ffmpeg. If so, selecting it should inform you how to fix this.
+* `H.265` should work on Chrome & Safari. Firefox does not support it.
+* `VP9` works only on web, on native this should inform that the codec is not supported.
+
 """
 
 
@@ -21,35 +27,54 @@ def run(args: Namespace) -> None:
 
     rr.log("readme", rr.TextDocument(README, media_type=rr.MediaType.MARKDOWN), timeless=True)
 
-    # Log video asset which is referred to by frame references.
-    video_path = os.path.dirname(__file__) + "/../../../tests/assets/video/Big_Buck_Bunny_1080_10s_av1.mp4"
-    video_asset = rr.AssetVideo(path=video_path)
-    rr.log("world/cam", video_asset, static=True)
+    for codec in ["av1", "h264", "h265", "vp9"]:
+        # Log video asset which is referred to by frame references.
+        video_path = os.path.dirname(__file__) + f"/../../../tests/assets/video/Big_Buck_Bunny_1080_10s_{codec}.mp4"
+        video_asset = rr.AssetVideo(path=video_path)
+        rr.log(codec, video_asset, static=True)
 
-    # Send automatically determined video frame timestamps.
-    frame_timestamps_ns = video_asset.read_frame_timestamps_ns()
-    rr.send_columns(
-        "world/cam",
-        # Note timeline values don't have to be the same as the video timestamps.
-        times=[rr.TimeNanosColumn("video_time", frame_timestamps_ns)],
-        components=[rr.VideoFrameReference.indicator(), rr.components.VideoTimestamp.nanoseconds(frame_timestamps_ns)],
-    )
+        # Send automatically determined video frame timestamps.
+        frame_timestamps_ns = video_asset.read_frame_timestamps_ns()
+        rr.send_columns(
+            codec,
+            # Note timeline values don't have to be the same as the video timestamps.
+            times=[rr.TimeNanosColumn("video_time", frame_timestamps_ns)],
+            components=[
+                rr.VideoFrameReference.indicator(),
+                rr.components.VideoTimestamp.nanoseconds(frame_timestamps_ns),
+            ],
+        )
 
+    # Use the av1 also in a 3D context
     rr.log(
-        "world/cam",
+        "av1",
         rr.Transform3D(
             translation=[10, 0, 0],
         ),
         static=True,  # Static, so it shows up in the "video_time" timeline!
     )
-
     rr.log(
-        "world/cam",
+        "av1",
         rr.Pinhole(
             resolution=[1920, 1080],
             focal_length=1920,
+            camera_xyz=rr.ViewCoordinates.RBU,
         ),
         static=True,  # Static, so it shows up in the "video_time" timeline!
+    )
+
+    rr.send_blueprint(
+        rrb.Blueprint(
+            rrb.Grid(
+                rrb.TextDocumentView(origin="readme", name="Instructions"),
+                rrb.Spatial3DView(origin="/", name="AV1 frustum", contents="av1"),
+                rrb.Spatial2DView(origin="av1", name="AV1"),
+                rrb.Spatial2DView(origin="h264", name="H.264"),
+                rrb.Spatial2DView(origin="h265", name="H.265"),
+                rrb.Spatial2DView(origin="vp9", name="VP9"),
+            ),
+            rrb.TimePanel(state="collapsed"),
+        )
     )
 
 


### PR DESCRIPTION
### What

Testing all the codecs now in the video release check.

Native (release):
![image](https://github.com/user-attachments/assets/0eeff8ec-ae1d-400c-8f4e-f52d1c0ff014)

Firefox:
![image](https://github.com/user-attachments/assets/fc921b0c-d245-41a6-ab27-26e4bd3abbb5)
(Running into new so far unknown issue https://github.com/rerun-io/rerun/issues/8079)

Chrome:
![image](https://github.com/user-attachments/assets/e968d77e-fc78-41f7-8b1c-1a8c86cae019)

Try it out yourself here:
https://rerun.io/viewer/pr/8065/?url=https://static.rerun.io/rrd/0.19.0/check_video_with_rbl_6dd367baba11e979be3cc361571b226d7589a9d6.rrd



### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8080?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8080?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8080)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.