### PR TITLE
Fix `Loggable` pretending to have semantics 

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/reflection.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/reflection.rs
@@ -46,7 +46,8 @@ pub fn generate_reflection(
         use re_types_core::{
             ArchetypeName,
             ComponentName,
-            Loggable,
+            Component,
+            Loggable as _,
             LoggableBatch as _,
             reflection::{
                 ArchetypeFieldReflection,
@@ -103,7 +104,7 @@ fn generate_component_reflection(
         let type_name = format_ident!("{}", obj.name);
 
         let quoted_name = if true {
-            quote!( <#type_name as Loggable>::name() )
+            quote!( <#type_name as Component>::name() )
         } else {
             // Works too
             let fqname = &obj.fqname;

--- a/crates/store/re_chunk/examples/latest_at.rs
+++ b/crates/store/re_chunk/examples/latest_at.rs
@@ -1,6 +1,6 @@
 use re_chunk::{Chunk, LatestAtQuery, RowId, Timeline};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint};
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 // ---
 

--- a/crates/store/re_chunk/examples/range.rs
+++ b/crates/store/re_chunk/examples/range.rs
@@ -3,7 +3,7 @@ use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint},
     ResolvedTimeRange,
 };
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 // ---
 

--- a/crates/store/re_chunk/src/batcher.rs
+++ b/crates/store/re_chunk/src/batcher.rs
@@ -985,7 +985,7 @@ mod tests {
     use crossbeam::channel::TryRecvError;
 
     use re_log_types::example_components::{MyPoint, MyPoint64};
-    use re_types_core::Loggable as _;
+    use re_types_core::{Component as _, Loggable as _};
 
     use super::*;
 

--- a/crates/store/re_chunk/src/merge.rs
+++ b/crates/store/re_chunk/src/merge.rs
@@ -274,7 +274,7 @@ mod tests {
     use super::*;
 
     use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoint64};
-    use re_types_core::Loggable;
+    use re_types_core::Component;
 
     use crate::{Chunk, RowId, Timeline};
 

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -321,7 +321,7 @@ mod tests {
         example_components::{MyColor, MyPoint},
         EntityPath, Timeline,
     };
-    use re_types_core::Loggable as _;
+    use re_types_core::Component as _;
 
     use crate::{ChunkId, RowId};
 

--- a/crates/store/re_chunk/src/slice.rs
+++ b/crates/store/re_chunk/src/slice.rs
@@ -875,7 +875,7 @@ mod tests {
         example_components::{MyColor, MyLabel, MyPoint},
         TimePoint,
     };
-    use re_types_core::{ComponentBatch, Loggable};
+    use re_types_core::Component;
 
     use crate::{Chunk, RowId, Timeline};
 
@@ -974,7 +974,7 @@ mod tests {
 
         eprintln!("chunk:\n{chunk}");
 
-        let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+        let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
             (row_id1, MyPoint::name(), Some(points1 as _)),
             (row_id2, MyLabel::name(), Some(labels4 as _)),
             (row_id3, MyColor::name(), None),
@@ -1101,7 +1101,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(2, got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id3, MyPoint::name(), Some(points3 as _)),
                 (row_id3, MyColor::name(), None),
                 (row_id3, MyLabel::name(), Some(labels3 as _)),
@@ -1124,7 +1124,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(5, got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id1, MyPoint::name(), Some(points1 as _)),
                 (row_id1, MyColor::name(), None),
                 (row_id1, MyLabel::name(), Some(labels1 as _)),
@@ -1232,7 +1232,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(1, got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id5, MyPoint::name(), None),
                 (row_id5, MyColor::name(), Some(colors5 as _)),
                 (row_id5, MyLabel::name(), Some(labels5 as _)),
@@ -1251,7 +1251,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(1, got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id5, MyPoint::name(), None),
                 (row_id5, MyColor::name(), Some(colors5 as _)),
                 (row_id5, MyLabel::name(), Some(labels5 as _)),
@@ -1370,7 +1370,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(filter.values_iter().filter(|&b| b).count(), got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id1, MyPoint::name(), Some(points1 as _)),
                 (row_id1, MyColor::name(), None),
                 (row_id1, MyLabel::name(), Some(labels1 as _)),
@@ -1517,7 +1517,7 @@ mod tests {
             eprintln!("got:\n{got}");
             assert_eq!(indices.len(), got.num_rows());
 
-            let expectations: &[(_, _, Option<&dyn ComponentBatch>)] = &[
+            let expectations: &[(_, _, Option<&dyn re_types_core::ComponentBatch>)] = &[
                 (row_id1, MyPoint::name(), Some(points1 as _)),
                 (row_id1, MyColor::name(), None),
                 (row_id1, MyLabel::name(), Some(labels1 as _)),

--- a/crates/store/re_chunk/src/transport.rs
+++ b/crates/store/re_chunk/src/transport.rs
@@ -13,7 +13,7 @@ use arrow2::{
 };
 
 use re_log_types::{EntityPath, Timeline};
-use re_types_core::{Loggable as _, SizeBytes};
+use re_types_core::{Component as _, Loggable as _, SizeBytes};
 
 use crate::{Chunk, ChunkError, ChunkId, ChunkResult, RowId, TimeColumn};
 

--- a/crates/store/re_chunk/tests/latest_at.rs
+++ b/crates/store/re_chunk/tests/latest_at.rs
@@ -3,7 +3,7 @@ use nohash_hasher::IntMap;
 
 use re_chunk::{Chunk, ComponentName, LatestAtQuery, RowId, TimePoint, Timeline};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint};
-use re_types_core::Loggable;
+use re_types_core::{Component, Loggable};
 
 // ---
 

--- a/crates/store/re_chunk/tests/range.rs
+++ b/crates/store/re_chunk/tests/range.rs
@@ -6,7 +6,7 @@ use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint},
     ResolvedTimeRange,
 };
-use re_types_core::Loggable as _;
+use re_types_core::{Component as _, Loggable as _};
 
 // ---
 

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -194,7 +194,7 @@ mod tests {
         example_components::{MyColor, MyIndex, MyPoint},
         EntityPath, TimeInt, TimePoint, Timeline,
     };
-    use re_types_core::{ComponentName, Loggable as _};
+    use re_types_core::{Component as _, ComponentName};
 
     use crate::{ChunkStore, GarbageCollectionOptions};
 

--- a/crates/store/re_chunk_store/tests/correctness.rs
+++ b/crates/store/re_chunk_store/tests/correctness.rs
@@ -10,7 +10,7 @@ use re_log_types::{
     build_frame_nr, build_log_time, Duration, EntityPath, Time, TimeInt, TimePoint, TimeType,
     Timeline,
 };
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 // ---
 

--- a/crates/store/re_chunk_store/tests/drop_time_range.rs
+++ b/crates/store/re_chunk_store/tests/drop_time_range.rs
@@ -7,7 +7,7 @@ use re_chunk::{Chunk, RowId};
 use re_chunk_store::{ChunkStore, ChunkStoreConfig};
 use re_log_types::{example_components::MyColor, ResolvedTimeRange};
 use re_log_types::{EntityPath, TimePoint, Timeline};
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 #[test]
 fn drop_time_range() -> anyhow::Result<()> {

--- a/crates/store/re_chunk_store/tests/gc.rs
+++ b/crates/store/re_chunk_store/tests/gc.rs
@@ -14,7 +14,7 @@ use re_log_types::{
     EntityPath, ResolvedTimeRange, Time, TimeType, Timeline,
 };
 use re_types::testing::build_some_large_structs;
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 // ---
 

--- a/crates/store/re_chunk_store/tests/memory_test.rs
+++ b/crates/store/re_chunk_store/tests/memory_test.rs
@@ -73,7 +73,7 @@ use re_chunk::{
 };
 use re_chunk_store::{ChunkStore, ChunkStoreConfig};
 use re_log_types::{TimePoint, TimeType, Timeline};
-use re_types::{components::Scalar, Loggable};
+use re_types::{components::Scalar, Component, Loggable};
 
 /// The memory overhead of storing many scalars in the store.
 #[test]

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -14,7 +14,7 @@ use re_log_types::{
 };
 use re_types::testing::{build_some_large_structs, LargeStruct};
 use re_types::ComponentNameSet;
-use re_types_core::{ComponentName, Loggable as _};
+use re_types_core::{Component as _, ComponentName};
 
 // ---
 

--- a/crates/store/re_chunk_store/tests/stats.rs
+++ b/crates/store/re_chunk_store/tests/stats.rs
@@ -7,7 +7,7 @@ use re_log_types::{
     example_components::{MyColor, MyPoint},
     EntityPath, Timeline,
 };
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 #[test]
 fn stats() -> anyhow::Result<()> {

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -535,7 +535,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
             (!chunk.is_empty()).then_some(chunk)
         }
 
-        use re_types_core::Loggable as _;
+        use re_types_core::Component as _;
         let component_names = [re_types_core::components::ClearIsRecursive::name()];
 
         // All unique entity paths present in the view contents.
@@ -1296,7 +1296,7 @@ mod tests {
     };
     use re_query::StorageEngine;
     use re_types::components::ClearIsRecursive;
-    use re_types_core::Loggable as _;
+    use re_types_core::Component as _;
 
     use crate::{QueryCache, QueryEngine};
 

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -38,7 +38,7 @@ fn get_custom_display<'a, F: std::fmt::Write + 'a>(
 
     if let Some(DataType::Extension(name, _, _)) = datatype {
         // TODO(#1775): This should be registered dynamically.
-        if name.as_str() == Tuid::name() {
+        if name.as_str() == Tuid::NAME {
             return Box::new(|w, index| {
                 if let Some(tuid) = parse_tuid(array, index) {
                     w.write_fmt(format_args!("{tuid}"))

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use re_types_core::{DeserializationError, Loggable, SizeBytes};
+use re_types_core::{Component, ComponentName, DeserializationError, Loggable, SizeBytes};
 
 // ----------------------------------------------------------------------------
 
@@ -30,7 +30,7 @@ impl re_types_core::Archetype for MyPoints {
 
     fn recommended_components() -> std::borrow::Cow<'static, [re_types_core::ComponentName]> {
         vec![
-            re_types_core::LoggableBatch::name(&Self::Indicator::default()),
+            re_types_core::ComponentBatch::name(&Self::Indicator::default()),
             MyColor::name(),
             MyLabel::name(),
         ]
@@ -75,12 +75,6 @@ impl SizeBytes for MyPoint {
 }
 
 impl Loggable for MyPoint {
-    type Name = re_types_core::ComponentName;
-
-    fn name() -> Self::Name {
-        "example.MyPoint".into()
-    }
-
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::DataType::Float32;
         arrow2::datatypes::DataType::Struct(Arc::new(vec![
@@ -147,6 +141,12 @@ impl Loggable for MyPoint {
     }
 }
 
+impl Component for MyPoint {
+    fn name() -> ComponentName {
+        "example.MyPoint".into()
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
@@ -184,12 +184,6 @@ impl SizeBytes for MyPoint64 {
 }
 
 impl Loggable for MyPoint64 {
-    type Name = re_types_core::ComponentName;
-
-    fn name() -> Self::Name {
-        "example.MyPoint64".into()
-    }
-
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         use arrow2::datatypes::DataType::Float64;
         arrow2::datatypes::DataType::Struct(Arc::new(vec![
@@ -256,6 +250,12 @@ impl Loggable for MyPoint64 {
     }
 }
 
+impl Component for MyPoint64 {
+    fn name() -> ComponentName {
+        "example.MyPoint64".into()
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, bytemuck::Pod, bytemuck::Zeroable)]
@@ -296,12 +296,6 @@ impl SizeBytes for MyColor {
 }
 
 impl Loggable for MyColor {
-    type Name = re_types_core::ComponentName;
-
-    fn name() -> Self::Name {
-        "example.MyColor".into()
-    }
-
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         arrow2::datatypes::DataType::UInt32
     }
@@ -330,6 +324,12 @@ impl Loggable for MyColor {
     }
 }
 
+impl Component for MyColor {
+    fn name() -> ComponentName {
+        "example.MyColor".into()
+    }
+}
+
 // ----------------------------------------------------------------------------
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -347,12 +347,6 @@ impl SizeBytes for MyLabel {
 }
 
 impl Loggable for MyLabel {
-    type Name = re_types_core::ComponentName;
-
-    fn name() -> Self::Name {
-        "example.MyLabel".into()
-    }
-
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         re_types_core::datatypes::Utf8::arrow_datatype()
     }
@@ -378,6 +372,12 @@ impl Loggable for MyLabel {
             .into_iter()
             .map(|opt| opt.map(|v| Self(v.0.to_string())))
             .collect())
+    }
+}
+
+impl Component for MyLabel {
+    fn name() -> ComponentName {
+        "example.MyLabel".into()
     }
 }
 
@@ -407,12 +407,6 @@ impl SizeBytes for MyIndex {
 }
 
 impl Loggable for MyIndex {
-    type Name = re_types_core::ComponentName;
-
-    fn name() -> Self::Name {
-        "example.MyIndex".into()
-    }
-
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         arrow2::datatypes::DataType::UInt64
     }
@@ -438,5 +432,11 @@ impl Loggable for MyIndex {
             .into_iter()
             .map(|opt| opt.map(|v| Self(v.0)))
             .collect())
+    }
+}
+
+impl Component for MyIndex {
+    fn name() -> ComponentName {
+        "example.MyIndex".into()
     }
 }

--- a/crates/store/re_log_types/src/path/entity_path.rs
+++ b/crates/store/re_log_types/src/path/entity_path.rs
@@ -422,13 +422,6 @@ use re_types_core::Loggable;
 re_types_core::macros::impl_into_cow!(EntityPath);
 
 impl Loggable for EntityPath {
-    type Name = re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.controls.EntityPath".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         re_types_core::datatypes::Utf8::arrow_datatype()
@@ -441,7 +434,7 @@ impl Loggable for EntityPath {
         Self: 'a,
     {
         Err(re_types_core::SerializationError::not_implemented(
-            Self::name(),
+            "rerun.controls.EntityPath",
             "EntityPaths are never nullable, use `to_arrow()` instead",
         ))
     }

--- a/crates/store/re_query/examples/latest_at.rs
+++ b/crates/store/re_query/examples/latest_at.rs
@@ -8,7 +8,7 @@ use re_chunk::{Chunk, RowId};
 use re_chunk_store::{ChunkStore, ChunkStoreHandle, LatestAtQuery};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
 use re_log_types::{build_frame_nr, Timeline};
-use re_types::{ComponentBatch, Loggable as _};
+use re_types::Component as _;
 use re_types_core::Archetype as _;
 
 use re_query::{clamped_zip_1x2, LatestAtResults};
@@ -116,7 +116,8 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
                 RowId::new(),
                 timepoint,
                 [
-                    &[MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)] as &dyn ComponentBatch, //
+                    &[MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)]
+                        as &dyn re_types_core::ComponentBatch, //
                     &[MyColor::from_rgb(255, 0, 0)],
                     &[MyLabel("a".into()), MyLabel("b".into())],
                 ],

--- a/crates/store/re_query/examples/range.rs
+++ b/crates/store/re_query/examples/range.rs
@@ -5,8 +5,7 @@ use re_chunk::{Chunk, RowId};
 use re_chunk_store::{ChunkStore, ChunkStoreHandle, RangeQuery};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint, MyPoints};
 use re_log_types::{build_frame_nr, ResolvedTimeRange, TimeType, Timeline};
-use re_types::ComponentBatch;
-use re_types_core::{Archetype as _, Loggable as _};
+use re_types_core::{Archetype as _, Component as _};
 
 use re_query::{clamped_zip_1x2, range_zip_1x2, RangeResults};
 
@@ -114,7 +113,8 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
                 RowId::new(),
                 timepoint,
                 [
-                    &[MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)] as &dyn ComponentBatch, //
+                    &[MyPoint::new(1.0, 2.0), MyPoint::new(3.0, 4.0)]
+                        as &dyn re_types_core::ComponentBatch, //
                     &[MyColor::from_rgb(255, 0, 0)],
                     &[MyLabel("a".into()), MyLabel("b".into())],
                 ],
@@ -136,7 +136,7 @@ fn store() -> anyhow::Result<ChunkStoreHandle> {
                         MyPoint::new(10.0, 20.0),
                         MyPoint::new(30.0, 40.0),
                         MyPoint::new(50.0, 60.0),
-                    ] as &dyn ComponentBatch, //
+                    ] as &dyn re_types_core::ComponentBatch, //
                     &[MyColor::from_rgb(255, 0, 0), MyColor::from_rgb(0, 0, 255)],
                 ],
             )

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use re_chunk::ChunkId;
 use re_chunk_store::{ChunkStoreDiff, ChunkStoreEvent, ChunkStoreHandle, ChunkStoreSubscriber};
 use re_log_types::{EntityPath, ResolvedTimeRange, StoreId, TimeInt, Timeline};
-use re_types_core::{components::ClearIsRecursive, ComponentName, Loggable as _};
+use re_types_core::{components::ClearIsRecursive, Component as _, ComponentName};
 
 use crate::{LatestAtCache, RangeCache};
 

--- a/crates/store/re_query/src/latest_at.rs
+++ b/crates/store/re_query/src/latest_at.rs
@@ -10,9 +10,7 @@ use parking_lot::RwLock;
 use re_chunk::{Chunk, RowId, UnitChunkShared};
 use re_chunk_store::{ChunkStore, LatestAtQuery, TimeInt};
 use re_log_types::EntityPath;
-use re_types_core::{
-    components::ClearIsRecursive, Component, ComponentName, Loggable as _, SizeBytes,
-};
+use re_types_core::{components::ClearIsRecursive, Component, ComponentName, SizeBytes};
 
 use crate::{QueryCache, QueryCacheKey, QueryError};
 

--- a/crates/store/re_query/tests/range.rs
+++ b/crates/store/re_query/tests/range.rs
@@ -17,7 +17,7 @@ use re_log_types::{
 };
 use re_query::QueryCache;
 use re_types::Archetype;
-use re_types_core::Loggable as _;
+use re_types_core::Component as _;
 
 // ---
 

--- a/crates/store/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/store/re_types/src/blueprint/components/active_tab.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for ActiveTab {
 ::re_types_core::macros::impl_into_cow!(ActiveTab);
 
 impl ::re_types_core::Loggable for ActiveTab {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ActiveTab".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::EntityPath::arrow_datatype()
@@ -105,5 +98,12 @@ impl ::re_types_core::Loggable for ActiveTab {
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ActiveTab {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ActiveTab".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
+++ b/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for ApplyLatestAt {
 ::re_types_core::macros::impl_into_cow!(ApplyLatestAt);
 
 impl ::re_types_core::Loggable for ApplyLatestAt {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ApplyLatestAt".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for ApplyLatestAt {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ApplyLatestAt {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ApplyLatestAt".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -83,13 +83,6 @@ impl std::fmt::Display for BackgroundKind {
 ::re_types_core::macros::impl_into_cow!(BackgroundKind);
 
 impl ::re_types_core::Loggable for BackgroundKind {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.BackgroundKind".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -162,5 +155,12 @@ impl ::re_types_core::Loggable for BackgroundKind {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.BackgroundKind")?)
+    }
+}
+
+impl ::re_types_core::Component for BackgroundKind {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.BackgroundKind".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/column_share.rs
+++ b/crates/store/re_types/src/blueprint/components/column_share.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for ColumnShare {
 ::re_types_core::macros::impl_into_cow!(ColumnShare);
 
 impl ::re_types_core::Loggable for ColumnShare {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ColumnShare".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for ColumnShare {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for ColumnShare {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ColumnShare".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for ComponentColumnSelector {
 ::re_types_core::macros::impl_into_cow!(ComponentColumnSelector);
 
 impl ::re_types_core::Loggable for ComponentColumnSelector {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ComponentColumnSelector".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::ComponentColumnSelector::arrow_datatype()
@@ -107,5 +100,12 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
     {
         crate::blueprint::datatypes::ComponentColumnSelector::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ComponentColumnSelector {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ComponentColumnSelector".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -85,13 +85,6 @@ impl std::fmt::Display for Corner2D {
 ::re_types_core::macros::impl_into_cow!(Corner2D);
 
 impl ::re_types_core::Loggable for Corner2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.Corner2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -165,5 +158,12 @@ impl ::re_types_core::Loggable for Corner2D {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.Corner2D")?)
+    }
+}
+
+impl ::re_types_core::Component for Corner2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.Corner2D".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_by_range.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for FilterByRange {
 ::re_types_core::macros::impl_into_cow!(FilterByRange);
 
 impl ::re_types_core::Loggable for FilterByRange {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.FilterByRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::FilterByRange::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for FilterByRange {
     {
         crate::blueprint::datatypes::FilterByRange::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for FilterByRange {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.FilterByRange".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for FilterIsNotNull {
 ::re_types_core::macros::impl_into_cow!(FilterIsNotNull);
 
 impl ::re_types_core::Loggable for FilterIsNotNull {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.FilterIsNotNull".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::FilterIsNotNull::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for FilterIsNotNull {
     {
         crate::blueprint::datatypes::FilterIsNotNull::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for FilterIsNotNull {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.FilterIsNotNull".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/included_content.rs
+++ b/crates/store/re_types/src/blueprint/components/included_content.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for IncludedContent {
 ::re_types_core::macros::impl_into_cow!(IncludedContent);
 
 impl ::re_types_core::Loggable for IncludedContent {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.IncludedContent".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::EntityPath::arrow_datatype()
@@ -106,5 +99,12 @@ impl ::re_types_core::Loggable for IncludedContent {
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for IncludedContent {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.IncludedContent".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/interactive.rs
+++ b/crates/store/re_types/src/blueprint/components/interactive.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for Interactive {
 ::re_types_core::macros::impl_into_cow!(Interactive);
 
 impl ::re_types_core::Loggable for Interactive {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.Interactive".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -103,5 +96,12 @@ impl ::re_types_core::Loggable for Interactive {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for Interactive {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.Interactive".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for LockRangeDuringZoom {
 ::re_types_core::macros::impl_into_cow!(LockRangeDuringZoom);
 
 impl ::re_types_core::Loggable for LockRangeDuringZoom {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.LockRangeDuringZoom".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -103,5 +96,12 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for LockRangeDuringZoom {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.LockRangeDuringZoom".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -85,13 +85,6 @@ impl std::fmt::Display for MapProvider {
 ::re_types_core::macros::impl_into_cow!(MapProvider);
 
 impl ::re_types_core::Loggable for MapProvider {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.MapProvider".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -165,5 +158,12 @@ impl ::re_types_core::Loggable for MapProvider {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.MapProvider")?)
+    }
+}
+
+impl ::re_types_core::Component for MapProvider {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.MapProvider".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -75,13 +75,6 @@ impl std::fmt::Display for PanelState {
 ::re_types_core::macros::impl_into_cow!(PanelState);
 
 impl ::re_types_core::Loggable for PanelState {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.PanelState".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -154,5 +147,12 @@ impl ::re_types_core::Loggable for PanelState {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.PanelState")?)
+    }
+}
+
+impl ::re_types_core::Component for PanelState {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.PanelState".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/store/re_types/src/blueprint/components/query_expression.rs
@@ -76,13 +76,6 @@ impl std::ops::DerefMut for QueryExpression {
 ::re_types_core::macros::impl_into_cow!(QueryExpression);
 
 impl ::re_types_core::Loggable for QueryExpression {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.QueryExpression".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -110,5 +103,12 @@ impl ::re_types_core::Loggable for QueryExpression {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for QueryExpression {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.QueryExpression".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/row_share.rs
+++ b/crates/store/re_types/src/blueprint/components/row_share.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for RowShare {
 ::re_types_core::macros::impl_into_cow!(RowShare);
 
 impl ::re_types_core::Loggable for RowShare {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.RowShare".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for RowShare {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for RowShare {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.RowShare".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/components/selected_columns.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for SelectedColumns {
 ::re_types_core::macros::impl_into_cow!(SelectedColumns);
 
 impl ::re_types_core::Loggable for SelectedColumns {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.SelectedColumns".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::SelectedColumns::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for SelectedColumns {
     {
         crate::blueprint::datatypes::SelectedColumns::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for SelectedColumns {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.SelectedColumns".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_class.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for SpaceViewClass {
 ::re_types_core::macros::impl_into_cow!(SpaceViewClass);
 
 impl ::re_types_core::Loggable for SpaceViewClass {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.SpaceViewClass".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for SpaceViewClass {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for SpaceViewClass {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.SpaceViewClass".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_origin.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for SpaceViewOrigin {
 ::re_types_core::macros::impl_into_cow!(SpaceViewOrigin);
 
 impl ::re_types_core::Loggable for SpaceViewOrigin {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.SpaceViewOrigin".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::EntityPath::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for SpaceViewOrigin {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.SpaceViewOrigin".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for TensorDimensionIndexSlider {
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSlider);
 
 impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.TensorDimensionIndexSlider".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::TensorDimensionIndexSlider::arrow_datatype()
@@ -107,5 +100,12 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
     {
         crate::blueprint::datatypes::TensorDimensionIndexSlider::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TensorDimensionIndexSlider {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.TensorDimensionIndexSlider".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/timeline_name.rs
+++ b/crates/store/re_types/src/blueprint/components/timeline_name.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for TimelineName {
 ::re_types_core::macros::impl_into_cow!(TimelineName);
 
 impl ::re_types_core::Loggable for TimelineName {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.TimelineName".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for TimelineName {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TimelineName {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.TimelineName".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -81,13 +81,6 @@ impl std::fmt::Display for ViewFit {
 ::re_types_core::macros::impl_into_cow!(ViewFit);
 
 impl ::re_types_core::Loggable for ViewFit {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ViewFit".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -160,5 +153,12 @@ impl ::re_types_core::Loggable for ViewFit {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.ViewFit")?)
+    }
+}
+
+impl ::re_types_core::Component for ViewFit {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewFit".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for ViewerRecommendationHash {
 ::re_types_core::macros::impl_into_cow!(ViewerRecommendationHash);
 
 impl ::re_types_core::Loggable for ViewerRecommendationHash {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ViewerRecommendationHash".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::UInt64::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
         Self: Sized,
     {
         crate::datatypes::UInt64::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for ViewerRecommendationHash {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ViewerRecommendationHash".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visible.rs
+++ b/crates/store/re_types/src/blueprint/components/visible.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Visible {
 ::re_types_core::macros::impl_into_cow!(Visible);
 
 impl ::re_types_core::Loggable for Visible {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.Visible".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for Visible {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for Visible {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.Visible".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/store/re_types/src/blueprint/components/visible_time_range.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for VisibleTimeRange {
 ::re_types_core::macros::impl_into_cow!(VisibleTimeRange);
 
 impl ::re_types_core::Loggable for VisibleTimeRange {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.VisibleTimeRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::VisibleTimeRange::arrow_datatype()
@@ -103,5 +96,12 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
     {
         crate::datatypes::VisibleTimeRange::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for VisibleTimeRange {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisibleTimeRange".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for VisualBounds2D {
 ::re_types_core::macros::impl_into_cow!(VisualBounds2D);
 
 impl ::re_types_core::Loggable for VisualBounds2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.VisualBounds2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Range2D::arrow_datatype()
@@ -104,5 +97,12 @@ impl ::re_types_core::Loggable for VisualBounds2D {
     {
         crate::datatypes::Range2D::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for VisualBounds2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisualBounds2D".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/zoom_level.rs
+++ b/crates/store/re_types/src/blueprint/components/zoom_level.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for ZoomLevel {
 ::re_types_core::macros::impl_into_cow!(ZoomLevel);
 
 impl ::re_types_core::Loggable for ZoomLevel {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ZoomLevel".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float64::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for ZoomLevel {
         Self: Sized,
     {
         crate::datatypes::Float64::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for ZoomLevel {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ZoomLevel".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for ComponentColumnSelector {
 ::re_types_core::macros::impl_into_cow!(ComponentColumnSelector);
 
 impl ::re_types_core::Loggable for ComponentColumnSelector {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.ComponentColumnSelector".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for FilterByRange {
 ::re_types_core::macros::impl_into_cow!(FilterByRange);
 
 impl ::re_types_core::Loggable for FilterByRange {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.FilterByRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
@@ -44,13 +44,6 @@ impl ::re_types_core::SizeBytes for FilterIsNotNull {
 ::re_types_core::macros::impl_into_cow!(FilterIsNotNull);
 
 impl ::re_types_core::Loggable for FilterIsNotNull {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.FilterIsNotNull".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -44,13 +44,6 @@ impl ::re_types_core::SizeBytes for SelectedColumns {
 ::re_types_core::macros::impl_into_cow!(SelectedColumns);
 
 impl ::re_types_core::Loggable for SelectedColumns {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.SelectedColumns".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
@@ -54,13 +54,6 @@ impl From<TensorDimensionIndexSlider> for u32 {
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSlider);
 
 impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.TensorDimensionIndexSlider".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -107,13 +107,6 @@ impl std::fmt::Display for AggregationPolicy {
 ::re_types_core::macros::impl_into_cow!(AggregationPolicy);
 
 impl ::re_types_core::Loggable for AggregationPolicy {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.AggregationPolicy".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -189,5 +182,12 @@ impl ::re_types_core::Loggable for AggregationPolicy {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.AggregationPolicy")?)
+    }
+}
+
+impl ::re_types_core::Component for AggregationPolicy {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.AggregationPolicy".into()
     }
 }

--- a/crates/store/re_types/src/components/albedo_factor.rs
+++ b/crates/store/re_types/src/components/albedo_factor.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for AlbedoFactor {
 ::re_types_core::macros::impl_into_cow!(AlbedoFactor);
 
 impl ::re_types_core::Loggable for AlbedoFactor {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.AlbedoFactor".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Rgba32::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for AlbedoFactor {
         Self: Sized,
     {
         crate::datatypes::Rgba32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for AlbedoFactor {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.AlbedoFactor".into()
     }
 }

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -54,13 +54,6 @@ impl<I: Into<crate::datatypes::ClassDescriptionMapElem>, T: IntoIterator<Item = 
 ::re_types_core::macros::impl_into_cow!(AnnotationContext);
 
 impl ::re_types_core::Loggable for AnnotationContext {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.AnnotationContext".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -186,5 +179,12 @@ impl ::re_types_core::Loggable for AnnotationContext {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.components.AnnotationContext#class_map")
         .with_context("rerun.components.AnnotationContext")?)
+    }
+}
+
+impl ::re_types_core::Component for AnnotationContext {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.AnnotationContext".into()
     }
 }

--- a/crates/store/re_types/src/components/axis_length.rs
+++ b/crates/store/re_types/src/components/axis_length.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for AxisLength {
 ::re_types_core::macros::impl_into_cow!(AxisLength);
 
 impl ::re_types_core::Loggable for AxisLength {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.AxisLength".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for AxisLength {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for AxisLength {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.AxisLength".into()
     }
 }

--- a/crates/store/re_types/src/components/blob.rs
+++ b/crates/store/re_types/src/components/blob.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for Blob {
 ::re_types_core::macros::impl_into_cow!(Blob);
 
 impl ::re_types_core::Loggable for Blob {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Blob".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Blob::arrow_datatype()
@@ -103,5 +96,12 @@ impl ::re_types_core::Loggable for Blob {
     {
         crate::datatypes::Blob::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for Blob {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Blob".into()
     }
 }

--- a/crates/store/re_types/src/components/class_id.rs
+++ b/crates/store/re_types/src/components/class_id.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for ClassId {
 ::re_types_core::macros::impl_into_cow!(ClassId);
 
 impl ::re_types_core::Loggable for ClassId {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ClassId".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::ClassId::arrow_datatype()
@@ -114,5 +107,12 @@ impl ::re_types_core::Loggable for ClassId {
         Self: Sized,
     {
         crate::datatypes::ClassId::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for ClassId {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ClassId".into()
     }
 }

--- a/crates/store/re_types/src/components/color.rs
+++ b/crates/store/re_types/src/components/color.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for Color {
 ::re_types_core::macros::impl_into_cow!(Color);
 
 impl ::re_types_core::Loggable for Color {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Color".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Rgba32::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for Color {
         Self: Sized,
     {
         crate::datatypes::Rgba32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Color {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Color".into()
     }
 }

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -144,13 +144,6 @@ impl std::fmt::Display for Colormap {
 ::re_types_core::macros::impl_into_cow!(Colormap);
 
 impl ::re_types_core::Loggable for Colormap {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Colormap".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -227,5 +220,12 @@ impl ::re_types_core::Loggable for Colormap {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.Colormap")?)
+    }
+}
+
+impl ::re_types_core::Component for Colormap {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Colormap".into()
     }
 }

--- a/crates/store/re_types/src/components/depth_meter.rs
+++ b/crates/store/re_types/src/components/depth_meter.rs
@@ -74,13 +74,6 @@ impl std::ops::DerefMut for DepthMeter {
 ::re_types_core::macros::impl_into_cow!(DepthMeter);
 
 impl ::re_types_core::Loggable for DepthMeter {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.DepthMeter".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -116,5 +109,12 @@ impl ::re_types_core::Loggable for DepthMeter {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for DepthMeter {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.DepthMeter".into()
     }
 }

--- a/crates/store/re_types/src/components/disconnected_space.rs
+++ b/crates/store/re_types/src/components/disconnected_space.rs
@@ -78,13 +78,6 @@ impl std::ops::DerefMut for DisconnectedSpace {
 ::re_types_core::macros::impl_into_cow!(DisconnectedSpace);
 
 impl ::re_types_core::Loggable for DisconnectedSpace {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.DisconnectedSpace".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for DisconnectedSpace {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for DisconnectedSpace {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.DisconnectedSpace".into()
     }
 }

--- a/crates/store/re_types/src/components/draw_order.rs
+++ b/crates/store/re_types/src/components/draw_order.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for DrawOrder {
 ::re_types_core::macros::impl_into_cow!(DrawOrder);
 
 impl ::re_types_core::Loggable for DrawOrder {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.DrawOrder".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -114,5 +107,12 @@ impl ::re_types_core::Loggable for DrawOrder {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for DrawOrder {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.DrawOrder".into()
     }
 }

--- a/crates/store/re_types/src/components/entity_path.rs
+++ b/crates/store/re_types/src/components/entity_path.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for EntityPath {
 ::re_types_core::macros::impl_into_cow!(EntityPath);
 
 impl ::re_types_core::Loggable for EntityPath {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.EntityPath".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::EntityPath::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for EntityPath {
     {
         crate::datatypes::EntityPath::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for EntityPath {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.EntityPath".into()
     }
 }

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -93,13 +93,6 @@ impl std::fmt::Display for FillMode {
 ::re_types_core::macros::impl_into_cow!(FillMode);
 
 impl ::re_types_core::Loggable for FillMode {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.FillMode".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -172,5 +165,12 @@ impl ::re_types_core::Loggable for FillMode {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.FillMode")?)
+    }
+}
+
+impl ::re_types_core::Component for FillMode {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.FillMode".into()
     }
 }

--- a/crates/store/re_types/src/components/fill_ratio.rs
+++ b/crates/store/re_types/src/components/fill_ratio.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for FillRatio {
 ::re_types_core::macros::impl_into_cow!(FillRatio);
 
 impl ::re_types_core::Loggable for FillRatio {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.FillRatio".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -114,5 +107,12 @@ impl ::re_types_core::Loggable for FillRatio {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for FillRatio {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.FillRatio".into()
     }
 }

--- a/crates/store/re_types/src/components/gamma_correction.rs
+++ b/crates/store/re_types/src/components/gamma_correction.rs
@@ -73,13 +73,6 @@ impl std::ops::DerefMut for GammaCorrection {
 ::re_types_core::macros::impl_into_cow!(GammaCorrection);
 
 impl ::re_types_core::Loggable for GammaCorrection {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.GammaCorrection".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -115,5 +108,12 @@ impl ::re_types_core::Loggable for GammaCorrection {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for GammaCorrection {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.GammaCorrection".into()
     }
 }

--- a/crates/store/re_types/src/components/geo_line_string.rs
+++ b/crates/store/re_types/src/components/geo_line_string.rs
@@ -44,13 +44,6 @@ impl<I: Into<crate::datatypes::DVec2D>, T: IntoIterator<Item = I>> From<T> for G
 ::re_types_core::macros::impl_into_cow!(GeoLineString);
 
 impl ::re_types_core::Loggable for GeoLineString {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.GeoLineString".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -261,5 +254,12 @@ impl ::re_types_core::Loggable for GeoLineString {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.components.GeoLineString#lat_lon")
         .with_context("rerun.components.GeoLineString")?)
+    }
+}
+
+impl ::re_types_core::Component for GeoLineString {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.GeoLineString".into()
     }
 }

--- a/crates/store/re_types/src/components/half_size2d.rs
+++ b/crates/store/re_types/src/components/half_size2d.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for HalfSize2D {
 ::re_types_core::macros::impl_into_cow!(HalfSize2D);
 
 impl ::re_types_core::Loggable for HalfSize2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.HalfSize2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec2D::arrow_datatype()
@@ -114,5 +107,12 @@ impl ::re_types_core::Loggable for HalfSize2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for HalfSize2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.HalfSize2D".into()
     }
 }

--- a/crates/store/re_types/src/components/half_size3d.rs
+++ b/crates/store/re_types/src/components/half_size3d.rs
@@ -72,13 +72,6 @@ impl std::ops::DerefMut for HalfSize3D {
 ::re_types_core::macros::impl_into_cow!(HalfSize3D);
 
 impl ::re_types_core::Loggable for HalfSize3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.HalfSize3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -114,5 +107,12 @@ impl ::re_types_core::Loggable for HalfSize3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for HalfSize3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.HalfSize3D".into()
     }
 }

--- a/crates/store/re_types/src/components/image_buffer.rs
+++ b/crates/store/re_types/src/components/image_buffer.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for ImageBuffer {
 ::re_types_core::macros::impl_into_cow!(ImageBuffer);
 
 impl ::re_types_core::Loggable for ImageBuffer {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ImageBuffer".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Blob::arrow_datatype()
@@ -103,5 +96,12 @@ impl ::re_types_core::Loggable for ImageBuffer {
     {
         crate::datatypes::Blob::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ImageBuffer {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ImageBuffer".into()
     }
 }

--- a/crates/store/re_types/src/components/image_format.rs
+++ b/crates/store/re_types/src/components/image_format.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for ImageFormat {
 ::re_types_core::macros::impl_into_cow!(ImageFormat);
 
 impl ::re_types_core::Loggable for ImageFormat {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ImageFormat".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::ImageFormat::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for ImageFormat {
     {
         crate::datatypes::ImageFormat::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ImageFormat {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ImageFormat".into()
     }
 }

--- a/crates/store/re_types/src/components/image_plane_distance.rs
+++ b/crates/store/re_types/src/components/image_plane_distance.rs
@@ -68,13 +68,6 @@ impl std::ops::DerefMut for ImagePlaneDistance {
 ::re_types_core::macros::impl_into_cow!(ImagePlaneDistance);
 
 impl ::re_types_core::Loggable for ImagePlaneDistance {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ImagePlaneDistance".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -110,5 +103,12 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for ImagePlaneDistance {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ImagePlaneDistance".into()
     }
 }

--- a/crates/store/re_types/src/components/keypoint_id.rs
+++ b/crates/store/re_types/src/components/keypoint_id.rs
@@ -84,13 +84,6 @@ impl std::ops::DerefMut for KeypointId {
 ::re_types_core::macros::impl_into_cow!(KeypointId);
 
 impl ::re_types_core::Loggable for KeypointId {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.KeypointId".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::KeypointId::arrow_datatype()
@@ -126,5 +119,12 @@ impl ::re_types_core::Loggable for KeypointId {
         Self: Sized,
     {
         crate::datatypes::KeypointId::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for KeypointId {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.KeypointId".into()
     }
 }

--- a/crates/store/re_types/src/components/lat_lon.rs
+++ b/crates/store/re_types/src/components/lat_lon.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for LatLon {
 ::re_types_core::macros::impl_into_cow!(LatLon);
 
 impl ::re_types_core::Loggable for LatLon {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.LatLon".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::DVec2D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for LatLon {
         Self: Sized,
     {
         crate::datatypes::DVec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for LatLon {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.LatLon".into()
     }
 }

--- a/crates/store/re_types/src/components/length.rs
+++ b/crates/store/re_types/src/components/length.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for Length {
 ::re_types_core::macros::impl_into_cow!(Length);
 
 impl ::re_types_core::Loggable for Length {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Length".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for Length {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Length {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Length".into()
     }
 }

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -54,13 +54,6 @@ impl<I: Into<crate::datatypes::Vec2D>, T: IntoIterator<Item = I>> From<T> for Li
 ::re_types_core::macros::impl_into_cow!(LineStrip2D);
 
 impl ::re_types_core::Loggable for LineStrip2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.LineStrip2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -270,5 +263,12 @@ impl ::re_types_core::Loggable for LineStrip2D {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.components.LineStrip2D#points")
         .with_context("rerun.components.LineStrip2D")?)
+    }
+}
+
+impl ::re_types_core::Component for LineStrip2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.LineStrip2D".into()
     }
 }

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -54,13 +54,6 @@ impl<I: Into<crate::datatypes::Vec3D>, T: IntoIterator<Item = I>> From<T> for Li
 ::re_types_core::macros::impl_into_cow!(LineStrip3D);
 
 impl ::re_types_core::Loggable for LineStrip3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.LineStrip3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -270,5 +263,12 @@ impl ::re_types_core::Loggable for LineStrip3D {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.components.LineStrip3D#points")
         .with_context("rerun.components.LineStrip3D")?)
+    }
+}
+
+impl ::re_types_core::Component for LineStrip3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.LineStrip3D".into()
     }
 }

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -79,13 +79,6 @@ impl std::fmt::Display for MagnificationFilter {
 ::re_types_core::macros::impl_into_cow!(MagnificationFilter);
 
 impl ::re_types_core::Loggable for MagnificationFilter {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.MagnificationFilter".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -157,5 +150,12 @@ impl ::re_types_core::Loggable for MagnificationFilter {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.MagnificationFilter")?)
+    }
+}
+
+impl ::re_types_core::Component for MagnificationFilter {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.MagnificationFilter".into()
     }
 }

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -121,13 +121,6 @@ impl std::fmt::Display for MarkerShape {
 ::re_types_core::macros::impl_into_cow!(MarkerShape);
 
 impl ::re_types_core::Loggable for MarkerShape {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.MarkerShape".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -207,5 +200,12 @@ impl ::re_types_core::Loggable for MarkerShape {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.MarkerShape")?)
+    }
+}
+
+impl ::re_types_core::Component for MarkerShape {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.MarkerShape".into()
     }
 }

--- a/crates/store/re_types/src/components/marker_size.rs
+++ b/crates/store/re_types/src/components/marker_size.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for MarkerSize {
 ::re_types_core::macros::impl_into_cow!(MarkerSize);
 
 impl ::re_types_core::Loggable for MarkerSize {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.MarkerSize".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for MarkerSize {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for MarkerSize {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.MarkerSize".into()
     }
 }

--- a/crates/store/re_types/src/components/media_type.rs
+++ b/crates/store/re_types/src/components/media_type.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for MediaType {
 ::re_types_core::macros::impl_into_cow!(MediaType);
 
 impl ::re_types_core::Loggable for MediaType {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.MediaType".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -104,5 +97,12 @@ impl ::re_types_core::Loggable for MediaType {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for MediaType {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.MediaType".into()
     }
 }

--- a/crates/store/re_types/src/components/name.rs
+++ b/crates/store/re_types/src/components/name.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Name {
 ::re_types_core::macros::impl_into_cow!(Name);
 
 impl ::re_types_core::Loggable for Name {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Name".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for Name {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for Name {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Name".into()
     }
 }

--- a/crates/store/re_types/src/components/opacity.rs
+++ b/crates/store/re_types/src/components/opacity.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for Opacity {
 ::re_types_core::macros::impl_into_cow!(Opacity);
 
 impl ::re_types_core::Loggable for Opacity {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Opacity".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for Opacity {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Opacity {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Opacity".into()
     }
 }

--- a/crates/store/re_types/src/components/pinhole_projection.rs
+++ b/crates/store/re_types/src/components/pinhole_projection.rs
@@ -76,13 +76,6 @@ impl std::ops::DerefMut for PinholeProjection {
 ::re_types_core::macros::impl_into_cow!(PinholeProjection);
 
 impl ::re_types_core::Loggable for PinholeProjection {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PinholeProjection".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Mat3x3::arrow_datatype()
@@ -118,5 +111,12 @@ impl ::re_types_core::Loggable for PinholeProjection {
         Self: Sized,
     {
         crate::datatypes::Mat3x3::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for PinholeProjection {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PinholeProjection".into()
     }
 }

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for PoseRotationAxisAngle {
 ::re_types_core::macros::impl_into_cow!(PoseRotationAxisAngle);
 
 impl ::re_types_core::Loggable for PoseRotationAxisAngle {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PoseRotationAxisAngle".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::RotationAxisAngle::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for PoseRotationAxisAngle {
     {
         crate::datatypes::RotationAxisAngle::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for PoseRotationAxisAngle {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PoseRotationAxisAngle".into()
     }
 }

--- a/crates/store/re_types/src/components/pose_rotation_quat.rs
+++ b/crates/store/re_types/src/components/pose_rotation_quat.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for PoseRotationQuat {
 ::re_types_core::macros::impl_into_cow!(PoseRotationQuat);
 
 impl ::re_types_core::Loggable for PoseRotationQuat {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PoseRotationQuat".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Quaternion::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for PoseRotationQuat {
         Self: Sized,
     {
         crate::datatypes::Quaternion::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for PoseRotationQuat {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PoseRotationQuat".into()
     }
 }

--- a/crates/store/re_types/src/components/pose_scale3d.rs
+++ b/crates/store/re_types/src/components/pose_scale3d.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for PoseScale3D {
 ::re_types_core::macros::impl_into_cow!(PoseScale3D);
 
 impl ::re_types_core::Loggable for PoseScale3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PoseScale3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -113,5 +106,12 @@ impl ::re_types_core::Loggable for PoseScale3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for PoseScale3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PoseScale3D".into()
     }
 }

--- a/crates/store/re_types/src/components/pose_transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/pose_transform_mat3x3.rs
@@ -79,13 +79,6 @@ impl std::ops::DerefMut for PoseTransformMat3x3 {
 ::re_types_core::macros::impl_into_cow!(PoseTransformMat3x3);
 
 impl ::re_types_core::Loggable for PoseTransformMat3x3 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PoseTransformMat3x3".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Mat3x3::arrow_datatype()
@@ -121,5 +114,12 @@ impl ::re_types_core::Loggable for PoseTransformMat3x3 {
         Self: Sized,
     {
         crate::datatypes::Mat3x3::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for PoseTransformMat3x3 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PoseTransformMat3x3".into()
     }
 }

--- a/crates/store/re_types/src/components/pose_translation3d.rs
+++ b/crates/store/re_types/src/components/pose_translation3d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for PoseTranslation3D {
 ::re_types_core::macros::impl_into_cow!(PoseTranslation3D);
 
 impl ::re_types_core::Loggable for PoseTranslation3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.PoseTranslation3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for PoseTranslation3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for PoseTranslation3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.PoseTranslation3D".into()
     }
 }

--- a/crates/store/re_types/src/components/position2d.rs
+++ b/crates/store/re_types/src/components/position2d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Position2D {
 ::re_types_core::macros::impl_into_cow!(Position2D);
 
 impl ::re_types_core::Loggable for Position2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Position2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec2D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Position2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Position2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Position2D".into()
     }
 }

--- a/crates/store/re_types/src/components/position3d.rs
+++ b/crates/store/re_types/src/components/position3d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Position3D {
 ::re_types_core::macros::impl_into_cow!(Position3D);
 
 impl ::re_types_core::Loggable for Position3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Position3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Position3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Position3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Position3D".into()
     }
 }

--- a/crates/store/re_types/src/components/radius.rs
+++ b/crates/store/re_types/src/components/radius.rs
@@ -74,13 +74,6 @@ impl std::ops::DerefMut for Radius {
 ::re_types_core::macros::impl_into_cow!(Radius);
 
 impl ::re_types_core::Loggable for Radius {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Radius".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -116,5 +109,12 @@ impl ::re_types_core::Loggable for Radius {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Radius {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Radius".into()
     }
 }

--- a/crates/store/re_types/src/components/range1d.rs
+++ b/crates/store/re_types/src/components/range1d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Range1D {
 ::re_types_core::macros::impl_into_cow!(Range1D);
 
 impl ::re_types_core::Loggable for Range1D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Range1D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Range1D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Range1D {
         Self: Sized,
     {
         crate::datatypes::Range1D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Range1D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Range1D".into()
     }
 }

--- a/crates/store/re_types/src/components/resolution.rs
+++ b/crates/store/re_types/src/components/resolution.rs
@@ -68,13 +68,6 @@ impl std::ops::DerefMut for Resolution {
 ::re_types_core::macros::impl_into_cow!(Resolution);
 
 impl ::re_types_core::Loggable for Resolution {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Resolution".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec2D::arrow_datatype()
@@ -110,5 +103,12 @@ impl ::re_types_core::Loggable for Resolution {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for Resolution {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Resolution".into()
     }
 }

--- a/crates/store/re_types/src/components/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/rotation_axis_angle.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for RotationAxisAngle {
 ::re_types_core::macros::impl_into_cow!(RotationAxisAngle);
 
 impl ::re_types_core::Loggable for RotationAxisAngle {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.RotationAxisAngle".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::RotationAxisAngle::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
     {
         crate::datatypes::RotationAxisAngle::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for RotationAxisAngle {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.RotationAxisAngle".into()
     }
 }

--- a/crates/store/re_types/src/components/rotation_quat.rs
+++ b/crates/store/re_types/src/components/rotation_quat.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for RotationQuat {
 ::re_types_core::macros::impl_into_cow!(RotationQuat);
 
 impl ::re_types_core::Loggable for RotationQuat {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.RotationQuat".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Quaternion::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for RotationQuat {
         Self: Sized,
     {
         crate::datatypes::Quaternion::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for RotationQuat {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.RotationQuat".into()
     }
 }

--- a/crates/store/re_types/src/components/scalar.rs
+++ b/crates/store/re_types/src/components/scalar.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for Scalar {
 ::re_types_core::macros::impl_into_cow!(Scalar);
 
 impl ::re_types_core::Loggable for Scalar {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Scalar".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float64::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for Scalar {
         Self: Sized,
     {
         crate::datatypes::Float64::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Scalar {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Scalar".into()
     }
 }

--- a/crates/store/re_types/src/components/scale3d.rs
+++ b/crates/store/re_types/src/components/scale3d.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for Scale3D {
 ::re_types_core::macros::impl_into_cow!(Scale3D);
 
 impl ::re_types_core::Loggable for Scale3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Scale3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -113,5 +106,12 @@ impl ::re_types_core::Loggable for Scale3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Scale3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Scale3D".into()
     }
 }

--- a/crates/store/re_types/src/components/show_labels.rs
+++ b/crates/store/re_types/src/components/show_labels.rs
@@ -73,13 +73,6 @@ impl std::ops::DerefMut for ShowLabels {
 ::re_types_core::macros::impl_into_cow!(ShowLabels);
 
 impl ::re_types_core::Loggable for ShowLabels {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ShowLabels".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -107,5 +100,12 @@ impl ::re_types_core::Loggable for ShowLabels {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for ShowLabels {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ShowLabels".into()
     }
 }

--- a/crates/store/re_types/src/components/stroke_width.rs
+++ b/crates/store/re_types/src/components/stroke_width.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for StrokeWidth {
 ::re_types_core::macros::impl_into_cow!(StrokeWidth);
 
 impl ::re_types_core::Loggable for StrokeWidth {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.StrokeWidth".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Float32::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for StrokeWidth {
         Self: Sized,
     {
         crate::datatypes::Float32::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for StrokeWidth {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.StrokeWidth".into()
     }
 }

--- a/crates/store/re_types/src/components/tensor_data.rs
+++ b/crates/store/re_types/src/components/tensor_data.rs
@@ -74,13 +74,6 @@ impl std::ops::DerefMut for TensorData {
 ::re_types_core::macros::impl_into_cow!(TensorData);
 
 impl ::re_types_core::Loggable for TensorData {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TensorData".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::TensorData::arrow_datatype()
@@ -108,5 +101,12 @@ impl ::re_types_core::Loggable for TensorData {
     {
         crate::datatypes::TensorData::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TensorData {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TensorData".into()
     }
 }

--- a/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
@@ -71,13 +71,6 @@ impl std::ops::DerefMut for TensorDimensionIndexSelection {
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSelection);
 
 impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TensorDimensionIndexSelection".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::TensorDimensionIndexSelection::arrow_datatype()
@@ -107,5 +100,12 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
     {
         crate::datatypes::TensorDimensionIndexSelection::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TensorDimensionIndexSelection {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TensorDimensionIndexSelection".into()
     }
 }

--- a/crates/store/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_height_dimension.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for TensorHeightDimension {
 ::re_types_core::macros::impl_into_cow!(TensorHeightDimension);
 
 impl ::re_types_core::Loggable for TensorHeightDimension {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TensorHeightDimension".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::TensorDimensionSelection::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
     {
         crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TensorHeightDimension {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TensorHeightDimension".into()
     }
 }

--- a/crates/store/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_width_dimension.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for TensorWidthDimension {
 ::re_types_core::macros::impl_into_cow!(TensorWidthDimension);
 
 impl ::re_types_core::Loggable for TensorWidthDimension {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TensorWidthDimension".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::TensorDimensionSelection::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
     {
         crate::datatypes::TensorDimensionSelection::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TensorWidthDimension {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TensorWidthDimension".into()
     }
 }

--- a/crates/store/re_types/src/components/texcoord2d.rs
+++ b/crates/store/re_types/src/components/texcoord2d.rs
@@ -82,13 +82,6 @@ impl std::ops::DerefMut for Texcoord2D {
 ::re_types_core::macros::impl_into_cow!(Texcoord2D);
 
 impl ::re_types_core::Loggable for Texcoord2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Texcoord2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec2D::arrow_datatype()
@@ -124,5 +117,12 @@ impl ::re_types_core::Loggable for Texcoord2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Texcoord2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Texcoord2D".into()
     }
 }

--- a/crates/store/re_types/src/components/text.rs
+++ b/crates/store/re_types/src/components/text.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Text {
 ::re_types_core::macros::impl_into_cow!(Text);
 
 impl ::re_types_core::Loggable for Text {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Text".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for Text {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for Text {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Text".into()
     }
 }

--- a/crates/store/re_types/src/components/text_log_level.rs
+++ b/crates/store/re_types/src/components/text_log_level.rs
@@ -75,13 +75,6 @@ impl std::ops::DerefMut for TextLogLevel {
 ::re_types_core::macros::impl_into_cow!(TextLogLevel);
 
 impl ::re_types_core::Loggable for TextLogLevel {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TextLogLevel".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Utf8::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for TextLogLevel {
     {
         crate::datatypes::Utf8::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for TextLogLevel {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TextLogLevel".into()
     }
 }

--- a/crates/store/re_types/src/components/transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/transform_mat3x3.rs
@@ -79,13 +79,6 @@ impl std::ops::DerefMut for TransformMat3x3 {
 ::re_types_core::macros::impl_into_cow!(TransformMat3x3);
 
 impl ::re_types_core::Loggable for TransformMat3x3 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TransformMat3x3".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Mat3x3::arrow_datatype()
@@ -121,5 +114,12 @@ impl ::re_types_core::Loggable for TransformMat3x3 {
         Self: Sized,
     {
         crate::datatypes::Mat3x3::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for TransformMat3x3 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TransformMat3x3".into()
     }
 }

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -82,13 +82,6 @@ impl std::fmt::Display for TransformRelation {
 ::re_types_core::macros::impl_into_cow!(TransformRelation);
 
 impl ::re_types_core::Loggable for TransformRelation {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TransformRelation".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -160,5 +153,12 @@ impl ::re_types_core::Loggable for TransformRelation {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.components.TransformRelation")?)
+    }
+}
+
+impl ::re_types_core::Component for TransformRelation {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TransformRelation".into()
     }
 }

--- a/crates/store/re_types/src/components/translation3d.rs
+++ b/crates/store/re_types/src/components/translation3d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Translation3D {
 ::re_types_core::macros::impl_into_cow!(Translation3D);
 
 impl ::re_types_core::Loggable for Translation3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Translation3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Translation3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Translation3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Translation3D".into()
     }
 }

--- a/crates/store/re_types/src/components/triangle_indices.rs
+++ b/crates/store/re_types/src/components/triangle_indices.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for TriangleIndices {
 ::re_types_core::macros::impl_into_cow!(TriangleIndices);
 
 impl ::re_types_core::Loggable for TriangleIndices {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.TriangleIndices".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::UVec3D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for TriangleIndices {
         Self: Sized,
     {
         crate::datatypes::UVec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for TriangleIndices {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.TriangleIndices".into()
     }
 }

--- a/crates/store/re_types/src/components/value_range.rs
+++ b/crates/store/re_types/src/components/value_range.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for ValueRange {
 ::re_types_core::macros::impl_into_cow!(ValueRange);
 
 impl ::re_types_core::Loggable for ValueRange {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ValueRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Range1D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for ValueRange {
         Self: Sized,
     {
         crate::datatypes::Range1D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for ValueRange {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ValueRange".into()
     }
 }

--- a/crates/store/re_types/src/components/vector2d.rs
+++ b/crates/store/re_types/src/components/vector2d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Vector2D {
 ::re_types_core::macros::impl_into_cow!(Vector2D);
 
 impl ::re_types_core::Loggable for Vector2D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Vector2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec2D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Vector2D {
         Self: Sized,
     {
         crate::datatypes::Vec2D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Vector2D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Vector2D".into()
     }
 }

--- a/crates/store/re_types/src/components/vector3d.rs
+++ b/crates/store/re_types/src/components/vector3d.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for Vector3D {
 ::re_types_core::macros::impl_into_cow!(Vector3D);
 
 impl ::re_types_core::Loggable for Vector3D {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.Vector3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Vec3D::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for Vector3D {
         Self: Sized,
     {
         crate::datatypes::Vec3D::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for Vector3D {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.Vector3D".into()
     }
 }

--- a/crates/store/re_types/src/components/video_timestamp.rs
+++ b/crates/store/re_types/src/components/video_timestamp.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for VideoTimestamp {
 ::re_types_core::macros::impl_into_cow!(VideoTimestamp);
 
 impl ::re_types_core::Loggable for VideoTimestamp {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.VideoTimestamp".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::VideoTimestamp::arrow_datatype()
@@ -110,5 +103,12 @@ impl ::re_types_core::Loggable for VideoTimestamp {
     {
         crate::datatypes::VideoTimestamp::from_arrow(arrow_data)
             .map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for VideoTimestamp {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.VideoTimestamp".into()
     }
 }

--- a/crates/store/re_types/src/components/view_coordinates.rs
+++ b/crates/store/re_types/src/components/view_coordinates.rs
@@ -87,13 +87,6 @@ impl std::ops::DerefMut for ViewCoordinates {
 ::re_types_core::macros::impl_into_cow!(ViewCoordinates);
 
 impl ::re_types_core::Loggable for ViewCoordinates {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ViewCoordinates".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::ViewCoordinates::arrow_datatype()
@@ -129,5 +122,12 @@ impl ::re_types_core::Loggable for ViewCoordinates {
         Self: Sized,
     {
         crate::datatypes::ViewCoordinates::from_arrow(arrow_data).map(bytemuck::cast_vec)
+    }
+}
+
+impl ::re_types_core::Component for ViewCoordinates {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ViewCoordinates".into()
     }
 }

--- a/crates/store/re_types/src/datatypes/angle.rs
+++ b/crates/store/re_types/src/datatypes/angle.rs
@@ -55,13 +55,6 @@ impl From<Angle> for f32 {
 ::re_types_core::macros::impl_into_cow!(Angle);
 
 impl ::re_types_core::Loggable for Angle {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Angle".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/annotation_info.rs
+++ b/crates/store/re_types/src/datatypes/annotation_info.rs
@@ -51,13 +51,6 @@ impl ::re_types_core::SizeBytes for AnnotationInfo {
 ::re_types_core::macros::impl_into_cow!(AnnotationInfo);
 
 impl ::re_types_core::Loggable for AnnotationInfo {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.AnnotationInfo".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -54,13 +54,6 @@ impl From<Blob> for ::re_types_core::ArrowBuffer<u8> {
 ::re_types_core::macros::impl_into_cow!(Blob);
 
 impl ::re_types_core::Loggable for Blob {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Blob".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/channel_datatype.rs
+++ b/crates/store/re_types/src/datatypes/channel_datatype.rs
@@ -129,13 +129,6 @@ impl std::fmt::Display for ChannelDatatype {
 ::re_types_core::macros::impl_into_cow!(ChannelDatatype);
 
 impl ::re_types_core::Loggable for ChannelDatatype {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ChannelDatatype".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/class_description.rs
+++ b/crates/store/re_types/src/datatypes/class_description.rs
@@ -63,13 +63,6 @@ impl ::re_types_core::SizeBytes for ClassDescription {
 ::re_types_core::macros::impl_into_cow!(ClassDescription);
 
 impl ::re_types_core::Loggable for ClassDescription {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ClassDescription".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/store/re_types/src/datatypes/class_description_map_elem.rs
@@ -45,13 +45,6 @@ impl ::re_types_core::SizeBytes for ClassDescriptionMapElem {
 ::re_types_core::macros::impl_into_cow!(ClassDescriptionMapElem);
 
 impl ::re_types_core::Loggable for ClassDescriptionMapElem {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ClassDescriptionMapElem".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/class_id.rs
+++ b/crates/store/re_types/src/datatypes/class_id.rs
@@ -67,13 +67,6 @@ impl From<ClassId> for u16 {
 ::re_types_core::macros::impl_into_cow!(ClassId);
 
 impl ::re_types_core::Loggable for ClassId {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ClassId".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/color_model.rs
+++ b/crates/store/re_types/src/datatypes/color_model.rs
@@ -91,13 +91,6 @@ impl std::fmt::Display for ColorModel {
 ::re_types_core::macros::impl_into_cow!(ColorModel);
 
 impl ::re_types_core::Loggable for ColorModel {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ColorModel".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/dvec2d.rs
+++ b/crates/store/re_types/src/datatypes/dvec2d.rs
@@ -52,13 +52,6 @@ impl From<DVec2D> for [f64; 2usize] {
 ::re_types_core::macros::impl_into_cow!(DVec2D);
 
 impl ::re_types_core::Loggable for DVec2D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.DVec2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/image_format.rs
+++ b/crates/store/re_types/src/datatypes/image_format.rs
@@ -66,13 +66,6 @@ impl ::re_types_core::SizeBytes for ImageFormat {
 ::re_types_core::macros::impl_into_cow!(ImageFormat);
 
 impl ::re_types_core::Loggable for ImageFormat {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ImageFormat".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_id.rs
@@ -69,13 +69,6 @@ impl From<KeypointId> for u16 {
 ::re_types_core::macros::impl_into_cow!(KeypointId);
 
 impl ::re_types_core::Loggable for KeypointId {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.KeypointId".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_pair.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for KeypointPair {
 ::re_types_core::macros::impl_into_cow!(KeypointPair);
 
 impl ::re_types_core::Loggable for KeypointPair {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.KeypointPair".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/mat3x3.rs
+++ b/crates/store/re_types/src/datatypes/mat3x3.rs
@@ -64,13 +64,6 @@ impl From<Mat3x3> for [f32; 9usize] {
 ::re_types_core::macros::impl_into_cow!(Mat3x3);
 
 impl ::re_types_core::Loggable for Mat3x3 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Mat3x3".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/mat4x4.rs
+++ b/crates/store/re_types/src/datatypes/mat4x4.rs
@@ -64,13 +64,6 @@ impl From<Mat4x4> for [f32; 16usize] {
 ::re_types_core::macros::impl_into_cow!(Mat4x4);
 
 impl ::re_types_core::Loggable for Mat4x4 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Mat4x4".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/pixel_format.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format.rs
@@ -211,13 +211,6 @@ impl std::fmt::Display for PixelFormat {
 ::re_types_core::macros::impl_into_cow!(PixelFormat);
 
 impl ::re_types_core::Loggable for PixelFormat {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.PixelFormat".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/quaternion.rs
+++ b/crates/store/re_types/src/datatypes/quaternion.rs
@@ -55,13 +55,6 @@ impl From<Quaternion> for [f32; 4usize] {
 ::re_types_core::macros::impl_into_cow!(Quaternion);
 
 impl ::re_types_core::Loggable for Quaternion {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Quaternion".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/range1d.rs
+++ b/crates/store/re_types/src/datatypes/range1d.rs
@@ -52,13 +52,6 @@ impl From<Range1D> for [f64; 2usize] {
 ::re_types_core::macros::impl_into_cow!(Range1D);
 
 impl ::re_types_core::Loggable for Range1D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Range1D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/range2d.rs
+++ b/crates/store/re_types/src/datatypes/range2d.rs
@@ -44,13 +44,6 @@ impl ::re_types_core::SizeBytes for Range2D {
 ::re_types_core::macros::impl_into_cow!(Range2D);
 
 impl ::re_types_core::Loggable for Range2D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Range2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/rgba32.rs
+++ b/crates/store/re_types/src/datatypes/rgba32.rs
@@ -57,13 +57,6 @@ impl From<Rgba32> for u32 {
 ::re_types_core::macros::impl_into_cow!(Rgba32);
 
 impl ::re_types_core::Loggable for Rgba32 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Rgba32".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
@@ -47,13 +47,6 @@ impl ::re_types_core::SizeBytes for RotationAxisAngle {
 ::re_types_core::macros::impl_into_cow!(RotationAxisAngle);
 
 impl ::re_types_core::Loggable for RotationAxisAngle {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.RotationAxisAngle".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -95,13 +95,6 @@ impl ::re_types_core::SizeBytes for TensorBuffer {
 ::re_types_core::macros::impl_into_cow!(TensorBuffer);
 
 impl ::re_types_core::Loggable for TensorBuffer {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TensorBuffer".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/tensor_data.rs
+++ b/crates/store/re_types/src/datatypes/tensor_data.rs
@@ -51,13 +51,6 @@ impl ::re_types_core::SizeBytes for TensorData {
 ::re_types_core::macros::impl_into_cow!(TensorData);
 
 impl ::re_types_core::Loggable for TensorData {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TensorData".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for TensorDimension {
 ::re_types_core::macros::impl_into_cow!(TensorDimension);
 
 impl ::re_types_core::Loggable for TensorDimension {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TensorDimension".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
@@ -45,13 +45,6 @@ impl ::re_types_core::SizeBytes for TensorDimensionIndexSelection {
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSelection);
 
 impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TensorDimensionIndexSelection".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for TensorDimensionSelection {
 ::re_types_core::macros::impl_into_cow!(TensorDimensionSelection);
 
 impl ::re_types_core::Loggable for TensorDimensionSelection {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TensorDimensionSelection".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/uuid.rs
+++ b/crates/store/re_types/src/datatypes/uuid.rs
@@ -55,13 +55,6 @@ impl From<Uuid> for [u8; 16usize] {
 ::re_types_core::macros::impl_into_cow!(Uuid);
 
 impl ::re_types_core::Loggable for Uuid {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Uuid".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/uvec2d.rs
+++ b/crates/store/re_types/src/datatypes/uvec2d.rs
@@ -52,13 +52,6 @@ impl From<UVec2D> for [u32; 2usize] {
 ::re_types_core::macros::impl_into_cow!(UVec2D);
 
 impl ::re_types_core::Loggable for UVec2D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UVec2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/uvec3d.rs
+++ b/crates/store/re_types/src/datatypes/uvec3d.rs
@@ -52,13 +52,6 @@ impl From<UVec3D> for [u32; 3usize] {
 ::re_types_core::macros::impl_into_cow!(UVec3D);
 
 impl ::re_types_core::Loggable for UVec3D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UVec3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/uvec4d.rs
+++ b/crates/store/re_types/src/datatypes/uvec4d.rs
@@ -52,13 +52,6 @@ impl From<UVec4D> for [u32; 4usize] {
 ::re_types_core::macros::impl_into_cow!(UVec4D);
 
 impl ::re_types_core::Loggable for UVec4D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UVec4D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/vec2d.rs
+++ b/crates/store/re_types/src/datatypes/vec2d.rs
@@ -52,13 +52,6 @@ impl From<Vec2D> for [f32; 2usize] {
 ::re_types_core::macros::impl_into_cow!(Vec2D);
 
 impl ::re_types_core::Loggable for Vec2D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Vec2D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/vec3d.rs
+++ b/crates/store/re_types/src/datatypes/vec3d.rs
@@ -52,13 +52,6 @@ impl From<Vec3D> for [f32; 3usize] {
 ::re_types_core::macros::impl_into_cow!(Vec3D);
 
 impl ::re_types_core::Loggable for Vec3D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Vec3D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/vec4d.rs
+++ b/crates/store/re_types/src/datatypes/vec4d.rs
@@ -52,13 +52,6 @@ impl From<Vec4D> for [f32; 4usize] {
 ::re_types_core::macros::impl_into_cow!(Vec4D);
 
 impl ::re_types_core::Loggable for Vec4D {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Vec4D".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/video_timestamp.rs
+++ b/crates/store/re_types/src/datatypes/video_timestamp.rs
@@ -57,13 +57,6 @@ impl From<VideoTimestamp> for i64 {
 ::re_types_core::macros::impl_into_cow!(VideoTimestamp);
 
 impl ::re_types_core::Loggable for VideoTimestamp {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.VideoTimestamp".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/datatypes/view_coordinates.rs
+++ b/crates/store/re_types/src/datatypes/view_coordinates.rs
@@ -72,13 +72,6 @@ impl From<ViewCoordinates> for [u8; 3usize] {
 ::re_types_core::macros::impl_into_cow!(ViewCoordinates);
 
 impl ::re_types_core::Loggable for ViewCoordinates {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.ViewCoordinates".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer1 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer1);
 
 impl ::re_types_core::Loggable for AffixFuzzer1 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer1".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer1 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer1".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer10 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer10);
 
 impl ::re_types_core::Loggable for AffixFuzzer10 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer10".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -181,5 +174,12 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer10#single_string_optional")
         .with_context("rerun.testing.components.AffixFuzzer10")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer10 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer10".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer11 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer11);
 
 impl ::re_types_core::Loggable for AffixFuzzer11 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer11".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -208,5 +201,12 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer11#many_floats_optional")
         .with_context("rerun.testing.components.AffixFuzzer11")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer11 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer11".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer12 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer12);
 
 impl ::re_types_core::Loggable for AffixFuzzer12 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer12".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -256,5 +249,12 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer12#many_strings_required")
         .with_context("rerun.testing.components.AffixFuzzer12")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer12 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer12".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer13 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer13);
 
 impl ::re_types_core::Loggable for AffixFuzzer13 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer13".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -256,5 +249,12 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer13#many_strings_optional")
         .with_context("rerun.testing.components.AffixFuzzer13")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer13 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer13".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer14 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer14);
 
 impl ::re_types_core::Loggable for AffixFuzzer14 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer14".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer3::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     {
         crate::testing::datatypes::AffixFuzzer3::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer14 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer14".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer15 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer15);
 
 impl ::re_types_core::Loggable for AffixFuzzer15 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer15".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -153,5 +146,12 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
                 .with_context("rerun.testing.components.AffixFuzzer15#single_optional_union")
                 .with_context("rerun.testing.components.AffixFuzzer15")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer15 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer15".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -44,13 +44,6 @@ impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer16);
 
 impl ::re_types_core::Loggable for AffixFuzzer16 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer16".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -178,5 +171,12 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer16#many_required_unions")
         .with_context("rerun.testing.components.AffixFuzzer16")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer16 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer16".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -44,13 +44,6 @@ impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer17);
 
 impl ::re_types_core::Loggable for AffixFuzzer17 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer17".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -178,5 +171,12 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer17#many_optional_unions")
         .with_context("rerun.testing.components.AffixFuzzer17")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer17 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer17".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -44,13 +44,6 @@ impl<I: Into<crate::testing::datatypes::AffixFuzzer4>, T: IntoIterator<Item = I>
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer18);
 
 impl ::re_types_core::Loggable for AffixFuzzer18 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer18".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -178,5 +171,12 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer18#many_optional_unions")
         .with_context("rerun.testing.components.AffixFuzzer18")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer18 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer18".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer19 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer19);
 
 impl ::re_types_core::Loggable for AffixFuzzer19 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer19".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer5::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     {
         crate::testing::datatypes::AffixFuzzer5::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer19 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer19".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer2 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer2);
 
 impl ::re_types_core::Loggable for AffixFuzzer2 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer2".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer2 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer2".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer20 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer20);
 
 impl ::re_types_core::Loggable for AffixFuzzer20 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer20".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer20::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     {
         crate::testing::datatypes::AffixFuzzer20::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer20 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer20".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer21 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer21);
 
 impl ::re_types_core::Loggable for AffixFuzzer21 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer21".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer21::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     {
         crate::testing::datatypes::AffixFuzzer21::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer21 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer21".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer22 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer22);
 
 impl ::re_types_core::Loggable for AffixFuzzer22 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer22".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -135,5 +128,12 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                 .with_context("rerun.testing.components.AffixFuzzer22#nullable_nested_array")
                 .with_context("rerun.testing.components.AffixFuzzer22")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer22 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer22".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer23 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer23);
 
 impl ::re_types_core::Loggable for AffixFuzzer23 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer23".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -139,5 +132,12 @@ impl ::re_types_core::Loggable for AffixFuzzer23 {
                 .with_context("rerun.testing.components.AffixFuzzer23#multi_enum")
                 .with_context("rerun.testing.components.AffixFuzzer23")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer23 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer23".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer3 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer3);
 
 impl ::re_types_core::Loggable for AffixFuzzer3 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer3".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::testing::datatypes::AffixFuzzer1::arrow_datatype()
@@ -99,5 +92,12 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     {
         crate::testing::datatypes::AffixFuzzer1::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer3 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer3".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer4 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer4);
 
 impl ::re_types_core::Loggable for AffixFuzzer4 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer4".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -166,5 +159,12 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                 .with_context("rerun.testing.components.AffixFuzzer4#single_optional")
                 .with_context("rerun.testing.components.AffixFuzzer4")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer4 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer4".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer5 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer5);
 
 impl ::re_types_core::Loggable for AffixFuzzer5 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer5".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -166,5 +159,12 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                 .with_context("rerun.testing.components.AffixFuzzer5#single_optional")
                 .with_context("rerun.testing.components.AffixFuzzer5")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer5 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer5".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
@@ -65,13 +65,6 @@ impl std::ops::DerefMut for AffixFuzzer6 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer6);
 
 impl ::re_types_core::Loggable for AffixFuzzer6 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer6".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -166,5 +159,12 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
                 .with_context("rerun.testing.components.AffixFuzzer6#single_optional")
                 .with_context("rerun.testing.components.AffixFuzzer6")?,
         )
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer6 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer6".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -44,13 +44,6 @@ impl<I: Into<crate::testing::datatypes::AffixFuzzer1>, T: IntoIterator<Item = I>
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer7);
 
 impl ::re_types_core::Loggable for AffixFuzzer7 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer7".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -176,5 +169,12 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer7#many_optional")
         .with_context("rerun.testing.components.AffixFuzzer7")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer7 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer7".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer8 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer8);
 
 impl ::re_types_core::Loggable for AffixFuzzer8 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer8".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -137,5 +130,12 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.testing.components.AffixFuzzer8#single_float_optional")
             .with_context("rerun.testing.components.AffixFuzzer8")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer8 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer8".into()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -66,13 +66,6 @@ impl std::ops::DerefMut for AffixFuzzer9 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer9);
 
 impl ::re_types_core::Loggable for AffixFuzzer9 {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.components.AffixFuzzer9".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -181,5 +174,12 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.components.AffixFuzzer9#single_string_required")
         .with_context("rerun.testing.components.AffixFuzzer9")?)
+    }
+}
+
+impl ::re_types_core::Component for AffixFuzzer9 {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.testing.components.AffixFuzzer9".into()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -62,13 +62,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer1 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer1);
 
 impl ::re_types_core::Loggable for AffixFuzzer1 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer1".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -50,13 +50,6 @@ impl From<AffixFuzzer2> for Option<f32> {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer2);
 
 impl ::re_types_core::Loggable for AffixFuzzer2 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer2".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -40,13 +40,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer20 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer20);
 
 impl ::re_types_core::Loggable for AffixFuzzer20 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer20".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -40,13 +40,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer21 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer21);
 
 impl ::re_types_core::Loggable for AffixFuzzer21 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer21".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -52,13 +52,6 @@ impl From<AffixFuzzer22> for [u8; 4usize] {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer22);
 
 impl ::re_types_core::Loggable for AffixFuzzer22 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer22".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -49,13 +49,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer3 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer3);
 
 impl ::re_types_core::Loggable for AffixFuzzer3 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer3".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -44,13 +44,6 @@ impl ::re_types_core::SizeBytes for AffixFuzzer4 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer4);
 
 impl ::re_types_core::Loggable for AffixFuzzer4 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer4".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for AffixFuzzer5 {
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer5);
 
 impl ::re_types_core::Loggable for AffixFuzzer5 {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.AffixFuzzer5".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/enum_test.rs
+++ b/crates/store/re_types/src/testing/datatypes/enum_test.rs
@@ -97,13 +97,6 @@ impl std::fmt::Display for EnumTest {
 ::re_types_core::macros::impl_into_cow!(EnumTest);
 
 impl ::re_types_core::Loggable for EnumTest {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.EnumTest".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -52,13 +52,6 @@ impl From<FlattenedScalar> for f32 {
 ::re_types_core::macros::impl_into_cow!(FlattenedScalar);
 
 impl ::re_types_core::Loggable for FlattenedScalar {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.FlattenedScalar".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/multi_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/multi_enum.rs
@@ -43,13 +43,6 @@ impl ::re_types_core::SizeBytes for MultiEnum {
 ::re_types_core::macros::impl_into_cow!(MultiEnum);
 
 impl ::re_types_core::Loggable for MultiEnum {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.MultiEnum".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/primitive_component.rs
@@ -51,13 +51,6 @@ impl From<PrimitiveComponent> for u32 {
 ::re_types_core::macros::impl_into_cow!(PrimitiveComponent);
 
 impl ::re_types_core::Loggable for PrimitiveComponent {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.PrimitiveComponent".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/string_component.rs
@@ -51,13 +51,6 @@ impl From<StringComponent> for ::re_types_core::ArrowString {
 ::re_types_core::macros::impl_into_cow!(StringComponent);
 
 impl ::re_types_core::Loggable for StringComponent {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.StringComponent".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types/src/testing/datatypes/valued_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/valued_enum.rs
@@ -79,13 +79,6 @@ impl std::fmt::Display for ValuedEnum {
 ::re_types_core::macros::impl_into_cow!(ValuedEnum);
 
 impl ::re_types_core::Loggable for ValuedEnum {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.testing.datatypes.ValuedEnum".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for AutoLayout {
 ::re_types_core::macros::impl_into_cow!(AutoLayout);
 
 impl ::re_types_core::Loggable for AutoLayout {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.AutoLayout".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for AutoLayout {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AutoLayout {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.AutoLayout".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for AutoSpaceViews {
 ::re_types_core::macros::impl_into_cow!(AutoSpaceViews);
 
 impl ::re_types_core::Loggable for AutoSpaceViews {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.AutoSpaceViews".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -101,5 +94,12 @@ impl ::re_types_core::Loggable for AutoSpaceViews {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for AutoSpaceViews {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.AutoSpaceViews".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
@@ -80,13 +80,6 @@ impl std::fmt::Display for ContainerKind {
 ::re_types_core::macros::impl_into_cow!(ContainerKind);
 
 impl ::re_types_core::Loggable for ContainerKind {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.ContainerKind".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]
@@ -160,5 +153,12 @@ impl ::re_types_core::Loggable for ContainerKind {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.blueprint.components.ContainerKind")?)
+    }
+}
+
+impl ::re_types_core::Component for ContainerKind {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.ContainerKind".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for GridColumns {
 ::re_types_core::macros::impl_into_cow!(GridColumns);
 
 impl ::re_types_core::Loggable for GridColumns {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.GridColumns".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::UInt32::arrow_datatype()
@@ -111,5 +104,12 @@ impl ::re_types_core::Loggable for GridColumns {
         Self: Sized,
     {
         crate::datatypes::UInt32::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for GridColumns {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.GridColumns".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/included_space_view.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/included_space_view.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for IncludedSpaceView {
 ::re_types_core::macros::impl_into_cow!(IncludedSpaceView);
 
 impl ::re_types_core::Loggable for IncludedSpaceView {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.IncludedSpaceView".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Uuid::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for IncludedSpaceView {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for IncludedSpaceView {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.IncludedSpaceView".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -70,13 +70,6 @@ impl std::ops::DerefMut for RootContainer {
 ::re_types_core::macros::impl_into_cow!(RootContainer);
 
 impl ::re_types_core::Loggable for RootContainer {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.RootContainer".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Uuid::arrow_datatype()
@@ -112,5 +105,12 @@ impl ::re_types_core::Loggable for RootContainer {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for RootContainer {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.RootContainer".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -67,13 +67,6 @@ impl std::ops::DerefMut for SpaceViewMaximized {
 ::re_types_core::macros::impl_into_cow!(SpaceViewMaximized);
 
 impl ::re_types_core::Loggable for SpaceViewMaximized {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.SpaceViewMaximized".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Uuid::arrow_datatype()
@@ -109,5 +102,12 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
         Self: Sized,
     {
         crate::datatypes::Uuid::from_arrow(arrow_data).map(|v| v.into_iter().map(Self).collect())
+    }
+}
+
+impl ::re_types_core::Component for SpaceViewMaximized {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.SpaceViewMaximized".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
@@ -102,13 +102,6 @@ impl std::ops::DerefMut for VisualizerOverrides {
 ::re_types_core::macros::impl_into_cow!(VisualizerOverrides);
 
 impl ::re_types_core::Loggable for VisualizerOverrides {
-    type Name = ::re_types_core::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.components.VisualizerOverrides".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::blueprint::datatypes::Utf8List::arrow_datatype()
@@ -136,5 +129,12 @@ impl ::re_types_core::Loggable for VisualizerOverrides {
     {
         crate::blueprint::datatypes::Utf8List::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl ::re_types_core::Component for VisualizerOverrides {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.blueprint.components.VisualizerOverrides".into()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -52,13 +52,6 @@ impl From<Utf8List> for Vec<::re_types_core::ArrowString> {
 ::re_types_core::macros::impl_into_cow!(Utf8List);
 
 impl ::re_types_core::Loggable for Utf8List {
-    type Name = ::re_types_core::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.blueprint.datatypes.Utf8List".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -215,15 +215,6 @@ impl<A: Archetype> Default for GenericIndicatorComponent<A> {
 }
 
 impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponent<A> {
-    type Name = ComponentName;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        format!("{}Indicator", A::name().full_name())
-            .replace("archetypes", "components")
-            .into()
-    }
-
     #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
         let datatype = arrow2::datatypes::DataType::Null;
@@ -231,7 +222,14 @@ impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponent<A> {
     }
 }
 
-impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponent<A> {}
+impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponent<A> {
+    #[inline]
+    fn name(&self) -> ComponentName {
+        format!("{}Indicator", A::name().full_name())
+            .replace("archetypes", "components")
+            .into()
+    }
+}
 
 /// A generic [indicator component] array of a given length.
 ///
@@ -248,13 +246,6 @@ pub struct GenericIndicatorComponentArray<A: Archetype> {
 }
 
 impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponentArray<A> {
-    type Name = ComponentName;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        GenericIndicatorComponent::<A>::DEFAULT.name()
-    }
-
     #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
         let datatype = arrow2::datatypes::DataType::Null;
@@ -262,7 +253,12 @@ impl<A: Archetype> crate::LoggableBatch for GenericIndicatorComponentArray<A> {
     }
 }
 
-impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponentArray<A> {}
+impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponentArray<A> {
+    #[inline]
+    fn name(&self) -> ComponentName {
+        GenericIndicatorComponent::<A>::DEFAULT.name()
+    }
+}
 
 // ---
 
@@ -285,13 +281,6 @@ impl NamedIndicatorComponent {
 }
 
 impl crate::LoggableBatch for NamedIndicatorComponent {
-    type Name = ComponentName;
-
-    #[inline]
-    fn name(&self) -> Self::Name {
-        self.0
-    }
-
     #[inline]
     fn to_arrow(&self) -> SerializationResult<Box<dyn arrow2::array::Array>> {
         let datatype = arrow2::datatypes::DataType::Null;
@@ -299,4 +288,9 @@ impl crate::LoggableBatch for NamedIndicatorComponent {
     }
 }
 
-impl crate::ComponentBatch for NamedIndicatorComponent {}
+impl crate::ComponentBatch for NamedIndicatorComponent {
+    #[inline]
+    fn name(&self) -> ComponentName {
+        self.0
+    }
+}

--- a/crates/store/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/store/re_types_core/src/components/clear_is_recursive.rs
@@ -69,13 +69,6 @@ impl std::ops::DerefMut for ClearIsRecursive {
 crate::macros::impl_into_cow!(ClearIsRecursive);
 
 impl crate::Loggable for ClearIsRecursive {
-    type Name = crate::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.components.ClearIsRecursive".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         crate::datatypes::Bool::arrow_datatype()
@@ -103,5 +96,12 @@ impl crate::Loggable for ClearIsRecursive {
     {
         crate::datatypes::Bool::from_arrow_opt(arrow_data)
             .map(|v| v.into_iter().map(|v| v.map(Self)).collect())
+    }
+}
+
+impl crate::Component for ClearIsRecursive {
+    #[inline]
+    fn name() -> ComponentName {
+        "rerun.components.ClearIsRecursive".into()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/bool.rs
+++ b/crates/store/re_types_core/src/datatypes/bool.rs
@@ -52,13 +52,6 @@ impl From<Bool> for bool {
 crate::macros::impl_into_cow!(Bool);
 
 impl crate::Loggable for Bool {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Bool".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/store/re_types_core/src/datatypes/entity_path.rs
@@ -52,13 +52,6 @@ impl From<EntityPath> for crate::ArrowString {
 crate::macros::impl_into_cow!(EntityPath);
 
 impl crate::Loggable for EntityPath {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.EntityPath".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/float32.rs
+++ b/crates/store/re_types_core/src/datatypes/float32.rs
@@ -52,13 +52,6 @@ impl From<Float32> for f32 {
 crate::macros::impl_into_cow!(Float32);
 
 impl crate::Loggable for Float32 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Float32".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/float64.rs
+++ b/crates/store/re_types_core/src/datatypes/float64.rs
@@ -52,13 +52,6 @@ impl From<Float64> for f64 {
 crate::macros::impl_into_cow!(Float64);
 
 impl crate::Loggable for Float64 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Float64".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/time_int.rs
+++ b/crates/store/re_types_core/src/datatypes/time_int.rs
@@ -51,13 +51,6 @@ impl From<TimeInt> for i64 {
 crate::macros::impl_into_cow!(TimeInt);
 
 impl crate::Loggable for TimeInt {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TimeInt".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range.rs
@@ -44,13 +44,6 @@ impl crate::SizeBytes for TimeRange {
 crate::macros::impl_into_cow!(TimeRange);
 
 impl crate::Loggable for TimeRange {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TimeRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -51,13 +51,6 @@ impl crate::SizeBytes for TimeRangeBoundary {
 crate::macros::impl_into_cow!(TimeRangeBoundary);
 
 impl crate::Loggable for TimeRangeBoundary {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.TimeRangeBoundary".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/uint16.rs
+++ b/crates/store/re_types_core/src/datatypes/uint16.rs
@@ -51,13 +51,6 @@ impl From<UInt16> for u16 {
 crate::macros::impl_into_cow!(UInt16);
 
 impl crate::Loggable for UInt16 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UInt16".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/uint32.rs
+++ b/crates/store/re_types_core/src/datatypes/uint32.rs
@@ -51,13 +51,6 @@ impl From<UInt32> for u32 {
 crate::macros::impl_into_cow!(UInt32);
 
 impl crate::Loggable for UInt32 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UInt32".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/uint64.rs
+++ b/crates/store/re_types_core/src/datatypes/uint64.rs
@@ -51,13 +51,6 @@ impl From<UInt64> for u64 {
 crate::macros::impl_into_cow!(UInt64);
 
 impl crate::Loggable for UInt64 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.UInt64".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/utf8.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8.rs
@@ -52,13 +52,6 @@ impl From<Utf8> for crate::ArrowString {
 crate::macros::impl_into_cow!(Utf8);
 
 impl crate::Loggable for Utf8 {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.Utf8".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/visible_time_range.rs
@@ -43,13 +43,6 @@ impl crate::SizeBytes for VisibleTimeRange {
 crate::macros::impl_into_cow!(VisibleTimeRange);
 
 impl crate::Loggable for VisibleTimeRange {
-    type Name = crate::DatatypeName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.datatypes.VisibleTimeRange".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         #![allow(clippy::wildcard_imports)]

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -18,13 +18,6 @@ impl SizeBytes for Tuid {
 }
 
 impl Loggable for Tuid {
-    type Name = crate::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "rerun.controls.TUID".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         DataType::Struct(Arc::new(vec![
@@ -40,7 +33,7 @@ impl Loggable for Tuid {
         Self: 'a,
     {
         Err(crate::SerializationError::not_implemented(
-            Self::name(),
+            Self::NAME,
             "TUIDs are never nullable, use `to_arrow()` instead",
         ))
     }
@@ -65,7 +58,7 @@ impl Loggable for Tuid {
         let validity = None;
 
         let datatype = arrow2::datatypes::DataType::Extension(
-            Self::name().to_string(),
+            Self::NAME.to_owned(),
             Arc::new(Self::arrow_datatype()),
             None,
         );
@@ -147,13 +140,6 @@ macro_rules! delegate_arrow_tuid {
         $crate::macros::impl_into_cow!($typ);
 
         impl $crate::Loggable for $typ {
-            type Name = $crate::ComponentName;
-
-            #[inline]
-            fn name() -> Self::Name {
-                $fqname.into()
-            }
-
             #[inline]
             fn arrow_datatype() -> ::arrow2::datatypes::DataType {
                 $crate::external::re_tuid::Tuid::arrow_datatype()
@@ -167,7 +153,7 @@ macro_rules! delegate_arrow_tuid {
                 Self: 'a,
             {
                 Err($crate::SerializationError::not_implemented(
-                    Self::name(),
+                    <Self as $crate::Component>::name(),
                     "TUIDs are never nullable, use `to_arrow()` instead",
                 ))
             }
@@ -195,6 +181,13 @@ macro_rules! delegate_arrow_tuid {
                         .map(|tuid| Self(tuid))
                         .collect(),
                 )
+            }
+        }
+
+        impl $crate::Component for $typ {
+            #[inline]
+            fn name() -> $crate::ComponentName {
+                $fqname.into()
             }
         }
     };

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -18,7 +18,7 @@ use re_log_types::{
     StoreId, StoreInfo, StoreKind, StoreSource, Time, TimeInt, TimePoint, TimeType, Timeline,
     TimelineName,
 };
-use re_types_core::{AsComponents, ComponentBatch, SerializationError};
+use re_types_core::{AsComponents, SerializationError};
 
 #[cfg(feature = "web_viewer")]
 use re_web_viewer_server::WebViewerServerPort;
@@ -1002,7 +1002,7 @@ impl RecordingStream {
         &self,
         ent_path: impl Into<EntityPath>,
         timelines: impl IntoIterator<Item = TimeColumn>,
-        components: impl IntoIterator<Item = &'a dyn ComponentBatch>,
+        components: impl IntoIterator<Item = &'a dyn re_types_core::ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         let id = ChunkId::new();
 
@@ -1120,7 +1120,7 @@ impl RecordingStream {
         )
     }
 
-    /// Logs a set of [`ComponentBatch`]es into Rerun.
+    /// Logs a set of [`re_types_core::ComponentBatch`]es into Rerun.
     ///
     /// If `static_` is set to `true`, all timestamp data associated with this message will be
     /// dropped right before sending it to Rerun.
@@ -1147,7 +1147,7 @@ impl RecordingStream {
         &self,
         ent_path: impl Into<EntityPath>,
         static_: bool,
-        comp_batches: impl IntoIterator<Item = &'a dyn ComponentBatch>,
+        comp_batches: impl IntoIterator<Item = &'a dyn re_types_core::ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         let row_id = RowId::new(); // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
         self.log_component_batches_impl(row_id, ent_path, static_, comp_batches)
@@ -1158,7 +1158,7 @@ impl RecordingStream {
         row_id: RowId,
         entity_path: impl Into<EntityPath>,
         static_: bool,
-        comp_batches: impl IntoIterator<Item = &'a dyn ComponentBatch>,
+        comp_batches: impl IntoIterator<Item = &'a dyn re_types_core::ComponentBatch>,
     ) -> RecordingStreamResult<()> {
         if !self.is_enabled() {
             return Ok(()); // silently drop the message
@@ -2528,7 +2528,7 @@ mod tests {
 
     fn example_rows(timeless: bool) -> Vec<PendingRow> {
         use re_log_types::example_components::{MyColor, MyLabel, MyPoint};
-        use re_types_core::Loggable as _;
+        use re_types_core::Component as _;
 
         let mut tick = 0i64;
         let mut timepoint = |frame_nr: i64| {

--- a/crates/utils/re_tuid/src/lib.rs
+++ b/crates/utils/re_tuid/src/lib.rs
@@ -18,6 +18,8 @@ pub struct Tuid {
 }
 
 impl Tuid {
+    pub const NAME: &'static str = "rerun.datatypes.TUID";
+
     /// Returns the total size of `self` on the heap, in bytes.
     ///
     /// NOTE: This crate cannot depend on `re_types_core`, therefore the actual implementation of

--- a/crates/utils/re_tuid/src/lib.rs
+++ b/crates/utils/re_tuid/src/lib.rs
@@ -18,6 +18,9 @@ pub struct Tuid {
 }
 
 impl Tuid {
+    /// We give an actual name to [`Tuid`], and inject that name into the Arrow datatype extensions,
+    /// as a hack so that we can compactly format them when printing Arrow data to the terminal.
+    /// Check out `re_format_arrow` for context.
     pub const NAME: &'static str = "rerun.datatypes.TUID";
 
     /// Returns the total size of `self` on the heap, in bytes.

--- a/crates/viewer/re_component_ui/src/lib.rs
+++ b/crates/viewer/re_component_ui/src/lib.rs
@@ -41,7 +41,7 @@ use re_types::{
         Opacity, Range1D, Scale3D, ShowLabels, StrokeWidth, Text, TransformRelation, Translation3D,
         ValueRange,
     },
-    Loggable as _,
+    Component as _,
 };
 use re_types_blueprint::blueprint::components::{
     IncludedSpaceView, RootContainer, SpaceViewMaximized,

--- a/crates/viewer/re_component_ui/src/timeline.rs
+++ b/crates/viewer/re_component_ui/src/timeline.rs
@@ -1,5 +1,5 @@
 use re_types::blueprint::components;
-use re_types_core::LoggableBatch as _;
+use re_types_core::ComponentBatch as _;
 use re_viewer_context::external::re_log_types::TimelineName;
 use re_viewer_context::{MaybeMutRef, ViewerContext};
 

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -8,7 +8,7 @@ use re_types::{
     archetypes, components,
     datatypes::{ChannelDatatype, ColorModel},
     image::ImageKind,
-    static_assert_struct_has_fields, Archetype, ComponentName, Loggable,
+    static_assert_struct_has_fields, Archetype, Component, ComponentName,
 };
 use re_ui::UiExt as _;
 use re_viewer_context::{

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -1185,7 +1185,7 @@ fn visible_interactive_toggle_ui(
     data_result: &DataResult,
 ) {
     use re_types::blueprint::components::Visible;
-    use re_types::Loggable as _;
+    use re_types::Component as _;
 
     {
         let visible_before = data_result.is_visible(ctx.viewer_ctx);

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -83,7 +83,7 @@ fn visible_time_range_ui(
     time_range_override_path: &EntityPath,
     is_space_view: bool,
 ) {
-    use re_types::Loggable as _;
+    use re_types::Component as _;
 
     let ranges = ctx
         .blueprint_db()

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_line_strings.rs
@@ -7,7 +7,7 @@ use re_space_view::{DataResultQuery as _, RangeResultsExt as _};
 use re_types::{
     archetypes::GeoLineStrings,
     components::{Color, GeoLineString, Radius},
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewHighlights,

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -7,7 +7,7 @@ use re_space_view::{
 use re_types::{
     archetypes::GeoPoints,
     components::{ClassId, Color, LatLon, Radius},
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewHighlights,

--- a/crates/viewer/re_space_view_spatial/src/contexts/depth_offsets.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/depth_offsets.rs
@@ -4,7 +4,7 @@ use ahash::HashMap;
 
 use re_log_types::EntityPathHash;
 use re_space_view::latest_at_with_blueprint_resolved_data;
-use re_types::{components::DrawOrder, ComponentNameSet, Loggable as _};
+use re_types::{components::DrawOrder, Component as _, ComponentNameSet};
 use re_viewer_context::{IdentifiedViewSystem, ViewContextSystem, ViewSystemIdentifier};
 
 use crate::visualizers::visualizers_processing_draw_order;

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -11,7 +11,7 @@ use re_types::{
         PoseRotationQuat, PoseScale3D, PoseTransformMat3x3, PoseTranslation3D, RotationAxisAngle,
         RotationQuat, Scale3D, TransformMat3x3, TransformRelation, Translation3D, ViewCoordinates,
     },
-    Archetype, ComponentNameSet, Loggable as _,
+    Archetype, Component as _, ComponentNameSet,
 };
 use re_viewer_context::{IdentifiedViewSystem, ViewContext, ViewContextSystem};
 use vec1::smallvec_v1::SmallVec1;

--- a/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -8,7 +8,7 @@ use re_log_types::{EntityPath, StoreId};
 use re_types::{
     components::{Blob, ImageFormat, MediaType},
     external::image,
-    Loggable,
+    Component, Loggable,
 };
 
 #[derive(Debug, Clone, Default)]

--- a/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
+++ b/crates/viewer/re_space_view_spatial/src/mesh_cache.rs
@@ -7,7 +7,7 @@ use re_chunk_store::{ChunkStoreEvent, RowId};
 use re_entity_db::VersionedInstancePathHash;
 use re_log_types::hash::Hash64;
 use re_renderer::RenderContext;
-use re_types::{components::MediaType, Loggable as _};
+use re_types::{components::MediaType, Component as _};
 use re_viewer_context::Cache;
 
 use crate::mesh_loader::LoadedMesh;

--- a/crates/viewer/re_space_view_spatial/src/spatial_topology.rs
+++ b/crates/viewer/re_space_view_spatial/src/spatial_topology.rs
@@ -9,7 +9,7 @@ use re_chunk_store::{
 use re_log_types::{EntityPath, EntityPathHash, StoreId};
 use re_types::{
     components::{DisconnectedSpace, PinholeProjection, ViewCoordinates},
-    Loggable,
+    Component,
 };
 
 bitflags::bitflags! {
@@ -432,7 +432,7 @@ mod tests {
     use re_log_types::EntityPath;
     use re_types::{
         components::{DisconnectedSpace, PinholeProjection, ViewCoordinates},
-        ComponentName, Loggable as _,
+        Component as _, ComponentName,
     };
 
     use crate::spatial_topology::{HeuristicHints, SubSpaceConnectionFlags};

--- a/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
+++ b/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
@@ -7,7 +7,7 @@ use re_chunk_store::{
     ChunkStoreSubscriberHandle,
 };
 use re_log_types::{EntityPath, EntityPathHash, StoreId};
-use re_types::{ComponentName, Loggable as _};
+use re_types::{Component as _, ComponentName};
 
 // ---
 

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -7,7 +7,7 @@ use re_log_types::EntityPath;
 use re_space_view::view_property_ui;
 use re_types::View;
 use re_types::{
-    blueprint::archetypes::Background, components::ViewCoordinates, Loggable,
+    blueprint::archetypes::Background, components::ViewCoordinates, Component,
     SpaceViewClassIdentifier,
 };
 use re_ui::UiExt as _;

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows2d.rs
@@ -6,7 +6,7 @@ use re_types::{
     components::{
         ClassId, Color, DrawOrder, KeypointId, Position2D, Radius, ShowLabels, Text, Vector2D,
     },
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/arrows3d.rs
@@ -4,7 +4,7 @@ use re_space_view::{process_annotation_slices, process_color_slice};
 use re_types::{
     archetypes::Arrows3D,
     components::{ClassId, Color, Position3D, Radius, ShowLabels, Text, Vector3D},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/assets3d.rs
@@ -5,7 +5,7 @@ use re_renderer::RenderContext;
 use re_types::{
     archetypes::Asset3D,
     components::{AlbedoFactor, Blob, MediaType},
-    ArrowBuffer, ArrowString, Loggable as _,
+    ArrowBuffer, ArrowString, Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes2d.rs
@@ -4,7 +4,7 @@ use re_space_view::{process_annotation_slices, process_color_slice};
 use re_types::{
     archetypes::Boxes2D,
     components::{ClassId, Color, DrawOrder, HalfSize2D, Position2D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/boxes3d.rs
@@ -3,7 +3,7 @@ use std::iter;
 use re_types::{
     archetypes::Boxes3D,
     components::{ClassId, Color, FillMode, HalfSize3D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/capsules3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/capsules3d.rs
@@ -5,7 +5,7 @@ use re_space_view::clamped_or_nothing;
 use re_types::{
     archetypes::Capsules3D,
     components::{self, ClassId, Color, FillMode, HalfSize3D, Length, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/depth_images.rs
@@ -10,7 +10,7 @@ use re_types::{
         ViewCoordinates,
     },
     image::ImageKind,
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, ColormapWithRange, IdentifiedViewSystem, ImageInfo, ImageStatsCache,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/ellipsoids.rs
@@ -3,7 +3,7 @@ use std::iter;
 use re_types::{
     archetypes::Ellipsoids3D,
     components::{ClassId, Color, FillMode, HalfSize3D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/encoded_image.rs
@@ -2,7 +2,7 @@ use re_space_view::{diff_component_filter, HybridResults};
 use re_types::{
     archetypes::EncodedImage,
     components::{Blob, DrawOrder, MediaType, Opacity},
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ImageDecodeCache, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/images.rs
@@ -3,7 +3,7 @@ use re_types::{
     archetypes::Image,
     components::{DrawOrder, ImageBuffer, ImageFormat, Opacity},
     image::ImageKind,
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ImageInfo, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines2d.rs
@@ -4,7 +4,7 @@ use re_space_view::{process_annotation_slices, process_color_slice};
 use re_types::{
     archetypes::LineStrips2D,
     components::{ClassId, Color, DrawOrder, LineStrip2D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/lines3d.rs
@@ -4,7 +4,7 @@ use re_space_view::{process_annotation_slices, process_color_slice};
 use re_types::{
     archetypes::LineStrips3D,
     components::{ClassId, Color, LineStrip3D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/meshes.rs
@@ -7,7 +7,7 @@ use re_types::{
         AlbedoFactor, ClassId, Color, ImageBuffer, ImageFormat, Position3D, Texcoord2D,
         TriangleIndices, Vector3D,
     },
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, QueryContext, SpaceViewSystemExecutionError,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points2d.rs
@@ -5,7 +5,7 @@ use re_space_view::{process_annotation_and_keypoint_slices, process_color_slice}
 use re_types::{
     archetypes::Points2D,
     components::{ClassId, Color, DrawOrder, KeypointId, Position2D, Radius, ShowLabels, Text},
-    ArrowString, Loggable as _,
+    ArrowString, Component as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/points3d.rs
@@ -5,7 +5,7 @@ use re_space_view::{process_annotation_and_keypoint_slices, process_color_slice}
 use re_types::{
     archetypes::Points3D,
     components::{ClassId, Color, KeypointId, Position3D, Radius, ShowLabels, Text},
-    ArrowString, Loggable,
+    ArrowString, Component,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, ApplicableEntities, IdentifiedViewSystem, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/segmentation_images.rs
@@ -2,7 +2,7 @@ use re_types::{
     archetypes::SegmentationImage,
     components::{DrawOrder, ImageBuffer, ImageFormat, Opacity},
     image::ImageKind,
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, ImageInfo, QueryContext,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -5,7 +5,7 @@ use re_space_view::{latest_at_with_blueprint_resolved_data, DataResultQuery};
 use re_types::{
     archetypes::{Pinhole, Transform3D},
     components::{AxisLength, ImagePlaneDistance},
-    Archetype as _, ComponentName, Loggable,
+    Archetype as _, Component, ComponentName,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, QueryContext, SpaceViewStateExt,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/utilities/labels.rs
@@ -5,7 +5,7 @@ use itertools::{izip, Either};
 use re_entity_db::InstancePathHash;
 use re_log_types::{EntityPath, Instance};
 use re_types::components::{ShowLabels, Text};
-use re_types::{Component, Loggable as _};
+use re_types::Component;
 use re_viewer_context::ResolvedAnnotationInfos;
 
 #[cfg(doc)]

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -12,7 +12,7 @@ use re_renderer::{
 use re_types::{
     archetypes::{AssetVideo, VideoFrameReference},
     components::{Blob, MediaType, VideoTimestamp},
-    Archetype, Loggable as _,
+    Archetype, Component as _,
 };
 use re_viewer_context::{
     ApplicableEntities, IdentifiedViewSystem, SpaceViewClass as _, SpaceViewId,

--- a/crates/viewer/re_space_view_tensor/src/visualizer_system.rs
+++ b/crates/viewer/re_space_view_tensor/src/visualizer_system.rs
@@ -3,7 +3,7 @@ use re_space_view::{latest_at_with_blueprint_resolved_data, RangeResultsExt};
 use re_types::{
     archetypes::Tensor,
     components::{TensorData, ValueRange},
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     IdentifiedViewSystem, SpaceViewSystemExecutionError, TensorStats, TensorStatsCache,

--- a/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
+++ b/crates/viewer/re_space_view_text_log/src/visualizer_system.rs
@@ -8,7 +8,7 @@ use re_space_view::{range_with_blueprint_resolved_data, RangeResultsExt};
 use re_types::{
     archetypes::TextLog,
     components::{Color, Text, TextLogLevel},
-    Loggable as _,
+    Component as _,
 };
 use re_viewer_context::{
     IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContext, ViewContextCollection,

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -9,7 +9,7 @@ use re_types::external::arrow2::datatypes::DataType as ArrowDatatype;
 use re_types::{
     archetypes::SeriesLine,
     components::{Color, Name, Scalar, StrokeWidth},
-    Archetype as _, Loggable,
+    Archetype as _, Component, Loggable,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewStateExt as _,

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -5,7 +5,7 @@ use re_types::{
     archetypes::{self, SeriesPoint},
     components::{Color, MarkerShape, MarkerSize, Name, Scalar},
     external::arrow2::datatypes::DataType as ArrowDatatype,
-    Archetype as _, Loggable as _,
+    Archetype as _, Component as _, Loggable as _,
 };
 use re_viewer_context::{
     auto_color_for_entity_path, IdentifiedViewSystem, QueryContext, SpaceViewStateExt as _,

--- a/crates/viewer/re_viewer/src/reflection/mod.rs
+++ b/crates/viewer/re_viewer/src/reflection/mod.rs
@@ -12,7 +12,7 @@ use re_types_core::{
         ArchetypeFieldReflection, ArchetypeReflection, ArchetypeReflectionMap, ComponentReflection,
         ComponentReflectionMap, Reflection,
     },
-    ArchetypeName, ComponentName, Loggable, LoggableBatch as _, SerializationError,
+    ArchetypeName, Component, ComponentName, Loggable as _, LoggableBatch as _, SerializationError,
 };
 
 /// Generates reflection about all known components.
@@ -35,7 +35,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
     re_tracing::profile_function!();
     let array = [
         (
-            <ActiveTab as Loggable>::name(),
+            <ActiveTab as Component>::name(),
             ComponentReflection {
                 docstring_md: "The active tab in a tabbed container.",
                 custom_placeholder: Some(ActiveTab::default().to_arrow()?),
@@ -43,7 +43,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ApplyLatestAt as Loggable>::name(),
+            <ApplyLatestAt as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether empty cells in a dataframe should be filled with a latest-at query.",
                 custom_placeholder: Some(ApplyLatestAt::default().to_arrow()?),
@@ -51,7 +51,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AutoLayout as Loggable>::name(),
+            <AutoLayout as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether the viewport layout is determined automatically.",
                 custom_placeholder: Some(AutoLayout::default().to_arrow()?),
@@ -59,7 +59,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AutoSpaceViews as Loggable>::name(),
+            <AutoSpaceViews as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether or not space views should be created automatically.",
                 custom_placeholder: Some(AutoSpaceViews::default().to_arrow()?),
@@ -67,7 +67,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <BackgroundKind as Loggable>::name(),
+            <BackgroundKind as Component>::name(),
             ComponentReflection {
                 docstring_md: "The type of the background in a view.",
                 custom_placeholder: Some(BackgroundKind::default().to_arrow()?),
@@ -75,7 +75,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ColumnShare as Loggable>::name(),
+            <ColumnShare as Component>::name(),
             ComponentReflection {
                 docstring_md: "The layout share of a column in the container.",
                 custom_placeholder: Some(ColumnShare::default().to_arrow()?),
@@ -83,7 +83,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ComponentColumnSelector as Loggable>::name(),
+            <ComponentColumnSelector as Component>::name(),
             ComponentReflection {
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(ComponentColumnSelector::default().to_arrow()?),
@@ -91,7 +91,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ContainerKind as Loggable>::name(),
+            <ContainerKind as Component>::name(),
             ComponentReflection {
                 docstring_md: "The kind of a blueprint container (tabs, grid, …).",
                 custom_placeholder: Some(ContainerKind::default().to_arrow()?),
@@ -99,7 +99,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Corner2D as Loggable>::name(),
+            <Corner2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "One of four 2D corners, typically used to align objects.",
                 custom_placeholder: Some(Corner2D::default().to_arrow()?),
@@ -107,7 +107,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <FilterByRange as Loggable>::name(),
+            <FilterByRange as Component>::name(),
             ComponentReflection {
                 docstring_md: "Configuration for a filter-by-range feature of the dataframe view.",
                 custom_placeholder: Some(FilterByRange::default().to_arrow()?),
@@ -115,7 +115,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <FilterIsNotNull as Loggable>::name(),
+            <FilterIsNotNull as Component>::name(),
             ComponentReflection {
                 docstring_md: "Configuration for the filter is not null feature of the dataframe view.",
                 custom_placeholder: Some(FilterIsNotNull::default().to_arrow()?),
@@ -123,7 +123,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <GridColumns as Loggable>::name(),
+            <GridColumns as Component>::name(),
             ComponentReflection {
                 docstring_md: "How many columns a grid container should have.",
                 custom_placeholder: Some(GridColumns::default().to_arrow()?),
@@ -131,7 +131,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <IncludedContent as Loggable>::name(),
+            <IncludedContent as Component>::name(),
             ComponentReflection {
                 docstring_md: "All the contents in the container.",
                 custom_placeholder: Some(IncludedContent::default().to_arrow()?),
@@ -139,7 +139,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <IncludedSpaceView as Loggable>::name(),
+            <IncludedSpaceView as Component>::name(),
             ComponentReflection {
                 docstring_md: "The unique id of a space view, used to refer to views in containers.",
                 custom_placeholder: Some(IncludedSpaceView::default().to_arrow()?),
@@ -147,7 +147,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Interactive as Loggable>::name(),
+            <Interactive as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether the entity can be interacted with.\n\nNon interactive components are still visible, but mouse interactions in the view are disabled.",
                 custom_placeholder: Some(Interactive::default().to_arrow()?),
@@ -155,7 +155,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <LockRangeDuringZoom as Loggable>::name(),
+            <LockRangeDuringZoom as Component>::name(),
             ComponentReflection {
                 docstring_md: "Indicate whether the range should be locked when zooming in on the data.\n\nDefault is `false`, i.e. zoom will change the visualized range.",
                 custom_placeholder: Some(LockRangeDuringZoom::default().to_arrow()?),
@@ -163,7 +163,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <MapProvider as Loggable>::name(),
+            <MapProvider as Component>::name(),
             ComponentReflection {
                 docstring_md: "Name of the map provider to be used in Map views.",
                 custom_placeholder: Some(MapProvider::default().to_arrow()?),
@@ -171,7 +171,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PanelState as Loggable>::name(),
+            <PanelState as Component>::name(),
             ComponentReflection {
                 docstring_md: "Tri-state for panel controls.",
                 custom_placeholder: Some(PanelState::default().to_arrow()?),
@@ -179,7 +179,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <QueryExpression as Loggable>::name(),
+            <QueryExpression as Component>::name(),
             ComponentReflection {
                 docstring_md: "An individual query expression used to filter a set of [`datatypes.EntityPath`](https://rerun.io/docs/reference/types/datatypes/entity_path)s.\n\nEach expression is either an inclusion or an exclusion expression.\nInclusions start with an optional `+` and exclusions must start with a `-`.\n\nMultiple expressions are combined together as part of `SpaceViewContents`.\n\nThe `/**` suffix matches the whole subtree, i.e. self and any child, recursively\n(`/world/**` matches both `/world` and `/world/car/driver`).\nOther uses of `*` are not (yet) supported.",
                 custom_placeholder: Some(QueryExpression::default().to_arrow()?),
@@ -187,7 +187,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <RootContainer as Loggable>::name(),
+            <RootContainer as Component>::name(),
             ComponentReflection {
                 docstring_md: "The container that sits at the root of a viewport.",
                 custom_placeholder: Some(RootContainer::default().to_arrow()?),
@@ -195,7 +195,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <RowShare as Loggable>::name(),
+            <RowShare as Component>::name(),
             ComponentReflection {
                 docstring_md: "The layout share of a row in the container.",
                 custom_placeholder: Some(RowShare::default().to_arrow()?),
@@ -203,7 +203,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <SelectedColumns as Loggable>::name(),
+            <SelectedColumns as Component>::name(),
             ComponentReflection {
                 docstring_md: "Describe a component column to be selected in the dataframe view.",
                 custom_placeholder: Some(SelectedColumns::default().to_arrow()?),
@@ -211,7 +211,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <SpaceViewClass as Loggable>::name(),
+            <SpaceViewClass as Component>::name(),
             ComponentReflection {
                 docstring_md: "The class identifier of view, e.g. `\"2D\"`, `\"TextLog\"`, ….",
                 custom_placeholder: Some(SpaceViewClass::default().to_arrow()?),
@@ -219,7 +219,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <SpaceViewMaximized as Loggable>::name(),
+            <SpaceViewMaximized as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether a space view is maximized.",
                 custom_placeholder: Some(SpaceViewMaximized::default().to_arrow()?),
@@ -227,7 +227,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <SpaceViewOrigin as Loggable>::name(),
+            <SpaceViewOrigin as Component>::name(),
             ComponentReflection {
                 docstring_md: "The origin of a `SpaceView`.",
                 custom_placeholder: Some(SpaceViewOrigin::default().to_arrow()?),
@@ -235,7 +235,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TensorDimensionIndexSlider as Loggable>::name(),
+            <TensorDimensionIndexSlider as Component>::name(),
             ComponentReflection {
                 docstring_md: "Show a slider for the index of some dimension of a slider.",
                 custom_placeholder: Some(
@@ -245,7 +245,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TimelineName as Loggable>::name(),
+            <TimelineName as Component>::name(),
             ComponentReflection {
                 docstring_md: "A timeline identified by its name.",
                 custom_placeholder: Some(TimelineName::default().to_arrow()?),
@@ -253,7 +253,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ViewFit as Loggable>::name(),
+            <ViewFit as Component>::name(),
             ComponentReflection {
                 docstring_md: "Determines whether an image or texture should be scaled to fit the viewport.",
                 custom_placeholder: Some(ViewFit::default().to_arrow()?),
@@ -261,7 +261,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ViewerRecommendationHash as Loggable>::name(),
+            <ViewerRecommendationHash as Component>::name(),
             ComponentReflection {
                 docstring_md: "Hash of a viewer recommendation.\n\nThe formation of this hash is considered an internal implementation detail of the viewer.",
                 custom_placeholder: Some(
@@ -271,7 +271,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Visible as Loggable>::name(),
+            <Visible as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether the container, view, entity or instance is currently visible.",
                 custom_placeholder: Some(Visible::default().to_arrow()?),
@@ -279,7 +279,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <VisibleTimeRange as Loggable>::name(),
+            <VisibleTimeRange as Component>::name(),
             ComponentReflection {
                 docstring_md: "The range of values on a given timeline that will be included in a view's query.\n\nRefer to `VisibleTimeRanges` archetype for more information.",
                 custom_placeholder: Some(VisibleTimeRange::default().to_arrow()?),
@@ -287,7 +287,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <VisualBounds2D as Loggable>::name(),
+            <VisualBounds2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "Visual bounds in 2D space used for `Spatial2DView`.",
                 custom_placeholder: Some(VisualBounds2D::default().to_arrow()?),
@@ -295,7 +295,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <VisualizerOverrides as Loggable>::name(),
+            <VisualizerOverrides as Component>::name(),
             ComponentReflection {
                 docstring_md: "Override the visualizers for an entity.\n\nThis component is a stop-gap mechanism based on the current implementation details\nof the visualizer system. It is not intended to be a long-term solution, but provides\nenough utility to be useful in the short term.\n\nThe long-term solution is likely to be based off: <https://github.com/rerun-io/rerun/issues/6626>\n\nThis can only be used as part of blueprints. It will have no effect if used\nin a regular entity.",
                 custom_placeholder: Some(VisualizerOverrides::default().to_arrow()?),
@@ -303,7 +303,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ZoomLevel as Loggable>::name(),
+            <ZoomLevel as Component>::name(),
             ComponentReflection {
                 docstring_md: "A zoom level determines how much of the world is visible on a map.",
                 custom_placeholder: Some(ZoomLevel::default().to_arrow()?),
@@ -311,7 +311,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AggregationPolicy as Loggable>::name(),
+            <AggregationPolicy as Component>::name(),
             ComponentReflection {
                 docstring_md: "Policy for aggregation of multiple scalar plot values.\n\nThis is used for lines in plots when the X axis distance of individual points goes below a single pixel,\ni.e. a single pixel covers more than one tick worth of data. It can greatly improve performance\n(and readability) in such situations as it prevents overdraw.",
                 custom_placeholder: Some(AggregationPolicy::default().to_arrow()?),
@@ -319,7 +319,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AlbedoFactor as Loggable>::name(),
+            <AlbedoFactor as Component>::name(),
             ComponentReflection {
                 docstring_md: "A color multiplier, usually applied to a whole entity, e.g. a mesh.",
                 custom_placeholder: Some(AlbedoFactor::default().to_arrow()?),
@@ -327,7 +327,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AnnotationContext as Loggable>::name(),
+            <AnnotationContext as Component>::name(),
             ComponentReflection {
                 docstring_md: "The annotation context provides additional information on how to display entities.\n\nEntities can use [`datatypes.ClassId`](https://rerun.io/docs/reference/types/datatypes/class_id)s and [`datatypes.KeypointId`](https://rerun.io/docs/reference/types/datatypes/keypoint_id)s to provide annotations, and\nthe labels and colors will be looked up in the appropriate\nannotation context. We use the *first* annotation context we find in the\npath-hierarchy when searching up through the ancestors of a given entity\npath.",
                 custom_placeholder: Some(AnnotationContext::default().to_arrow()?),
@@ -335,7 +335,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <AxisLength as Loggable>::name(),
+            <AxisLength as Component>::name(),
             ComponentReflection {
                 docstring_md: "The length of an axis in local units of the space.",
                 custom_placeholder: Some(AxisLength::default().to_arrow()?),
@@ -343,7 +343,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Blob as Loggable>::name(),
+            <Blob as Component>::name(),
             ComponentReflection {
                 docstring_md: "A binary blob of data.",
                 custom_placeholder: None,
@@ -351,7 +351,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ClassId as Loggable>::name(),
+            <ClassId as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 16-bit ID representing a type of semantic class.",
                 custom_placeholder: Some(ClassId::default().to_arrow()?),
@@ -359,7 +359,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ClearIsRecursive as Loggable>::name(),
+            <ClearIsRecursive as Component>::name(),
             ComponentReflection {
                 docstring_md: "Configures how a clear operation should behave - recursive or not.",
                 custom_placeholder: Some(ClearIsRecursive::default().to_arrow()?),
@@ -367,7 +367,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Color as Loggable>::name(),
+            <Color as Component>::name(),
             ComponentReflection {
                 docstring_md: "An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.\n\nThe color is stored as a 32-bit integer, where the most significant\nbyte is `R` and the least significant byte is `A`.",
                 custom_placeholder: Some(Color::default().to_arrow()?),
@@ -375,7 +375,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Colormap as Loggable>::name(),
+            <Colormap as Component>::name(),
             ComponentReflection {
                 docstring_md: "Colormap for mapping scalar values within a given range to a color.\n\nThis provides a number of popular pre-defined colormaps.\nIn the future, the Rerun Viewer will allow users to define their own colormaps,\nbut currently the Viewer is limited to the types defined here.",
                 custom_placeholder: Some(Colormap::default().to_arrow()?),
@@ -383,7 +383,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <DepthMeter as Loggable>::name(),
+            <DepthMeter as Component>::name(),
             ComponentReflection {
                 docstring_md: "The world->depth map scaling factor.\n\nThis measures how many depth map units are in a world unit.\nFor instance, if a depth map uses millimeters and the world uses meters,\nthis value would be `1000`.\n\nNote that the only effect on 2D views is the physical depth values shown when hovering the image.\nIn 3D views on the other hand, this affects where the points of the point cloud are placed.",
                 custom_placeholder: Some(DepthMeter::default().to_arrow()?),
@@ -391,7 +391,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <DisconnectedSpace as Loggable>::name(),
+            <DisconnectedSpace as Component>::name(),
             ComponentReflection {
                 docstring_md: "Spatially disconnect this entity from its parent.\n\nSpecifies that the entity path at which this is logged is spatially disconnected from its parent,\nmaking it impossible to transform the entity path into its parent's space and vice versa.\nIt *only* applies to space views that work with spatial transformations, i.e. 2D & 3D space views.\nThis is useful for specifying that a subgraph is independent of the rest of the scene.",
                 custom_placeholder: Some(DisconnectedSpace::default().to_arrow()?),
@@ -399,7 +399,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <DrawOrder as Loggable>::name(),
+            <DrawOrder as Component>::name(),
             ComponentReflection {
                 docstring_md: "Draw order of 2D elements. Higher values are drawn on top of lower values.\n\nAn entity can have only a single draw order component.\nWithin an entity draw order is governed by the order of the components.\n\nDraw order for entities with the same draw order is generally undefined.",
                 custom_placeholder: Some(DrawOrder::default().to_arrow()?),
@@ -407,7 +407,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <EntityPath as Loggable>::name(),
+            <EntityPath as Component>::name(),
             ComponentReflection {
                 docstring_md: "A path to an entity, usually to reference some data that is part of the target entity.",
                 custom_placeholder: Some(EntityPath::default().to_arrow()?),
@@ -415,7 +415,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <FillMode as Loggable>::name(),
+            <FillMode as Component>::name(),
             ComponentReflection {
                 docstring_md: "How a geometric shape is drawn and colored.",
                 custom_placeholder: Some(FillMode::default().to_arrow()?),
@@ -423,7 +423,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <FillRatio as Loggable>::name(),
+            <FillRatio as Component>::name(),
             ComponentReflection {
                 docstring_md: "How much a primitive fills out the available space.\n\nUsed for instance to scale the points of the point cloud created from [`archetypes.DepthImage`](https://rerun.io/docs/reference/types/archetypes/depth_image) projection in 3D views.\nValid range is from 0 to max float although typically values above 1.0 are not useful.\n\nDefaults to 1.0.",
                 custom_placeholder: Some(FillRatio::default().to_arrow()?),
@@ -431,7 +431,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <GammaCorrection as Loggable>::name(),
+            <GammaCorrection as Component>::name(),
             ComponentReflection {
                 docstring_md: "A gamma correction value to be used with a scalar value or color.\n\nUsed to adjust the gamma of a color or scalar value between 0 and 1 before rendering.\n`new_value = old_value ^ gamma`\n\nValid range is from 0 (excluding) to max float.\nDefaults to 1.0 unless otherwise specified.",
                 custom_placeholder: Some(GammaCorrection::default().to_arrow()?),
@@ -439,7 +439,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <GeoLineString as Loggable>::name(),
+            <GeoLineString as Component>::name(),
             ComponentReflection {
                 docstring_md: "A geospatial line string expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).",
                 custom_placeholder: Some(GeoLineString::default().to_arrow()?),
@@ -447,7 +447,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <HalfSize2D as Loggable>::name(),
+            <HalfSize2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "Half-size (radius) of a 2D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize2D::default().to_arrow()?),
@@ -455,7 +455,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <HalfSize3D as Loggable>::name(),
+            <HalfSize3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "Half-size (radius) of a 3D box.\n\nMeasured in its local coordinate system.\n\nThe box extends both in negative and positive direction along each axis.\nNegative sizes indicate that the box is flipped along the respective axis, but this has no effect on how it is displayed.",
                 custom_placeholder: Some(HalfSize3D::default().to_arrow()?),
@@ -463,7 +463,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ImageBuffer as Loggable>::name(),
+            <ImageBuffer as Component>::name(),
             ComponentReflection {
                 docstring_md: "A buffer that is known to store image data.\n\nTo interpret the contents of this buffer, see, [`components.ImageFormat`](https://rerun.io/docs/reference/types/components/image_format).",
                 custom_placeholder: None,
@@ -471,7 +471,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ImageFormat as Loggable>::name(),
+            <ImageFormat as Component>::name(),
             ComponentReflection {
                 docstring_md: "The metadata describing the contents of a [`components.ImageBuffer`](https://rerun.io/docs/reference/types/components/image_buffer).",
                 custom_placeholder: Some(ImageFormat::default().to_arrow()?),
@@ -479,7 +479,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ImagePlaneDistance as Loggable>::name(),
+            <ImagePlaneDistance as Component>::name(),
             ComponentReflection {
                 docstring_md: "The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.\n\nThis is only used for visualization purposes, and does not affect the projection itself.",
                 custom_placeholder: Some(ImagePlaneDistance::default().to_arrow()?),
@@ -487,7 +487,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <KeypointId as Loggable>::name(),
+            <KeypointId as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 16-bit ID representing a type of semantic keypoint within a class.",
                 custom_placeholder: Some(KeypointId::default().to_arrow()?),
@@ -495,7 +495,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <LatLon as Loggable>::name(),
+            <LatLon as Component>::name(),
             ComponentReflection {
                 docstring_md: "A geospatial position expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).",
                 custom_placeholder: Some(LatLon::default().to_arrow()?),
@@ -503,7 +503,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Length as Loggable>::name(),
+            <Length as Component>::name(),
             ComponentReflection {
                 docstring_md: "Length, or one-dimensional size.\n\nMeasured in its local coordinate system; consult the archetype in use to determine which\naxis or part of the entity this is the length of.",
                 custom_placeholder: Some(Length::default().to_arrow()?),
@@ -511,7 +511,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <LineStrip2D as Loggable>::name(),
+            <LineStrip2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A line strip in 2D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip2D::default().to_arrow()?),
@@ -519,7 +519,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <LineStrip3D as Loggable>::name(),
+            <LineStrip3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A line strip in 3D space.\n\nA line strip is a list of points connected by line segments. It can be used to draw\napproximations of smooth curves.\n\nThe points will be connected in order, like so:\n```text\n       2------3     5\n      /        \\   /\n0----1          \\ /\n                 4\n```",
                 custom_placeholder: Some(LineStrip3D::default().to_arrow()?),
@@ -527,7 +527,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <MagnificationFilter as Loggable>::name(),
+            <MagnificationFilter as Component>::name(),
             ComponentReflection {
                 docstring_md: "Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.",
                 custom_placeholder: Some(MagnificationFilter::default().to_arrow()?),
@@ -535,7 +535,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <MarkerShape as Loggable>::name(),
+            <MarkerShape as Component>::name(),
             ComponentReflection {
                 docstring_md: "The visual appearance of a point in e.g. a 2D plot.",
                 custom_placeholder: Some(MarkerShape::default().to_arrow()?),
@@ -543,7 +543,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <MarkerSize as Loggable>::name(),
+            <MarkerSize as Component>::name(),
             ComponentReflection {
                 docstring_md: "Radius of a marker of a point in e.g. a 2D plot, measured in UI points.",
                 custom_placeholder: Some(MarkerSize::default().to_arrow()?),
@@ -551,7 +551,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <MediaType as Loggable>::name(),
+            <MediaType as Component>::name(),
             ComponentReflection {
                 docstring_md: "A standardized media type (RFC2046, formerly known as MIME types), encoded as a string.\n\nThe complete reference of officially registered media types is maintained by the IANA and can be\nconsulted at <https://www.iana.org/assignments/media-types/media-types.xhtml>.",
                 custom_placeholder: Some(MediaType::default().to_arrow()?),
@@ -559,7 +559,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Name as Loggable>::name(),
+            <Name as Component>::name(),
             ComponentReflection {
                 docstring_md: "A display name, typically for an entity or a item like a plot series.",
                 custom_placeholder: Some(Name::default().to_arrow()?),
@@ -567,7 +567,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Opacity as Loggable>::name(),
+            <Opacity as Component>::name(),
             ComponentReflection {
                 docstring_md: "Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque).\n\nThe final opacity value may be a result of multiplication with alpha values as specified by other color sources.\nUnless otherwise specified, the default value is 1.",
                 custom_placeholder: Some(Opacity::default().to_arrow()?),
@@ -575,7 +575,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PinholeProjection as Loggable>::name(),
+            <PinholeProjection as Component>::name(),
             ComponentReflection {
                 docstring_md: "Camera projection, from image coordinates to view coordinates.\n\nChild from parent.\nImage coordinates from camera view coordinates.\n\nExample:\n```text\n1496.1     0.0  980.5\n   0.0  1496.1  744.5\n   0.0     0.0    1.0\n```",
                 custom_placeholder: Some(PinholeProjection::default().to_arrow()?),
@@ -583,7 +583,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PoseRotationAxisAngle as Loggable>::name(),
+            <PoseRotationAxisAngle as Component>::name(),
             ComponentReflection {
                 docstring_md: "3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.",
                 custom_placeholder: Some(PoseRotationAxisAngle::default().to_arrow()?),
@@ -591,7 +591,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PoseRotationQuat as Loggable>::name(),
+            <PoseRotationQuat as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3D rotation expressed as a quaternion that doesn't propagate in the transform hierarchy.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.",
                 custom_placeholder: Some(PoseRotationQuat::default().to_arrow()?),
@@ -599,7 +599,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PoseScale3D as Loggable>::name(),
+            <PoseScale3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3D scale factor that doesn't propagate in the transform hierarchy.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(PoseScale3D::default().to_arrow()?),
@@ -607,7 +607,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PoseTransformMat3x3 as Loggable>::name(),
+            <PoseTransformMat3x3 as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3x3 transformation matrix Matrix that doesn't propagate in the transform hierarchy.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(PoseTransformMat3x3::default().to_arrow()?),
@@ -615,7 +615,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <PoseTranslation3D as Loggable>::name(),
+            <PoseTranslation3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A translation vector in 3D space that doesn't propagate in the transform hierarchy.",
                 custom_placeholder: Some(PoseTranslation3D::default().to_arrow()?),
@@ -623,7 +623,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Position2D as Loggable>::name(),
+            <Position2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A position in 2D space.",
                 custom_placeholder: Some(Position2D::default().to_arrow()?),
@@ -631,7 +631,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Position3D as Loggable>::name(),
+            <Position3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A position in 3D space.",
                 custom_placeholder: Some(Position3D::default().to_arrow()?),
@@ -639,7 +639,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Radius as Loggable>::name(),
+            <Radius as Component>::name(),
             ComponentReflection {
                 docstring_md: "The radius of something, e.g. a point.\n\nInternally, positive values indicate scene units, whereas negative values\nare interpreted as UI points.\n\nUI points are independent of zooming in Views, but are sensitive to the application UI scaling.\nat 100% UI scaling, UI points are equal to pixels\nThe Viewer's UI scaling defaults to the OS scaling which typically is 100% for full HD screens and 200% for 4k screens.",
                 custom_placeholder: Some(Radius::default().to_arrow()?),
@@ -647,7 +647,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Range1D as Loggable>::name(),
+            <Range1D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 1D range, specifying a lower and upper bound.",
                 custom_placeholder: Some(Range1D::default().to_arrow()?),
@@ -655,7 +655,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Resolution as Loggable>::name(),
+            <Resolution as Component>::name(),
             ComponentReflection {
                 docstring_md: "Pixel resolution width & height, e.g. of a camera sensor.\n\nTypically in integer units, but for some use cases floating point may be used.",
                 custom_placeholder: Some(Resolution::default().to_arrow()?),
@@ -663,7 +663,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <RotationAxisAngle as Loggable>::name(),
+            <RotationAxisAngle as Component>::name(),
             ComponentReflection {
                 docstring_md: "3D rotation represented by a rotation around a given axis.",
                 custom_placeholder: Some(RotationAxisAngle::default().to_arrow()?),
@@ -671,7 +671,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <RotationQuat as Loggable>::name(),
+            <RotationQuat as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3D rotation expressed as a quaternion.\n\nNote: although the x,y,z,w components of the quaternion will be passed through to the\ndatastore as provided, when used in the Viewer, quaternions will always be normalized.",
                 custom_placeholder: Some(RotationQuat::default().to_arrow()?),
@@ -679,7 +679,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Scalar as Loggable>::name(),
+            <Scalar as Component>::name(),
             ComponentReflection {
                 docstring_md: "A scalar value, encoded as a 64-bit floating point.\n\nUsed for time series plots.",
                 custom_placeholder: Some(Scalar::default().to_arrow()?),
@@ -687,7 +687,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Scale3D as Loggable>::name(),
+            <Scale3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3D scale factor.\n\nA scale of 1.0 means no scaling.\nA scale of 2.0 means doubling the size.\nEach component scales along the corresponding axis.",
                 custom_placeholder: Some(Scale3D::default().to_arrow()?),
@@ -695,7 +695,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ShowLabels as Loggable>::name(),
+            <ShowLabels as Component>::name(),
             ComponentReflection {
                 docstring_md: "Whether the entity's [`components.Text`](https://rerun.io/docs/reference/types/components/text) label is shown.\n\nThe main purpose of this component existing separately from the labels themselves\nis to be overridden when desired, to allow hiding and showing from the viewer and\nblueprints.",
                 custom_placeholder: None,
@@ -703,7 +703,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <StrokeWidth as Loggable>::name(),
+            <StrokeWidth as Component>::name(),
             ComponentReflection {
                 docstring_md: "The width of a stroke specified in UI points.",
                 custom_placeholder: Some(StrokeWidth::default().to_arrow()?),
@@ -711,7 +711,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TensorData as Loggable>::name(),
+            <TensorData as Component>::name(),
             ComponentReflection {
                 docstring_md: "An N-dimensional array of numbers.\n\nThe number of dimensions and their respective lengths is specified by the `shape` field.\nThe dimensions are ordered from outermost to innermost. For example, in the common case of\na 2D RGB Image, the shape would be `[height, width, channel]`.\n\nThese dimensions are combined with an index to look up values from the `buffer` field,\nwhich stores a contiguous array of typed values.",
                 custom_placeholder: Some(TensorData::default().to_arrow()?),
@@ -719,7 +719,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TensorDimensionIndexSelection as Loggable>::name(),
+            <TensorDimensionIndexSelection as Component>::name(),
             ComponentReflection {
                 docstring_md: "Specifies a concrete index on a tensor dimension.",
                 custom_placeholder: Some(
@@ -729,7 +729,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TensorHeightDimension as Loggable>::name(),
+            <TensorHeightDimension as Component>::name(),
             ComponentReflection {
                 docstring_md: "Specifies which dimension to use for height.",
                 custom_placeholder: Some(TensorHeightDimension::default().to_arrow()?),
@@ -737,7 +737,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TensorWidthDimension as Loggable>::name(),
+            <TensorWidthDimension as Component>::name(),
             ComponentReflection {
                 docstring_md: "Specifies which dimension to use for width.",
                 custom_placeholder: Some(TensorWidthDimension::default().to_arrow()?),
@@ -745,7 +745,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Texcoord2D as Loggable>::name(),
+            <Texcoord2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 2D texture UV coordinate.\n\nTexture coordinates specify a position on a 2D texture.\nA range from 0-1 covers the entire texture in the respective dimension.\nUnless configured otherwise, the texture repeats outside of this range.\nRerun uses top-left as the origin for UV coordinates.\n\n  0     U     1\n0 + --------- →\n  |           .\nV |           .\n  |           .\n1 ↓ . . . . . .\n\nThis is the same convention as in Vulkan/Metal/DX12/WebGPU, but (!) unlike OpenGL,\nwhich places the origin at the bottom-left.",
                 custom_placeholder: Some(Texcoord2D::default().to_arrow()?),
@@ -753,7 +753,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Text as Loggable>::name(),
+            <Text as Component>::name(),
             ComponentReflection {
                 docstring_md: "A string of text, e.g. for labels and text documents.",
                 custom_placeholder: Some(Text::default().to_arrow()?),
@@ -761,7 +761,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TextLogLevel as Loggable>::name(),
+            <TextLogLevel as Component>::name(),
             ComponentReflection {
                 docstring_md: "The severity level of a text log message.\n\nRecommended to be one of:\n* `\"CRITICAL\"`\n* `\"ERROR\"`\n* `\"WARN\"`\n* `\"INFO\"`\n* `\"DEBUG\"`\n* `\"TRACE\"`",
                 custom_placeholder: Some(TextLogLevel::default().to_arrow()?),
@@ -769,7 +769,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TransformMat3x3 as Loggable>::name(),
+            <TransformMat3x3 as Component>::name(),
             ComponentReflection {
                 docstring_md: "A 3x3 transformation matrix Matrix.\n\n3x3 matrixes are able to represent any affine transformation in 3D space,\ni.e. rotation, scaling, shearing, reflection etc.\n\nMatrices in Rerun are stored as flat list of coefficients in column-major order:\n```text\n            column 0       column 1       column 2\n       -------------------------------------------------\nrow 0 | flat_columns[0] flat_columns[3] flat_columns[6]\nrow 1 | flat_columns[1] flat_columns[4] flat_columns[7]\nrow 2 | flat_columns[2] flat_columns[5] flat_columns[8]\n```",
                 custom_placeholder: Some(TransformMat3x3::default().to_arrow()?),
@@ -777,7 +777,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TransformRelation as Loggable>::name(),
+            <TransformRelation as Component>::name(),
             ComponentReflection {
                 docstring_md: "Specifies relation a spatial transform describes.",
                 custom_placeholder: Some(TransformRelation::default().to_arrow()?),
@@ -785,7 +785,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Translation3D as Loggable>::name(),
+            <Translation3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A translation vector in 3D space.",
                 custom_placeholder: Some(Translation3D::default().to_arrow()?),
@@ -793,7 +793,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <TriangleIndices as Loggable>::name(),
+            <TriangleIndices as Component>::name(),
             ComponentReflection {
                 docstring_md: "The three indices of a triangle in a triangle mesh.",
                 custom_placeholder: Some(TriangleIndices::default().to_arrow()?),
@@ -801,7 +801,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ValueRange as Loggable>::name(),
+            <ValueRange as Component>::name(),
             ComponentReflection {
                 docstring_md: "Range of expected or valid values, specifying a lower and upper bound.",
                 custom_placeholder: Some(ValueRange::default().to_arrow()?),
@@ -809,7 +809,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Vector2D as Loggable>::name(),
+            <Vector2D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A vector in 2D space.",
                 custom_placeholder: Some(Vector2D::default().to_arrow()?),
@@ -817,7 +817,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <Vector3D as Loggable>::name(),
+            <Vector3D as Component>::name(),
             ComponentReflection {
                 docstring_md: "A vector in 3D space.",
                 custom_placeholder: Some(Vector3D::default().to_arrow()?),
@@ -825,7 +825,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <VideoTimestamp as Loggable>::name(),
+            <VideoTimestamp as Component>::name(),
             ComponentReflection {
                 docstring_md: "Timestamp inside a [`archetypes.AssetVideo`](https://rerun.io/docs/reference/types/archetypes/asset_video).",
                 custom_placeholder: Some(VideoTimestamp::default().to_arrow()?),
@@ -833,7 +833,7 @@ fn generate_component_reflection() -> Result<ComponentReflectionMap, Serializati
             },
         ),
         (
-            <ViewCoordinates as Loggable>::name(),
+            <ViewCoordinates as Component>::name(),
             ComponentReflection {
                 docstring_md: "How we interpret the coordinate system of an entity/space.\n\nFor instance: What is \"up\"? What does the Z axis mean?\n\nThe three coordinates are always ordered as [x, y, z].\n\nFor example [Right, Down, Forward] means that the X axis points to the right, the Y axis points\ndown, and the Z axis points forward.\n\n⚠ [Rerun does not yet support left-handed coordinate systems](https://github.com/rerun-io/rerun/issues/5032).\n\nThe following constants are used to represent the different directions:\n * Up = 1\n * Down = 2\n * Right = 3\n * Left = 4\n * Forward = 5\n * Back = 6",
                 custom_placeholder: Some(ViewCoordinates::default().to_arrow()?),

--- a/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_decode_cache.rs
@@ -8,7 +8,7 @@ use re_types::{
     archetypes::Image,
     components::MediaType,
     image::{ImageKind, ImageLoadError},
-    Loggable as _,
+    Component as _,
 };
 
 use crate::{Cache, ImageInfo};

--- a/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/image_stats_cache.rs
@@ -4,7 +4,7 @@ use itertools::Either;
 use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
-use re_types::Loggable as _;
+use re_types::Component as _;
 
 use crate::{Cache, ImageInfo, ImageStats};
 

--- a/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/tensor_stats_cache.rs
@@ -3,7 +3,7 @@ use itertools::Either;
 
 use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
-use re_types::{datatypes::TensorData, Loggable as _};
+use re_types::{datatypes::TensorData, Component as _};
 
 use crate::{Cache, TensorStats};
 

--- a/crates/viewer/re_viewer_context/src/cache/video_cache.rs
+++ b/crates/viewer/re_viewer_context/src/cache/video_cache.rs
@@ -10,7 +10,7 @@ use re_chunk::RowId;
 use re_chunk_store::ChunkStoreEvent;
 use re_log_types::hash::Hash64;
 use re_renderer::{external::re_video::VideoLoadError, video::Video};
-use re_types::{components::MediaType, Loggable as _};
+use re_types::{components::MediaType, Component as _};
 use re_video::decode::DecodeSettings;
 
 use crate::Cache;

--- a/crates/viewer/re_viewer_context/src/component_fallbacks.rs
+++ b/crates/viewer/re_viewer_context/src/component_fallbacks.rs
@@ -101,7 +101,7 @@ macro_rules! impl_component_fallback_provider {
                 _component_name: re_types::ComponentName,
             ) -> $crate::ComponentFallbackProviderResult {
                 $(
-                    if _component_name == <$component as re_types::Loggable>::name() {
+                    if _component_name == <$component as re_types::Component>::name() {
                         return  $crate::TypedComponentFallbackProvider::<$component>::fallback_for(self, _ctx).into();
                     }
                 )*

--- a/crates/viewer/re_viewport_blueprint/src/space_view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view.rs
@@ -459,7 +459,7 @@ mod tests {
         example_components::{MyColor, MyLabel, MyPoint},
         StoreId, StoreKind, TimePoint,
     };
-    use re_types::{ComponentBatch, ComponentName, Loggable as _};
+    use re_types::{Component as _, ComponentName};
     use re_viewer_context::{
         test_context::TestContext, ApplicableEntities, DataResult, IndicatedEntities, OverridePath,
         PerVisualizer, StoreContext, VisualizableEntities,
@@ -534,8 +534,8 @@ mod tests {
         );
 
         struct Scenario {
-            recursive_overrides: Vec<(EntityPath, Box<dyn ComponentBatch>)>,
-            individual_overrides: Vec<(EntityPath, Box<dyn ComponentBatch>)>,
+            recursive_overrides: Vec<(EntityPath, Box<dyn re_types_core::ComponentBatch>)>,
+            individual_overrides: Vec<(EntityPath, Box<dyn re_types_core::ComponentBatch>)>,
             expected_overrides: HashMap<EntityPath, HashMap<ComponentName, EntityPath>>,
         }
 
@@ -704,17 +704,18 @@ mod tests {
             // Reset blueprint store for each scenario.
             test_ctx.blueprint_store = EntityDb::new(StoreId::random(StoreKind::Blueprint));
 
-            let mut add_to_blueprint = |path: &EntityPath, batch: &dyn ComponentBatch| {
-                let chunk = Chunk::builder(path.clone())
-                    .with_component_batch(RowId::new(), TimePoint::default(), batch as _)
-                    .build()
-                    .unwrap();
+            let mut add_to_blueprint =
+                |path: &EntityPath, batch: &dyn re_types_core::ComponentBatch| {
+                    let chunk = Chunk::builder(path.clone())
+                        .with_component_batch(RowId::new(), TimePoint::default(), batch as _)
+                        .build()
+                        .unwrap();
 
-                test_ctx
-                    .blueprint_store
-                    .add_chunk(&Arc::new(chunk))
-                    .unwrap();
-            };
+                    test_ctx
+                        .blueprint_store
+                        .add_chunk(&Arc::new(chunk))
+                        .unwrap();
+                };
 
             // log individual and override components as instructed.
             for (entity_path, batch) in recursive_overrides {

--- a/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
+++ b/crates/viewer/re_viewport_blueprint/src/space_view_contents.rs
@@ -1,5 +1,4 @@
 use nohash_hasher::IntMap;
-use re_types_blueprint::blueprint::components::VisualizerOverrides;
 use slotmap::SlotMap;
 use smallvec::SmallVec;
 
@@ -14,6 +13,7 @@ use re_types::{
     },
     Archetype as _, SpaceViewClassIdentifier,
 };
+use re_types_blueprint::blueprint::components::VisualizerOverrides;
 use re_types_core::ComponentName;
 use re_viewer_context::{
     ApplicableEntities, DataQueryResult, DataResult, DataResultHandle, DataResultNode,
@@ -480,7 +480,7 @@ impl DataQueryPropertyResolver<'_> {
                 }
 
                 // Figure out relevant visual time range.
-                use re_types::Loggable as _;
+                use re_types::Component as _;
                 let latest_at_results = blueprint.latest_at(
                     blueprint_query,
                     &recursive_override_path,

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -3,6 +3,7 @@
 use rerun::{
     demo_util::grid,
     external::{arrow2, glam, re_types},
+    ComponentName,
 };
 
 // ---
@@ -56,13 +57,6 @@ impl rerun::SizeBytes for Confidence {
 }
 
 impl rerun::Loggable for Confidence {
-    type Name = rerun::ComponentName;
-
-    #[inline]
-    fn name() -> Self::Name {
-        "user.Confidence".into()
-    }
-
     #[inline]
     fn arrow_datatype() -> arrow2::datatypes::DataType {
         rerun::Float32::arrow_datatype()
@@ -76,6 +70,13 @@ impl rerun::Loggable for Confidence {
         Self: 'a,
     {
         rerun::Float32::to_arrow_opt(data.into_iter().map(|opt| opt.map(Into::into).map(|c| c.0)))
+    }
+}
+
+impl rerun::Component for Confidence {
+    #[inline]
+    fn name() -> ComponentName {
+        "user.Confidence".into()
     }
 }
 

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -2,7 +2,7 @@ use re_viewer::external::{
     egui,
     re_log_types::{EntityPath, Instance},
     re_renderer,
-    re_types::{self, components::Color, ComponentName, Loggable as _},
+    re_types::{self, components::Color, Component as _, ComponentName},
     re_viewer_context::{
         self, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContext,
         ViewContextCollection, ViewQuery, ViewSystemIdentifier, VisualizerQueryInfo,


### PR DESCRIPTION
Remove `Loggable`'s associated `Name` type and simplify the `Loggable` and `Component` types accordingly.

A `Loggable` doesn't have a name, in fact it doesn't have any semantics at all: it's just arrow-serializable data.
`Component` is where semantics live at.

Not only is this wrong, this adds a whole bunch of useless code that makes future improvements (hints: tags) more complicated for no reason.

* [x] :crab: 