### PR TITLE
gRPC spec update - common application level error

### DIFF
--- a/crates/store/re_protos/proto/rerun/v0/common.proto
+++ b/crates/store/re_protos/proto/rerun/v0/common.proto
@@ -161,25 +161,3 @@ enum SparseFillStrategy {
     NONE = 0;
     LATEST_AT_GLOBAL = 1;
 }
-
-// Application level error - use as `details` in the `google.rpc.Status` message
-message RemoteStoreError {
-    // error code
-    ErrorCode code = 1;
-    // unique identifier associated with the request (e.g. recording id, recording storage url)
-    string id = 2;
-    // human readable details about the error
-    string message = 3;
-}
-
-// Error codes for application level errors
-enum ErrorCode {
-    // unused
-    _UNUSED = 0;
-
-    // object store access error
-    OBJECT_STORE_ERROR = 1;
-
-    // metadata database access error
-    METADATA_DB_ERROR = 2;
-}

--- a/crates/store/re_protos/proto/rerun/v0/common.proto
+++ b/crates/store/re_protos/proto/rerun/v0/common.proto
@@ -162,6 +162,16 @@ enum SparseFillStrategy {
     LATEST_AT_GLOBAL = 1;
 }
 
+// Application level error - use as `details` in the `google.rpc.Status` message
+message RemoteStoreError {
+    // error code
+    ErrorCode code = 1;
+    // unique identifier associated with the request (e.g. recording id, recording storage url)
+    string id = 2;
+    // human readable details about the error
+    string message = 3;
+}
+
 // Error codes for application level errors
 enum ErrorCode {
     // unused

--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -152,4 +152,7 @@ enum ErrorCode {
 
     // metadata database access error
     METADATA_DB_ERROR = 2;
+
+    // Encoding / decoding error
+    CODEC_ERROR = 3;
 }

--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -45,16 +45,6 @@ message RegisterRecordingResponse {
     RecordingMetadata metadata = 2;
 }
 
-// Server can include details about the error as part of gRPC error (Status)
-message RegistrationError {
-    // error code
-    ErrorCode code = 1;
-    // storage url of the recording that failed to register
-    string storage_url = 2;
-    // human readable details about the error
-    string message = 3;
-}
-
 // ---------------- GetRecordingMetadata  -----------------
 
 message GetRecordingMetadataRequest {

--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -131,3 +131,25 @@ message FetchRecordingResponse {
     // payload is raw bytes that the relevant codec can interpret
     bytes payload = 2;
 }
+
+// Application level error - use as `details` in the `google.rpc.Status` message
+message RemoteStoreError {
+    // error code
+    ErrorCode code = 1;
+    // unique identifier associated with the request (e.g. recording id, recording storage url)
+    string id = 2;
+    // human readable details about the error
+    string message = 3;
+}
+
+// Error codes for application level errors
+enum ErrorCode {
+    // unused
+    _UNUSED = 0;
+
+    // object store access error
+    OBJECT_STORE_ERROR = 1;
+
+    // metadata database access error
+    METADATA_DB_ERROR = 2;
+}

--- a/crates/store/re_protos/src/lib.rs
+++ b/crates/store/re_protos/src/lib.rs
@@ -333,13 +333,13 @@ pub mod v0 {
     }
 
     // ------- Application level errors -------
-    impl std::error::Error for RegistrationError {}
+    impl std::error::Error for RemoteStoreError {}
 
-    impl std::fmt::Display for RegistrationError {
+    impl std::fmt::Display for RemoteStoreError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.write_fmt(format_args!(
-                "Failed to register recording: {}, error code: {}, error message: {}",
-                self.storage_url, self.code, self.message
+                "Remote store error. Request identifier: {}, error msg: {}, error code: {}",
+                self.id, self.message, self.code
             ))
         }
     }

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -397,6 +397,8 @@ pub enum ErrorCode {
     ObjectStoreError = 1,
     /// metadata database access error
     MetadataDbError = 2,
+    /// Encoding / decoding error
+    CodecError = 3,
 }
 impl ErrorCode {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -408,6 +410,7 @@ impl ErrorCode {
             Self::Unused => "_UNUSED",
             Self::ObjectStoreError => "OBJECT_STORE_ERROR",
             Self::MetadataDbError => "METADATA_DB_ERROR",
+            Self::CodecError => "CODEC_ERROR",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -416,6 +419,7 @@ impl ErrorCode {
             "_UNUSED" => Some(Self::Unused),
             "OBJECT_STORE_ERROR" => Some(Self::ObjectStoreError),
             "METADATA_DB_ERROR" => Some(Self::MetadataDbError),
+            "CODEC_ERROR" => Some(Self::CodecError),
             _ => None,
         }
     }

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -182,6 +182,19 @@ pub struct ComponentColumnSelector {
     #[prost(message, optional, tag = "2")]
     pub component: ::core::option::Option<Component>,
 }
+/// Application level error - use as `details` in the `google.rpc.Status` message
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoteStoreError {
+    /// error code
+    #[prost(enumeration = "ErrorCode", tag = "1")]
+    pub code: i32,
+    /// unique identifier associated with the request (e.g. recording id, recording storage url)
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    /// human readable details about the error
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
+}
 /// Specifies how null values should be filled in the returned dataframe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -276,19 +289,6 @@ pub struct RegisterRecordingResponse {
     /// or 3/ do it always
     #[prost(message, optional, tag = "2")]
     pub metadata: ::core::option::Option<RecordingMetadata>,
-}
-/// Server can include details about the error as part of gRPC error (Status)
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RegistrationError {
-    /// error code
-    #[prost(enumeration = "ErrorCode", tag = "1")]
-    pub code: i32,
-    /// storage url of the recording that failed to register
-    #[prost(string, tag = "2")]
-    pub storage_url: ::prost::alloc::string::String,
-    /// human readable details about the error
-    #[prost(string, tag = "3")]
-    pub message: ::prost::alloc::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetRecordingMetadataRequest {

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -182,19 +182,6 @@ pub struct ComponentColumnSelector {
     #[prost(message, optional, tag = "2")]
     pub component: ::core::option::Option<Component>,
 }
-/// Application level error - use as `details` in the `google.rpc.Status` message
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoteStoreError {
-    /// error code
-    #[prost(enumeration = "ErrorCode", tag = "1")]
-    pub code: i32,
-    /// unique identifier associated with the request (e.g. recording id, recording storage url)
-    #[prost(string, tag = "2")]
-    pub id: ::prost::alloc::string::String,
-    /// human readable details about the error
-    #[prost(string, tag = "3")]
-    pub message: ::prost::alloc::string::String,
-}
 /// Specifies how null values should be filled in the returned dataframe.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -218,39 +205,6 @@ impl SparseFillStrategy {
         match value {
             "NONE" => Some(Self::None),
             "LATEST_AT_GLOBAL" => Some(Self::LatestAtGlobal),
-            _ => None,
-        }
-    }
-}
-/// Error codes for application level errors
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum ErrorCode {
-    /// unused
-    Unused = 0,
-    /// object store access error
-    ObjectStoreError = 1,
-    /// metadata database access error
-    MetadataDbError = 2,
-}
-impl ErrorCode {
-    /// String value of the enum field names used in the ProtoBuf definition.
-    ///
-    /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn as_str_name(&self) -> &'static str {
-        match self {
-            Self::Unused => "_UNUSED",
-            Self::ObjectStoreError => "OBJECT_STORE_ERROR",
-            Self::MetadataDbError => "METADATA_DB_ERROR",
-        }
-    }
-    /// Creates an enum from field names used in the ProtoBuf definition.
-    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
-        match value {
-            "_UNUSED" => Some(Self::Unused),
-            "OBJECT_STORE_ERROR" => Some(Self::ObjectStoreError),
-            "METADATA_DB_ERROR" => Some(Self::MetadataDbError),
             _ => None,
         }
     }
