### PR TITLE
Let the WebSocket server serve its data even without the web-viewer feature

### DIFF
--- a/crates/store/re_ws_comms/src/server.rs
+++ b/crates/store/re_ws_comms/src/server.rs
@@ -171,6 +171,15 @@ impl RerunServer {
         self.num_accepted_clients.load(Ordering::Relaxed)
     }
 
+    /// Blocks execution as long as the server is running.
+    ///
+    /// There's no way of shutting the server down from the outside right now.
+    pub fn block(mut self) {
+        if let Some(listener_join_handle) = self.listener_join_handle.take() {
+            listener_join_handle.join().ok();
+        }
+    }
+
     fn listen_thread_func(
         poller: &Poller,
         listener_socket: &TcpListener,

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -795,6 +795,12 @@ fn run_impl(
                 .block(); // dropping should stop the server
             }
 
+            #[cfg(not(feature = "web_viewer"))]
+            {
+                // Returning from this function so soon would drop and therefore stop the server.
+                _ws_server.block();
+            }
+
             return Ok(());
         }
     } else if is_another_viewer_running {


### PR DESCRIPTION
* Fixes https://github.com/rerun-io/rerun/issues/8140

* [x] :ship: 