### PR TITLE
Don't shade `GeoPoint`s in the map view

### DIFF
--- a/crates/viewer/re_renderer/src/point_cloud_builder.rs
+++ b/crates/viewer/re_renderer/src/point_cloud_builder.rs
@@ -68,14 +68,18 @@ impl<'ctx> PointCloudBuilder<'ctx> {
     pub fn batch(&mut self, label: impl Into<DebugLabel>) -> PointCloudBatchBuilder<'_, 'ctx> {
         self.batches.push(PointCloudBatchInfo {
             label: label.into(),
-            world_from_obj: glam::Affine3A::IDENTITY,
-            flags: PointCloudBatchFlags::FLAG_ENABLE_SHADING,
-            point_count: 0,
-            overall_outline_mask_ids: OutlineMaskPreference::NONE,
-            additional_outline_mask_ids_vertex_ranges: Vec::new(),
-            picking_object_id: Default::default(),
-            depth_offset: 0,
+            ..PointCloudBatchInfo::default()
         });
+
+        PointCloudBatchBuilder(self)
+    }
+
+    #[inline]
+    pub fn batch_with_info(
+        &mut self,
+        info: PointCloudBatchInfo,
+    ) -> PointCloudBatchBuilder<'_, 'ctx> {
+        self.batches.push(info);
 
         PointCloudBatchBuilder(self)
     }

--- a/crates/viewer/re_renderer/src/renderer/point_cloud.rs
+++ b/crates/viewer/re_renderer/src/renderer/point_cloud.rs
@@ -151,6 +151,22 @@ pub struct PointCloudBatchInfo {
     pub depth_offset: DepthOffset,
 }
 
+impl Default for PointCloudBatchInfo {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            label: DebugLabel::default(),
+            world_from_obj: glam::Affine3A::IDENTITY,
+            flags: PointCloudBatchFlags::FLAG_ENABLE_SHADING,
+            point_count: 0,
+            overall_outline_mask_ids: OutlineMaskPreference::NONE,
+            additional_outline_mask_ids_vertex_ranges: Vec::new(),
+            picking_object_id: Default::default(),
+            depth_offset: 0,
+        }
+    }
+}
+
 #[derive(thiserror::Error, Debug, PartialEq, Eq)]
 pub enum PointCloudDrawDataError {
     #[error("Failed to transfer data to the GPU: {0}")]

--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -151,7 +151,11 @@ impl GeoPointsVisualizer {
             let outline = highlight.entity_outline_mask(entity_path.hash());
 
             let mut point_batch = points
-                .batch(entity_path.to_string())
+                .batch_with_info(re_renderer::renderer::PointCloudBatchInfo {
+                    label: entity_path.to_string().into(),
+                    flags: re_renderer::renderer::PointCloudBatchFlags::empty(),
+                    ..re_renderer::renderer::PointCloudBatchInfo::default()
+                })
                 .picking_object_id(re_renderer::PickingLayerObjectId(entity_path.hash64()))
                 .outline_mask_ids(outline.overall);
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/129aaf17-b85f-41f4-96d3-09ddcc838a68)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8110?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8110?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8110)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.