@@ -374,6 +328,19 @@ pub struct FetchRecordingResponse {
     #[prost(bytes = "vec", tag = "2")]
     pub payload: ::prost::alloc::vec::Vec<u8>,
 }
+/// Application level error - use as `details` in the `google.rpc.Status` message
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RemoteStoreError {
+    /// error code
+    #[prost(enumeration = "ErrorCode", tag = "1")]
+    pub code: i32,
+    /// unique identifier associated with the request (e.g. recording id, recording storage url)
+    #[prost(string, tag = "2")]
+    pub id: ::prost::alloc::string::String,
+    /// human readable details about the error
+    #[prost(string, tag = "3")]
+    pub message: ::prost::alloc::string::String,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum EncoderVersion {
@@ -416,6 +383,39 @@ impl RecordingType {
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
             "RRD" => Some(Self::Rrd),
+            _ => None,
+        }
+    }
+}
+/// Error codes for application level errors
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ErrorCode {
+    /// unused
+    Unused = 0,
+    /// object store access error
+    ObjectStoreError = 1,
+    /// metadata database access error
+    MetadataDbError = 2,
+}
+impl ErrorCode {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unused => "_UNUSED",
+            Self::ObjectStoreError => "OBJECT_STORE_ERROR",
+            Self::MetadataDbError => "METADATA_DB_ERROR",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "_UNUSED" => Some(Self::Unused),
+            "OBJECT_STORE_ERROR" => Some(Self::ObjectStoreError),
+            "METADATA_DB_ERROR" => Some(Self::MetadataDbError),
             _ => None,
         }
     }


### PR DESCRIPTION

### What

Move error codes into ``remote_store.proto`` so that all remote service related types are there. Also, switch to using a single error type for now for all remote store application level errors. 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8139?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8139?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8139)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.