### PR TITLE
Don't boost the outlined radius of `GeoPoint`s

### DIFF
--- a/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
+++ b/crates/viewer/re_space_view_map/src/visualizers/geo_points.rs
@@ -132,9 +132,8 @@ impl GeoPointsVisualizer {
         highlight: &SpaceViewHighlights,
     ) -> Result<(), PointCloudDrawDataError> {
         let mut points = re_renderer::PointCloudBuilder::new(render_ctx);
-        points.radius_boost_in_ui_points_for_outlines(
-            re_space_view::SIZE_BOOST_IN_POINTS_FOR_POINT_OUTLINES,
-        );
+        // NOTE: Do not `points.radius_boost_in_ui_points_for_outlines`! The points are not shaded,
+        // so boosting the outline radius would make it erreously large.
 
         for (entity_path, batch) in &self.batches {
             let (positions, radii): (Vec<_>, Vec<_>) = batch


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/1e29f44b-12c7-419f-a76c-a13311d083f1)

After:
![image](https://github.com/user-attachments/assets/e681086c-b685-4ca6-84c3-e686c9395683)


* [x] :dotted_line_face: 