### PR TITLE
Fix listing of enabled features in `rerun --version`

### DIFF
--- a/.github/workflows/contrib_rerun_py.yml
+++ b/.github/workflows/contrib_rerun_py.yml
@@ -57,9 +57,6 @@ jobs:
           environments: wheel-test-min
 
       - name: Build rerun-cli
-        env:
-          # this stops `re_web_viewer_server/build.rs` from running
-          RERUN_IS_PUBLISHING: true
         run: |
           pixi run rerun-build-native-and-web-release
 

--- a/.github/workflows/reusable_build_and_upload_rerun_cli.yml
+++ b/.github/workflows/reusable_build_and_upload_rerun_cli.yml
@@ -172,9 +172,6 @@ jobs:
       # This does not run in the pixi environment, doing so
       # causes it to select the wrong compiler on macos-arm64
       - name: Build rerun-cli
-        env:
-          # this stops `re_web_viewer_server/build.rs` from running
-          RERUN_IS_PUBLISHING: true
         run: |
           pixi run cargo build \
             --locked \

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -93,9 +93,9 @@ impl Environment {
     pub fn detect() -> Self {
         let is_in_rerun_workspace = is_tracked_env_var_set("IS_IN_RERUN_WORKSPACE");
 
-        if is_tracked_env_var_set("RERUN_IS_PUBLISHING") {
-            // "RERUN_IS_PUBLISHING" is set by `scripts/ci/crates.py`
-            eprintln!("Environment: env-var RERUN_IS_PUBLISHING is set");
+        if is_tracked_env_var_set("RERUN_IS_PUBLISHING_CRATES") {
+            // "RERUN_IS_PUBLISHING_CRATES" is set by `scripts/ci/crates.py`
+            eprintln!("Environment: env-var RERUN_IS_PUBLISHING_CRATES is set");
             Self::PublishingCrates
         } else if is_in_rerun_workspace && std::env::var("CI").is_ok() {
             // `CI` is an env-var set by GitHub actions.

--- a/crates/viewer/re_web_viewer_server/build.rs
+++ b/crates/viewer/re_web_viewer_server/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    // Once we bump to Rust 1.80+ this will tell the checker that this flag actually exists for releases.
     println!("cargo::rustc-check-cfg=cfg(disable_web_viewer_server)");
 }

--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -88,7 +88,6 @@ def build_and_upload(bucket: Bucket | None, mode: BuildMode, gcs_dir: str, targe
         f"--target {target} "
         f"{maturin_feature_flags} "
         f"--out {dist}",
-        env={**os.environ.copy(), "RERUN_IS_PUBLISHING": "yes"},  # stop `re_web_viewer` from building here
     )
 
     pkg = os.listdir(dist)[0]

--- a/scripts/ci/crates.py
+++ b/scripts/ci/crates.py
@@ -469,7 +469,7 @@ def publish_unpublished_crates_in_parallel(all_crates: dict[str, Crate], version
 
     # walk the dependency graph in parallel and publish each crate
     print(f"Publishing {len(unpublished_crates)} crates…")
-    env = {**os.environ.copy(), "RERUN_IS_PUBLISHING": "yes"}
+    env = {**os.environ.copy(), "RERUN_IS_PUBLISHING_CRATES": "yes"}
     DAG(dependency_graph).walk_parallel(
         lambda name: publish_crate(unpublished_crates[name], token, version, env),  # noqa: E731
         # 30 tokens per minute (burst limit in crates.io)


### PR DESCRIPTION
### What
`RERUN_IS_PUBLISHING` was incorrectly set when we weren't publishing crates.
This lead to a `rerun --version` not showing the correct feature flags in our release.
This should fix it.
I'll make an alpha-release once merged to verify.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8095?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8095?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8095)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.