### PR TITLE
Never direct users towards using `RecordingStream::log_component_batches`

### DIFF
--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -89,6 +89,40 @@ impl<C: Component> AsComponents for C {
     }
 }
 
+impl AsComponents for dyn ComponentBatch {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+        vec![MaybeOwnedComponentBatch::Ref(self)]
+    }
+}
+
+impl<const N: usize> AsComponents for [&dyn ComponentBatch; N] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+        self.iter()
+            .map(|batch| MaybeOwnedComponentBatch::Ref(*batch))
+            .collect()
+    }
+}
+
+impl AsComponents for &[&dyn ComponentBatch] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+        self.iter()
+            .map(|batch| MaybeOwnedComponentBatch::Ref(*batch))
+            .collect()
+    }
+}
+
+impl AsComponents for Vec<&dyn ComponentBatch> {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+        self.iter()
+            .map(|batch| MaybeOwnedComponentBatch::Ref(*batch))
+            .collect()
+    }
+}
+
 // ---
 
 mod archetype;

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -23,11 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log the ImageFormat and indicator once, as static.
     let format = rerun::components::ImageFormat::rgb8([width as _, height as _]);
-    rec.log_component_batches(
-        "images",
-        true,
-        [&format as _, &rerun::Image::indicator() as _],
-    )?;
+    rec.log_static("images", &[&format as _, &rerun::Image::indicator() as _])?;
 
     // Split up the image data into several components referencing the underlying data.
     let image_size_in_bytes = width * height * 3;

--- a/docs/snippets/all/archetypes/manual_indicator.rs
+++ b/docs/snippets/all/archetypes/manual_indicator.rs
@@ -7,10 +7,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Specify both a Mesh3D and a Points3D indicator component so that the data is shown as both a
     // 3D mesh _and_ a point cloud by default.
-    rec.log_component_batches(
+    rec.log(
         "points_and_mesh",
-        false,
-        [
+        &[
             rerun::Points3D::indicator().as_ref() as &dyn rerun::ComponentBatch,
             rerun::Mesh3D::indicator().as_ref(),
             &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(rerun::Position3D::from),

--- a/docs/snippets/all/archetypes/mesh3d_partial_updates.rs
+++ b/docs/snippets/all/archetypes/mesh3d_partial_updates.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
             (glam::Vec3::from(vertex_positions[2]) * factor).into(),
         ];
-        rec.log_component_batches("triangle", false, [&vertex_positions as _])?;
+        rec.log("triangle", &[&vertex_positions as _])?;
     }
 
     Ok(())

--- a/docs/snippets/all/concepts/different_data_per_timeline.rs
+++ b/docs/snippets/all/concepts/different_data_per_timeline.rs
@@ -11,19 +11,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Log a red color on one timeline.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_seconds("red timeline", 1.0);
-    rec.log_component_batches(
+    rec.log(
         "points",
-        false,
-        [&rerun::components::Color::from_u32(0xFF0000FF) as &dyn rerun::ComponentBatch],
+        &[&rerun::components::Color::from_u32(0xFF0000FF) as &dyn rerun::ComponentBatch],
     )?;
 
     // And a blue color on the other.
     rec.reset_time(); // Clears all set timeline info.
     rec.set_time_sequence("blue timeline", 1);
-    rec.log_component_batches(
+    rec.log(
         "points",
-        false,
-        [&rerun::components::Color::from_u32(0x0000FFFF) as &dyn rerun::ComponentBatch],
+        &[&rerun::components::Color::from_u32(0x0000FFFF) as &dyn rerun::ComponentBatch],
     )?;
 
     // TODO(#5521): log VisualBounds2D

--- a/examples/rust/incremental_logging/src/main.rs
+++ b/examples/rust/incremental_logging/src/main.rs
@@ -38,7 +38,7 @@ let radii = [rerun::Radius(0.1); 10];
 
 // Only log colors and radii once.
 rec.set_time_sequence("frame_nr", 0);
-rec.log_component_batches("points", false /* static */, [&colors as &dyn rerun::ComponentBatch, &radii])?;
+rec.log("points", &[&colors as &dyn rerun::ComponentBatch, &radii])?;
 
 let mut rng = rand::thread_rng();
 let dist = Uniform::new(-5., 5.);
@@ -63,17 +63,9 @@ fn run(rec: &rerun::RecordingStream) -> anyhow::Result<()> {
 
     // Only log colors and radii once.
     rec.set_time_sequence("frame_nr", 0);
-    rec.log_component_batches(
-        "points",
-        false, /* static */
-        [&colors as &dyn rerun::ComponentBatch, &radii],
-    )?;
+    rec.log("points", &[&colors as &dyn rerun::ComponentBatch, &radii])?;
     // Logging statically would also work.
-    // rec.log_component_batches(
-    //     "points",
-    //     true, /* static */
-    //     [&colors as &dyn rerun::ComponentBatch, &radii],
-    // )?;
+    // rec.log_static("points", &[&colors as &dyn rerun::ComponentBatch, &radii])?;
 
     let mut rng = rand::thread_rng();
     let dist = Uniform::new(-5., 5.);


### PR DESCRIPTION
`RecordingStream::log_component_batches` is a clunky implementation detail, at best. Users should be directed towards `RecordingStream::log{_static}`, always.

To do so, we implement `AsComponents` for basic collections of `dyn ComponentBatch`es, and update all examples accordingly.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8149?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8149?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8149)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.