### PR TITLE
Show data density graph in collapsed time panel

### DIFF
--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -158,6 +158,8 @@ impl TimePanel {
             return;
         }
 
+        self.data_density_graph_painter.begin_frame(ui.ctx());
+
         // Naturally, many parts of the time panel need the time control.
         // Copy it once, read/edit, and then write back at the end if there was a change.
         let time_ctrl_before = rec_cfg.time_ctrl.read().clone();
@@ -343,8 +345,6 @@ impl TimePanel {
         time_ctrl: &mut TimeControl,
     ) {
         re_tracing::profile_function!();
-
-        self.data_density_graph_painter.begin_frame(ui.ctx());
 
         //               |timeline            |
         // ------------------------------------

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -1049,7 +1049,7 @@ fn collapsed_time_marker_and_time(
                 ui.painter(),
                 ui,
                 &time_ranges_ui,
-                time_range_rect.shrink2(egui::vec2(0.0, 8.0)),
+                time_range_rect.shrink2(egui::vec2(0.0, 10.0)),
                 &TimePanelItem::entity_path(EntityPath::root()),
             );
 

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -298,7 +298,13 @@ impl TimePanel {
                         entity_db.times_per_timeline(),
                         ui,
                     );
-                    collapsed_time_marker_and_time(ui, ctx, entity_db, time_ctrl);
+                    collapsed_time_marker_and_time(
+                        ui,
+                        ctx,
+                        &mut self.data_density_graph_painter,
+                        entity_db,
+                        time_ctrl,
+                    );
                 });
             });
         } else {
@@ -318,7 +324,13 @@ impl TimePanel {
                 self.time_control_ui.fps_ui(time_ctrl, ui);
             }
 
-            collapsed_time_marker_and_time(ui, ctx, entity_db, time_ctrl);
+            collapsed_time_marker_and_time(
+                ui,
+                ctx,
+                &mut self.data_density_graph_painter,
+                entity_db,
+                time_ctrl,
+            );
         }
     }
 
@@ -983,6 +995,7 @@ fn highlight_timeline_row(
 fn collapsed_time_marker_and_time(
     ui: &mut egui::Ui,
     ctx: &ViewerContext<'_>,
+    data_density_graph_painter: &mut data_density_graph::DataDensityGraphPainter,
     entity_db: &re_entity_db::EntityDb,
     time_ctrl: &mut TimeControl,
 ) {
@@ -1027,6 +1040,19 @@ fn collapsed_time_marker_and_time(
                 time_range_rect.center().y,
                 ui.visuals().widgets.noninteractive.fg_stroke,
             );
+
+            data_density_graph::data_density_graph_ui(
+                data_density_graph_painter,
+                ctx,
+                time_ctrl,
+                entity_db,
+                ui.painter(),
+                ui,
+                &time_ranges_ui,
+                time_range_rect.shrink2(egui::vec2(0.0, 8.0)),
+                &TimePanelItem::entity_path(EntityPath::root()),
+            );
+
             time_marker_ui(
                 &time_ranges_ui,
                 time_ctrl,

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -1005,6 +1005,8 @@ fn collapsed_time_marker_and_time(
         time_range_rect.max.x -= space_needed_for_current_time;
 
         if time_range_rect.width() > 50.0 {
+            ui.allocate_rect(time_range_rect, egui::Sense::hover());
+
             let time_ranges_ui =
                 initialize_time_ranges_ui(entity_db, time_ctrl, time_range_rect.x_range(), None);
             time_ranges_ui.snap_time_control(time_ctrl);
@@ -1033,8 +1035,6 @@ fn collapsed_time_marker_and_time(
                 &painter,
                 &time_range_rect,
             );
-
-            ui.allocate_rect(time_range_rect, egui::Sense::hover());
         }
     }
 


### PR DESCRIPTION
### What
![image](https://github.com/user-attachments/assets/fcb58ca4-9908-46e8-b29b-6b2704c04ba4)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8137?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8137?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8137)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.