### PR TITLE
Calculate and show frame number

### DIFF
--- a/crates/store/re_video/src/decode/av1.rs
+++ b/crates/store/re_video/src/decode/av1.rs
@@ -255,6 +255,7 @@ fn create_frame(debug_name: &str, picture: &dav1d::Picture) -> Result<Frame> {
         info: FrameInfo {
             is_sync: None,    // TODO(emilk)
             sample_idx: None, // TODO(emilk),
+            frame_nr: None,   // TODO(emilk),
             presentation_timestamp: Time(picture.timestamp().unwrap_or(0)),
             duration: Time(picture.duration()),
             latest_decode_timestamp: None,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -285,7 +285,7 @@ pub struct FrameInfo {
     /// In MP4, one sample is one frame, but we may be reordering samples when decoding.
     ///
     /// This is the order of which the samples appear in the container,
-    /// which is usually ordered by [`Self::decode_timestamp`].
+    /// which is usually ordered by [`Self::latest_decode_timestamp`].
     ///
     /// None = unknown.
     pub sample_idx: Option<usize>,

--- a/crates/store/re_video/src/decode/mod.rs
+++ b/crates/store/re_video/src/decode/mod.rs
@@ -161,6 +161,8 @@ pub fn new_decoder(
 ) -> Result<Box<dyn AsyncDecoder>> {
     #![allow(unused_variables, clippy::needless_return)] // With some feature flags
 
+    re_tracing::profile_function!();
+
     re_log::trace!(
         "Looking for decoder for {}",
         video.human_readable_codec_string()
@@ -226,7 +228,18 @@ pub struct Chunk {
     pub data: Vec<u8>,
 
     /// Which sample (frame) did this chunk come from?
+    ///
+    /// This is the order of which the samples appear in the container,
+    /// which is usually ordered by [`Self::decode_timestamp`].
     pub sample_idx: usize,
+
+    /// Which frame does this chunk belong to?
+    ///
+    /// This is on the assumption that each sample produces a single frame,
+    /// which is true for MP4.
+    ///
+    /// This is the index of samples ordered by [`Self::presentation_timestamp`].
+    pub frame_nr: usize,
 
     /// Decode timestamp of this sample.
     /// Chunks are expected to be submitted in the order of decode timestamp.
@@ -271,8 +284,21 @@ pub struct FrameInfo {
     ///
     /// In MP4, one sample is one frame, but we may be reordering samples when decoding.
     ///
+    /// This is the order of which the samples appear in the container,
+    /// which is usually ordered by [`Self::decode_timestamp`].
+    ///
     /// None = unknown.
     pub sample_idx: Option<usize>,
+
+    /// Which frame is this?
+    ///
+    /// This is on the assumption that each sample produces a single frame,
+    /// which is true for MP4.
+    ///
+    /// This is the index of frames ordered by [`Self::presentation_timestamp`].
+    ///
+    /// None = unknown.
+    pub frame_nr: Option<usize>,
 
     /// The presentation timestamp of the frame.
     pub presentation_timestamp: Time,

--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -204,8 +204,9 @@ fn init_video_decoder(
             on_output(Ok(Frame {
                 content: WebVideoFrame(frame),
                 info: FrameInfo {
-                    sample_idx: None,
-                    is_sync: None,
+                    is_sync: None,    // TODO(emilk)
+                    sample_idx: None, // TODO(emilk)
+                    frame_nr: None,   // TODO(emilk)
                     presentation_timestamp,
                     duration,
                     latest_decode_timestamp: None,

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -674,6 +674,7 @@ mod tests {
             .map(|(sample_idx, (pts, dts))| Sample {
                 is_sync: false,
                 sample_idx,
+                frame_nr: 0, // unused
                 decode_timestamp: Time(dts),
                 presentation_timestamp: Time(pts),
                 duration: Time(1),

--- a/crates/store/re_video/src/demux/mod.rs
+++ b/crates/store/re_video/src/demux/mod.rs
@@ -466,7 +466,18 @@ pub struct Sample {
     pub is_sync: bool,
 
     /// Which sample is this in the video?
+    ///
+    /// This is the order of which the samples appear in the container,
+    /// which is usually ordered by [`Self::decode_timestamp`].
     pub sample_idx: usize,
+
+    /// Which frame does this sample belong to?
+    ///
+    /// This is on the assumption that each sample produces a single frame,
+    /// which is true for MP4.
+    ///
+    /// This is the index of samples ordered by [`Self::presentation_timestamp`].
+    pub frame_nr: usize,
 
     /// Time at which this sample appears in the decoded bitstream, in time units.
     ///
@@ -508,6 +519,7 @@ impl Sample {
         Some(Chunk {
             data,
             sample_idx: self.sample_idx,
+            frame_nr: self.frame_nr,
             decode_timestamp: self.decode_timestamp,
             presentation_timestamp: self.presentation_timestamp,
             duration: self.duration,

--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -94,8 +94,8 @@ impl VideoData {
                     window[0].decode_timestamp <= window[1].decode_timestamp;
             }
             if !samples_are_in_decode_order {
-                re_log::debug!(
-                    "Video samples are NOT in decode order. This is weird an inefficient."
+                re_log::warn!(
+                    "Video samples are NOT in decode order. This implies either invalid video data or a bug in parsing the mp4."
                 );
             }
         }

--- a/crates/store/re_video/src/demux/mp4.rs
+++ b/crates/store/re_video/src/demux/mp4.rs
@@ -66,6 +66,7 @@ impl VideoData {
                 samples.push(Sample {
                     is_sync: sample.is_sync,
                     sample_idx,
+                    frame_nr: 0, // filled in after the loop
                     decode_timestamp,
                     presentation_timestamp,
                     duration,
@@ -75,6 +76,7 @@ impl VideoData {
             }
         }
 
+        // Append the last GOP if there are any samples left:
         if !samples.is_empty() {
             let start = samples[gop_sample_start_index].decode_timestamp;
             let sample_range = gop_sample_start_index as u32..samples.len() as u32;
@@ -82,6 +84,29 @@ impl VideoData {
                 decode_start_time: start,
                 sample_range,
             });
+        }
+
+        {
+            re_tracing::profile_scope!("Sanity-check samples");
+            let mut samples_are_in_decode_order = true;
+            for window in samples.windows(2) {
+                samples_are_in_decode_order &=
+                    window[0].decode_timestamp <= window[1].decode_timestamp;
+            }
+            if !samples_are_in_decode_order {
+                re_log::debug!(
+                    "Video samples are NOT in decode order. This is weird an inefficient."
+                );
+            }
+        }
+
+        {
+            re_tracing::profile_scope!("Calculate frame numbers");
+            let mut samples_sorted_by_pts = samples.iter_mut().collect::<Vec<_>>();
+            samples_sorted_by_pts.sort_by_key(|s| s.presentation_timestamp);
+            for (frame_nr, sample) in samples_sorted_by_pts.into_iter().enumerate() {
+                sample.frame_nr = frame_nr;
+            }
         }
 
         let samples_statistics = SamplesStatistics::new(&samples);

--- a/crates/viewer/re_data_ui/src/image.rs
+++ b/crates/viewer/re_data_ui/src/image.rs
@@ -85,10 +85,13 @@ pub fn texture_preview_ui(
         )
         .inner
     } else {
+        // TODO(emilk): we should limit the HEIGHT primarily,
+        // since if the image uses up too much vertical space,
+        // it is really annoying in the selection panel.
         let size_range = if ui_layout == UiLayout::Tooltip {
             egui::Rangef::new(64.0, 128.0)
         } else {
-            egui::Rangef::new(240.0, 640.0)
+            egui::Rangef::new(240.0, 320.0)
         };
         let preview_size = Vec2::splat(
             size_range

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -117,7 +117,13 @@ fn video_data_ui(ui: &mut egui::Ui, ui_layout: UiLayout, video_data: &VideoData)
         });
 
         ui.list_item_collapsible_noninteractive_label("Video samples", false, |ui| {
+            egui::Resize::default()
+                .with_stroke(true)
+                .resizable([false, true])
+                .max_height(611.0) // Odd value so the user can see half-hidden rows
+                .show(ui, |ui| {
             samples_table_ui(ui, video_data);
+        });
         });
     }
 }
@@ -128,7 +134,7 @@ fn samples_table_ui(ui: &mut egui::Ui, video_data: &VideoData) {
     egui_extras::TableBuilder::new(ui)
         .auto_shrink([false, true])
         .vscroll(true)
-        .max_scroll_height(800.0)
+        .max_scroll_height(611.0) // Odd value so the user can see half-hidden rows
         .columns(Column::auto(), 8)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
         .header(DesignTokens::table_header_height(), |mut header| {

--- a/crates/viewer/re_data_ui/src/video.rs
+++ b/crates/viewer/re_data_ui/src/video.rs
@@ -122,8 +122,8 @@ fn video_data_ui(ui: &mut egui::Ui, ui_layout: UiLayout, video_data: &VideoData)
                 .resizable([false, true])
                 .max_height(611.0) // Odd value so the user can see half-hidden rows
                 .show(ui, |ui| {
-            samples_table_ui(ui, video_data);
-        });
+                    samples_table_ui(ui, video_data);
+                });
         });
     }
 }


### PR DESCRIPTION
### What
Show frame number in selection panel when selecting a video.

![image](https://github.com/user-attachments/assets/4cab373d-44f0-4bb0-ab9a-a92b10cd0277)

We may want to make it more prominent though? 🤔

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8112?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8112?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8112)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.