### PR TITLE
Much nicer looking error and warning messages

### DIFF
--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -3,7 +3,7 @@ use egui::NumExt;
 use re_chunk_store::UnitChunkShared;
 use re_entity_db::InstancePath;
 use re_log_types::{ComponentPath, Instance, TimeInt};
-use re_ui::{ContextExt as _, SyntaxHighlighting as _};
+use re_ui::{ContextExt as _, SyntaxHighlighting as _, UiExt};
 use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
@@ -81,11 +81,11 @@ impl<'a> DataUi for ComponentPathLatestAtResults<'a> {
                         *component_name,
                     );
                 if temporal_message_count > 0 {
-                    ui.label(ui.ctx().error_text(format!(
+                    ui.error_label(&format!(
                         "Static component has {} event{} logged on timelines",
                         temporal_message_count,
                         if temporal_message_count > 1 { "s" } else { "" }
-                    )))
+                    ))
                     .on_hover_text(
                         "Components should be logged either as static or on timelines, but \
                         never both. Values for static components logged to timelines cannot be \

--- a/crates/viewer/re_data_ui/src/component_path.rs
+++ b/crates/viewer/re_data_ui/src/component_path.rs
@@ -1,5 +1,5 @@
 use re_log_types::ComponentPath;
-use re_ui::ContextExt as _;
+use re_ui::UiExt;
 use re_viewer_context::{UiLayout, ViewerContext};
 
 use super::DataUi;
@@ -47,10 +47,7 @@ impl DataUi for ComponentPath {
                     ));
                 }
             } else {
-                ui.label(
-                    ui.ctx()
-                        .error_text(format!("Unknown component path: {self}")),
-                );
+                ui.error_label(&format!("Unknown component path: {self}"));
             }
         }
     }

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -10,7 +10,7 @@ use re_types::{
     image::ImageKind,
     static_assert_struct_has_fields, Archetype, ComponentName, Loggable,
 };
