### PR TITLE
Fix some anchor links in docs

### DIFF
--- a/docs/content/concepts/app-model.md
+++ b/docs/content/concepts/app-model.md
@@ -129,7 +129,7 @@ Reference:
 * [🌊 C++ `save`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a555a7940a076c93d951de5b139d14918)
 
 <!--
-## Logging data on native and visualizing it on the web.
+Logging data on native and visualizing it on the web.
 
 TODO(#8046): incoming.
 -->
@@ -172,22 +172,24 @@ rerun --port 6789 image.jpg &
 
 <!--
 
-### What happens when I use `rr.spawn()` from my SDK of choice?
+(these are headings, not marked as such since it confuses svelte's link checking)
+
+What happens when I use `rr.spawn()` from my SDK of choice?
 
 TODO(#8046): incoming.
 
 
-### What happens when I use `rr.serve()` from my SDK of choice?
+What happens when I use `rr.serve()` from my SDK of choice?
 
 TODO(#8046): incoming.
 
 
-### What happens when I use `rerun --serve`?
+What happens when I use `rerun --serve`?
 
 TODO(#8046): incoming.
 
 
-### Can the **Native Viewer** pull data from a **WebSocket Server**, like the **Web Viewer** does?
+Can the **Native Viewer** pull data from a **WebSocket Server**, like the **Web Viewer** does?
 
 TODO(#8046): incoming.
 

--- a/docs/content/concepts/blueprint.md
+++ b/docs/content/concepts/blueprint.md
@@ -100,7 +100,7 @@ blueprint data-store has several advantages:
     a dependency on the Viewer libraries.
 -   The blueprint is capable of representing any data that a recording can
     represent. This means that blueprint-sourced data
-    [overrides](visualizers-and-overrides.md#per-entity-component-override) are
+    [overrides](visualizers-and-overrides.md#Per-entity-component-override) are
     just as expressive as any logged data.
 -   The blueprint is actually stored as a full time-series, simplifying future
     implementations of things like snapshots and undo/redo mechanisms.

--- a/docs/content/getting-started/navigating-the-viewer.md
+++ b/docs/content/getting-started/navigating-the-viewer.md
@@ -5,7 +5,7 @@ order: 500
 
 This guide will familiarize you with the basics of using the Rerun Viewer with an example dataset. By the end you should be comfortable with the following topics:
 
--   [Launching the demo](#launching-the-demo)
+-   [Launching the demo](#launching-an-example)
 -   [The Viewer panels](#the-viewer-panels)
 -   [Exploring data](#exploring-data)
 -   [Navigating the timeline](#navigating-the-timeline)

--- a/docs/content/reference/video.md
+++ b/docs/content/reference/video.md
@@ -87,7 +87,7 @@ We tested the following codecs in more detail:
 | ---------- | ------------- | ---------------- | ------------- | ------------ | ------------ | --------------- | ------------------ |
 | AV1        | ✅             | ✅                | ✅             | ✅            | 🚧[^4]        | ✅               | ✅                  |
 | H.264/avc  | ✅[^4]         | ✅                | ✅             | ✅            | ✅            | ✅               | ✅                  |
-| H.265/hevc | ❌             | ❌                | ❌             | ✅            | 🚧[^6]        | ❌               | 🚧[^7]              |
+| H.265/hevc | ❌             | ❌                | ❌             | ✅            | 🚧[^5]        | ❌               | 🚧[^6]              |
 
 [^1]: Firefox on Linux has been observed to [stutter when playing back H.264 video](https://github.com/rerun-io/rerun/issues/7532).
 [^2]: Any Chromium-based browser should work, but we don't test all of them.

--- a/docs/content/reference/viewer/blueprint.md
+++ b/docs/content/reference/viewer/blueprint.md
@@ -47,5 +47,5 @@ Adding Entities
 To (re-)add an entity to a space view, you need first need to select the respective space view.
 You then can open a dedicated menu through a button in the [Selection view](selection.md).
 
-This allows you to add any entity with a matching [category](viewport.md#space-view-classes) and a valid [transform](../../concepts/spaces-and-transforms.md) to your
+This allows you to add any entity with a matching [category](viewport.md#view-classes) and a valid [transform](../../concepts/spaces-and-transforms.md) to your
 space view's path.


### PR DESCRIPTION
### What

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8152?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8152?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8152)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.