### PR TITLE
Update env var documentation in `rerun --help`

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -28,14 +28,22 @@ The Rerun command-line interface:
 "#;
 
 // Place the important help _last_, to make it most visible in the terminal.
-const EXAMPLES: &str = r#"
+const ENVIRONMENT_VARIABLES_AND_EXAMPLES: &str = r#"
 Environment variables:
+    RERUN_CHUNK_MAX_BYTES     Maximum chunk size thershold for the compactor.            
+    RERUN_CHUNK_MAX_ROWS      Maximum chunk row count threshold for the compactor (sorted chunks). 
+    RERUN_CHUNK_MAX_ROWS_IF_UNSORTED
+                              Maximum chunk row count threshold for the compactor (unsorted chunks).
     RERUN_SHADER_PATH         The search path for shader/shader-imports. Only available in developer builds.
-    RERUN_TRACK_ALLOCATIONS   Track memory allocations to diagnose memory leaks in the viewer. WARNING: slows down the viewer by a lot!
+    RERUN_TRACK_ALLOCATIONS   Track memory allocations to diagnose memory leaks in the viewer.
+                              WARNING: slows down the viewer by a lot!
+    RERUN_MAPBOX_ACCESS_TOKEN The Mapbox access token to use the Mapbox-provided backgrounds in the map view.                               
     RUST_LOG                  Change the log level of the viewer, e.g. `RUST_LOG=debug`.
     WGPU_BACKEND              Overwrites the graphics backend used, must be one of `vulkan`, `metal` or `gl`.
-                              Default is `vulkan` everywhere except on Mac where we use `metal`. What is supported depends on your OS.
-    WGPU_POWER_PREF           Overwrites the power setting used for choosing a graphics adapter, must be `high` or `low`. (Default is `high`)
+                              Default is `vulkan` everywhere except on Mac where we use `metal`. What is
+                              supported depends on your OS.
+    WGPU_POWER_PREF           Overwrites the power setting used for choosing a graphics adapter, must be `high`
+                              or `low`. (Default is `high`)
 
 
 Examples:
@@ -65,7 +73,7 @@ Examples:
 #[clap(
     long_about = LONG_ABOUT,
     // Place most of the help last, as that is most visible in the terminal.
-    after_long_help = EXAMPLES
+    after_long_help = ENVIRONMENT_VARIABLES_AND_EXAMPLES
 )]
 struct Args {
     // Note: arguments are sorted lexicographically for nicer `--help` message.

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -30,14 +30,14 @@ The Rerun command-line interface:
 // Place the important help _last_, to make it most visible in the terminal.
 const ENVIRONMENT_VARIABLES_AND_EXAMPLES: &str = r#"
 Environment variables:
-    RERUN_CHUNK_MAX_BYTES     Maximum chunk size thershold for the compactor.            
-    RERUN_CHUNK_MAX_ROWS      Maximum chunk row count threshold for the compactor (sorted chunks). 
+    RERUN_CHUNK_MAX_BYTES     Maximum chunk size threshold for the compactor.
+    RERUN_CHUNK_MAX_ROWS      Maximum chunk row count threshold for the compactor (sorted chunks).
     RERUN_CHUNK_MAX_ROWS_IF_UNSORTED
                               Maximum chunk row count threshold for the compactor (unsorted chunks).
     RERUN_SHADER_PATH         The search path for shader/shader-imports. Only available in developer builds.
     RERUN_TRACK_ALLOCATIONS   Track memory allocations to diagnose memory leaks in the viewer.
                               WARNING: slows down the viewer by a lot!
-    RERUN_MAPBOX_ACCESS_TOKEN The Mapbox access token to use the Mapbox-provided backgrounds in the map view.                               
+    RERUN_MAPBOX_ACCESS_TOKEN The Mapbox access token to use the Mapbox-provided backgrounds in the map view.
     RUST_LOG                  Change the log level of the viewer, e.g. `RUST_LOG=debug`.
     WGPU_BACKEND              Overwrites the graphics backend used, must be one of `vulkan`, `metal` or `gl`.
                               Default is `vulkan` everywhere except on Mac where we use `metal`. What is


### PR DESCRIPTION
### What

- Part of https://github.com/rerun-io/rerun/issues/3869

```
$ rerun --help
[...]
Environment variables:
    RERUN_CHUNK_MAX_BYTES     Maximum chunk size thershold for the compactor.            
    RERUN_CHUNK_MAX_ROWS      Maximum chunk row count threshold for the compactor (sorted chunks). 
    RERUN_CHUNK_MAX_ROWS_IF_UNSORTED
                              Maximum chunk row count threshold for the compactor (unsorted chunks).
    RERUN_SHADER_PATH         The search path for shader/shader-imports. Only available in developer builds.
    RERUN_TRACK_ALLOCATIONS   Track memory allocations to diagnose memory leaks in the viewer.
                              WARNING: slows down the viewer by a lot!
    RERUN_MAPBOX_ACCESS_TOKEN The Mapbox access token to use the Mapbox-provided backgrounds in the map view.                               
    RUST_LOG                  Change the log level of the viewer, e.g. `RUST_LOG=debug`.
    WGPU_BACKEND              Overwrites the graphics backend used, must be one of `vulkan`, `metal` or `gl`.
                              Default is `vulkan` everywhere except on Mac where we use `metal`. What is
                              supported depends on your OS.
    WGPU_POWER_PREF           Overwrites the power setting used for choosing a graphics adapter, must be `high`
                              or `low`. (Default is `high`)
[...]
```

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8133?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8133?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8133)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.