### PR TITLE
Make sure videos all end up in different space views

### DIFF
--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -389,7 +389,16 @@ fn recommended_space_views_with_image_splits(
         &re_types::archetypes::AssetVideo::indicator().name(),
     );
 
-    if found_image_dimensions.len() > 1 || image_count > 1 || depth_count > 1 || video_count > 1 {
+    let all_have_same_size = found_image_dimensions.len() <= 1;
+
+    // NOTE: we allow stacking segmentation images, since that can be quite useful sometimes.
+    let overlap = all_have_same_size && image_count + video_count <= 1 && depth_count <= 1;
+
+    if overlap {
+        // If there are multiple images of the same size but of different types, then we can overlap them on top of each other.
+        // This can be useful for comparing a segmentation image on top of an RGB image, for instance.
+        recommended.push(RecommendedSpaceView::new_subtree(recommended_root.clone()));
+    } else {
         // Split the space and recurse
 
         // If the root also had a visualizable entity, give it its own space.
@@ -418,8 +427,5 @@ fn recommended_space_views_with_image_splits(
                 );
             }
         }
-    } else {
-        // Otherwise we can use the space as it is.
-        recommended.push(RecommendedSpaceView::new_subtree(recommended_root.clone()));
     }
 }

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -381,10 +381,16 @@ fn recommended_space_views_with_image_splits(
         &DepthImage::indicator().name(),
     );
 
-    // If there are images of multiple dimensions, more than 1 image, or more than 1 depth image
-    // then split the space.
-    if found_image_dimensions.len() > 1 || image_count > 1 || depth_count > 1 {
-        // Otherwise, split the space and recurse
+    let video_count = count_non_nested_images_with_component(
+        image_dimensions,
+        entities,
+        ctx.recording(),
+        subtree,
+        &re_types::archetypes::AssetVideo::indicator().name(),
+    );
+
+    if found_image_dimensions.len() > 1 || image_count > 1 || depth_count > 1 || video_count > 1 {
+        // Split the space and recurse
 
         // If the root also had a visualizable entity, give it its own space.
         // TODO(jleibs): Maybe merge this entity into each child


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/7821

My previous "fix" in https://github.com/rerun-io/rerun/pull/7869 only solved the problems for videos with different dimensions. This solves the problem for all videos.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8085?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8085?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8085)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.