### PR TITLE
WebSocket server now indefinitely keeps track of non-data RPC commands

### DIFF
--- a/crates/store/re_ws_comms/src/server.rs
+++ b/crates/store/re_ws_comms/src/server.rs
@@ -28,6 +28,9 @@ use crate::{server_url, RerunServerError, RerunServerPort};
 struct MessageQueue {
     server_memory_limit: MemoryLimit,
     messages: VecDeque<Vec<u8>>,
+
+    /// Never garbage collected.
+    messages_static: VecDeque<Vec<u8>>,
 }
 
 impl MessageQueue {
@@ -35,12 +38,22 @@ impl MessageQueue {
         Self {
             server_memory_limit,
             messages: Default::default(),
+            messages_static: Default::default(),
         }
     }
 
     pub fn push(&mut self, msg: Vec<u8>) {
         self.gc_if_using_too_much_ram();
         self.messages.push_back(msg);
+    }
+
+    /// Messages pushed using this method will stay around indefinitely.
+    ///
+    /// Useful e.g. for `SetStoreInfo` messages, so that clients late to the party actually get a
+    /// chance of receiving them.
+    pub fn push_static(&mut self, msg: Vec<u8>) {
+        self.gc_if_using_too_much_ram();
+        self.messages_static.push_back(msg);
     }
 
     fn gc_if_using_too_much_ram(&mut self) {
@@ -356,7 +369,13 @@ impl ReceiveSetBroadcaster {
                         }
                     });
 
-                    inner.history.push(msg);
+                    let msg_is_data = matches!(data, LogMsg::ArrowMsg(_, _));
+                    if msg_is_data {
+                        inner.history.push(msg);
+                    } else {
+                        // Keep non-data commands around for clients late to the party.
+                        inner.history.push_static(msg);
+                    }
                 }
 
                 re_smart_channel::SmartMessagePayload::Flush { on_flush_done } => {
@@ -385,6 +404,13 @@ impl ReceiveSetBroadcaster {
         // the problem with this is that now we won't be able to keep the other clients fed, until this one is done!
         // Meaning that if a new one connects, we stall the old connections until we have sent all messages to this one.
         let mut inner = self.inner.lock();
+
+        for msg in &inner.history.messages_static {
+            if let Err(err) = client.send(tungstenite::Message::Binary(msg.clone())) {
+                re_log::warn!("Error sending static message to web socket client: {err}");
+                return;
+            }
+        }
 
         for msg in &inner.history.messages {
             if let Err(err) = client.send(tungstenite::Message::Binary(msg.clone())) {


### PR DESCRIPTION
* Fixes https://github.com/rerun-io/rerun/issues/5344

* [x] :ship: 