### PR TITLE
Fix video on web sometimes not showing last few frames for some videos

### DIFF
--- a/crates/store/re_video/src/decode/webcodecs.rs
+++ b/crates/store/re_video/src/decode/webcodecs.rs
@@ -178,6 +178,28 @@ impl AsyncDecoder for WebVideoDecoder {
 
         Ok(())
     }
+
+    /// Called after submitting the last chunk.
+    ///
+    /// Should flush all pending frames.
+    fn end_of_video(&mut self) -> Result<()> {
+        // This returns a promise that resolves once all pending messages have been processed.
+        // https://developer.mozilla.org/en-US/docs/Web/API/VideoDecoder/flush
+        //
+        // It has been observed that if we don't call this, it can happen that the last few frames are never decoded.
+        // Notably, MDN writes about flush methods in general here https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API#processing_model
+        // """
+        // Methods named flush() can be used to wait for the completion of all work that was pending at the time flush() was called.
+        // However, it should generally only be called once all desired work is queued.
+        // It is not intended to force progress at regular intervals.
+        // Calling it unnecessarily will affect encoder quality and cause decoders to require the next input to be a key frame.
+        // """
+        // -> Nothing of this indicates that we _have_ to call it and rather discourages it,
+        // but it points out that it might be a good idea once "all desired work is queued".
+        let _ = self.decoder.flush();
+
+        Ok(())
+    }
 }
 
 fn init_video_decoder(


### PR DESCRIPTION
### What

* part of #8073

Tested on top of https://github.com/rerun-io/rerun/pull/8111 in Chrome @ Windows with a video that would previously not show the last two frames.

![image](https://github.com/user-attachments/assets/f804cc94-3870-46a9-a58d-6d4daf76f677)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8117?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8117?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8117)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.