-use re_ui::{ContextExt as _, UiExt as _};
+use re_ui::UiExt as _;
 use re_viewer_context::{
     gpu_bridge::image_data_range_heuristic, ColormapWithRange, HoverHighlight, ImageInfo,
     ImageStatsCache, Item, UiLayout, ViewerContext,
@@ -46,11 +46,7 @@ impl DataUi for InstancePath {
                 .store()
                 .all_components_on_timeline(&query.timeline(), entity_path)
         } else {
-            ui_layout.label(
-                ui,
-                ui.ctx()
-                    .error_text(format!("Unknown entity: {entity_path:?}")),
-            );
+            ui.error_label(&format!("Unknown entity: {entity_path:?}"));
             return;
         };
         let Some(components) = component else {

--- a/crates/viewer/re_space_view_tensor/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_tensor/src/space_view_class.rs
@@ -13,7 +13,7 @@ use re_types::{
     datatypes::{TensorData, TensorDimension},
     SpaceViewClassIdentifier, View,
 };
-use re_ui::{list_item, ContextExt as _, UiExt as _};
+use re_ui::{list_item, UiExt as _};
 use re_viewer_context::{
     gpu_bridge, ApplicableEntities, ColormapWithRange, IdentifiedViewSystem as _,
     IndicatedEntities, PerVisualizer, SpaceViewClass, SpaceViewClassRegistryError, SpaceViewId,
@@ -282,7 +282,7 @@ impl TensorSpaceView {
             if let Err(err) =
                 self.tensor_slice_ui(ctx, ui, state, view_id, dimension_labels, &slice_selection)
             {
-                ui.label(ui.ctx().error_text(err.to_string()));
+                ui.error_label(&err.to_string());
             }
         });
 

--- a/crates/viewer/re_ui/examples/re_ui_example/main.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/main.rs
@@ -457,14 +457,19 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
         _tile_id: egui_tiles::TileId,
         _pane: &mut Tab,
     ) -> egui_tiles::UiResponse {
-        egui::warn_if_debug_build(ui);
-        ui.label("Hover me for a tooltip")
-            .on_hover_text("This is a tooltip");
+        egui::Frame::none().inner_margin(4.0).show(ui, |ui| {
+            egui::warn_if_debug_build(ui);
+            ui.label("Hover me for a tooltip")
+                .on_hover_text("This is a tooltip");
 
-        ui.label(
-            egui::RichText::new("Welcome to the ReUi example")
-                .text_style(DesignTokens::welcome_screen_h1()),
-        );
+            ui.label(
+                egui::RichText::new("Welcome to the ReUi example")
+                    .text_style(DesignTokens::welcome_screen_h1()),
+            );
+
+            ui.error_label("This is an example of a long error label.");
+            ui.warning_label("This is an example of a long warning label.");
+        });
 
         Default::default()
     }

--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -310,7 +310,14 @@ impl UICommand {
             Self::ToggleSelectionPanel => Some(ctrl_shift(Key::S)),
             Self::ToggleTimePanel => Some(ctrl_shift(Key::T)),
             Self::ToggleChunkStoreBrowser => Some(ctrl_shift(Key::D)),
-            Self::Settings => None,
+            Self::Settings => {
+                if cfg!(target_os = "macos") {
+                    Some(KeyboardShortcut::new(Modifiers::MAC_CMD, Key::Comma))
+                } else {
+                    // TODO(emilk): shortcut for web and non-mac too
+                    None
+                }
+            }
 
             #[cfg(debug_assertions)]
             Self::ToggleBlueprintInspectionPanel => Some(ctrl_shift(Key::I)),

--- a/crates/viewer/re_ui/src/context_ext.rs
+++ b/crates/viewer/re_ui/src/context_ext.rs
@@ -59,17 +59,26 @@ pub trait ContextExt {
         // egui::Stroke::new(stroke_width, color)
     }
 
+    /// Text colored to indicate success.
     #[must_use]
     fn success_text(&self, text: impl Into<String>) -> egui::RichText {
         egui::RichText::new(text).color(SUCCESS_COLOR)
     }
 
+    /// Text colored to indicate a warning.
+    ///
+    /// For most cases, you should use [`crate::UiExt::warning_label`] instead,
+    /// which has a nice fat border around it.
     #[must_use]
     fn warning_text(&self, text: impl Into<String>) -> egui::RichText {
         let style = self.ctx().style();
         egui::RichText::new(text).color(style.visuals.warn_fg_color)
     }
 
+    /// Text colored to indicate an error.
+    ///
+    /// For most cases, you should use [`crate::UiExt::error_label`] instead,
+    /// which has a nice fat border around it.
     #[must_use]
     fn error_text(&self, text: impl Into<String>) -> egui::RichText {
         let style = self.ctx().style();

--- a/crates/viewer/re_ui/src/context_ext.rs
+++ b/crates/viewer/re_ui/src/context_ext.rs
@@ -70,22 +70,10 @@ pub trait ContextExt {
         egui::RichText::new(text).color(style.visuals.warn_fg_color)
     }
 
-    /// NOTE: duplicated in [`Self::error_text_format`]
     #[must_use]
     fn error_text(&self, text: impl Into<String>) -> egui::RichText {
         let style = self.ctx().style();
         egui::RichText::new(text).color(style.visuals.error_fg_color)
-    }
-
-    /// NOTE: duplicated in [`Self::error_text`]
-    fn error_text_format(&self) -> egui::TextFormat {
-        let style = self.ctx().style();
-        let font_id = egui::TextStyle::Body.resolve(&style);
-        egui::TextFormat {
-            font_id,
-            color: style.visuals.error_fg_color,
-            ..Default::default()
-        }
     }
 
     fn top_bar_style(&self, style_like_web: bool) -> TopBarStyle {

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -243,6 +243,7 @@ impl DesignTokens {
         egui_style.visuals.image_loading_spinners = false;
 
         egui_style.visuals.error_fg_color = egui::Color32::from_rgb(0xAB, 0x01, 0x16);
+        egui_style.visuals.warn_fg_color = egui::Color32::from_rgb(0xFF, 0x7A, 0x0C);
 
         ctx.set_style(egui_style);
     }

--- a/crates/viewer/re_ui/src/design_tokens.rs
+++ b/crates/viewer/re_ui/src/design_tokens.rs
@@ -242,6 +242,8 @@ impl DesignTokens {
 
         egui_style.visuals.image_loading_spinners = false;
 
+        egui_style.visuals.error_fg_color = egui::Color32::from_rgb(0xAB, 0x01, 0x16);
+
         ctx.set_style(egui_style);
     }
 

--- a/crates/viewer/re_ui/src/toasts.rs
+++ b/crates/viewer/re_ui/src/toasts.rs
@@ -5,9 +5,7 @@ use std::collections::HashMap;
 use egui::Color32;
 
 pub const INFO_COLOR: Color32 = Color32::from_rgb(0, 155, 255);
-pub const WARNING_COLOR: Color32 = Color32::from_rgb(255, 212, 0);
-pub const ERROR_COLOR: Color32 = Color32::from_rgb(255, 32, 0);
-pub const SUCCESS_COLOR: Color32 = Color32::from_rgb(0, 255, 32);
+pub const SUCCESS_COLOR: Color32 = Color32::from_rgb(0, 240, 32);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ToastKind {
@@ -139,8 +137,8 @@ fn default_toast_contents(ui: &mut egui::Ui, toast: &Toast) -> egui::Response {
 
                 if toast.options.show_icon {
                     let (icon, icon_color) = match toast.kind {
-                        ToastKind::Warning => ("⚠", WARNING_COLOR),
-                        ToastKind::Error => ("❗", ERROR_COLOR),
+                        ToastKind::Warning => ("⚠", ui.style().visuals.warn_fg_color),
+                        ToastKind::Error => ("❗", ui.style().visuals.error_fg_color),
                         ToastKind::Success => ("✔", SUCCESS_COLOR),
                         _ => ("ℹ", INFO_COLOR),
                     };

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -8,7 +8,7 @@ use egui::{
 use crate::{
     design_tokens, icons, list_item,
     list_item::{LabelContent, ListItem},
-    ContextExt, DesignTokens, Icon, LabelStyle,
+    DesignTokens, Icon, LabelStyle,
 };
 
 static FULL_SPAN_TAG: &str = "rerun_full_span";

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -53,23 +53,26 @@ pub trait UiExt {
     fn ui(&self) -> &egui::Ui;
     fn ui_mut(&mut self) -> &mut egui::Ui;
 
-    /// Show the label with a success color.
-    fn success_label(&mut self, text: &str) -> egui::Response {
-        let label = egui::Label::new(self.ui().ctx().success_text(text));
-        self.ui_mut().add(label)
-    }
-
-    /// Shows a warning label.
+    /// Shows a warning label with a large border.
+    ///
+    /// If you don't want a border, use [`crate::ContextExt::warning_text`].
     fn warning_label(&mut self, warning_text: &str) -> egui::Response {
-        let label = egui::Label::new(self.ui().ctx().warning_text(warning_text));
-        self.ui_mut().add(label)
+        let ui = self.ui_mut();
+        warning_or_error_label(
+            ui,
+            ui.style().visuals.warn_fg_color,
+            warning_text,
+            warning_text,
+        )
     }
 
-    /// Shows a small error label with the given text on hover and copies the text to the clipboard on click.
+    /// Shows a small error label with the given text on hover and copies the text to the clipboard on click with a large border.
+    ///
+    /// This has a large border! If you don't want a border, use [`crate::ContextExt::error_text`].
     fn error_with_details_on_hover(&mut self, error_text: &str) -> egui::Response {
         let ui = self.ui_mut();
         warning_or_error_label(ui, ui.style().visuals.error_fg_color, "Error", error_text)
-        }
+    }
 
     fn error_label_background_color(&self) -> egui::Color32 {
         error_label_bg_color(self.ui().style().visuals.error_fg_color)
@@ -79,6 +82,8 @@ pub trait UiExt {
     ///
     /// Use this only if the error message is short, or you have a lot of room.
     /// Otherwise, use [`Self::error_with_details_on_hover`].
+    ///
+    /// This has a large border! If you don't want a border, use [`crate::ContextExt::error_text`].
     fn error_label(&mut self, error_text: &str) -> egui::Response {
         let ui = self.ui_mut();
         warning_or_error_label(

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -31,7 +31,7 @@ fn notification_label(
         .fill(error_label_bg_color(fg_color))
         .rounding(4.0)
         .inner_margin(3.0)
-        .outer_margin(1.0) // HACK because we set clip_rect_margin. TODO(emilk): https://github.com/emilk/egui/issues/4019
+        .outer_margin(1.0) // Needed because we set clip_rect_margin. TODO(emilk): https://github.com/emilk/egui/issues/4019
         .show(ui, |ui| {
             ui.horizontal(|ui| {
                 ui.spacing_mut().item_spacing.x = 4.0;

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -204,40 +204,39 @@ fn video_section_ui(ui: &mut Ui, app_options: &mut AppOptions) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn ffmpeg_path_status_ui(ui: &mut Ui, app_options: &AppOptions) {
+    use re_ui::ContextExt as _;
     use re_video::decode::{FFmpegVersion, FFmpegVersionParseError};
 
     let path = app_options
         .video_decoder_override_ffmpeg_path
         .then(|| std::path::Path::new(&app_options.video_decoder_ffmpeg_path));
 
-    if let Some(path) = path {
-        if !path.is_file() {
-            ui.error_label("The specified FFmpeg binary path does not exist or is not a file.");
-            return;
-        }
-    }
+    let ctx = ui.ctx();
+    let label_text = if path.is_some_and(|path| !path.is_file()) {
+        ctx.error_text("The specified FFmpeg binary path does not exist or is not a file.")
+    } else {
+        let res = FFmpegVersion::for_executable(path);
 
-    let res = FFmpegVersion::for_executable(path);
-    match res {
-        Ok(version) => {
-            if version.is_compatible() {
-                ui.success_label(&format!("FFmpeg found (version {version})"));
-            } else {
-                ui.error_label(&format!("Incompatible FFmpeg version: {version}"));
+        match res {
+            Ok(version) => {
+                if version.is_compatible() {
+                    ctx.success_text(format!("FFmpeg found (version {version})"))
+                } else {
+                    ctx.error_text(format!("Incompatible FFmpeg version: {version}"))
+                }
             }
-        }
-        Err(FFmpegVersionParseError::ParseVersion { raw_version }) => {
-            // We make this one a warning instead of an error because version parsing is flaky, and
-            // it might end up still working.
-            ui.warning_label(&format!(
-                "FFmpeg binary found but unable to parse version: {raw_version}"
-            ));
-        }
+            Err(FFmpegVersionParseError::ParseVersion { raw_version }) => {
+                // We make this one a warning instead of an error because version parsing is flaky, and
+                // it might end up still working.
+                ctx.warning_text(format!(
+                    "FFmpeg binary found but unable to parse version: {raw_version}"
+                ))
+            }
 
-        Err(err) => {
-            ui.error_label(&format!("Unable to check FFmpeg version: {err}"));
+            Err(err) => ctx.error_text(format!("Unable to check FFmpeg version: {err}")),
         }
-    }
+    };
+    ui.label(label_text);
 }
 
 fn separator_with_some_space(ui: &mut egui::Ui) {

--- a/crates/viewer/re_viewer/src/ui/settings_screen.rs
+++ b/crates/viewer/re_viewer/src/ui/settings_screen.rs
@@ -204,39 +204,38 @@ fn video_section_ui(ui: &mut Ui, app_options: &mut AppOptions) {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn ffmpeg_path_status_ui(ui: &mut Ui, app_options: &AppOptions) {
-    use re_ui::ContextExt as _;
     use re_video::decode::{FFmpegVersion, FFmpegVersionParseError};
 
     let path = app_options
         .video_decoder_override_ffmpeg_path
         .then(|| std::path::Path::new(&app_options.video_decoder_ffmpeg_path));
 
-    let ctx = ui.ctx();
-    let label_text = if path.is_some_and(|path| !path.is_file()) {
-        ctx.error_text("The specified FFmpeg binary path does not exist or is not a file.")
+    if path.is_some_and(|path| !path.is_file()) {
+        ui.error_label("The specified FFmpeg binary path does not exist or is not a file.");
     } else {
         let res = FFmpegVersion::for_executable(path);
 
         match res {
             Ok(version) => {
                 if version.is_compatible() {
-                    ctx.success_text(format!("FFmpeg found (version {version})"))
+                    ui.success_label(&format!("FFmpeg found (version {version})"));
                 } else {
-                    ctx.error_text(format!("Incompatible FFmpeg version: {version}"))
+                    ui.error_label(&format!("Incompatible FFmpeg version: {version}"));
                 }
             }
             Err(FFmpegVersionParseError::ParseVersion { raw_version }) => {
                 // We make this one a warning instead of an error because version parsing is flaky, and
                 // it might end up still working.
-                ctx.warning_text(format!(
+                ui.warning_label(&format!(
                     "FFmpeg binary found but unable to parse version: {raw_version}"
-                ))
+                ));
             }
 
-            Err(err) => ctx.error_text(format!("Unable to check FFmpeg version: {err}")),
+            Err(err) => {
+                ui.error_label(&format!("Unable to check FFmpeg version: {err}"));
+            }
         }
     };
-    ui.label(label_text);
 }
 
 fn separator_with_some_space(ui: &mut egui::Ui) {


### PR DESCRIPTION
### What
* Closes https://github.com/rerun-io/rerun/issues/8091

## Before
![image](https://github.com/user-attachments/assets/e7df583a-0032-41e9-87b7-0a2a8a84579c)
![image](https://github.com/user-attachments/assets/8ca98429-e00d-4925-96c0-edfe0d986e11)
![image](https://github.com/user-attachments/assets/345d7023-066f-4741-a121-8ab372589ed6)


## After
![image](https://github.com/user-attachments/assets/1c86d97f-3fac-4f70-9ac5-d67b3418cf3d)
![image](https://github.com/user-attachments/assets/03f6d1e7-6474-43d3-aae3-d4573c416ee5)
![image](https://github.com/user-attachments/assets/07260f8b-a8a2-4223-92e5-da67521e88a6)


### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8127?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8127?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8127)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.