### PR TITLE
Add missing screenshot to `GeoLineStrings` docs

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_line_strings.fbs
@@ -8,8 +8,7 @@ namespace rerun.archetypes;
 ///
 /// **Note**: Geospatial entities are experimental.
 ///
-/// \example archetypes/geo_line_string_simple title="Log a geospatial line string"
-// TODO(ab): add screenshot
+/// \example archetypes/geo_line_string_simple title="Log a geospatial line string" image="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png"
 table GeoLineStrings (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/geo_points.fbs
@@ -5,7 +5,6 @@ namespace rerun.archetypes;
 /// **Note**: Geospatial entities are experimental.
 ///
 /// \example archetypes/geo_point_simple title="Log a geospatial point" image="https://static.rerun.io/geopoint_simple/146b0783c5aea1c1b6a9aab938879942b7c820e2/1200w.png"
-// TODO(ab): screenshot
 table GeoPoints (
   "attr.rust.derive": "PartialEq",
   "attr.rust.new_pub_crate",

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -47,6 +47,15 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 ///     Ok(())
 /// }
 /// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png">
+///   <img src="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/full.png" width="640">
+/// </picture>
+/// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct GeoLineStrings {
     /// The line strings, expressed in [EPSG:4326](https://epsg.io/4326) coordinates (North/East-positive degrees).

--- a/docs/content/reference/types/archetypes/geo_line_strings.md
+++ b/docs/content/reference/types/archetypes/geo_line_strings.md
@@ -30,3 +30,11 @@ Also known as "line strips" or "polylines".
 
 snippet: archetypes/geo_line_string_simple
 
+<picture data-inline-viewer="snippets/geo_line_string_simple">
+  <source media="(max-width: 480px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/480w.png">
+  <source media="(max-width: 768px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/768w.png">
+  <source media="(max-width: 1024px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1024w.png">
+  <source media="(max-width: 1200px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png">
+  <img src="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/full.png">
+</picture>
+

--- a/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
+++ b/rerun_cpp/src/rerun/archetypes/geo_line_strings.hpp
@@ -27,6 +27,8 @@ namespace rerun::archetypes {
     /// ## Example
     ///
     /// ### Log a geospatial line string
+    /// ![image](https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/full.png)
+    ///
     /// ```cpp
     /// #include <rerun.hpp>
     ///

--- a/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/geo_line_strings.py
@@ -48,6 +48,15 @@ class GeoLineStrings(GeoLineStringsExt, Archetype):
         ),
     )
     ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png">
+      <img src="https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/full.png" width="640">
+    </picture>
+    </center>
 
     """
 


### PR DESCRIPTION
### What

☝🏻 

![](https://static.rerun.io/geo_line_strings_simple/5669983eb10906ace303755b5b5039cad75b917f/1200w.png)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8084?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8084?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8084)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.