### PR TITLE
Improve `FrameInfo` handling

### DIFF
--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -253,6 +253,7 @@ fn create_frame(debug_name: &str, picture: &dav1d::Picture) -> Result<Frame> {
             format,
         },
         info: FrameInfo {
+            is_sync: None, // TODO(emilk)
             presentation_timestamp: Time(picture.timestamp().unwrap_or(0)),
             duration: Time(picture.duration()),
             latest_decode_timestamp: None,

--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -255,7 +255,7 @@ fn create_frame(debug_name: &str, picture: &dav1d::Picture) -> Result<Frame> {
         info: FrameInfo {
             presentation_timestamp: Time(picture.timestamp().unwrap_or(0)),
             duration: Time(picture.duration()),
-            ..Default::default()
+            latest_decode_timestamp: None,
         },
     })
 }

--- a/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/store/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -95,8 +95,8 @@ impl From<Error> for crate::decode::Error {
 struct FfmpegFrameInfo {
     /// The start of a new [`crate::demux::GroupOfPictures`]?
     ///
-    /// If true, an entire frame can be decoded from this one sample,
-    /// otherwise it needs the context of other samples.
+    /// This probably means this is a _keyframe_, and that and entire frame
+    /// can be decoded from only this one sample (though I'm not 100% sure).
     is_sync: bool,
     presentation_timestamp: Time,
     duration: Time,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -252,31 +252,15 @@ pub type FrameContent = webcodecs::WebVideoFrame;
 pub struct FrameInfo {
     /// The presentation timestamp of the frame.
     ///
-    /// Decoders are required to report this.
-    /// A timestamp of [`Time::MAX`] indicates that the frame is invalid or not yet available.
     pub presentation_timestamp: Time,
 
     /// How long the frame is valid.
-    ///
-    /// Decoders are required to report this.
-    /// A duration of [`Time::MAX`] indicates that the frame is invalid or not yet available.
-    // Implementation note: unlike with presentation timestamp we may be able fine with making this optional.
     pub duration: Time,
 
     /// The decode timestamp of the last chunk that was needed to decode this frame.
     ///
     /// None indicates that the information is not available.
     pub latest_decode_timestamp: Option<Time>,
-}
-
-impl Default for FrameInfo {
-    fn default() -> Self {
-        Self {
-            presentation_timestamp: Time::MAX,
-            duration: Time::MAX,
-            latest_decode_timestamp: None,
-        }
-    }
 }
 
 impl FrameInfo {

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -216,8 +216,8 @@ pub fn new_decoder(
 pub struct Chunk {
     /// The start of a new [`crate::demux::GroupOfPictures`]?
     ///
-    /// If true, an entire frame can be decoded from this one sample,
-    /// otherwise it needs the context of other samples.
+    /// This probably means this is a _keyframe_, and that and entire frame
+    /// can be decoded from only this one sample (though I'm not 100% sure).
     pub is_sync: bool,
 
     pub data: Vec<u8>,
@@ -255,8 +255,8 @@ pub type FrameContent = webcodecs::WebVideoFrame;
 pub struct FrameInfo {
     /// The start of a new [`crate::demux::GroupOfPictures`]?
     ///
-    /// If true, an entire frame can be decoded from this one sample,
-    /// otherwise it needs the context of other samples.
+    /// This probably means this is a _keyframe_, and that and entire frame
+    /// can be decoded from only this one sample (though I'm not 100% sure).
     ///
     /// None indicates that the information is not available.
     pub is_sync: Option<bool>,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -215,6 +215,9 @@ pub fn new_decoder(
 /// For details on how to interpret the data, see [`crate::Sample`].
 pub struct Chunk {
     /// The start of a new [`crate::demux::GroupOfPictures`]?
+    ///
+    /// If true, an entire frame can be decoded from this one sample,
+    /// otherwise it needs the context of other samples.
     pub is_sync: bool,
 
     pub data: Vec<u8>,
@@ -250,8 +253,15 @@ pub type FrameContent = webcodecs::WebVideoFrame;
 /// Meta information about a decoded video frame, as reported by the decoder.
 #[derive(Debug, Clone)]
 pub struct FrameInfo {
-    /// The presentation timestamp of the frame.
+    /// The start of a new [`crate::demux::GroupOfPictures`]?
     ///
+    /// If true, an entire frame can be decoded from this one sample,
+    /// otherwise it needs the context of other samples.
+    ///
+    /// None indicates that the information is not available.
+    pub is_sync: Option<bool>,
+
+    /// The presentation timestamp of the frame.
     pub presentation_timestamp: Time,
 
     /// How long the frame is valid.

--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -204,9 +204,10 @@ fn init_video_decoder(
             on_output(Ok(Frame {
                 content: WebVideoFrame(frame),
                 info: FrameInfo {
+                    is_sync: None,
                     presentation_timestamp,
                     duration,
-                    ..Default::default()
+                    latest_decode_timestamp: None,
                 },
             }));
         }) as Box<dyn Fn(web_sys::VideoFrame)>)

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -459,8 +459,8 @@ impl GroupOfPictures {
 pub struct Sample {
     /// Is this the start of a new [`GroupOfPictures`]?
     ///
-    /// If true, an entire frame can be decoded from this one sample,
-    /// otherwise it needs the context of other samples.
+    /// This probably means this is a _keyframe_, and that and entire frame
+    /// can be decoded from only this one sample (though I'm not 100% sure).
     pub is_sync: bool,
 
     /// Time at which this sample appears in the decoded bitstream, in time units.

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -457,7 +457,10 @@ impl GroupOfPictures {
 /// > The decoding of each access unit results in one decoded picture.
 #[derive(Debug, Clone)]
 pub struct Sample {
-    /// Is t his the start of a new [`GroupOfPictures`]?
+    /// Is this the start of a new [`GroupOfPictures`]?
+    ///
+    /// If true, an entire frame can be decoded from this one sample,
+    /// otherwise it needs the context of other samples.
     pub is_sync: bool,
 
     /// Time at which this sample appears in the decoded bitstream, in time units.

--- a/crates/utils/re_log/src/setup.rs
+++ b/crates/utils/re_log/src/setup.rs
@@ -39,7 +39,8 @@ pub fn setup_logging() {
                 use std::io::Write as _;
                 writeln!(
                     buf,
-                    "{}:{} {}",
+                    "{} {}:{} {}",
+                    record.level(),
                     record.file().unwrap_or_default(),
                     record.line().unwrap_or_default(),
                     record.args()

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -166,6 +166,7 @@ pub fn show_decoded_frame_info(
         }) => {
             re_ui::list_item::list_item_scope(ui, "decoded_frame_ui", |ui| {
                 let default_open = false;
+                if let Some(frame_info) = frame_info {
                 ui.list_item_collapsible_noninteractive_label(
                     "Current decoded frame",
                     default_open,
@@ -174,6 +175,7 @@ pub fn show_decoded_frame_info(
                         source_image_data_format_ui(ui, &source_pixel_format);
                     },
                 );
+                }
             });
 
             let response = crate::image::texture_preview_ui(

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -289,7 +289,7 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
                 video_data.latest_sample_index_at_presentation_timestamp(presentation_timestamp)
             {
                 ui.list_item_flat_noninteractive(
-                    PropertyContent::new("Highest PTS so far").value_text(has_sample_highest_pts_so_far[sample_idx].to_string())
+                    PropertyContent::new("Highest PTS so far").value_bool(has_sample_highest_pts_so_far[sample_idx])
                 ).on_hover_text("Whether the presentation timestamp (PTS) at the this frame is the highest encountered so far. If false there are lower PTS values prior in the list.");
             }
         }

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -239,9 +239,7 @@ fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_vide
         ui.list_item_flat_noninteractive(PropertyContent::new("Sync").value_bool(is_sync))
             .on_hover_text(
                 "The start of a new GOP (Group of Frames)?\n\
-                \n\
-                If true, an entire frame can be decoded from this one sample, \
-                otherwise it needs the context of other samples.",
+                If true, it likely means the frame is a keyframe.",
             );
     }
 

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -167,14 +167,14 @@ pub fn show_decoded_frame_info(
             re_ui::list_item::list_item_scope(ui, "decoded_frame_ui", |ui| {
                 let default_open = false;
                 if let Some(frame_info) = frame_info {
-                ui.list_item_collapsible_noninteractive_label(
-                    "Current decoded frame",
-                    default_open,
-                    |ui| {
-                        frame_info_ui(ui, &frame_info, video.data());
-                        source_image_data_format_ui(ui, &source_pixel_format);
-                    },
-                );
+                    ui.list_item_collapsible_noninteractive_label(
+                        "Current decoded frame",
+                        default_open,
+                        |ui| {
+                            frame_info_ui(ui, &frame_info, video.data());
+                            source_image_data_format_ui(ui, &source_pixel_format);
+                        },
+                    );
                 }
             });
 
@@ -229,10 +229,21 @@ fn samples_statistics_ui(ui: &mut egui::Ui, samples_statistics: &SamplesStatisti
 
 fn frame_info_ui(ui: &mut egui::Ui, frame_info: &FrameInfo, video_data: &re_video::VideoData) {
     let FrameInfo {
+        is_sync,
         presentation_timestamp,
         duration,
         latest_decode_timestamp,
     } = *frame_info;
+
+    if let Some(is_sync) = is_sync {
+        ui.list_item_flat_noninteractive(PropertyContent::new("Sync").value_bool(is_sync))
+            .on_hover_text(
+                "The start of a new GOP (Group of Frames)?\n\
+                \n\
+                If true, an entire frame can be decoded from this one sample, \
+                otherwise it needs the context of other samples.",
+            );
+    }
 
     let presentation_time_range = presentation_timestamp..presentation_timestamp + duration;
     ui.list_item_flat_noninteractive(PropertyContent::new("Time range").value_text(format!(

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -58,7 +58,7 @@ impl VideoChunkDecoder {
                 Err(err) => {
                     // Many of the errors we get from a decoder are recoverable.
                     // They may be very frequent, but it's still useful to see them in the debug log for troubleshooting.
-                    re_log::debug!("Error during decoding of {debug_name}: {err}");
+                    re_log::debug_once!("Error during decoding of {debug_name}: {err}");
 
                     let err = VideoPlayerError::Decoding(err);
                     let mut output = decoder_output.lock();

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -119,9 +119,12 @@ impl VideoChunkDecoder {
 
         let frame_time_range = frame.info.presentation_time_range();
 
-        if frame_time_range.contains(&presentation_timestamp)
-            && video_texture.frame_info.presentation_time_range() != frame_time_range
-        {
+        let is_up_to_date = video_texture
+            .frame_info
+            .as_ref()
+            .is_some_and(|info| info.presentation_time_range() == frame_time_range);
+
+        if frame_time_range.contains(&presentation_timestamp) && !is_up_to_date {
             #[cfg(target_arch = "wasm32")]
             {
                 video_texture.source_pixel_format = copy_web_video_frame_to_texture(
@@ -139,7 +142,7 @@ impl VideoChunkDecoder {
                 )?;
             }
 
-            video_texture.frame_info = frame.info.clone();
+            video_texture.frame_info = Some(frame.info.clone());
         }
 
         Ok(())

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -80,7 +80,7 @@ impl VideoChunkDecoder {
     }
 
     /// Start decoding the given chunk.
-    pub fn decode(&mut self, chunk: Chunk, _is_keyframe: bool) -> Result<(), VideoPlayerError> {
+    pub fn decode(&mut self, chunk: Chunk) -> Result<(), VideoPlayerError> {
         self.decoder.submit_chunk(chunk)?;
         Ok(())
     }

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -1,7 +1,7 @@
 mod chunk_decoder;
 mod player;
 
-use std::{collections::hash_map::Entry, ops::Range, sync::Arc};
+use std::{collections::hash_map::Entry, sync::Arc};
 
 use ahash::HashMap;
 use parking_lot::Mutex;
@@ -64,14 +64,7 @@ pub struct VideoFrameTexture {
     pub source_pixel_format: SourceImageDataFormat,
 
     /// Meta information about the decoded frame.
-    pub frame_info: re_video::decode::FrameInfo,
-}
-
-impl VideoFrameTexture {
-    pub fn presentation_time_range(&self) -> Range<re_video::Time> {
-        self.frame_info.presentation_timestamp
-            ..self.frame_info.presentation_timestamp + self.frame_info.duration
-    }
+    pub frame_info: Option<re_video::decode::FrameInfo>,
 }
 
 /// Identifier for an independent video decoding stream.

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -144,33 +144,33 @@ impl VideoPlayer {
             let time_range = frame_info.presentation_time_range();
             let is_active_frame = time_range.contains(&presentation_timestamp);
 
-                let is_pending = !is_active_frame;
+            let is_pending = !is_active_frame;
 
             let show_spinner = if is_pending && error_on_last_frame_at {
-                    // If we switched from error to pending, clear the texture.
-                    // This is important to avoid flickering, in particular when switching from
-                    // benign errors like DecodingError::NegativeTimestamp.
-                    // If we don't do this, we see the last valid texture which can look really weird.
-                    clear_texture(render_ctx, &self.video_texture.texture);
+                // If we switched from error to pending, clear the texture.
+                // This is important to avoid flickering, in particular when switching from
+                // benign errors like DecodingError::NegativeTimestamp.
+                // If we don't do this, we see the last valid texture which can look really weird.
+                clear_texture(render_ctx, &self.video_texture.texture);
                 self.video_texture.frame_info = None;
                 true
             } else if presentation_timestamp < time_range.start {
-                    // We're seeking backwards and somehow forgot to reset.
-                    true
-                } else if presentation_timestamp < time_range.end {
-                    false // it is an active frame
+                // We're seeking backwards and somehow forgot to reset.
+                true
+            } else if presentation_timestamp < time_range.end {
+                false // it is an active frame
+            } else {
+                let how_outdated = presentation_timestamp - time_range.end;
+                if how_outdated.duration(self.data.timescale) < DECODING_GRACE_DELAY {
+                    false // Just outdated by a little bit - show no spinner
                 } else {
-                    let how_outdated = presentation_timestamp - time_range.end;
-                    if how_outdated.duration(self.data.timescale) < DECODING_GRACE_DELAY {
-                        false // Just outdated by a little bit - show no spinner
-                    } else {
-                        true // Very old frame - show spinner
-                    }
-                };
-                Ok(VideoFrameTexture {
-                    texture: self.video_texture.texture.clone(),
-                    is_pending,
-                    show_spinner,
+                    true // Very old frame - show spinner
+                }
+            };
+            Ok(VideoFrameTexture {
+                texture: self.video_texture.texture.clone(),
+                is_pending,
+                show_spinner,
                 frame_info: Some(frame_info),
                 source_pixel_format: self.video_texture.source_pixel_format,
             })
@@ -180,8 +180,8 @@ impl VideoPlayer {
                 is_pending: true,
                 show_spinner: true,
                 frame_info: None,
-                    source_pixel_format: self.video_texture.source_pixel_format,
-                })
+                source_pixel_format: self.video_texture.source_pixel_format,
+            })
         }
     }
 

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -325,10 +325,9 @@ impl VideoPlayer {
 
         let samples = &self.data.samples[gop.decode_time_range()];
 
-        for (i, sample) in samples.iter().enumerate() {
+        for sample in samples {
             let chunk = sample.get(video_data).ok_or(VideoPlayerError::BadData)?;
-            let is_keyframe = i == 0;
-            self.chunk_decoder.decode(chunk, is_keyframe)?;
+            self.chunk_decoder.decode(chunk)?;
         }
 
         Ok(())

--- a/crates/viewer/re_ui/src/list_item/property_content.rs
+++ b/crates/viewer/re_ui/src/list_item/property_content.rs
@@ -152,9 +152,14 @@ impl<'a> PropertyContent<'a> {
     /// Show a read-only boolean in the value column.
     #[inline]
     pub fn value_bool(self, mut b: bool) -> Self {
-        self.value_fn(move |ui: &mut Ui, _| {
-            ui.add_enabled_ui(false, |ui| ui.re_checkbox(&mut b, ""));
-        })
+        if true {
+            self.value_text(b.to_string())
+        } else {
+            // This is not readable, which is why it is disabled
+            self.value_fn(move |ui: &mut Ui, _| {
+                ui.add_enabled_ui(false, |ui| ui.re_checkbox(&mut b, ""));
+            })
+        }
     }
 
     /// Show an editable boolean in the value column.


### PR DESCRIPTION
### What
Added `is_sync` and make sure `FrameInfo` is either valid or `None`.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)