### PR TITLE
Show all samples/frames in a video in a nice table

### DIFF
--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -305,7 +305,7 @@ impl VideoData {
         // Segments are guaranteed to be sorted among each other, but within a segment,
         // presentation timestamps may not be sorted since this is sorted by decode timestamps.
         self.gops.iter().flat_map(|seg| {
-            self.samples[seg.decode_time_range()]
+            self.samples[seg.sample_range_usize()]
                 .iter()
                 .map(|sample| sample.presentation_timestamp)
                 .sorted()
@@ -432,7 +432,7 @@ pub struct GroupOfPictures {
 
 impl GroupOfPictures {
     /// The GOP's `sample_range` mapped to `usize` for slicing.
-    pub fn decode_time_range(&self) -> Range<usize> {
+    pub fn sample_range_usize(&self) -> Range<usize> {
         Range {
             start: self.sample_range.start as usize,
             end: self.sample_range.end as usize,

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -4,7 +4,7 @@ use re_viewer_context::UiLayout;
 
 use crate::{
     image::image_preview_ui,
-    video::{show_decoded_frame_info, show_video_blob_info},
+    video::{show_decoded_frame_info, video_result_ui},
     EntityDataUi,
 };
 
@@ -131,7 +131,7 @@ pub fn blob_preview_and_save_ui(
                     ctx.app_options.video_decoder_hw_acceleration,
                 )
             });
-            show_video_blob_info(ui, ui_layout, &video_result);
+            video_result_ui(ui, ui_layout, &video_result);
             video_result_for_frame_preview = Some(video_result);
         }
     }

--- a/crates/viewer/re_renderer/src/video/player.rs
+++ b/crates/viewer/re_renderer/src/video/player.rs
@@ -323,7 +323,7 @@ impl VideoPlayer {
             return Ok(());
         };
 
-        let samples = &self.data.samples[gop.decode_time_range()];
+        let samples = &self.data.samples[gop.sample_range_usize()];
 
         for sample in samples {
             let chunk = sample.get(video_data).ok_or(VideoPlayerError::BadData)?;


### PR DESCRIPTION
### What
Add a table showing all the samples (=frames) in a video:

![image](https://github.com/user-attachments/assets/2808ed30-5787-47a1-ab77-7d76f28ec0c7)

![image](https://github.com/user-attachments/assets/c879a4ec-cb03-4884-a979-5949363c85c8)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8102?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8102?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8102)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.