### PR TITLE
Improve NuScenes example with more geo data & blueprint

### DIFF
--- a/examples/python/nuscenes_dataset/README.md
+++ b/examples/python/nuscenes_dataset/README.md
@@ -2,7 +2,7 @@
 title = "nuScenes"
 tags = ["Lidar", "3D", "2D", "Object detection", "Pinhole camera", "Blueprint"]
 thumbnail = "https://static.rerun.io/nuscenes_dataset/3724a84d6e95f15a71db2ccc443fb67bfae58843/480w.png"
-thumbnail_dimensions = [480, 480]
+thumbnail_dimensions = [480, 301]
 channel = "release"
 build_args = ["--seconds=5"]
 -->

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -313,7 +313,12 @@ def main() -> None:
     ]
     blueprint = rrb.Vertical(
         rrb.Horizontal(
-            rrb.Spatial3DView(name="3D", origin="world"),
+            rrb.Spatial3DView(
+                name="3D",
+                origin="world",
+                # Set the image plane distance to 5m for all camera visualizations.
+                defaults=[rr.components.ImagePlaneDistance(5.0)],
+            ),
             rrb.Vertical(
                 rrb.TextDocumentView(origin="description", name="Description"),
                 rrb.MapView(

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -144,7 +144,7 @@ def log_lidar_and_ego_pose(
         # log GPS data
         (lat, long) = derive_latlon(location, ego_pose)
         rr.log(
-            "world/ego_vehicle/gps",
+            "world/ego_vehicle",
             rr.GeoPoints(lat_lon=[[lat, long]]),
         )
 
@@ -305,7 +305,7 @@ def main() -> None:
             rrb.Vertical(
                 rrb.TextDocumentView(origin="description", name="Description"),
                 rrb.MapView(
-                    origin="world/ego_vehicle/gps",
+                    origin="world/ego_vehicle",
                     name="MapView",
                     zoom=rrb.archetypes.MapZoom(18.0),
                     background=rrb.archetypes.MapBackground(rrb.components.MapProvider.OpenStreetMap),

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -294,6 +294,9 @@ def main() -> None:
         rrb.Spatial2DView(
             name=sensor_name,
             origin=f"world/ego_vehicle/{sensor_name}",
+            contents=["$origin/**", "world/anns"],
+            # TODO(#6670): Can't specify rr.components.FillMode.MajorWireframe right now, need to use batch type instead.
+            overrides={"world/anns": [rr.components.FillModeBatch("majorwireframe")]},
         )
         for sensor_name in nuscene_sensor_names(nusc, args.scene_name)
     ]

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -141,6 +141,7 @@ def log_lidar_and_ego_pose(
             rr.Transform3D(
                 translation=ego_pose["translation"],
                 rotation=rr.Quaternion(xyzw=rotation_xyzw),
+                axis_length=10.0,  # The length of the visualized axis.
                 from_parent=False,
             ),
             rr.GeoPoints(lat_lon=position_lat_lon, radii=rr.Radius.ui_points(8.0), colors=0xFF0000FF),

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/__main__.py
@@ -143,14 +143,14 @@ def log_lidar_and_ego_pose(
                 rotation=rr.Quaternion(xyzw=rotation_xyzw),
                 from_parent=False,
             ),
-            rr.GeoPoints(lat_lon=position_lat_lon, colors=0xFF0000FF),
+            rr.GeoPoints(lat_lon=position_lat_lon, radii=rr.Radius.ui_points(8.0), colors=0xFF0000FF),
         )
         # TODO(#6889): We don't want the radius for the trajectory line to be the same as the radius of the points.
         # However, rr.GeoPoints uses the same `rr.components.Radius` for this, so these two archetypes would influence each other
         # if logged on the same entity. In the future, they will have different tags, which will allow them to live side by side.
         rr.log(
             "world/ego_vehicle/trajectory",
-            rr.GeoLineStrings(lat_lon=ego_trajectory_lat_lon, radii=1.0, colors=0xFF0000FF),
+            rr.GeoLineStrings(lat_lon=ego_trajectory_lat_lon, radii=rr.Radius.ui_points(1.0), colors=0xFF0000FF),
         )
 
         current_lidar_token = sample_data["next"]
@@ -241,9 +241,8 @@ def log_annotations(location: str, first_sample_token: str, nusc: nuscenes.NuSce
         )
         current_sample_token = sample_data["next"]
 
-    # skipping for now since labels take too much space in 3D view (see https://github.com/rerun-io/rerun/issues/4451)
-    # annotation_context = [(i, label) for label, i in label2id.items()]
-    # rr.log("world/anns", rr.AnnotationContext(annotation_context), static=True)
+    annotation_context = [(i, label) for label, i in label2id.items()]
+    rr.log("world/anns", rr.AnnotationContext(annotation_context), static=True)
 
 
 def log_sensor_calibration(sample_data: dict[str, Any], nusc: nuscenes.NuScenes) -> None:

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
@@ -18,7 +18,7 @@ MINISPLIT_SCENES = [
     "scene-0796",  # Drive straight only.
     "scene-0916",  # Driving in a circle on a parking lot.
     "scene-1077",  # Straight drive on an artery road at night.
-    "scene-1094",  # Slow drive drive at night.
+    "scene-1094",  # Slow drive at night.
     "scene-1100",  # Standing on front of traffic light at night.
 ]
 MINISPLIT_URL = "https://www.nuscenes.org/data/v1.0-mini.tgz"

--- a/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
+++ b/examples/python/nuscenes_dataset/nuscenes_dataset/download_dataset.py
@@ -10,16 +10,16 @@ import requests
 import tqdm
 
 MINISPLIT_SCENES = [
-    "scene-0061",
-    "scene-0103",
-    "scene-0553",
-    "scene-0655",
-    "scene-0757",
-    "scene-0796",
-    "scene-0916",
-    "scene-1077",
-    "scene-1094",
-    "scene-1100",
+    "scene-0061",  # Driving around a corner.
+    "scene-0103",  # Driving straight on a city road.
+    "scene-0553",  # Standing in front of a traffic light.
+    "scene-0655",  # Drive straight only.
+    "scene-0757",  # Goes straight rather slowly.
+    "scene-0796",  # Drive straight only.
+    "scene-0916",  # Driving in a circle on a parking lot.
+    "scene-1077",  # Straight drive on an artery road at night.
+    "scene-1094",  # Slow drive drive at night.
+    "scene-1100",  # Standing on front of traffic light at night.
 ]
 MINISPLIT_URL = "https://www.nuscenes.org/data/v1.0-mini.tgz"
 


### PR DESCRIPTION
### What

https://github.com/user-attachments/assets/0d09ae1b-100e-4c9e-bca6-de0f38dacff5

Draft todo:
* [x] update thumbnail screenshots
* [x] ?

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8130?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8130?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8130)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.