### PR TITLE
Make old ffmpeg version a hard error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,6 +6478,7 @@ dependencies = [
 name = "re_video"
 version = "0.20.0-alpha.4+dev"
 dependencies = [
+ "anyhow",
  "bit-vec",
  "cfg_aliases 0.2.1",
  "criterion",
@@ -6487,6 +6488,7 @@ dependencies = [
  "indicatif",
  "itertools 0.13.0",
  "js-sys",
+ "once_cell",
  "parking_lot",
  "re_build_info",
  "re_build_tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6478,7 +6478,6 @@ dependencies = [
 name = "re_video"
 version = "0.20.0-alpha.4+dev"
 dependencies = [
- "anyhow",
  "bit-vec",
  "cfg_aliases 0.2.1",
  "criterion",

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -47,10 +47,12 @@ re_build_info.workspace = true
 re_log.workspace = true
 re_tracing.workspace = true
 
+anyhow.workspace = true
 bit-vec.workspace = true
 crossbeam.workspace = true
 econtext.workspace = true
 itertools.workspace = true
+once_cell.workspace = true
 parking_lot.workspace = true
 re_mp4.workspace = true
 thiserror.workspace = true

--- a/crates/store/re_video/Cargo.toml
+++ b/crates/store/re_video/Cargo.toml
@@ -47,7 +47,6 @@ re_build_info.workspace = true
 re_log.workspace = true
 re_tracing.workspace = true
 
-anyhow.workspace = true
 bit-vec.workspace = true
 crossbeam.workspace = true
 econtext.workspace = true

--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -659,7 +659,7 @@ impl FFmpegCliH264Decoder {
 
         // TODO(ab): Pass executable path here.
         if !ffmpeg_sidecar::command::ffmpeg_is_installed() {
-            return Err(Error::FfmpegNotInstalled);
+            return Err(Error::FFmpegNotInstalled);
         }
 
         // Check the version once ahead of running FFmpeg.

--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -659,14 +659,14 @@ impl FfmpegCliH264Decoder {
     ) -> Result<Self, Error> {
         re_tracing::profile_function!();
 
-        // TODO(ab): Pass exectuable path here.
+        // TODO(ab): Pass executable path here.
         if !ffmpeg_sidecar::command::ffmpeg_is_installed() {
             return Err(Error::FfmpegNotInstalled);
         }
 
         // Check the version once ahead of running FFmpeg.
         // The error is still handled if it happens while running FFmpeg, but it's a bit unclear if we can get it to start in the first place then.
-        // TODO(ab): Pass exectuable path here.
+        // TODO(ab): Pass executable path here.
         match FFmpegVersion::for_executable(None) {
             Ok(version) => {
                 if !version.is_compatible() {

--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -618,16 +618,22 @@ fn read_ffmpeg_output(
                 }
 
                 // Version strings can get pretty wild!
-                // E.g. choco installed ffmpeg on Windows gives me "7.1-essentials_build-www.gyan.dev".
-                let mut version_parts = ffmpeg_version.version.split('.');
+                // E.g.
+                // * choco installed ffmpeg on Windows gives me "7.1-essentials_build-www.gyan.dev".
+                // * Linux builds may come with `n7.0.2`
+                // Seems to be easiest to just strip out any non-digit first.
+                let stripped_version = ffmpeg_version
+                    .version
+                    .chars()
+                    .filter(|c| c.is_ascii_digit() || *c == '.')
+                    .collect::<String>();
+                let mut version_parts = stripped_version.split('.');
                 let major = version_parts
                     .next()
                     .and_then(|part| part.parse::<u32>().ok());
-                let minor = version_parts.next().and_then(|part| {
-                    part.split('-')
+                let minor = version_parts
                     .next()
-                        .and_then(|part| part.parse::<u32>().ok())
-                });
+                    .and_then(|part| part.parse::<u32>().ok());
 
                 if let (Some(major), Some(minor)) = (major, minor) {
                     re_log::debug_once!("Parsed FFmpeg version as {}.{}", major, minor);

--- a/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
@@ -5,3 +5,10 @@ mod version;
 
 pub use ffmpeg::{Error, FfmpegCliH264Decoder};
 pub use version::{FFmpegVersion, FFMPEG_MINIMUM_VERSION_MAJOR, FFMPEG_MINIMUM_VERSION_MINOR};
+
+/// Download URL for the latest version of `FFmpeg` on the current platform.
+/// None if the platform is not supported.
+// TODO(andreas): as of writing, ffmpeg-sidecar doesn't define a download URL for linux arm.
+pub fn ffmpeg_download_url() -> Option<&'static str> {
+    ffmpeg_sidecar::download::ffmpeg_download_url().ok()
+}

--- a/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
@@ -1,5 +1,7 @@
 mod ffmpeg;
 mod nalu;
 mod sps;
+mod version;
 
 pub use ffmpeg::{Error, FfmpegCliH264Decoder};
+pub use version::{FFmpegVersion, FFMPEG_MINIMUM_VERSION_MAJOR, FFMPEG_MINIMUM_VERSION_MINOR};

--- a/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/mod.rs
@@ -3,8 +3,11 @@ mod nalu;
 mod sps;
 mod version;
 
-pub use ffmpeg::{Error, FfmpegCliH264Decoder};
-pub use version::{FFmpegVersion, FFMPEG_MINIMUM_VERSION_MAJOR, FFMPEG_MINIMUM_VERSION_MINOR};
+pub use ffmpeg::{Error, FFmpegCliH264Decoder};
+pub use version::{
+    FFmpegVersion, FFmpegVersionParseError, FFMPEG_MINIMUM_VERSION_MAJOR,
+    FFMPEG_MINIMUM_VERSION_MINOR,
+};
 
 /// Download URL for the latest version of `FFmpeg` on the current platform.
 /// None if the platform is not supported.

--- a/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
@@ -19,7 +19,11 @@ pub struct FFmpegVersion {
 
 impl std::fmt::Display for FFmpegVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}.{} ({})", self.major, self.minor, self.raw_version)
+        // Alternative with more information:
+        //write!(f, "{}.{} ({})", self.major, self.minor, self.raw_version)
+        // The drawback of that is that it can look repetitive for trivial versions.
+        // So let's show just the raw version instead since that's the more important information.
+        self.raw_version.fmt(f)
     }
 }
 

--- a/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
@@ -77,7 +77,7 @@ impl FFmpegVersion {
 
         // Check first if we already have the version cached.
         let mut cache = CACHE.lock();
-        let cache_key = path.unwrap_or(&std::path::Path::new("ffmpeg"));
+        let cache_key = path.unwrap_or(std::path::Path::new("ffmpeg"));
         if let Some(cached) = cache.get(cache_key) {
             if modification_time == cached.0 {
                 return Ok(cached.1.clone());

--- a/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/version.rs
@@ -1,0 +1,118 @@
+// FFmpeg 5.1 "Riemann" is from 2022-07-22.
+// It's simply the oldest I tested manually as of writing. We might be able to go lower.
+// However, we also know that FFmpeg 4.4 is already no longer working.
+pub const FFMPEG_MINIMUM_VERSION_MAJOR: u32 = 5;
+pub const FFMPEG_MINIMUM_VERSION_MINOR: u32 = 1;
+
+/// A successfully parsed FFmpeg version.
+#[derive(Debug, PartialEq, Eq)]
+pub struct FFmpegVersion {
+    major: u32,
+    minor: u32,
+    raw_version: String,
+}
+
+impl std::fmt::Display for FFmpegVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{} ({})", self.major, self.minor, self.raw_version)
+    }
+}
+
+impl FFmpegVersion {
+    pub fn parse(raw_version: &str) -> Option<Self> {
+        // Version strings can get pretty wild!
+        // E.g.
+        // * choco installed ffmpeg on Windows gives me "7.1-essentials_build-www.gyan.dev".
+        // * Linux builds may come with `n7.0.2`
+        // Seems to be easiest to just strip out any non-digit first.
+        let stripped_version = raw_version
+            .chars()
+            .filter(|c| c.is_ascii_digit() || *c == '.')
+            .collect::<String>();
+        let mut version_parts = stripped_version.split('.');
+
+        // Major version is a strict requirement.
+        let major = version_parts
+            .next()
+            .and_then(|part| part.parse::<u32>().ok())?;
+
+        // Minor version is optional.
+        let minor = version_parts
+            .next()
+            .and_then(|part| part.parse::<u32>().ok())
+            .unwrap_or(0);
+
+        Some(Self {
+            major,
+            minor,
+            raw_version: raw_version.to_owned(),
+        })
+    }
+
+    /// Returns true if this version is compatible with Rerun's minimum requirements.
+    pub fn is_compatible(&self) -> bool {
+        self.major > FFMPEG_MINIMUM_VERSION_MAJOR
+            || (self.major == FFMPEG_MINIMUM_VERSION_MAJOR
+                && self.minor >= FFMPEG_MINIMUM_VERSION_MINOR)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::decode::ffmpeg_h264::FFmpegVersion;
+
+    #[test]
+    fn test_parse_ffmpeg_version() {
+        // Real world examples:
+        assert_eq!(
+            FFmpegVersion::parse("7.1"),
+            Some(FFmpegVersion {
+                major: 7,
+                minor: 1,
+                raw_version: "7.1".to_owned(),
+            })
+        );
+        assert_eq!(
+            FFmpegVersion::parse("4.4.5"),
+            Some(FFmpegVersion {
+                major: 4,
+                minor: 4,
+                raw_version: "4.4.5".to_owned(),
+            })
+        );
+        assert_eq!(
+            FFmpegVersion::parse("7.1.2-essentials_build-www.gyan.dev"),
+            Some(FFmpegVersion {
+                major: 7,
+                minor: 1,
+                raw_version: "7.1.2-essentials_build-www.gyan.dev".to_owned(),
+            })
+        );
+        assert_eq!(
+            FFmpegVersion::parse("n7.0.2"),
+            Some(FFmpegVersion {
+                major: 7,
+                minor: 0,
+                raw_version: "n7.0.2".to_owned(),
+            })
+        );
+
+        // Made up stuff:
+        assert_eq!(
+            FFmpegVersion::parse("123"),
+            Some(FFmpegVersion {
+                major: 123,
+                minor: 0,
+                raw_version: "123".to_owned(),
+            })
+        );
+        assert_eq!(
+            FFmpegVersion::parse("lol321wut.23"),
+            Some(FFmpegVersion {
+                major: 321,
+                minor: 23,
+                raw_version: "lol321wut.23".to_owned(),
+            })
+        );
+    }
+}

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -86,7 +86,7 @@ mod av1;
 mod ffmpeg_h264;
 
 #[cfg(with_ffmpeg)]
-pub use ffmpeg_h264::Error as FfmpegError;
+pub use ffmpeg_h264::{ffmpeg_download_url, Error as FfmpegError};
 
 #[cfg(target_arch = "wasm32")]
 mod webcodecs;

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -86,7 +86,7 @@ mod av1;
 mod ffmpeg_h264;
 
 #[cfg(with_ffmpeg)]
-pub use ffmpeg_h264::{ffmpeg_download_url, Error as FfmpegError};
+pub use ffmpeg_h264::{ffmpeg_download_url, Error as FFmpegError, FFmpegVersionParseError};
 
 #[cfg(target_arch = "wasm32")]
 mod webcodecs;
@@ -120,7 +120,7 @@ pub enum Error {
 
     #[cfg(with_ffmpeg)]
     #[error(transparent)]
-    Ffmpeg(std::sync::Arc<FfmpegError>),
+    Ffmpeg(std::sync::Arc<FFmpegError>),
 
     #[error("Unsupported bits per component: {0}")]
     BadBitsPerComponent(usize),
@@ -193,7 +193,7 @@ pub fn new_decoder(
         #[cfg(with_ffmpeg)]
         re_mp4::StsdBoxContent::Avc1(avc1_box) => {
             re_log::trace!("Decoding H.264…");
-            Ok(Box::new(ffmpeg_h264::FfmpegCliH264Decoder::new(
+            Ok(Box::new(ffmpeg_h264::FFmpegCliH264Decoder::new(
                 debug_name.to_owned(),
                 avc1_box.clone(),
                 on_output,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -85,6 +85,9 @@ mod av1;
 #[cfg(with_ffmpeg)]
 mod ffmpeg_h264;
 
+#[cfg(with_ffmpeg)]
+pub use ffmpeg_h264::Error as FfmpegError;
+
 #[cfg(target_arch = "wasm32")]
 mod webcodecs;
 
@@ -117,16 +120,7 @@ pub enum Error {
 
     #[cfg(with_ffmpeg)]
     #[error(transparent)]
-    Ffmpeg(std::sync::Arc<ffmpeg_h264::Error>),
-
-    // We need to check for this one and don't want to infect more crates with the feature requirement.
-    #[error("Couldn't find an installation of the FFmpeg executable.")]
-    FfmpegNotInstalled {
-        /// Download URL for the latest version of `FFmpeg` on the current platform.
-        /// None if the platform is not supported.
-        // TODO(andreas): as of writing, ffmpeg-sidecar doesn't define a download URL for linux arm.
-        download_url: Option<&'static str>,
-    },
+    Ffmpeg(std::sync::Arc<FfmpegError>),
 
     #[error("Unsupported bits per component: {0}")]
     BadBitsPerComponent(usize),

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -32,7 +32,7 @@ re_types = { workspace = true, features = [
 ] }
 re_types_core.workspace = true
 re_ui.workspace = true
-re_video.workspace = true
+re_video = { workspace = true, features = ["ffmpeg"] }
 re_viewer_context.workspace = true
 
 ahash.workspace = true

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -203,13 +203,24 @@ pub fn show_decoded_frame_info(
         Err(err) => {
             ui.error_label(&err.to_string());
 
+            #[cfg(not(target_arch = "wasm32"))]
             if let re_renderer::video::VideoPlayerError::Decoding(
-                re_video::decode::Error::FfmpegNotInstalled {
-                    download_url: Some(url),
-                },
-            ) = err
+                re_video::decode::Error::Ffmpeg(err),
+            ) = &err
             {
-                ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
+                match err.as_ref() {
+                    re_video::decode::FfmpegError::UnsupportedFFmpegVersion {
+                        download_url: Some(url),
+                        ..
+                    }
+                    | re_video::decode::FfmpegError::FfmpegNotInstalled {
+                        download_url: Some(url),
+                    } => {
+                        ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
+                    }
+
+                    _ => {}
+                }
             }
         }
     }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -209,9 +209,9 @@ pub fn show_decoded_frame_info(
             ) = &err
             {
                 match err.as_ref() {
-                    re_video::decode::FfmpegError::UnsupportedFFmpegVersion { .. }
-                    | re_video::decode::FfmpegError::FailedToDetermineFFmpegVersion(_)
-                    | re_video::decode::FfmpegError::FfmpegNotInstalled => {
+                    re_video::decode::FFmpegError::UnsupportedFFmpegVersion { .. }
+                    | re_video::decode::FFmpegError::FailedToDetermineFFmpegVersion(_)
+                    | re_video::decode::FFmpegError::FfmpegNotInstalled => {
                         if let Some(download_url) = re_video::decode::ffmpeg_download_url() {
                             ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({download_url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
                         }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -209,14 +209,12 @@ pub fn show_decoded_frame_info(
             ) = &err
             {
                 match err.as_ref() {
-                    re_video::decode::FfmpegError::UnsupportedFFmpegVersion {
-                        download_url: Some(url),
-                        ..
-                    }
-                    | re_video::decode::FfmpegError::FfmpegNotInstalled {
-                        download_url: Some(url),
-                    } => {
-                        ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
+                    re_video::decode::FfmpegError::UnsupportedFFmpegVersion { .. }
+                    | re_video::decode::FfmpegError::FailedToDetermineFFmpegVersion(_)
+                    | re_video::decode::FfmpegError::FfmpegNotInstalled => {
+                        if let Some(download_url) = re_video::decode::ffmpeg_download_url() {
+                            ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({download_url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
+                        }
                     }
 
                     _ => {}

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -211,7 +211,7 @@ pub fn show_decoded_frame_info(
                 match err.as_ref() {
                     re_video::decode::FFmpegError::UnsupportedFFmpegVersion { .. }
                     | re_video::decode::FFmpegError::FailedToDetermineFFmpegVersion(_)
-                    | re_video::decode::FFmpegError::FfmpegNotInstalled => {
+                    | re_video::decode::FFmpegError::FFmpegNotInstalled => {
                         if let Some(download_url) = re_video::decode::ffmpeg_download_url() {
                             ui.markdown_ui(&format!("You can download a build of `FFmpeg` [here]({download_url}). For Rerun to be able to use it, its binaries need to be reachable from `PATH`."));
                         }


### PR DESCRIPTION
### What

... and make ffmpeg version parsing more robust


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8094?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8094?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8094)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.