### PR TITLE
0.20 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ TODO: add link to release video
 - Enable dataframe streaming across Python FFI [#7935](https://github.com/rerun-io/rerun/pull/7935)
 - Fix python SDK's shutdown unsafely dropping cross-FFI resources [#8038](https://github.com/rerun-io/rerun/pull/8038)
 - Improve edge-cases and warn on ambiguity for Rgba32 datatype [#8054](https://github.com/rerun-io/rerun/pull/8054)
+- Check rerun notebook version on first import [#8030](https://github.com/rerun-io/rerun/pull/8030)
 
 #### 🦀 Rust API
 - Allow logging individual components directly (Impl `AsComponents` for all `ObjectKind::Component`) [#7756](https://github.com/rerun-io/rerun/pull/7756) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
@@ -55,9 +56,13 @@ TODO: add link to release video
 - ChunkStore: fix row-id computation when removing dangling static chunks [#8020](https://github.com/rerun-io/rerun/pull/8020)
 - Fix some videos having offsetted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
 - Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
+- Make sure videos all end up in different space views [#8085](https://github.com/rerun-io/rerun/pull/8085)
+- `EntityTree`: only check for entity deletions when necessary [#8103](https://github.com/rerun-io/rerun/pull/8103)
+- Fix video on web sometimes not showing last few frames for some videos [#8117](https://github.com/rerun-io/rerun/pull/8117)
+- Fix issues with seeking in some H.264 videos on native & web [#8111](https://github.com/rerun-io/rerun/pull/8111)
 
 #### 🌁 Viewer improvements
-- Fix view heuristics for videos [#7869](https://github.com/rerun-io/rerun/pull/7869)
+- Fix view creation heuristics for videos [#7869](https://github.com/rerun-io/rerun/pull/7869)
 - A Rerun Viewer session now matches 1:1 to a Rerun TCP server [#6951](https://github.com/rerun-io/rerun/pull/6951) (thanks [@petertheprocess](https://github.com/petertheprocess)!)
 - Implement support for in-place drag-n-drop [#7880](https://github.com/rerun-io/rerun/pull/7880)
 - Implement `Menu > Import` and associated command [#7882](https://github.com/rerun-io/rerun/pull/7882)
@@ -66,9 +71,11 @@ TODO: add link to release video
 - Update crates, including `rfd` for better file dialogs [#7953](https://github.com/rerun-io/rerun/pull/7953)
 - Support H.264 on native via user installed ffmpeg executable [#7962](https://github.com/rerun-io/rerun/pull/7962)
 - Expose basic information about group of pictures in video data in the selection panel [#8043](https://github.com/rerun-io/rerun/pull/8043)
+- Line strips are no longer a disconnected series of quads [#8065](https://github.com/rerun-io/rerun/pull/8065)
+- Calculate and show video frame number [#8112](https://github.com/rerun-io/rerun/pull/8112)
 
 #### 🚀 Performance improvements
-- Don't keep around additional cpu copy of loaded mesh files [#7824](https://github.com/rerun-io/rerun/pull/7824)
+- Don't keep around additional CPU copy of loaded mesh files [#7824](https://github.com/rerun-io/rerun/pull/7824)
 - Make mp4 parsing **a lot** faster & tremendously lower memory overhead [#7860](https://github.com/rerun-io/rerun/pull/7860)
 - Fix slow receive when using native WebSocket [#7875](https://github.com/rerun-io/rerun/pull/7875)
 - Implement support for fully asynchronous `QueryHandle`s [#7964](https://github.com/rerun-io/rerun/pull/7964)
@@ -92,15 +99,20 @@ TODO: add link to release video
 #### 🖼 UI improvements
 - Map View and `GeoPoints` archetype [#6561](https://github.com/rerun-io/rerun/pull/6561) (thanks [@tfoldi](https://github.com/tfoldi)!)
 - Replace the "Options" submenu with a settings screen [#8001](https://github.com/rerun-io/rerun/pull/8001)
+- Improve error message style slightly [#8092](https://github.com/rerun-io/rerun/pull/8092)
+- Show all samples/frames in a video in a nice table [#8102](https://github.com/rerun-io/rerun/pull/8102)
+- Much nicer looking error and warning messages [#8127](https://github.com/rerun-io/rerun/pull/8127)
 
 #### 🧑‍💻 Dev-experience
 - Show list of enabled feature with `rerun --version` [#7885](https://github.com/rerun-io/rerun/pull/7885)
 
 #### 📦 Dependencies
 - Bump numpy -> 0.23, pyo3 -> 0.22.5, and arrow -> 53.1 [#7834](https://github.com/rerun-io/rerun/pull/7834)
+- Update re_mp4 to fix integer overflow bug [#8096](https://github.com/rerun-io/rerun/pull/8096)
 
 #### 🤷‍ Other
 - Implement safe storage handles [#7934](https://github.com/rerun-io/rerun/pull/7934)
+- Fix listing of enabled features in `rerun --version` [#8095](https://github.com/rerun-io/rerun/pull/8095)
 
 
 ## [0.19.1](https://github.com/rerun-io/rerun/compare/0.19.0..0.19.1) - Web viewer fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 
-## [0.20.0](https://github.com/rerun-io/rerun/compare/0.19.1...0.20.0) - Experimental Map & native H.264 support
+## [0.20.0](https://github.com/rerun-io/rerun/compare/0.19.1...0.20.0) - Map view & native H.264 video support
 
 TODO: add link to release video
 
@@ -10,25 +10,26 @@ TODO: add link to release video
 🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-20
 
 ### ✨ Overview & highlights
-* 🗺️ There is now an experimental map view!
-* 🎬 Native viewer supports now H.264 video if ffmpeg is installed.
-* 📽️ Videos load now a lot faster and take less memory.
+* 🗺️ There is now an map view!
+* 🎬 Native viewer now supports H.264 video if ffmpeg is installed.
+* 📽️ Videos now load a lot faster use less RAM.
 * 📂 Logging files now uses the active app/recording id, allowing to combine several rrd files in the viewer.
   * Relatedly, there's now an `Import File` option in the menu to import arbitrary files into the active recording.
 
 ### ⚠️ Breaking changes
-* 🎨 In Python, lists of numbers without type information are noweassumed to be packed integer color representations, unless the length is exactly 3 or 4.
 * 🐍 Python 3.8 is being deprecated
+* 🎨 In Python, lists of numbers without type information are now assumed to be packed integer color representations, unless the length is exactly 3 or 4
 🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-20
 
 ### 🔎 Details
 
 #### 🎬 Video
 - Support H.264 video on native via user installed ffmpeg executable [#7962](https://github.com/rerun-io/rerun/pull/7962)
+- Make mp4 parsing **a lot** faster & tremendously lower memory overhead [#7860](https://github.com/rerun-io/rerun/pull/7860)
+- Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
 - Show all samples/frames in a video in a nice table [#8102](https://github.com/rerun-io/rerun/pull/8102)
 - Calculate and show video frame number [#8112](https://github.com/rerun-io/rerun/pull/8112)
 - Expose basic information about group of pictures in video data in the selection panel [#8043](https://github.com/rerun-io/rerun/pull/8043)
-- Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
 - Fix some videos having offsetted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
 - Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
 - Make sure videos all end up in different space views [#8085](https://github.com/rerun-io/rerun/pull/8085)
@@ -39,6 +40,7 @@ TODO: add link to release video
 - Update re_mp4 to fix integer overflow bug [#8096](https://github.com/rerun-io/rerun/pull/8096)
 
 #### 🪵 Log API
+- Add `Capsules3D` archetype [#7574](https://github.com/rerun-io/rerun/pull/7574) (thanks [@kpreid](https://github.com/kpreid)!)
 - `rr.log_file_from_path` now defaults to the active app/recording ID [#7864](https://github.com/rerun-io/rerun/pull/7864)
 - Allow overriding albedo color on `Asset3D` [#7458](https://github.com/rerun-io/rerun/pull/7458) (thanks [@EtaLoop](https://github.com/EtaLoop)!)
 - `rr.serve` -> `rr.serve_web`, `rr.connect` -> `rr.connect_tcp` [#7906](https://github.com/rerun-io/rerun/pull/7906)
@@ -74,7 +76,6 @@ TODO: add link to release video
 - A Rerun Viewer session now matches 1:1 to a Rerun TCP server [#6951](https://github.com/rerun-io/rerun/pull/6951) (thanks [@petertheprocess](https://github.com/petertheprocess)!)
 - Implement support for in-place drag-n-drop [#7880](https://github.com/rerun-io/rerun/pull/7880)
 - Implement `Menu > Import` and associated command [#7882](https://github.com/rerun-io/rerun/pull/7882)
-- Add `Capsules3D` archetype [#7574](https://github.com/rerun-io/rerun/pull/7574) (thanks [@kpreid](https://github.com/kpreid)!)
 - Expose additional information about decoded frames in the viewer [#7932](https://github.com/rerun-io/rerun/pull/7932)
 - Update crates, including `rfd` for better file dialogs [#7953](https://github.com/rerun-io/rerun/pull/7953)
 - Line strips are no longer a disconnected series of quads [#8065](https://github.com/rerun-io/rerun/pull/8065)
@@ -86,8 +87,8 @@ TODO: add link to release video
 - Implement support for fully asynchronous `QueryHandle`s [#7964](https://github.com/rerun-io/rerun/pull/7964)
 
 #### 🧑‍🏫 Examples
-- Fix Rust dna sample writing to a temporary file [#7827](https://github.com/rerun-io/rerun/pull/7827)
-- Add ml_depth_pro example [#7832](https://github.com/rerun-io/rerun/pull/7832) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
+- Fix Rust DNA sample writing to a temporary file [#7827](https://github.com/rerun-io/rerun/pull/7827)
+- Add `ml_depth_pro` example [#7832](https://github.com/rerun-io/rerun/pull/7832) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
 - Add map view to nuscenes python example [#8034](https://github.com/rerun-io/rerun/pull/8034) (thanks [@tfoldi](https://github.com/tfoldi)!)
 - Add an example to display OpenStreetMap-sourced data on the map view [#8044](https://github.com/rerun-io/rerun/pull/8044)
 
@@ -107,14 +108,13 @@ TODO: add link to release video
 - Much nicer looking error and warning messages [#8127](https://github.com/rerun-io/rerun/pull/8127)
 
 #### 🧑‍💻 Dev-experience
-- Show list of enabled feature with `rerun --version` [#7885](https://github.com/rerun-io/rerun/pull/7885)
+- Show list of enabled features with `rerun --version` [#7885](https://github.com/rerun-io/rerun/pull/7885) [#8095](https://github.com/rerun-io/rerun/pull/8095)
 
 #### 📦 Dependencies
 - Bump numpy -> 0.23, pyo3 -> 0.22.5, and arrow -> 53.1 [#7834](https://github.com/rerun-io/rerun/pull/7834)
 
 #### 🤷‍ Other
 - Implement safe storage handles [#7934](https://github.com/rerun-io/rerun/pull/7934)
-- Fix listing of enabled features in `rerun --version` [#8095](https://github.com/rerun-io/rerun/pull/8095)
 
 
 ## [0.19.1](https://github.com/rerun-io/rerun/compare/0.19.0..0.19.1) - Web viewer fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ TODO: add link to release video
 
 ### 🔎 Details
 
+#### 🎬 Video
+- Support H.264 video on native via user installed ffmpeg executable [#7962](https://github.com/rerun-io/rerun/pull/7962)
+- Show all samples/frames in a video in a nice table [#8102](https://github.com/rerun-io/rerun/pull/8102)
+- Calculate and show video frame number [#8112](https://github.com/rerun-io/rerun/pull/8112)
+- Expose basic information about group of pictures in video data in the selection panel [#8043](https://github.com/rerun-io/rerun/pull/8043)
+- Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
+- Fix some videos having offsetted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
+- Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
+- Make sure videos all end up in different space views [#8085](https://github.com/rerun-io/rerun/pull/8085)
+- Fix video on web sometimes not showing last few frames for some videos [#8117](https://github.com/rerun-io/rerun/pull/8117)
+- Fix issues with seeking in some H.264 videos on native & web [#8111](https://github.com/rerun-io/rerun/pull/8111)
+- Fix view creation heuristics for videos [#7869](https://github.com/rerun-io/rerun/pull/7869)
+- Improve video doc page [#8007](https://github.com/rerun-io/rerun/pull/8007)
+- Update re_mp4 to fix integer overflow bug [#8096](https://github.com/rerun-io/rerun/pull/8096)
+
 #### 🪵 Log API
 - `rr.log_file_from_path` now defaults to the active app/recording ID [#7864](https://github.com/rerun-io/rerun/pull/7864)
 - Allow overriding albedo color on `Asset3D` [#7458](https://github.com/rerun-io/rerun/pull/7458) (thanks [@EtaLoop](https://github.com/EtaLoop)!)
@@ -51,28 +66,18 @@ TODO: add link to release video
 - [bugfix] Make sure blueprint gets sent to the notebook view being created [#7811](https://github.com/rerun-io/rerun/pull/7811)
 - Fix too short picking ray in pinhole-only scenarios [#7899](https://github.com/rerun-io/rerun/pull/7899)
 - Update zune-jpeg to fix crash on bad JPEGs [#7952](https://github.com/rerun-io/rerun/pull/7952)
-- Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
 - Consistent open/import/log_file behaviors in all common scenarios [#7966](https://github.com/rerun-io/rerun/pull/7966)
 - ChunkStore: fix row-id computation when removing dangling static chunks [#8020](https://github.com/rerun-io/rerun/pull/8020)
-- Fix some videos having offsetted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
-- Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
-- Make sure videos all end up in different space views [#8085](https://github.com/rerun-io/rerun/pull/8085)
 - `EntityTree`: only check for entity deletions when necessary [#8103](https://github.com/rerun-io/rerun/pull/8103)
-- Fix video on web sometimes not showing last few frames for some videos [#8117](https://github.com/rerun-io/rerun/pull/8117)
-- Fix issues with seeking in some H.264 videos on native & web [#8111](https://github.com/rerun-io/rerun/pull/8111)
 
 #### 🌁 Viewer improvements
-- Fix view creation heuristics for videos [#7869](https://github.com/rerun-io/rerun/pull/7869)
 - A Rerun Viewer session now matches 1:1 to a Rerun TCP server [#6951](https://github.com/rerun-io/rerun/pull/6951) (thanks [@petertheprocess](https://github.com/petertheprocess)!)
 - Implement support for in-place drag-n-drop [#7880](https://github.com/rerun-io/rerun/pull/7880)
 - Implement `Menu > Import` and associated command [#7882](https://github.com/rerun-io/rerun/pull/7882)
 - Add `Capsules3D` archetype [#7574](https://github.com/rerun-io/rerun/pull/7574) (thanks [@kpreid](https://github.com/kpreid)!)
 - Expose additional information about decoded frames in the viewer [#7932](https://github.com/rerun-io/rerun/pull/7932)
 - Update crates, including `rfd` for better file dialogs [#7953](https://github.com/rerun-io/rerun/pull/7953)
-- Support H.264 on native via user installed ffmpeg executable [#7962](https://github.com/rerun-io/rerun/pull/7962)
-- Expose basic information about group of pictures in video data in the selection panel [#8043](https://github.com/rerun-io/rerun/pull/8043)
 - Line strips are no longer a disconnected series of quads [#8065](https://github.com/rerun-io/rerun/pull/8065)
-- Calculate and show video frame number [#8112](https://github.com/rerun-io/rerun/pull/8112)
 
 #### 🚀 Performance improvements
 - Don't keep around additional CPU copy of loaded mesh files [#7824](https://github.com/rerun-io/rerun/pull/7824)
@@ -94,13 +99,11 @@ TODO: add link to release video
 - Docs: "How-to: reuse blueprints across languages" [#7886](https://github.com/rerun-io/rerun/pull/7886)
 - Docs: application model part 1: native workflows [#7905](https://github.com/rerun-io/rerun/pull/7905)
 - Document arrow datatypes [#7986](https://github.com/rerun-io/rerun/pull/7986)
-- Improve video doc page [#8007](https://github.com/rerun-io/rerun/pull/8007)
 
 #### 🖼 UI improvements
 - Map View and `GeoPoints` archetype [#6561](https://github.com/rerun-io/rerun/pull/6561) (thanks [@tfoldi](https://github.com/tfoldi)!)
 - Replace the "Options" submenu with a settings screen [#8001](https://github.com/rerun-io/rerun/pull/8001)
 - Improve error message style slightly [#8092](https://github.com/rerun-io/rerun/pull/8092)
-- Show all samples/frames in a video in a nice table [#8102](https://github.com/rerun-io/rerun/pull/8102)
 - Much nicer looking error and warning messages [#8127](https://github.com/rerun-io/rerun/pull/8127)
 
 #### 🧑‍💻 Dev-experience
@@ -108,7 +111,6 @@ TODO: add link to release video
 
 #### 📦 Dependencies
 - Bump numpy -> 0.23, pyo3 -> 0.22.5, and arrow -> 53.1 [#7834](https://github.com/rerun-io/rerun/pull/7834)
-- Update re_mp4 to fix integer overflow bug [#8096](https://github.com/rerun-io/rerun/pull/8096)
 
 #### 🤷‍ Other
 - Implement safe storage handles [#7934](https://github.com/rerun-io/rerun/pull/7934)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ TODO: add link to release video
 - Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
 - Consistent open/import/log_file behaviors in all common scenarios [#7966](https://github.com/rerun-io/rerun/pull/7966)
 - ChunkStore: fix row-id computation when removing dangling static chunks [#8020](https://github.com/rerun-io/rerun/pull/8020)
-- Fix some videos having offseted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
+- Fix some videos having offsetted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
 - Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
 
 #### 🌁 Viewer improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ TODO: add link to release video
 
 #### 🧑‍🏫 Examples
 - Fix Rust dna sample writing to a temporary file [#7827](https://github.com/rerun-io/rerun/pull/7827)
-- Add  ml_depth_pro example [#7832](https://github.com/rerun-io/rerun/pull/7832) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
+- Add ml_depth_pro example [#7832](https://github.com/rerun-io/rerun/pull/7832) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
 - Add map view to nuscenes python example [#8034](https://github.com/rerun-io/rerun/pull/8034) (thanks [@tfoldi](https://github.com/tfoldi)!)
 - Add an example to display OpenStreetMap-sourced data on the map view [#8044](https://github.com/rerun-io/rerun/pull/8044)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,106 @@
 # Rerun changelog
 
-
 ## [Unreleased](https://github.com/rerun-io/rerun/compare/latest...HEAD)
 
+## [0.20.0](https://github.com/rerun-io/rerun/compare/0.19.1...0.20.0) - Experimental Map & native H.264 support
+
+TODO: add link to release video
+
+📖 Release blogpost: TODO: add link
+🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-20
+
+### ✨ Overview & highlights
+* 🗺️ There is now an experimental map view!
+* 🎬 Native viewer supports now H.264 video if ffmpeg is installed.
+* 📽️ Videos load now a lot faster and take less memory.
+* 📂 Logging files now uses the active app/recording id, allowing to combine several rrd files in the viewer.
+  * Relatedly, there's now an `Import File` option in the menu to import arbitrary files into the active recording.
+
+### ⚠️ Breaking changes
+* 🎨 In Python, lists of numbers without type information are noweassumed to be packed integer color representations, unless the length is exactly 3 or 4.
+* 🐍 Python 3.8 is being deprecated
+🧳 Migration guide: http://rerun.io/docs/reference/migration/migration-0-20
+
+### 🔎 Details
+
+#### 🪵 Log API
+- `rr.log_file_from_path` now defaults to the active app/recording ID [#7864](https://github.com/rerun-io/rerun/pull/7864)
+- Allow overriding albedo color on `Asset3D` [#7458](https://github.com/rerun-io/rerun/pull/7458) (thanks [@EtaLoop](https://github.com/EtaLoop)!)
+- `rr.serve` -> `rr.serve_web`, `rr.connect` -> `rr.connect_tcp` [#7906](https://github.com/rerun-io/rerun/pull/7906)
+
+#### 🌊 C++ API
+- C++: Improve error message when finding X11 macro `Unsorted` [#7855](https://github.com/rerun-io/rerun/pull/7855)
+- Forward `CMAKE_TOOLCHAIN_FILE` to arrow build for sdk cross-compilation [#7866](https://github.com/rerun-io/rerun/pull/7866) (thanks [@SunDoge](https://github.com/SunDoge)!)
+- Update the python package to support python 3.13, update C++ arrow to 18.0.0 [#7930](https://github.com/rerun-io/rerun/pull/7930)
+
+#### 🐍 Python API
+- Allow passing seconds/nanoseconds to `VideoFrameReference` archetype [#7833](https://github.com/rerun-io/rerun/pull/7833)
+- Officially deprecate support for python 3.8 [#7933](https://github.com/rerun-io/rerun/pull/7933)
+- Update the python package to support python 3.13, update C++ arrow to 18.0.0 [#7930](https://github.com/rerun-io/rerun/pull/7930)
+- Remove the upper bound constraint on python version [#7949](https://github.com/rerun-io/rerun/pull/7949)
+- Enable dataframe streaming across Python FFI [#7935](https://github.com/rerun-io/rerun/pull/7935)
+- Fix python SDK's shutdown unsafely dropping cross-FFI resources [#8038](https://github.com/rerun-io/rerun/pull/8038)
+- Improve edge-cases and warn on ambiguity for Rgba32 datatype [#8054](https://github.com/rerun-io/rerun/pull/8054)
+
+#### 🦀 Rust API
+- Allow logging individual components directly (Impl `AsComponents` for all `ObjectKind::Component`) [#7756](https://github.com/rerun-io/rerun/pull/7756) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
+- `re_query::Caches` -> `re_query::QueryCache` [#7915](https://github.com/rerun-io/rerun/pull/7915)
+
+#### 🪳 Bug fixes
+- [bugfix] Make sure blueprint gets sent to the notebook view being created [#7811](https://github.com/rerun-io/rerun/pull/7811)
+- Fix too short picking ray in pinhole-only scenarios [#7899](https://github.com/rerun-io/rerun/pull/7899)
+- Update zune-jpeg to fix crash on bad JPEGs [#7952](https://github.com/rerun-io/rerun/pull/7952)
+- Fix playback of HDR AV1 videos in native viewer [#7978](https://github.com/rerun-io/rerun/pull/7978)
+- Consistent open/import/log_file behaviors in all common scenarios [#7966](https://github.com/rerun-io/rerun/pull/7966)
+- ChunkStore: fix row-id computation when removing dangling static chunks [#8020](https://github.com/rerun-io/rerun/pull/8020)
+- Fix some videos having offseted (incorrect) timestamps [#8029](https://github.com/rerun-io/rerun/pull/8029)
+- Fix video backward seeking / stepping back sometimes getting stuck (in the presence of b-frames) [#8053](https://github.com/rerun-io/rerun/pull/8053)
+
+#### 🌁 Viewer improvements
+- Fix view heuristics for videos [#7869](https://github.com/rerun-io/rerun/pull/7869)
+- A Rerun Viewer session now matches 1:1 to a Rerun TCP server [#6951](https://github.com/rerun-io/rerun/pull/6951) (thanks [@petertheprocess](https://github.com/petertheprocess)!)
+- Implement support for in-place drag-n-drop [#7880](https://github.com/rerun-io/rerun/pull/7880)
+- Implement `Menu > Import` and associated command [#7882](https://github.com/rerun-io/rerun/pull/7882)
+- Add `Capsules3D` archetype [#7574](https://github.com/rerun-io/rerun/pull/7574) (thanks [@kpreid](https://github.com/kpreid)!)
+- Expose additional information about decoded frames in the viewer [#7932](https://github.com/rerun-io/rerun/pull/7932)
+- Update crates, including `rfd` for better file dialogs [#7953](https://github.com/rerun-io/rerun/pull/7953)
+- Support H.264 on native via user installed ffmpeg executable [#7962](https://github.com/rerun-io/rerun/pull/7962)
+- Expose basic information about group of pictures in video data in the selection panel [#8043](https://github.com/rerun-io/rerun/pull/8043)
+
+#### 🚀 Performance improvements
+- Don't keep around additional cpu copy of loaded mesh files [#7824](https://github.com/rerun-io/rerun/pull/7824)
+- Make mp4 parsing **a lot** faster & tremendously lower memory overhead [#7860](https://github.com/rerun-io/rerun/pull/7860)
+- Fix slow receive when using native WebSocket [#7875](https://github.com/rerun-io/rerun/pull/7875)
+- Implement support for fully asynchronous `QueryHandle`s [#7964](https://github.com/rerun-io/rerun/pull/7964)
+
+#### 🧑‍🏫 Examples
+- Fix Rust dna sample writing to a temporary file [#7827](https://github.com/rerun-io/rerun/pull/7827)
+- Add  ml_depth_pro example [#7832](https://github.com/rerun-io/rerun/pull/7832) (thanks [@oxkitsune](https://github.com/oxkitsune)!)
+- Add map view to nuscenes python example [#8034](https://github.com/rerun-io/rerun/pull/8034) (thanks [@tfoldi](https://github.com/tfoldi)!)
+- Add an example to display OpenStreetMap-sourced data on the map view [#8044](https://github.com/rerun-io/rerun/pull/8044)
+
+#### 📚 Docs
+- Clarify viewport documentation and reference the type list for view classes [#7826](https://github.com/rerun-io/rerun/pull/7826)
+- Finish dataframe reference page [#7865](https://github.com/rerun-io/rerun/pull/7865)
+- Docs: static data [#7856](https://github.com/rerun-io/rerun/pull/7856)
+- Docs: concepts > recordings [#7896](https://github.com/rerun-io/rerun/pull/7896)
+- Docs: "How-to: reuse blueprints across languages" [#7886](https://github.com/rerun-io/rerun/pull/7886)
+- Docs: application model part 1: native workflows [#7905](https://github.com/rerun-io/rerun/pull/7905)
+- Document arrow datatypes [#7986](https://github.com/rerun-io/rerun/pull/7986)
+- Improve video doc page [#8007](https://github.com/rerun-io/rerun/pull/8007)
+
+#### 🖼 UI improvements
+- Map View and `GeoPoints` archetype [#6561](https://github.com/rerun-io/rerun/pull/6561) (thanks [@tfoldi](https://github.com/tfoldi)!)
+- Replace the "Options" submenu with a settings screen [#8001](https://github.com/rerun-io/rerun/pull/8001)
+
+#### 🧑‍💻 Dev-experience
+- Show list of enabled feature with `rerun --version` [#7885](https://github.com/rerun-io/rerun/pull/7885)
+
+#### 📦 Dependencies
+- Bump numpy -> 0.23, pyo3 -> 0.22.5, and arrow -> 53.1 [#7834](https://github.com/rerun-io/rerun/pull/7834)
+
+#### 🤷‍ Other
+- Implement safe storage handles [#7934](https://github.com/rerun-io/rerun/pull/7934)
 
 
 ## [0.19.1](https://github.com/rerun-io/rerun/compare/0.19.0..0.19.1) - Web viewer fix


### PR DESCRIPTION
Draft. Should go to 0.20 release branch

[Rendered](https://github.com/rerun-io/rerun/blob/andreas/changelog-0.20/CHANGELOG.md)

Make sure all changes in the generic part of the changelog are reflected in updates of the respective PR titles, so we can regen this part easily