### PR TITLE
OSM example: Fewer log-lines and all static data

### DIFF
--- a/examples/python/openstreetmap_data/openstreetmap_data.py
+++ b/examples/python/openstreetmap_data/openstreetmap_data.py
@@ -56,8 +56,12 @@ def log_node(node: dict[str, Any]) -> None:
     node_id = node["id"]
     entity_path = f"nodes/{node_id}"
 
-    rr.log(entity_path, rr.GeoPoints(lat_lon=[node["lat"], node["lon"]], radii=rr.components.Radius.ui_points(7.0)))
-    rr.log(entity_path, rr.AnyValues(**node.get("tags", {})))
+    rr.log(
+        entity_path,
+        rr.GeoPoints(lat_lon=[node["lat"], node["lon"]], radii=rr.components.Radius.ui_points(7.0)),
+        rr.AnyValues(**node.get("tags", {})),
+        static=True,
+    )
 
 
 def log_way(way: dict[str, Any]) -> None:
@@ -66,14 +70,18 @@ def log_way(way: dict[str, Any]) -> None:
 
     coords = [(node["lat"], node["lon"]) for node in way["geometry"]]
 
-    rr.log(entity_path, rr.GeoLineStrings(lat_lon=[coords], radii=rr.components.Radius.ui_points(2.0)))
-    rr.log(entity_path, rr.AnyValues(**way.get("tags", {})))
+    rr.log(
+        entity_path,
+        rr.GeoLineStrings(lat_lon=[coords], radii=rr.components.Radius.ui_points(2.0)),
+        rr.AnyValues(**way.get("tags", {})),
+        static=True,
+    )
 
 
 def log_data(data: dict[str, Any]) -> None:
     try:
         copyright_text = data["osm3s"]["copyright"]
-        rr.log_components("copyright", [rr.components.Text(copyright_text)])
+        rr.log_components("copyright", [rr.components.Text(copyright_text)], static=True)
     except KeyError:
         pass
 


### PR DESCRIPTION
### What
⬆️

Code more like this:
```python
rr.log(
    entity_path,
    rr.GeoLineStrings(lat_lon=[coords], radii=rr.components.Radius.ui_points(2.0)),
    rr.AnyValues(**way.get("tags", {})),
    static=True,
)
```
![image](https://github.com/user-attachments/assets/a397d771-fa32-46d2-900f-9fd288b2aeba)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8116?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8116?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8116)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.