### PR TITLE
Do not generate, instantiate, nor carry Arrow extensions around

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -1868,7 +1868,6 @@ fn quote_arrow_support_from_obj(
 
     let datatype = quote_arrow_datatype(&arrow_registry.get(fqname));
     let extension_batch = format!("{name}Batch");
-    let extension_type = format!("{name}Type");
 
     let native_to_pa_array_impl = match quote_arrow_serialization(
         reporter,
@@ -1900,12 +1899,6 @@ fn quote_arrow_support_from_obj(
                 )
             }
         }
-    };
-
-    let type_superclass_decl = if type_superclasses.is_empty() {
-        String::new()
-    } else {
-        format!("({})", type_superclasses.join(","))
     };
 
     let batch_superclass_decl = if batch_superclasses.is_empty() {

--- a/rerun_py/rerun_sdk/rerun/_baseclasses.py
+++ b/rerun_py/rerun_sdk/rerun/_baseclasses.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generic, Iterable, Protocol, TypeVar
+from typing import Generic, Iterable, Protocol, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -56,7 +56,7 @@ class Archetype:
                 comp = getattr(self, fld.name)
                 datatype = getattr(comp, "type", None)
                 if datatype:
-                    s += f"  {datatype.extension_name}<{datatype.storage_type}>(\n    {comp.to_pylist()}\n  )\n"
+                    s += f"  {datatype.extension_name}<{datatype}>(\n    {comp.to_pylist()}\n  )\n"
         s += ")"
 
         return s
@@ -112,36 +112,8 @@ class Archetype:
     __repr__ = __str__
 
 
-class BaseExtensionType(pa.ExtensionType):  # type: ignore[misc]
-    """Extension type for datatypes and non-delegating components."""
-
-    _TYPE_NAME: str
-    """The name used when constructing the extension type.
-
-    Should following rerun typing conventions:
-     - `rerun.datatypes.<TYPE>` for datatypes
-     - `rerun.components.<TYPE>` for components
-
-    Many component types simply subclass a datatype type and override
-    the `_TYPE_NAME` field.
-    """
-
-    _ARRAY_TYPE: type[pa.ExtensionArray] = pa.ExtensionArray
-    """The extension array class associated with this class."""
-
-    # Note: (de)serialization is not used in the Python SDK
-
-    def __arrow_ext_serialize__(self) -> bytes:
-        return b""
-
-    # noinspection PyMethodOverriding
-    @classmethod
-    def __arrow_ext_deserialize__(cls, storage_type: Any, serialized: Any) -> pa.ExtensionType:
-        return cls()
-
-
 class BaseBatch(Generic[T]):
-    _ARROW_TYPE: BaseExtensionType = None  # type: ignore[assignment]
+    _ARROW_DATATYPE: pa.DataType | None = None
     """The pyarrow type of this batch."""
 
     def __init__(self, data: T | None, strict: bool | None = None) -> None:
@@ -173,17 +145,14 @@ class BaseBatch(Generic[T]):
         if data is not None:
             with catch_and_log_exceptions(self.__class__.__name__, strict=strict):
                 # If data is already an arrow array, use it
-                if isinstance(data, pa.Array) and data.type == self._ARROW_TYPE:
+                if isinstance(data, pa.Array) and data.type == self._ARROW_DATATYPE:
                     self.pa_array = data
-                elif isinstance(data, pa.Array) and data.type == self._ARROW_TYPE.storage_type:
-                    self.pa_array = self._ARROW_TYPE.wrap_array(data)
                 else:
-                    array = self._native_to_pa_array(data, self._ARROW_TYPE.storage_type)
-                    self.pa_array = self._ARROW_TYPE.wrap_array(array)
+                    self.pa_array = self._native_to_pa_array(data, self._ARROW_DATATYPE)
                 return
 
         # If we didn't return above, default to the empty array
-        self.pa_array = _empty_pa_array(self._ARROW_TYPE)
+        self.pa_array = _empty_pa_array(self._ARROW_DATATYPE)
 
     @classmethod
     def _required(cls, data: T | None) -> BaseBatch[T]:
@@ -317,7 +286,7 @@ class ComponentBatchMixin(ComponentBatchLike):
 
         Part of the `ComponentBatchLike` logging interface.
         """
-        return self._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
+        return self._COMPONENT_NAME  # type: ignore[attr-defined, no-any-return]
 
     def partition(self, lengths: npt.ArrayLike) -> ComponentColumn:
         """
@@ -355,7 +324,7 @@ class ComponentMixin(ComponentBatchLike):
 
         Part of the `ComponentBatchLike` logging interface.
         """
-        return cls._BATCH_TYPE._ARROW_TYPE.storage_type  # type: ignore[attr-defined, no-any-return]
+        return cls._BATCH_TYPE._ARROW_DATATYPE  # type: ignore[attr-defined, no-any-return]
 
     def component_name(self) -> str:
         """
@@ -363,7 +332,7 @@ class ComponentMixin(ComponentBatchLike):
 
         Part of the `ComponentBatchLike` logging interface.
         """
-        return self._BATCH_TYPE._ARROW_TYPE._TYPE_NAME  # type: ignore[attr-defined, no-any-return]
+        return self._BATCH_TYPE._COMPONENT_NAME  # type: ignore[attr-defined, no-any-return]
 
     def as_arrow_array(self) -> pa.Array:
         """

--- a/rerun_py/rerun_sdk/rerun/_log.py
+++ b/rerun_py/rerun_sdk/rerun/_log.py
@@ -288,11 +288,6 @@ def log_components(
         else:
             added.add(name)
 
-        # Strip off the ExtensionArray if it's present. We will always log via component_name.
-        # TODO(jleibs): Maybe warn if there is a name mismatch here.
-        if isinstance(array, pa.ExtensionArray):
-            array = array.storage
-
         instanced[name] = array
 
     bindings.log_arrow_msg(  # pyright: ignore[reportGeneralTypeIssues]

--- a/rerun_py/rerun_sdk/rerun/archetypes/asset_video_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/asset_video_ext.py
@@ -76,6 +76,6 @@ class AssetVideoExt:
             raise RuntimeError("Asset video has no video buffer")
 
         if self.media_type is not None:
-            media_type = self.media_type.as_arrow_array().storage[0].as_py()
+            media_type = self.media_type.as_arrow_array()[0].as_py()
 
         return np.array(bindings.asset_video_read_frame_timestamps_ns(video_buffer, media_type), dtype=np.int64)

--- a/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/bar_chart_ext.py
@@ -21,7 +21,7 @@ class BarChartExt:
 
         # TODO(jleibs): Doing this on raw arrow data is not great. Clean this up
         # once we coerce to a canonical non-arrow type.
-        shape_dims = tensor_data.as_arrow_array()[0].value["shape"].values.field(0).to_numpy()
+        shape_dims = tensor_data.as_arrow_array()[0][0].values.field(0).to_numpy()
 
         if len([d for d in shape_dims if d != 1]) != 1:
             _send_warning_or_raise(

--- a/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/image_ext.py
@@ -264,7 +264,7 @@ class ImageExt:
             if self.format is None:
                 raise ValueError("Cannot JPEG compress an image without a known image_format")
 
-            image_format_arrow = self.format.as_arrow_array().storage[0].as_py()
+            image_format_arrow = self.format.as_arrow_array()[0].as_py()
 
             image_format = ImageFormat(
                 width=image_format_arrow["width"],
@@ -292,11 +292,7 @@ class ImageExt:
 
             buf = None
             if self.buffer is not None:
-                buf = (
-                    self.buffer.as_arrow_array()
-                    .storage.values.to_numpy()
-                    .view(image_format.channel_datatype.to_np_dtype())
-                )
+                buf = self.buffer.as_arrow_array().values.to_numpy().view(image_format.channel_datatype.to_np_dtype())
 
             if buf is None:
                 raise ValueError("Cannot JPEG compress an image without data")

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/__init__.py
@@ -2,178 +2,120 @@
 
 from __future__ import annotations
 
-from .active_tab import ActiveTab, ActiveTabBatch, ActiveTabType
-from .apply_latest_at import ApplyLatestAt, ApplyLatestAtBatch, ApplyLatestAtType
-from .auto_layout import AutoLayout, AutoLayoutBatch, AutoLayoutType
-from .auto_space_views import AutoSpaceViews, AutoSpaceViewsBatch, AutoSpaceViewsType
-from .background_kind import (
-    BackgroundKind,
-    BackgroundKindArrayLike,
-    BackgroundKindBatch,
-    BackgroundKindLike,
-    BackgroundKindType,
-)
-from .column_share import ColumnShare, ColumnShareBatch, ColumnShareType
-from .component_column_selector import (
-    ComponentColumnSelector,
-    ComponentColumnSelectorBatch,
-    ComponentColumnSelectorType,
-)
-from .container_kind import (
-    ContainerKind,
-    ContainerKindArrayLike,
-    ContainerKindBatch,
-    ContainerKindLike,
-    ContainerKindType,
-)
-from .corner2d import Corner2D, Corner2DArrayLike, Corner2DBatch, Corner2DLike, Corner2DType
-from .filter_by_range import FilterByRange, FilterByRangeBatch, FilterByRangeType
-from .filter_is_not_null import FilterIsNotNull, FilterIsNotNullBatch, FilterIsNotNullType
-from .grid_columns import GridColumns, GridColumnsBatch, GridColumnsType
-from .included_content import IncludedContent, IncludedContentBatch, IncludedContentType
-from .included_space_view import IncludedSpaceView, IncludedSpaceViewBatch, IncludedSpaceViewType
-from .interactive import Interactive, InteractiveBatch, InteractiveType
-from .lock_range_during_zoom import LockRangeDuringZoom, LockRangeDuringZoomBatch, LockRangeDuringZoomType
-from .map_provider import MapProvider, MapProviderArrayLike, MapProviderBatch, MapProviderLike, MapProviderType
-from .panel_state import PanelState, PanelStateArrayLike, PanelStateBatch, PanelStateLike, PanelStateType
-from .query_expression import QueryExpression, QueryExpressionBatch, QueryExpressionType
-from .root_container import RootContainer, RootContainerBatch, RootContainerType
-from .row_share import RowShare, RowShareBatch, RowShareType
-from .selected_columns import SelectedColumns, SelectedColumnsBatch, SelectedColumnsType
-from .space_view_class import SpaceViewClass, SpaceViewClassBatch, SpaceViewClassType
-from .space_view_maximized import SpaceViewMaximized, SpaceViewMaximizedBatch, SpaceViewMaximizedType
-from .space_view_origin import SpaceViewOrigin, SpaceViewOriginBatch, SpaceViewOriginType
-from .tensor_dimension_index_slider import (
-    TensorDimensionIndexSlider,
-    TensorDimensionIndexSliderBatch,
-    TensorDimensionIndexSliderType,
-)
-from .timeline_name import TimelineName, TimelineNameBatch, TimelineNameType
-from .view_fit import ViewFit, ViewFitArrayLike, ViewFitBatch, ViewFitLike, ViewFitType
-from .viewer_recommendation_hash import (
-    ViewerRecommendationHash,
-    ViewerRecommendationHashBatch,
-    ViewerRecommendationHashType,
-)
-from .visible import Visible, VisibleBatch, VisibleType
-from .visible_time_range import VisibleTimeRange, VisibleTimeRangeBatch, VisibleTimeRangeType
-from .visual_bounds2d import VisualBounds2D, VisualBounds2DBatch, VisualBounds2DType
-from .visualizer_overrides import VisualizerOverrides, VisualizerOverridesBatch, VisualizerOverridesType
-from .zoom_level import ZoomLevel, ZoomLevelBatch, ZoomLevelType
+from .active_tab import ActiveTab, ActiveTabBatch
+from .apply_latest_at import ApplyLatestAt, ApplyLatestAtBatch
+from .auto_layout import AutoLayout, AutoLayoutBatch
+from .auto_space_views import AutoSpaceViews, AutoSpaceViewsBatch
+from .background_kind import BackgroundKind, BackgroundKindArrayLike, BackgroundKindBatch, BackgroundKindLike
+from .column_share import ColumnShare, ColumnShareBatch
+from .component_column_selector import ComponentColumnSelector, ComponentColumnSelectorBatch
+from .container_kind import ContainerKind, ContainerKindArrayLike, ContainerKindBatch, ContainerKindLike
+from .corner2d import Corner2D, Corner2DArrayLike, Corner2DBatch, Corner2DLike
+from .filter_by_range import FilterByRange, FilterByRangeBatch
+from .filter_is_not_null import FilterIsNotNull, FilterIsNotNullBatch
+from .grid_columns import GridColumns, GridColumnsBatch
+from .included_content import IncludedContent, IncludedContentBatch
+from .included_space_view import IncludedSpaceView, IncludedSpaceViewBatch
+from .interactive import Interactive, InteractiveBatch
+from .lock_range_during_zoom import LockRangeDuringZoom, LockRangeDuringZoomBatch
+from .map_provider import MapProvider, MapProviderArrayLike, MapProviderBatch, MapProviderLike
+from .panel_state import PanelState, PanelStateArrayLike, PanelStateBatch, PanelStateLike
+from .query_expression import QueryExpression, QueryExpressionBatch
+from .root_container import RootContainer, RootContainerBatch
+from .row_share import RowShare, RowShareBatch
+from .selected_columns import SelectedColumns, SelectedColumnsBatch
+from .space_view_class import SpaceViewClass, SpaceViewClassBatch
+from .space_view_maximized import SpaceViewMaximized, SpaceViewMaximizedBatch
+from .space_view_origin import SpaceViewOrigin, SpaceViewOriginBatch
+from .tensor_dimension_index_slider import TensorDimensionIndexSlider, TensorDimensionIndexSliderBatch
+from .timeline_name import TimelineName, TimelineNameBatch
+from .view_fit import ViewFit, ViewFitArrayLike, ViewFitBatch, ViewFitLike
+from .viewer_recommendation_hash import ViewerRecommendationHash, ViewerRecommendationHashBatch
+from .visible import Visible, VisibleBatch
+from .visible_time_range import VisibleTimeRange, VisibleTimeRangeBatch
+from .visual_bounds2d import VisualBounds2D, VisualBounds2DBatch
+from .visualizer_overrides import VisualizerOverrides, VisualizerOverridesBatch
+from .zoom_level import ZoomLevel, ZoomLevelBatch
 
 __all__ = [
     "ActiveTab",
     "ActiveTabBatch",
-    "ActiveTabType",
     "ApplyLatestAt",
     "ApplyLatestAtBatch",
-    "ApplyLatestAtType",
     "AutoLayout",
     "AutoLayoutBatch",
-    "AutoLayoutType",
     "AutoSpaceViews",
     "AutoSpaceViewsBatch",
-    "AutoSpaceViewsType",
     "BackgroundKind",
     "BackgroundKindArrayLike",
     "BackgroundKindBatch",
     "BackgroundKindLike",
-    "BackgroundKindType",
     "ColumnShare",
     "ColumnShareBatch",
-    "ColumnShareType",
     "ComponentColumnSelector",
     "ComponentColumnSelectorBatch",
-    "ComponentColumnSelectorType",
     "ContainerKind",
     "ContainerKindArrayLike",
     "ContainerKindBatch",
     "ContainerKindLike",
-    "ContainerKindType",
     "Corner2D",
     "Corner2DArrayLike",
     "Corner2DBatch",
     "Corner2DLike",
-    "Corner2DType",
     "FilterByRange",
     "FilterByRangeBatch",
-    "FilterByRangeType",
     "FilterIsNotNull",
     "FilterIsNotNullBatch",
-    "FilterIsNotNullType",
     "GridColumns",
     "GridColumnsBatch",
-    "GridColumnsType",
     "IncludedContent",
     "IncludedContentBatch",
-    "IncludedContentType",
     "IncludedSpaceView",
     "IncludedSpaceViewBatch",
-    "IncludedSpaceViewType",
     "Interactive",
     "InteractiveBatch",
-    "InteractiveType",
     "LockRangeDuringZoom",
     "LockRangeDuringZoomBatch",
-    "LockRangeDuringZoomType",
     "MapProvider",
     "MapProviderArrayLike",
     "MapProviderBatch",
     "MapProviderLike",
-    "MapProviderType",
     "PanelState",
     "PanelStateArrayLike",
     "PanelStateBatch",
     "PanelStateLike",
-    "PanelStateType",
     "QueryExpression",
     "QueryExpressionBatch",
-    "QueryExpressionType",
     "RootContainer",
     "RootContainerBatch",
-    "RootContainerType",
     "RowShare",
     "RowShareBatch",
-    "RowShareType",
     "SelectedColumns",
     "SelectedColumnsBatch",
-    "SelectedColumnsType",
     "SpaceViewClass",
     "SpaceViewClassBatch",
-    "SpaceViewClassType",
     "SpaceViewMaximized",
     "SpaceViewMaximizedBatch",
-    "SpaceViewMaximizedType",
     "SpaceViewOrigin",
     "SpaceViewOriginBatch",
-    "SpaceViewOriginType",
     "TensorDimensionIndexSlider",
     "TensorDimensionIndexSliderBatch",
-    "TensorDimensionIndexSliderType",
     "TimelineName",
     "TimelineNameBatch",
-    "TimelineNameType",
     "ViewFit",
     "ViewFitArrayLike",
     "ViewFitBatch",
     "ViewFitLike",
-    "ViewFitType",
     "ViewerRecommendationHash",
     "ViewerRecommendationHashBatch",
-    "ViewerRecommendationHashType",
     "Visible",
     "VisibleBatch",
     "VisibleTimeRange",
     "VisibleTimeRangeBatch",
-    "VisibleTimeRangeType",
-    "VisibleType",
     "VisualBounds2D",
     "VisualBounds2DBatch",
-    "VisualBounds2DType",
     "VisualizerOverrides",
     "VisualizerOverridesBatch",
-    "VisualizerOverridesType",
     "ZoomLevel",
     "ZoomLevelBatch",
-    "ZoomLevelType",
 ]

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ActiveTab", "ActiveTabBatch", "ActiveTabType"]
+__all__ = ["ActiveTab", "ActiveTabBatch"]
 
 
 class ActiveTab(datatypes.EntityPath, ComponentMixin):
@@ -24,12 +24,8 @@ class ActiveTab(datatypes.EntityPath, ComponentMixin):
     pass
 
 
-class ActiveTabType(datatypes.EntityPathType):
-    _TYPE_NAME: str = "rerun.blueprint.components.ActiveTab"
-
-
 class ActiveTabBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ActiveTabType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ActiveTab"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ApplyLatestAt", "ApplyLatestAtBatch", "ApplyLatestAtType"]
+__all__ = ["ApplyLatestAt", "ApplyLatestAtBatch"]
 
 
 class ApplyLatestAt(datatypes.Bool, ComponentMixin):
@@ -24,12 +24,8 @@ class ApplyLatestAt(datatypes.Bool, ComponentMixin):
     pass
 
 
-class ApplyLatestAtType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.ApplyLatestAt"
-
-
 class ApplyLatestAtBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ApplyLatestAtType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ApplyLatestAt"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["AutoLayout", "AutoLayoutBatch", "AutoLayoutType"]
+__all__ = ["AutoLayout", "AutoLayoutBatch"]
 
 
 class AutoLayout(datatypes.Bool, ComponentMixin):
@@ -24,12 +24,8 @@ class AutoLayout(datatypes.Bool, ComponentMixin):
     pass
 
 
-class AutoLayoutType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.AutoLayout"
-
-
 class AutoLayoutBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = AutoLayoutType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoLayout"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["AutoSpaceViews", "AutoSpaceViewsBatch", "AutoSpaceViewsType"]
+__all__ = ["AutoSpaceViews", "AutoSpaceViewsBatch"]
 
 
 class AutoSpaceViews(datatypes.Bool, ComponentMixin):
@@ -24,12 +24,8 @@ class AutoSpaceViews(datatypes.Bool, ComponentMixin):
     pass
 
 
-class AutoSpaceViewsType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.AutoSpaceViews"
-
-
 class AutoSpaceViewsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = AutoSpaceViewsType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoSpaceViews"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -11,17 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = [
-    "BackgroundKind",
-    "BackgroundKindArrayLike",
-    "BackgroundKindBatch",
-    "BackgroundKindLike",
-    "BackgroundKindType",
-]
+__all__ = ["BackgroundKind", "BackgroundKindArrayLike", "BackgroundKindBatch", "BackgroundKindLike"]
 
 
 from enum import Enum
@@ -76,15 +69,9 @@ BackgroundKindLike = Union[
 BackgroundKindArrayLike = Union[BackgroundKindLike, Sequence[BackgroundKindLike]]
 
 
-class BackgroundKindType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.BackgroundKind"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class BackgroundKindBatch(BaseBatch[BackgroundKindArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = BackgroundKindType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.BackgroundKind"
 
     @staticmethod
     def _native_to_pa_array(data: BackgroundKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ColumnShare", "ColumnShareBatch", "ColumnShareType"]
+__all__ = ["ColumnShare", "ColumnShareBatch"]
 
 
 class ColumnShare(datatypes.Float32, ComponentMixin):
@@ -24,12 +24,8 @@ class ColumnShare(datatypes.Float32, ComponentMixin):
     pass
 
 
-class ColumnShareType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.ColumnShare"
-
-
 class ColumnShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ColumnShareType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ColumnShare"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["ComponentColumnSelector", "ComponentColumnSelectorBatch", "ComponentColumnSelectorType"]
+__all__ = ["ComponentColumnSelector", "ComponentColumnSelectorBatch"]
 
 
 class ComponentColumnSelector(blueprint_datatypes.ComponentColumnSelector, ComponentMixin):
@@ -24,12 +24,8 @@ class ComponentColumnSelector(blueprint_datatypes.ComponentColumnSelector, Compo
     pass
 
 
-class ComponentColumnSelectorType(blueprint_datatypes.ComponentColumnSelectorType):
-    _TYPE_NAME: str = "rerun.blueprint.components.ComponentColumnSelector"
-
-
 class ComponentColumnSelectorBatch(blueprint_datatypes.ComponentColumnSelectorBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ComponentColumnSelectorType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ComponentColumnSelector"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["ContainerKind", "ContainerKindArrayLike", "ContainerKindBatch", "ContainerKindLike", "ContainerKindType"]
+__all__ = ["ContainerKind", "ContainerKindArrayLike", "ContainerKindBatch", "ContainerKindLike"]
 
 
 from enum import Enum
@@ -63,15 +62,9 @@ ContainerKindLike = Union[
 ContainerKindArrayLike = Union[ContainerKindLike, Sequence[ContainerKindLike]]
 
 
-class ContainerKindType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.ContainerKind"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ContainerKindBatch(BaseBatch[ContainerKindArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = ContainerKindType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ContainerKind"
 
     @staticmethod
     def _native_to_pa_array(data: ContainerKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["Corner2D", "Corner2DArrayLike", "Corner2DBatch", "Corner2DLike", "Corner2DType"]
+__all__ = ["Corner2D", "Corner2DArrayLike", "Corner2DBatch", "Corner2DLike"]
 
 
 from enum import Enum
@@ -65,15 +64,9 @@ Corner2DLike = Union[
 Corner2DArrayLike = Union[Corner2DLike, Sequence[Corner2DLike]]
 
 
-class Corner2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.Corner2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class Corner2DBatch(BaseBatch[Corner2DArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = Corner2DType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.Corner2D"
 
     @staticmethod
     def _native_to_pa_array(data: Corner2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["FilterByRange", "FilterByRangeBatch", "FilterByRangeType"]
+__all__ = ["FilterByRange", "FilterByRangeBatch"]
 
 
 class FilterByRange(blueprint_datatypes.FilterByRange, ComponentMixin):
@@ -24,12 +24,8 @@ class FilterByRange(blueprint_datatypes.FilterByRange, ComponentMixin):
     pass
 
 
-class FilterByRangeType(blueprint_datatypes.FilterByRangeType):
-    _TYPE_NAME: str = "rerun.blueprint.components.FilterByRange"
-
-
 class FilterByRangeBatch(blueprint_datatypes.FilterByRangeBatch, ComponentBatchMixin):
-    _ARROW_TYPE = FilterByRangeType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterByRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["FilterIsNotNull", "FilterIsNotNullBatch", "FilterIsNotNullType"]
+__all__ = ["FilterIsNotNull", "FilterIsNotNullBatch"]
 
 
 class FilterIsNotNull(blueprint_datatypes.FilterIsNotNull, ComponentMixin):
@@ -24,12 +24,8 @@ class FilterIsNotNull(blueprint_datatypes.FilterIsNotNull, ComponentMixin):
     pass
 
 
-class FilterIsNotNullType(blueprint_datatypes.FilterIsNotNullType):
-    _TYPE_NAME: str = "rerun.blueprint.components.FilterIsNotNull"
-
-
 class FilterIsNotNullBatch(blueprint_datatypes.FilterIsNotNullBatch, ComponentBatchMixin):
-    _ARROW_TYPE = FilterIsNotNullType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterIsNotNull"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["GridColumns", "GridColumnsBatch", "GridColumnsType"]
+__all__ = ["GridColumns", "GridColumnsBatch"]
 
 
 class GridColumns(datatypes.UInt32, ComponentMixin):
@@ -24,12 +24,8 @@ class GridColumns(datatypes.UInt32, ComponentMixin):
     pass
 
 
-class GridColumnsType(datatypes.UInt32Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.GridColumns"
-
-
 class GridColumnsBatch(datatypes.UInt32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = GridColumnsType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.GridColumns"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["IncludedContent", "IncludedContentBatch", "IncludedContentType"]
+__all__ = ["IncludedContent", "IncludedContentBatch"]
 
 
 class IncludedContent(datatypes.EntityPath, ComponentMixin):
@@ -24,12 +24,8 @@ class IncludedContent(datatypes.EntityPath, ComponentMixin):
     pass
 
 
-class IncludedContentType(datatypes.EntityPathType):
-    _TYPE_NAME: str = "rerun.blueprint.components.IncludedContent"
-
-
 class IncludedContentBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _ARROW_TYPE = IncludedContentType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.IncludedContent"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_space_view.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["IncludedSpaceView", "IncludedSpaceViewBatch", "IncludedSpaceViewType"]
+__all__ = ["IncludedSpaceView", "IncludedSpaceViewBatch"]
 
 
 class IncludedSpaceView(datatypes.Uuid, ComponentMixin):
@@ -24,12 +24,8 @@ class IncludedSpaceView(datatypes.Uuid, ComponentMixin):
     pass
 
 
-class IncludedSpaceViewType(datatypes.UuidType):
-    _TYPE_NAME: str = "rerun.blueprint.components.IncludedSpaceView"
-
-
 class IncludedSpaceViewBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _ARROW_TYPE = IncludedSpaceViewType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.IncludedSpaceView"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/interactive.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/interactive.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Interactive", "InteractiveBatch", "InteractiveType"]
+__all__ = ["Interactive", "InteractiveBatch"]
 
 
 class Interactive(datatypes.Bool, ComponentMixin):
@@ -28,12 +28,8 @@ class Interactive(datatypes.Bool, ComponentMixin):
     pass
 
 
-class InteractiveType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.Interactive"
-
-
 class InteractiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = InteractiveType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.Interactive"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["LockRangeDuringZoom", "LockRangeDuringZoomBatch", "LockRangeDuringZoomType"]
+__all__ = ["LockRangeDuringZoom", "LockRangeDuringZoomBatch"]
 
 
 class LockRangeDuringZoom(datatypes.Bool, ComponentMixin):
@@ -28,12 +28,8 @@ class LockRangeDuringZoom(datatypes.Bool, ComponentMixin):
     pass
 
 
-class LockRangeDuringZoomType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.LockRangeDuringZoom"
-
-
 class LockRangeDuringZoomBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = LockRangeDuringZoomType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.LockRangeDuringZoom"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["MapProvider", "MapProviderArrayLike", "MapProviderBatch", "MapProviderLike", "MapProviderType"]
+__all__ = ["MapProvider", "MapProviderArrayLike", "MapProviderBatch", "MapProviderLike"]
 
 
 from enum import Enum
@@ -74,15 +73,9 @@ MapProviderLike = Union[
 MapProviderArrayLike = Union[MapProviderLike, Sequence[MapProviderLike]]
 
 
-class MapProviderType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.MapProvider"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class MapProviderBatch(BaseBatch[MapProviderArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = MapProviderType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.MapProvider"
 
     @staticmethod
     def _native_to_pa_array(data: MapProviderArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["PanelState", "PanelStateArrayLike", "PanelStateBatch", "PanelStateLike", "PanelStateType"]
+__all__ = ["PanelState", "PanelStateArrayLike", "PanelStateBatch", "PanelStateLike"]
 
 
 from enum import Enum
@@ -58,15 +57,9 @@ PanelStateLike = Union[PanelState, Literal["Collapsed", "Expanded", "Hidden", "c
 PanelStateArrayLike = Union[PanelStateLike, Sequence[PanelStateLike]]
 
 
-class PanelStateType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.PanelState"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class PanelStateBatch(BaseBatch[PanelStateArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = PanelStateType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.PanelState"
 
     @staticmethod
     def _native_to_pa_array(data: PanelStateArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["QueryExpression", "QueryExpressionBatch", "QueryExpressionType"]
+__all__ = ["QueryExpression", "QueryExpressionBatch"]
 
 
 class QueryExpression(datatypes.Utf8, ComponentMixin):
@@ -35,12 +35,8 @@ class QueryExpression(datatypes.Utf8, ComponentMixin):
     pass
 
 
-class QueryExpressionType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.QueryExpression"
-
-
 class QueryExpressionBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = QueryExpressionType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.QueryExpression"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["RootContainer", "RootContainerBatch", "RootContainerType"]
+__all__ = ["RootContainer", "RootContainerBatch"]
 
 
 class RootContainer(datatypes.Uuid, ComponentMixin):
@@ -24,12 +24,8 @@ class RootContainer(datatypes.Uuid, ComponentMixin):
     pass
 
 
-class RootContainerType(datatypes.UuidType):
-    _TYPE_NAME: str = "rerun.blueprint.components.RootContainer"
-
-
 class RootContainerBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _ARROW_TYPE = RootContainerType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.RootContainer"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["RowShare", "RowShareBatch", "RowShareType"]
+__all__ = ["RowShare", "RowShareBatch"]
 
 
 class RowShare(datatypes.Float32, ComponentMixin):
@@ -24,12 +24,8 @@ class RowShare(datatypes.Float32, ComponentMixin):
     pass
 
 
-class RowShareType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.RowShare"
-
-
 class RowShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = RowShareType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.RowShare"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["SelectedColumns", "SelectedColumnsBatch", "SelectedColumnsType"]
+__all__ = ["SelectedColumns", "SelectedColumnsBatch"]
 
 
 class SelectedColumns(blueprint_datatypes.SelectedColumns, ComponentMixin):
@@ -24,12 +24,8 @@ class SelectedColumns(blueprint_datatypes.SelectedColumns, ComponentMixin):
     pass
 
 
-class SelectedColumnsType(blueprint_datatypes.SelectedColumnsType):
-    _TYPE_NAME: str = "rerun.blueprint.components.SelectedColumns"
-
-
 class SelectedColumnsBatch(blueprint_datatypes.SelectedColumnsBatch, ComponentBatchMixin):
-    _ARROW_TYPE = SelectedColumnsType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.SelectedColumns"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["SpaceViewClass", "SpaceViewClassBatch", "SpaceViewClassType"]
+__all__ = ["SpaceViewClass", "SpaceViewClassBatch"]
 
 
 class SpaceViewClass(datatypes.Utf8, ComponentMixin):
@@ -24,12 +24,8 @@ class SpaceViewClass(datatypes.Utf8, ComponentMixin):
     pass
 
 
-class SpaceViewClassType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.SpaceViewClass"
-
-
 class SpaceViewClassBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = SpaceViewClassType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewClass"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["SpaceViewMaximized", "SpaceViewMaximizedBatch", "SpaceViewMaximizedType"]
+__all__ = ["SpaceViewMaximized", "SpaceViewMaximizedBatch"]
 
 
 class SpaceViewMaximized(datatypes.Uuid, ComponentMixin):
@@ -24,12 +24,8 @@ class SpaceViewMaximized(datatypes.Uuid, ComponentMixin):
     pass
 
 
-class SpaceViewMaximizedType(datatypes.UuidType):
-    _TYPE_NAME: str = "rerun.blueprint.components.SpaceViewMaximized"
-
-
 class SpaceViewMaximizedBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _ARROW_TYPE = SpaceViewMaximizedType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewMaximized"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["SpaceViewOrigin", "SpaceViewOriginBatch", "SpaceViewOriginType"]
+__all__ = ["SpaceViewOrigin", "SpaceViewOriginBatch"]
 
 
 class SpaceViewOrigin(datatypes.EntityPath, ComponentMixin):
@@ -24,12 +24,8 @@ class SpaceViewOrigin(datatypes.EntityPath, ComponentMixin):
     pass
 
 
-class SpaceViewOriginType(datatypes.EntityPathType):
-    _TYPE_NAME: str = "rerun.blueprint.components.SpaceViewOrigin"
-
-
 class SpaceViewOriginBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _ARROW_TYPE = SpaceViewOriginType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewOrigin"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["TensorDimensionIndexSlider", "TensorDimensionIndexSliderBatch", "TensorDimensionIndexSliderType"]
+__all__ = ["TensorDimensionIndexSlider", "TensorDimensionIndexSliderBatch"]
 
 
 class TensorDimensionIndexSlider(blueprint_datatypes.TensorDimensionIndexSlider, ComponentMixin):
@@ -24,12 +24,8 @@ class TensorDimensionIndexSlider(blueprint_datatypes.TensorDimensionIndexSlider,
     pass
 
 
-class TensorDimensionIndexSliderType(blueprint_datatypes.TensorDimensionIndexSliderType):
-    _TYPE_NAME: str = "rerun.blueprint.components.TensorDimensionIndexSlider"
-
-
 class TensorDimensionIndexSliderBatch(blueprint_datatypes.TensorDimensionIndexSliderBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TensorDimensionIndexSliderType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.TensorDimensionIndexSlider"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TimelineName", "TimelineNameBatch", "TimelineNameType"]
+__all__ = ["TimelineName", "TimelineNameBatch"]
 
 
 class TimelineName(datatypes.Utf8, ComponentMixin):
@@ -24,12 +24,8 @@ class TimelineName(datatypes.Utf8, ComponentMixin):
     pass
 
 
-class TimelineNameType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.TimelineName"
-
-
 class TimelineNameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = TimelineNameType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.TimelineName"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["ViewFit", "ViewFitArrayLike", "ViewFitBatch", "ViewFitLike", "ViewFitType"]
+__all__ = ["ViewFit", "ViewFitArrayLike", "ViewFitBatch", "ViewFitLike"]
 
 
 from enum import Enum
@@ -60,15 +59,9 @@ ViewFitLike = Union[
 ViewFitArrayLike = Union[ViewFitLike, Sequence[ViewFitLike]]
 
 
-class ViewFitType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.components.ViewFit"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ViewFitBatch(BaseBatch[ViewFitArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = ViewFitType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewFit"
 
     @staticmethod
     def _native_to_pa_array(data: ViewFitArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ViewerRecommendationHash", "ViewerRecommendationHashBatch", "ViewerRecommendationHashType"]
+__all__ = ["ViewerRecommendationHash", "ViewerRecommendationHashBatch"]
 
 
 class ViewerRecommendationHash(datatypes.UInt64, ComponentMixin):
@@ -28,12 +28,8 @@ class ViewerRecommendationHash(datatypes.UInt64, ComponentMixin):
     pass
 
 
-class ViewerRecommendationHashType(datatypes.UInt64Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.ViewerRecommendationHash"
-
-
 class ViewerRecommendationHashBatch(datatypes.UInt64Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ViewerRecommendationHashType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewerRecommendationHash"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Visible", "VisibleBatch", "VisibleType"]
+__all__ = ["Visible", "VisibleBatch"]
 
 
 class Visible(datatypes.Bool, ComponentMixin):
@@ -24,12 +24,8 @@ class Visible(datatypes.Bool, ComponentMixin):
     pass
 
 
-class VisibleType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.blueprint.components.Visible"
-
-
 class VisibleBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = VisibleType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.Visible"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["VisibleTimeRange", "VisibleTimeRangeBatch", "VisibleTimeRangeType"]
+__all__ = ["VisibleTimeRange", "VisibleTimeRangeBatch"]
 
 
 class VisibleTimeRange(datatypes.VisibleTimeRange, ComponentMixin):
@@ -28,12 +28,8 @@ class VisibleTimeRange(datatypes.VisibleTimeRange, ComponentMixin):
     pass
 
 
-class VisibleTimeRangeType(datatypes.VisibleTimeRangeType):
-    _TYPE_NAME: str = "rerun.blueprint.components.VisibleTimeRange"
-
-
 class VisibleTimeRangeBatch(datatypes.VisibleTimeRangeBatch, ComponentBatchMixin):
-    _ARROW_TYPE = VisibleTimeRangeType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisibleTimeRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
@@ -12,7 +12,7 @@ from ..._baseclasses import (
 )
 from .visual_bounds2d_ext import VisualBounds2DExt
 
-__all__ = ["VisualBounds2D", "VisualBounds2DBatch", "VisualBounds2DType"]
+__all__ = ["VisualBounds2D", "VisualBounds2DBatch"]
 
 
 class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D, ComponentMixin):
@@ -25,12 +25,8 @@ class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D, ComponentMixin):
     pass
 
 
-class VisualBounds2DType(datatypes.Range2DType):
-    _TYPE_NAME: str = "rerun.blueprint.components.VisualBounds2D"
-
-
 class VisualBounds2DBatch(datatypes.Range2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = VisualBounds2DType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualBounds2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_overrides.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_overrides.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
 )
 from ...blueprint import datatypes as blueprint_datatypes
 
-__all__ = ["VisualizerOverrides", "VisualizerOverridesBatch", "VisualizerOverridesType"]
+__all__ = ["VisualizerOverrides", "VisualizerOverridesBatch"]
 
 
 class VisualizerOverrides(blueprint_datatypes.Utf8List, ComponentMixin):
@@ -35,12 +35,8 @@ class VisualizerOverrides(blueprint_datatypes.Utf8List, ComponentMixin):
     pass
 
 
-class VisualizerOverridesType(blueprint_datatypes.Utf8ListType):
-    _TYPE_NAME: str = "rerun.blueprint.components.VisualizerOverrides"
-
-
 class VisualizerOverridesBatch(blueprint_datatypes.Utf8ListBatch, ComponentBatchMixin):
-    _ARROW_TYPE = VisualizerOverridesType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualizerOverrides"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
@@ -11,7 +11,7 @@ from ..._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ZoomLevel", "ZoomLevelBatch", "ZoomLevelType"]
+__all__ = ["ZoomLevel", "ZoomLevelBatch"]
 
 
 class ZoomLevel(datatypes.Float64, ComponentMixin):
@@ -24,12 +24,8 @@ class ZoomLevel(datatypes.Float64, ComponentMixin):
     pass
 
 
-class ZoomLevelType(datatypes.Float64Type):
-    _TYPE_NAME: str = "rerun.blueprint.components.ZoomLevel"
-
-
 class ZoomLevelBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ZoomLevelType()
+    _COMPONENT_NAME: str = "rerun.blueprint.components.ZoomLevel"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/__init__.py
@@ -7,67 +7,41 @@ from .component_column_selector import (
     ComponentColumnSelectorArrayLike,
     ComponentColumnSelectorBatch,
     ComponentColumnSelectorLike,
-    ComponentColumnSelectorType,
 )
-from .filter_by_range import (
-    FilterByRange,
-    FilterByRangeArrayLike,
-    FilterByRangeBatch,
-    FilterByRangeLike,
-    FilterByRangeType,
-)
-from .filter_is_not_null import (
-    FilterIsNotNull,
-    FilterIsNotNullArrayLike,
-    FilterIsNotNullBatch,
-    FilterIsNotNullLike,
-    FilterIsNotNullType,
-)
-from .selected_columns import (
-    SelectedColumns,
-    SelectedColumnsArrayLike,
-    SelectedColumnsBatch,
-    SelectedColumnsLike,
-    SelectedColumnsType,
-)
+from .filter_by_range import FilterByRange, FilterByRangeArrayLike, FilterByRangeBatch, FilterByRangeLike
+from .filter_is_not_null import FilterIsNotNull, FilterIsNotNullArrayLike, FilterIsNotNullBatch, FilterIsNotNullLike
+from .selected_columns import SelectedColumns, SelectedColumnsArrayLike, SelectedColumnsBatch, SelectedColumnsLike
 from .tensor_dimension_index_slider import (
     TensorDimensionIndexSlider,
     TensorDimensionIndexSliderArrayLike,
     TensorDimensionIndexSliderBatch,
     TensorDimensionIndexSliderLike,
-    TensorDimensionIndexSliderType,
 )
-from .utf8list import Utf8List, Utf8ListArrayLike, Utf8ListBatch, Utf8ListLike, Utf8ListType
+from .utf8list import Utf8List, Utf8ListArrayLike, Utf8ListBatch, Utf8ListLike
 
 __all__ = [
     "ComponentColumnSelector",
     "ComponentColumnSelectorArrayLike",
     "ComponentColumnSelectorBatch",
     "ComponentColumnSelectorLike",
-    "ComponentColumnSelectorType",
     "FilterByRange",
     "FilterByRangeArrayLike",
     "FilterByRangeBatch",
     "FilterByRangeLike",
-    "FilterByRangeType",
     "FilterIsNotNull",
     "FilterIsNotNullArrayLike",
     "FilterIsNotNullBatch",
     "FilterIsNotNullLike",
-    "FilterIsNotNullType",
     "SelectedColumns",
     "SelectedColumnsArrayLike",
     "SelectedColumnsBatch",
     "SelectedColumnsLike",
-    "SelectedColumnsType",
     "TensorDimensionIndexSlider",
     "TensorDimensionIndexSliderArrayLike",
     "TensorDimensionIndexSliderBatch",
     "TensorDimensionIndexSliderLike",
-    "TensorDimensionIndexSliderType",
     "Utf8List",
     "Utf8ListArrayLike",
     "Utf8ListBatch",
     "Utf8ListLike",
-    "Utf8ListType",
 ]

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_column_selector.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_column_selector.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from ... import datatypes
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .component_column_selector_ext import ComponentColumnSelectorExt
 
@@ -22,7 +21,6 @@ __all__ = [
     "ComponentColumnSelectorArrayLike",
     "ComponentColumnSelectorBatch",
     "ComponentColumnSelectorLike",
-    "ComponentColumnSelectorType",
 ]
 
 
@@ -72,22 +70,11 @@ ComponentColumnSelectorArrayLike = Union[
 ]
 
 
-class ComponentColumnSelectorType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.ComponentColumnSelector"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
-                pa.field("component", pa.utf8(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class ComponentColumnSelectorBatch(BaseBatch[ComponentColumnSelectorArrayLike]):
-    _ARROW_TYPE = ComponentColumnSelectorType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
+        pa.field("component", pa.utf8(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: ComponentColumnSelectorArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_column_selector_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/component_column_selector_ext.py
@@ -65,8 +65,8 @@ class ComponentColumnSelectorExt:
 
         return pa.StructArray.from_arrays(
             [
-                EntityPathBatch([x.entity_path for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                Utf8Batch([x.component for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                EntityPathBatch([x.entity_path for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                Utf8Batch([x.component for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_by_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_by_range.py
@@ -13,11 +13,10 @@ from attrs import define, field
 from ... import datatypes
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .filter_by_range_ext import FilterByRangeExt
 
-__all__ = ["FilterByRange", "FilterByRangeArrayLike", "FilterByRangeBatch", "FilterByRangeLike", "FilterByRangeType"]
+__all__ = ["FilterByRange", "FilterByRangeArrayLike", "FilterByRangeBatch", "FilterByRangeLike"]
 
 
 @define(init=False)
@@ -62,22 +61,11 @@ FilterByRangeArrayLike = Union[
 ]
 
 
-class FilterByRangeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.FilterByRange"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("start", pa.int64(), nullable=False, metadata={}),
-                pa.field("end", pa.int64(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class FilterByRangeBatch(BaseBatch[FilterByRangeArrayLike]):
-    _ARROW_TYPE = FilterByRangeType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("start", pa.int64(), nullable=False, metadata={}),
+        pa.field("end", pa.int64(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: FilterByRangeArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -88,8 +76,8 @@ class FilterByRangeBatch(BaseBatch[FilterByRangeArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                TimeIntBatch([x.start for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                TimeIntBatch([x.end for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                TimeIntBatch([x.start for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                TimeIntBatch([x.end for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_is_not_null.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_is_not_null.py
@@ -13,18 +13,11 @@ from attrs import define, field
 from ... import datatypes
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from ...blueprint import datatypes as blueprint_datatypes
 from .filter_is_not_null_ext import FilterIsNotNullExt
 
-__all__ = [
-    "FilterIsNotNull",
-    "FilterIsNotNullArrayLike",
-    "FilterIsNotNullBatch",
-    "FilterIsNotNullLike",
-    "FilterIsNotNullType",
-]
+__all__ = ["FilterIsNotNull", "FilterIsNotNullArrayLike", "FilterIsNotNullBatch", "FilterIsNotNullLike"]
 
 
 def _filter_is_not_null__active__special_field_converter_override(x: datatypes.BoolLike) -> datatypes.Bool:
@@ -76,30 +69,19 @@ FilterIsNotNullArrayLike = Union[
 ]
 
 
-class FilterIsNotNullType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.FilterIsNotNull"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("active", pa.bool_(), nullable=False, metadata={}),
-                pa.field(
-                    "column",
-                    pa.struct([
-                        pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
-                        pa.field("component", pa.utf8(), nullable=False, metadata={}),
-                    ]),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class FilterIsNotNullBatch(BaseBatch[FilterIsNotNullArrayLike]):
-    _ARROW_TYPE = FilterIsNotNullType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("active", pa.bool_(), nullable=False, metadata={}),
+        pa.field(
+            "column",
+            pa.struct([
+                pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
+                pa.field("component", pa.utf8(), nullable=False, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: FilterIsNotNullArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_is_not_null_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/filter_is_not_null_ext.py
@@ -32,12 +32,10 @@ class FilterIsNotNullExt:
 
         return pa.StructArray.from_arrays(
             [
-                BoolBatch([x.active for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                BoolBatch([x.active for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
                 ComponentColumnSelectorBatch(
                     [x.column for x in data],
-                )
-                .as_arrow_array()
-                .storage,  # type: ignore[misc, arg-type]
+                ).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/selected_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/selected_columns.py
@@ -13,18 +13,11 @@ from attrs import define, field
 from ... import datatypes
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from ...blueprint import datatypes as blueprint_datatypes
 from .selected_columns_ext import SelectedColumnsExt
 
-__all__ = [
-    "SelectedColumns",
-    "SelectedColumnsArrayLike",
-    "SelectedColumnsBatch",
-    "SelectedColumnsLike",
-    "SelectedColumnsType",
-]
+__all__ = ["SelectedColumns", "SelectedColumnsArrayLike", "SelectedColumnsBatch", "SelectedColumnsLike"]
 
 
 @define(init=False)
@@ -57,42 +50,31 @@ SelectedColumnsArrayLike = Union[
 ]
 
 
-class SelectedColumnsType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.SelectedColumns"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field(
-                    "time_columns",
-                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "component_columns",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.struct([
-                                pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
-                                pa.field("component", pa.utf8(), nullable=False, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class SelectedColumnsBatch(BaseBatch[SelectedColumnsArrayLike]):
-    _ARROW_TYPE = SelectedColumnsType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "time_columns",
+            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "component_columns",
+            pa.list_(
+                pa.field(
+                    "item",
+                    pa.struct([
+                        pa.field("entity_path", pa.utf8(), nullable=False, metadata={}),
+                        pa.field("component", pa.utf8(), nullable=False, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: SelectedColumnsArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/selected_columns_ext.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/selected_columns_ext.py
@@ -76,9 +76,7 @@ class SelectedColumnsExt:
             offsets=_compute_offsets(d.time_columns for d in data),
             values=Utf8Batch(
                 list(itertools.chain.from_iterable(d.time_columns for d in data)),
-            )
-            .as_arrow_array()
-            .storage,
+            ).as_arrow_array(),
             type=data_type.field(0).type,
         )
 
@@ -86,9 +84,7 @@ class SelectedColumnsExt:
             offsets=_compute_offsets(d.component_columns for d in data),
             values=ComponentColumnSelectorBatch(
                 list(itertools.chain.from_iterable(d.component_columns for d in data)),
-            )
-            .as_arrow_array()
-            .storage,  # type: ignore[misc, arg-type]
+            ).as_arrow_array(),  # type: ignore[misc, arg-type]
             type=data_type.field(1).type,
         )
 

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/tensor_dimension_index_slider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/tensor_dimension_index_slider.py
@@ -14,7 +14,6 @@ from attrs import define, field
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .tensor_dimension_index_slider_ext import TensorDimensionIndexSliderExt
 
@@ -23,7 +22,6 @@ __all__ = [
     "TensorDimensionIndexSliderArrayLike",
     "TensorDimensionIndexSliderBatch",
     "TensorDimensionIndexSliderLike",
-    "TensorDimensionIndexSliderType",
 ]
 
 
@@ -71,17 +69,8 @@ TensorDimensionIndexSliderArrayLike = Union[
 ]
 
 
-class TensorDimensionIndexSliderType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.TensorDimensionIndexSlider"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.struct([pa.field("dimension", pa.uint32(), nullable=False, metadata={})]), self._TYPE_NAME
-        )
-
-
 class TensorDimensionIndexSliderBatch(BaseBatch[TensorDimensionIndexSliderArrayLike]):
-    _ARROW_TYPE = TensorDimensionIndexSliderType()
+    _ARROW_DATATYPE = pa.struct([pa.field("dimension", pa.uint32(), nullable=False, metadata={})])
 
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionIndexSliderArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/datatypes/utf8list.py
@@ -12,11 +12,10 @@ from attrs import define, field
 
 from ..._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .utf8list_ext import Utf8ListExt
 
-__all__ = ["Utf8List", "Utf8ListArrayLike", "Utf8ListBatch", "Utf8ListLike", "Utf8ListType"]
+__all__ = ["Utf8List", "Utf8ListArrayLike", "Utf8ListBatch", "Utf8ListLike"]
 
 
 @define(init=False)
@@ -45,17 +44,8 @@ Utf8ListArrayLike = Union[
 ]
 
 
-class Utf8ListType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.blueprint.datatypes.Utf8List"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})), self._TYPE_NAME
-        )
-
-
 class Utf8ListBatch(BaseBatch[Utf8ListArrayLike]):
-    _ARROW_TYPE = Utf8ListType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
 
     @staticmethod
     def _native_to_pa_array(data: Utf8ListArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/components/__init__.py
@@ -7,319 +7,239 @@ from .aggregation_policy import (
     AggregationPolicyArrayLike,
     AggregationPolicyBatch,
     AggregationPolicyLike,
-    AggregationPolicyType,
 )
-from .albedo_factor import AlbedoFactor, AlbedoFactorBatch, AlbedoFactorType
+from .albedo_factor import AlbedoFactor, AlbedoFactorBatch
 from .annotation_context import (
     AnnotationContext,
     AnnotationContextArrayLike,
     AnnotationContextBatch,
     AnnotationContextLike,
-    AnnotationContextType,
 )
-from .axis_length import AxisLength, AxisLengthBatch, AxisLengthType
-from .blob import Blob, BlobBatch, BlobType
-from .class_id import ClassId, ClassIdBatch, ClassIdType
-from .clear_is_recursive import ClearIsRecursive, ClearIsRecursiveBatch, ClearIsRecursiveType
-from .color import Color, ColorBatch, ColorType
-from .colormap import Colormap, ColormapArrayLike, ColormapBatch, ColormapLike, ColormapType
-from .depth_meter import DepthMeter, DepthMeterBatch, DepthMeterType
-from .disconnected_space import DisconnectedSpace, DisconnectedSpaceBatch, DisconnectedSpaceType
-from .draw_order import DrawOrder, DrawOrderBatch, DrawOrderType
-from .entity_path import EntityPath, EntityPathBatch, EntityPathType
-from .fill_mode import FillMode, FillModeArrayLike, FillModeBatch, FillModeLike, FillModeType
-from .fill_ratio import FillRatio, FillRatioBatch, FillRatioType
-from .gamma_correction import GammaCorrection, GammaCorrectionBatch, GammaCorrectionType
-from .geo_line_string import (
-    GeoLineString,
-    GeoLineStringArrayLike,
-    GeoLineStringBatch,
-    GeoLineStringLike,
-    GeoLineStringType,
-)
-from .half_size2d import HalfSize2D, HalfSize2DBatch, HalfSize2DType
-from .half_size3d import HalfSize3D, HalfSize3DBatch, HalfSize3DType
-from .image_buffer import ImageBuffer, ImageBufferBatch, ImageBufferType
-from .image_format import ImageFormat, ImageFormatBatch, ImageFormatType
-from .image_plane_distance import ImagePlaneDistance, ImagePlaneDistanceBatch, ImagePlaneDistanceType
-from .keypoint_id import KeypointId, KeypointIdBatch, KeypointIdType
-from .lat_lon import LatLon, LatLonBatch, LatLonType
-from .length import Length, LengthBatch, LengthType
-from .line_strip2d import LineStrip2D, LineStrip2DArrayLike, LineStrip2DBatch, LineStrip2DLike, LineStrip2DType
-from .line_strip3d import LineStrip3D, LineStrip3DArrayLike, LineStrip3DBatch, LineStrip3DLike, LineStrip3DType
+from .axis_length import AxisLength, AxisLengthBatch
+from .blob import Blob, BlobBatch
+from .class_id import ClassId, ClassIdBatch
+from .clear_is_recursive import ClearIsRecursive, ClearIsRecursiveBatch
+from .color import Color, ColorBatch
+from .colormap import Colormap, ColormapArrayLike, ColormapBatch, ColormapLike
+from .depth_meter import DepthMeter, DepthMeterBatch
+from .disconnected_space import DisconnectedSpace, DisconnectedSpaceBatch
+from .draw_order import DrawOrder, DrawOrderBatch
+from .entity_path import EntityPath, EntityPathBatch
+from .fill_mode import FillMode, FillModeArrayLike, FillModeBatch, FillModeLike
+from .fill_ratio import FillRatio, FillRatioBatch
+from .gamma_correction import GammaCorrection, GammaCorrectionBatch
+from .geo_line_string import GeoLineString, GeoLineStringArrayLike, GeoLineStringBatch, GeoLineStringLike
+from .half_size2d import HalfSize2D, HalfSize2DBatch
+from .half_size3d import HalfSize3D, HalfSize3DBatch
+from .image_buffer import ImageBuffer, ImageBufferBatch
+from .image_format import ImageFormat, ImageFormatBatch
+from .image_plane_distance import ImagePlaneDistance, ImagePlaneDistanceBatch
+from .keypoint_id import KeypointId, KeypointIdBatch
+from .lat_lon import LatLon, LatLonBatch
+from .length import Length, LengthBatch
+from .line_strip2d import LineStrip2D, LineStrip2DArrayLike, LineStrip2DBatch, LineStrip2DLike
+from .line_strip3d import LineStrip3D, LineStrip3DArrayLike, LineStrip3DBatch, LineStrip3DLike
 from .magnification_filter import (
     MagnificationFilter,
     MagnificationFilterArrayLike,
     MagnificationFilterBatch,
     MagnificationFilterLike,
-    MagnificationFilterType,
 )
-from .marker_shape import MarkerShape, MarkerShapeArrayLike, MarkerShapeBatch, MarkerShapeLike, MarkerShapeType
-from .marker_size import MarkerSize, MarkerSizeBatch, MarkerSizeType
-from .media_type import MediaType, MediaTypeBatch, MediaTypeType
-from .name import Name, NameBatch, NameType
-from .opacity import Opacity, OpacityBatch, OpacityType
-from .pinhole_projection import PinholeProjection, PinholeProjectionBatch, PinholeProjectionType
-from .pose_rotation_axis_angle import PoseRotationAxisAngle, PoseRotationAxisAngleBatch, PoseRotationAxisAngleType
-from .pose_rotation_quat import PoseRotationQuat, PoseRotationQuatBatch, PoseRotationQuatType
-from .pose_scale3d import PoseScale3D, PoseScale3DBatch, PoseScale3DType
-from .pose_transform_mat3x3 import PoseTransformMat3x3, PoseTransformMat3x3Batch, PoseTransformMat3x3Type
-from .pose_translation3d import PoseTranslation3D, PoseTranslation3DBatch, PoseTranslation3DType
-from .position2d import Position2D, Position2DBatch, Position2DType
-from .position3d import Position3D, Position3DBatch, Position3DType
-from .radius import Radius, RadiusBatch, RadiusType
-from .range1d import Range1D, Range1DBatch, Range1DType
-from .resolution import Resolution, ResolutionBatch, ResolutionType
-from .rotation_axis_angle import RotationAxisAngle, RotationAxisAngleBatch, RotationAxisAngleType
-from .rotation_quat import RotationQuat, RotationQuatBatch, RotationQuatType
-from .scalar import Scalar, ScalarBatch, ScalarType
-from .scale3d import Scale3D, Scale3DBatch, Scale3DType
-from .show_labels import ShowLabels, ShowLabelsBatch, ShowLabelsType
-from .stroke_width import StrokeWidth, StrokeWidthBatch, StrokeWidthType
-from .tensor_data import TensorData, TensorDataBatch, TensorDataType
-from .tensor_dimension_index_selection import (
-    TensorDimensionIndexSelection,
-    TensorDimensionIndexSelectionBatch,
-    TensorDimensionIndexSelectionType,
-)
-from .tensor_height_dimension import TensorHeightDimension, TensorHeightDimensionBatch, TensorHeightDimensionType
-from .tensor_width_dimension import TensorWidthDimension, TensorWidthDimensionBatch, TensorWidthDimensionType
-from .texcoord2d import Texcoord2D, Texcoord2DBatch, Texcoord2DType
-from .text import Text, TextBatch, TextType
-from .text_log_level import TextLogLevel, TextLogLevelBatch, TextLogLevelType
-from .transform_mat3x3 import TransformMat3x3, TransformMat3x3Batch, TransformMat3x3Type
+from .marker_shape import MarkerShape, MarkerShapeArrayLike, MarkerShapeBatch, MarkerShapeLike
+from .marker_size import MarkerSize, MarkerSizeBatch
+from .media_type import MediaType, MediaTypeBatch
+from .name import Name, NameBatch
+from .opacity import Opacity, OpacityBatch
+from .pinhole_projection import PinholeProjection, PinholeProjectionBatch
+from .pose_rotation_axis_angle import PoseRotationAxisAngle, PoseRotationAxisAngleBatch
+from .pose_rotation_quat import PoseRotationQuat, PoseRotationQuatBatch
+from .pose_scale3d import PoseScale3D, PoseScale3DBatch
+from .pose_transform_mat3x3 import PoseTransformMat3x3, PoseTransformMat3x3Batch
+from .pose_translation3d import PoseTranslation3D, PoseTranslation3DBatch
+from .position2d import Position2D, Position2DBatch
+from .position3d import Position3D, Position3DBatch
+from .radius import Radius, RadiusBatch
+from .range1d import Range1D, Range1DBatch
+from .resolution import Resolution, ResolutionBatch
+from .rotation_axis_angle import RotationAxisAngle, RotationAxisAngleBatch
+from .rotation_quat import RotationQuat, RotationQuatBatch
+from .scalar import Scalar, ScalarBatch
+from .scale3d import Scale3D, Scale3DBatch
+from .show_labels import ShowLabels, ShowLabelsBatch
+from .stroke_width import StrokeWidth, StrokeWidthBatch
+from .tensor_data import TensorData, TensorDataBatch
+from .tensor_dimension_index_selection import TensorDimensionIndexSelection, TensorDimensionIndexSelectionBatch
+from .tensor_height_dimension import TensorHeightDimension, TensorHeightDimensionBatch
+from .tensor_width_dimension import TensorWidthDimension, TensorWidthDimensionBatch
+from .texcoord2d import Texcoord2D, Texcoord2DBatch
+from .text import Text, TextBatch
+from .text_log_level import TextLogLevel, TextLogLevelBatch
+from .transform_mat3x3 import TransformMat3x3, TransformMat3x3Batch
 from .transform_relation import (
     TransformRelation,
     TransformRelationArrayLike,
     TransformRelationBatch,
     TransformRelationLike,
-    TransformRelationType,
 )
-from .translation3d import Translation3D, Translation3DBatch, Translation3DType
-from .triangle_indices import TriangleIndices, TriangleIndicesBatch, TriangleIndicesType
-from .value_range import ValueRange, ValueRangeBatch, ValueRangeType
-from .vector2d import Vector2D, Vector2DBatch, Vector2DType
-from .vector3d import Vector3D, Vector3DBatch, Vector3DType
-from .video_timestamp import VideoTimestamp, VideoTimestampBatch, VideoTimestampType
-from .view_coordinates import ViewCoordinates, ViewCoordinatesBatch, ViewCoordinatesType
+from .translation3d import Translation3D, Translation3DBatch
+from .triangle_indices import TriangleIndices, TriangleIndicesBatch
+from .value_range import ValueRange, ValueRangeBatch
+from .vector2d import Vector2D, Vector2DBatch
+from .vector3d import Vector3D, Vector3DBatch
+from .video_timestamp import VideoTimestamp, VideoTimestampBatch
+from .view_coordinates import ViewCoordinates, ViewCoordinatesBatch
 
 __all__ = [
     "AggregationPolicy",
     "AggregationPolicyArrayLike",
     "AggregationPolicyBatch",
     "AggregationPolicyLike",
-    "AggregationPolicyType",
     "AlbedoFactor",
     "AlbedoFactorBatch",
-    "AlbedoFactorType",
     "AnnotationContext",
     "AnnotationContextArrayLike",
     "AnnotationContextBatch",
     "AnnotationContextLike",
-    "AnnotationContextType",
     "AxisLength",
     "AxisLengthBatch",
-    "AxisLengthType",
     "Blob",
     "BlobBatch",
-    "BlobType",
     "ClassId",
     "ClassIdBatch",
-    "ClassIdType",
     "ClearIsRecursive",
     "ClearIsRecursiveBatch",
-    "ClearIsRecursiveType",
     "Color",
     "ColorBatch",
-    "ColorType",
     "Colormap",
     "ColormapArrayLike",
     "ColormapBatch",
     "ColormapLike",
-    "ColormapType",
     "DepthMeter",
     "DepthMeterBatch",
-    "DepthMeterType",
     "DisconnectedSpace",
     "DisconnectedSpaceBatch",
-    "DisconnectedSpaceType",
     "DrawOrder",
     "DrawOrderBatch",
-    "DrawOrderType",
     "EntityPath",
     "EntityPathBatch",
-    "EntityPathType",
     "FillMode",
     "FillModeArrayLike",
     "FillModeBatch",
     "FillModeLike",
-    "FillModeType",
     "FillRatio",
     "FillRatioBatch",
-    "FillRatioType",
     "GammaCorrection",
     "GammaCorrectionBatch",
-    "GammaCorrectionType",
     "GeoLineString",
     "GeoLineStringArrayLike",
     "GeoLineStringBatch",
     "GeoLineStringLike",
-    "GeoLineStringType",
     "HalfSize2D",
     "HalfSize2DBatch",
-    "HalfSize2DType",
     "HalfSize3D",
     "HalfSize3DBatch",
-    "HalfSize3DType",
     "ImageBuffer",
     "ImageBufferBatch",
-    "ImageBufferType",
     "ImageFormat",
     "ImageFormatBatch",
-    "ImageFormatType",
     "ImagePlaneDistance",
     "ImagePlaneDistanceBatch",
-    "ImagePlaneDistanceType",
     "KeypointId",
     "KeypointIdBatch",
-    "KeypointIdType",
     "LatLon",
     "LatLonBatch",
-    "LatLonType",
     "Length",
     "LengthBatch",
-    "LengthType",
     "LineStrip2D",
     "LineStrip2DArrayLike",
     "LineStrip2DBatch",
     "LineStrip2DLike",
-    "LineStrip2DType",
     "LineStrip3D",
     "LineStrip3DArrayLike",
     "LineStrip3DBatch",
     "LineStrip3DLike",
-    "LineStrip3DType",
     "MagnificationFilter",
     "MagnificationFilterArrayLike",
     "MagnificationFilterBatch",
     "MagnificationFilterLike",
-    "MagnificationFilterType",
     "MarkerShape",
     "MarkerShapeArrayLike",
     "MarkerShapeBatch",
     "MarkerShapeLike",
-    "MarkerShapeType",
     "MarkerSize",
     "MarkerSizeBatch",
-    "MarkerSizeType",
     "MediaType",
     "MediaTypeBatch",
-    "MediaTypeType",
     "Name",
     "NameBatch",
-    "NameType",
     "Opacity",
     "OpacityBatch",
-    "OpacityType",
     "PinholeProjection",
     "PinholeProjectionBatch",
-    "PinholeProjectionType",
     "PoseRotationAxisAngle",
     "PoseRotationAxisAngleBatch",
-    "PoseRotationAxisAngleType",
     "PoseRotationQuat",
     "PoseRotationQuatBatch",
-    "PoseRotationQuatType",
     "PoseScale3D",
     "PoseScale3DBatch",
-    "PoseScale3DType",
     "PoseTransformMat3x3",
     "PoseTransformMat3x3Batch",
-    "PoseTransformMat3x3Type",
     "PoseTranslation3D",
     "PoseTranslation3DBatch",
-    "PoseTranslation3DType",
     "Position2D",
     "Position2DBatch",
-    "Position2DType",
     "Position3D",
     "Position3DBatch",
-    "Position3DType",
     "Radius",
     "RadiusBatch",
-    "RadiusType",
     "Range1D",
     "Range1DBatch",
-    "Range1DType",
     "Resolution",
     "ResolutionBatch",
-    "ResolutionType",
     "RotationAxisAngle",
     "RotationAxisAngleBatch",
-    "RotationAxisAngleType",
     "RotationQuat",
     "RotationQuatBatch",
-    "RotationQuatType",
     "Scalar",
     "ScalarBatch",
-    "ScalarType",
     "Scale3D",
     "Scale3DBatch",
-    "Scale3DType",
     "ShowLabels",
     "ShowLabelsBatch",
-    "ShowLabelsType",
     "StrokeWidth",
     "StrokeWidthBatch",
-    "StrokeWidthType",
     "TensorData",
     "TensorDataBatch",
-    "TensorDataType",
     "TensorDimensionIndexSelection",
     "TensorDimensionIndexSelectionBatch",
-    "TensorDimensionIndexSelectionType",
     "TensorHeightDimension",
     "TensorHeightDimensionBatch",
-    "TensorHeightDimensionType",
     "TensorWidthDimension",
     "TensorWidthDimensionBatch",
-    "TensorWidthDimensionType",
     "Texcoord2D",
     "Texcoord2DBatch",
-    "Texcoord2DType",
     "Text",
     "TextBatch",
     "TextLogLevel",
     "TextLogLevelBatch",
-    "TextLogLevelType",
-    "TextType",
     "TransformMat3x3",
     "TransformMat3x3Batch",
-    "TransformMat3x3Type",
     "TransformRelation",
     "TransformRelationArrayLike",
     "TransformRelationBatch",
     "TransformRelationLike",
-    "TransformRelationType",
     "Translation3D",
     "Translation3DBatch",
-    "Translation3DType",
     "TriangleIndices",
     "TriangleIndicesBatch",
-    "TriangleIndicesType",
     "ValueRange",
     "ValueRangeBatch",
-    "ValueRangeType",
     "Vector2D",
     "Vector2DBatch",
-    "Vector2DType",
     "Vector3D",
     "Vector3DBatch",
-    "Vector3DType",
     "VideoTimestamp",
     "VideoTimestampBatch",
-    "VideoTimestampType",
     "ViewCoordinates",
     "ViewCoordinatesBatch",
-    "ViewCoordinatesType",
 ]

--- a/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
+++ b/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
@@ -11,17 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = [
-    "AggregationPolicy",
-    "AggregationPolicyArrayLike",
-    "AggregationPolicyBatch",
-    "AggregationPolicyLike",
-    "AggregationPolicyType",
-]
+__all__ = ["AggregationPolicy", "AggregationPolicyArrayLike", "AggregationPolicyBatch", "AggregationPolicyLike"]
 
 
 from enum import Enum
@@ -100,15 +93,9 @@ AggregationPolicyLike = Union[
 AggregationPolicyArrayLike = Union[AggregationPolicyLike, Sequence[AggregationPolicyLike]]
 
 
-class AggregationPolicyType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.AggregationPolicy"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class AggregationPolicyBatch(BaseBatch[AggregationPolicyArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AggregationPolicyType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.AggregationPolicy"
 
     @staticmethod
     def _native_to_pa_array(data: AggregationPolicyArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
+++ b/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["AlbedoFactor", "AlbedoFactorBatch", "AlbedoFactorType"]
+__all__ = ["AlbedoFactor", "AlbedoFactorBatch"]
 
 
 class AlbedoFactor(datatypes.Rgba32, ComponentMixin):
@@ -24,12 +24,8 @@ class AlbedoFactor(datatypes.Rgba32, ComponentMixin):
     pass
 
 
-class AlbedoFactorType(datatypes.Rgba32Type):
-    _TYPE_NAME: str = "rerun.components.AlbedoFactor"
-
-
 class AlbedoFactorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AlbedoFactorType()
+    _COMPONENT_NAME: str = "rerun.components.AlbedoFactor"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -13,19 +13,12 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 from .annotation_context_ext import AnnotationContextExt
 
-__all__ = [
-    "AnnotationContext",
-    "AnnotationContextArrayLike",
-    "AnnotationContextBatch",
-    "AnnotationContextLike",
-    "AnnotationContextType",
-]
+__all__ = ["AnnotationContext", "AnnotationContextArrayLike", "AnnotationContextBatch", "AnnotationContextLike"]
 
 
 @define(init=False)
@@ -77,22 +70,30 @@ AnnotationContextArrayLike = Union[
 ]
 
 
-class AnnotationContextType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.AnnotationContext"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
+class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBatchMixin):
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.struct([
+                pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
                 pa.field(
-                    "item",
+                    "class_description",
                     pa.struct([
-                        pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
                         pa.field(
-                            "class_description",
+                            "info",
                             pa.struct([
+                                pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                                pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                                pa.field("color", pa.uint32(), nullable=True, metadata={}),
+                            ]),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field(
+                            "keypoint_annotations",
+                            pa.list_(
                                 pa.field(
-                                    "info",
+                                    "item",
                                     pa.struct([
                                         pa.field("id", pa.uint16(), nullable=False, metadata={}),
                                         pa.field("label", pa.utf8(), nullable=True, metadata={}),
@@ -100,55 +101,37 @@ class AnnotationContextType(BaseExtensionType):
                                     ]),
                                     nullable=False,
                                     metadata={},
-                                ),
+                                )
+                            ),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field(
+                            "keypoint_connections",
+                            pa.list_(
                                 pa.field(
-                                    "keypoint_annotations",
-                                    pa.list_(
-                                        pa.field(
-                                            "item",
-                                            pa.struct([
-                                                pa.field("id", pa.uint16(), nullable=False, metadata={}),
-                                                pa.field("label", pa.utf8(), nullable=True, metadata={}),
-                                                pa.field("color", pa.uint32(), nullable=True, metadata={}),
-                                            ]),
-                                            nullable=False,
-                                            metadata={},
-                                        )
-                                    ),
+                                    "item",
+                                    pa.struct([
+                                        pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                                        pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
+                                    ]),
                                     nullable=False,
                                     metadata={},
-                                ),
-                                pa.field(
-                                    "keypoint_connections",
-                                    pa.list_(
-                                        pa.field(
-                                            "item",
-                                            pa.struct([
-                                                pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
-                                                pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
-                                            ]),
-                                            nullable=False,
-                                            metadata={},
-                                        )
-                                    ),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                            ]),
+                                )
+                            ),
                             nullable=False,
                             metadata={},
                         ),
                     ]),
                     nullable=False,
                     metadata={},
-                )
-            ),
-            self._TYPE_NAME,
+                ),
+            ]),
+            nullable=False,
+            metadata={},
         )
-
-
-class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AnnotationContextType()
+    )
+    _COMPONENT_NAME: str = "rerun.components.AnnotationContext"
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context_ext.py
@@ -38,6 +38,6 @@ class AnnotationContextExt:
         if not isinstance(data, AnnotationContext):
             data = AnnotationContext(class_map=data)  # type: ignore[arg-type]
 
-        internal_array = ClassDescriptionMapElemBatch(data.class_map).as_arrow_array().storage
+        internal_array = ClassDescriptionMapElemBatch(data.class_map).as_arrow_array()
 
         return pa.ListArray.from_arrays(offsets=[0, len(internal_array)], values=internal_array).cast(data_type)

--- a/rerun_py/rerun_sdk/rerun/components/axis_length.py
+++ b/rerun_py/rerun_sdk/rerun/components/axis_length.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["AxisLength", "AxisLengthBatch", "AxisLengthType"]
+__all__ = ["AxisLength", "AxisLengthBatch"]
 
 
 class AxisLength(datatypes.Float32, ComponentMixin):
@@ -24,12 +24,8 @@ class AxisLength(datatypes.Float32, ComponentMixin):
     pass
 
 
-class AxisLengthType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.AxisLength"
-
-
 class AxisLengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AxisLengthType()
+    _COMPONENT_NAME: str = "rerun.components.AxisLength"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Blob", "BlobBatch", "BlobType"]
+__all__ = ["Blob", "BlobBatch"]
 
 
 class Blob(datatypes.Blob, ComponentMixin):
@@ -24,12 +24,8 @@ class Blob(datatypes.Blob, ComponentMixin):
     pass
 
 
-class BlobType(datatypes.BlobType):
-    _TYPE_NAME: str = "rerun.components.Blob"
-
-
 class BlobBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _ARROW_TYPE = BlobType()
+    _COMPONENT_NAME: str = "rerun.components.Blob"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ClassId", "ClassIdBatch", "ClassIdType"]
+__all__ = ["ClassId", "ClassIdBatch"]
 
 
 class ClassId(datatypes.ClassId, ComponentMixin):
@@ -24,12 +24,8 @@ class ClassId(datatypes.ClassId, ComponentMixin):
     pass
 
 
-class ClassIdType(datatypes.ClassIdType):
-    _TYPE_NAME: str = "rerun.components.ClassId"
-
-
 class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ClassIdType()
+    _COMPONENT_NAME: str = "rerun.components.ClassId"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .clear_is_recursive_ext import ClearIsRecursiveExt
 
-__all__ = ["ClearIsRecursive", "ClearIsRecursiveBatch", "ClearIsRecursiveType"]
+__all__ = ["ClearIsRecursive", "ClearIsRecursiveBatch"]
 
 
 class ClearIsRecursive(ClearIsRecursiveExt, datatypes.Bool, ComponentMixin):
@@ -25,12 +25,8 @@ class ClearIsRecursive(ClearIsRecursiveExt, datatypes.Bool, ComponentMixin):
     pass
 
 
-class ClearIsRecursiveType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.components.ClearIsRecursive"
-
-
 class ClearIsRecursiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ClearIsRecursiveType()
+    _COMPONENT_NAME: str = "rerun.components.ClearIsRecursive"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Color", "ColorBatch", "ColorType"]
+__all__ = ["Color", "ColorBatch"]
 
 
 class Color(datatypes.Rgba32, ComponentMixin):
@@ -33,12 +33,8 @@ class Color(datatypes.Rgba32, ComponentMixin):
     pass
 
 
-class ColorType(datatypes.Rgba32Type):
-    _TYPE_NAME: str = "rerun.components.Color"
-
-
 class ColorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ColorType()
+    _COMPONENT_NAME: str = "rerun.components.Color"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["Colormap", "ColormapArrayLike", "ColormapBatch", "ColormapLike", "ColormapType"]
+__all__ = ["Colormap", "ColormapArrayLike", "ColormapBatch", "ColormapLike"]
 
 
 from enum import Enum
@@ -132,15 +131,9 @@ ColormapLike = Union[
 ColormapArrayLike = Union[ColormapLike, Sequence[ColormapLike]]
 
 
-class ColormapType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.Colormap"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ColormapBatch(BaseBatch[ColormapArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = ColormapType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.Colormap"
 
     @staticmethod
     def _native_to_pa_array(data: ColormapArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["DepthMeter", "DepthMeterBatch", "DepthMeterType"]
+__all__ = ["DepthMeter", "DepthMeterBatch"]
 
 
 class DepthMeter(datatypes.Float32, ComponentMixin):
@@ -33,12 +33,8 @@ class DepthMeter(datatypes.Float32, ComponentMixin):
     pass
 
 
-class DepthMeterType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.DepthMeter"
-
-
 class DepthMeterBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = DepthMeterType()
+    _COMPONENT_NAME: str = "rerun.components.DepthMeter"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .disconnected_space_ext import DisconnectedSpaceExt
 
-__all__ = ["DisconnectedSpace", "DisconnectedSpaceBatch", "DisconnectedSpaceType"]
+__all__ = ["DisconnectedSpace", "DisconnectedSpaceBatch"]
 
 
 class DisconnectedSpace(DisconnectedSpaceExt, datatypes.Bool, ComponentMixin):
@@ -32,12 +32,8 @@ class DisconnectedSpace(DisconnectedSpaceExt, datatypes.Bool, ComponentMixin):
     pass
 
 
-class DisconnectedSpaceType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.components.DisconnectedSpace"
-
-
 class DisconnectedSpaceBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = DisconnectedSpaceType()
+    _COMPONENT_NAME: str = "rerun.components.DisconnectedSpace"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["DrawOrder", "DrawOrderBatch", "DrawOrderType"]
+__all__ = ["DrawOrder", "DrawOrderBatch"]
 
 
 class DrawOrder(datatypes.Float32, ComponentMixin):
@@ -31,12 +31,8 @@ class DrawOrder(datatypes.Float32, ComponentMixin):
     pass
 
 
-class DrawOrderType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.DrawOrder"
-
-
 class DrawOrderBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = DrawOrderType()
+    _COMPONENT_NAME: str = "rerun.components.DrawOrder"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/components/entity_path.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["EntityPath", "EntityPathBatch", "EntityPathType"]
+__all__ = ["EntityPath", "EntityPathBatch"]
 
 
 class EntityPath(datatypes.EntityPath, ComponentMixin):
@@ -24,12 +24,8 @@ class EntityPath(datatypes.EntityPath, ComponentMixin):
     pass
 
 
-class EntityPathType(datatypes.EntityPathType):
-    _TYPE_NAME: str = "rerun.components.EntityPath"
-
-
 class EntityPathBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _ARROW_TYPE = EntityPathType()
+    _COMPONENT_NAME: str = "rerun.components.EntityPath"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/fill_mode.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_mode.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["FillMode", "FillModeArrayLike", "FillModeBatch", "FillModeLike", "FillModeType"]
+__all__ = ["FillMode", "FillModeArrayLike", "FillModeBatch", "FillModeLike"]
 
 
 from enum import Enum
@@ -76,15 +75,9 @@ FillModeLike = Union[
 FillModeArrayLike = Union[FillModeLike, Sequence[FillModeLike]]
 
 
-class FillModeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.FillMode"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class FillModeBatch(BaseBatch[FillModeArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = FillModeType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.FillMode"
 
     @staticmethod
     def _native_to_pa_array(data: FillModeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["FillRatio", "FillRatioBatch", "FillRatioType"]
+__all__ = ["FillRatio", "FillRatioBatch"]
 
 
 class FillRatio(datatypes.Float32, ComponentMixin):
@@ -31,12 +31,8 @@ class FillRatio(datatypes.Float32, ComponentMixin):
     pass
 
 
-class FillRatioType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.FillRatio"
-
-
 class FillRatioBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = FillRatioType()
+    _COMPONENT_NAME: str = "rerun.components.FillRatio"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
+++ b/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["GammaCorrection", "GammaCorrectionBatch", "GammaCorrectionType"]
+__all__ = ["GammaCorrection", "GammaCorrectionBatch"]
 
 
 class GammaCorrection(datatypes.Float32, ComponentMixin):
@@ -32,12 +32,8 @@ class GammaCorrection(datatypes.Float32, ComponentMixin):
     pass
 
 
-class GammaCorrectionType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.GammaCorrection"
-
-
 class GammaCorrectionBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = GammaCorrectionType()
+    _COMPONENT_NAME: str = "rerun.components.GammaCorrection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
@@ -15,13 +15,12 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 from .geo_line_string_ext import GeoLineStringExt
 
-__all__ = ["GeoLineString", "GeoLineStringArrayLike", "GeoLineStringBatch", "GeoLineStringLike", "GeoLineStringType"]
+__all__ = ["GeoLineString", "GeoLineStringArrayLike", "GeoLineStringBatch", "GeoLineStringLike"]
 
 
 @define(init=False)
@@ -42,26 +41,16 @@ else:
 GeoLineStringArrayLike = Union[GeoLineString, Sequence[GeoLineStringLike], npt.NDArray[np.float64]]
 
 
-class GeoLineStringType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.GeoLineString"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
-                pa.field(
-                    "item",
-                    pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
-                    nullable=False,
-                    metadata={},
-                )
-            ),
-            self._TYPE_NAME,
-        )
-
-
 class GeoLineStringBatch(BaseBatch[GeoLineStringArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = GeoLineStringType()
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
+            nullable=False,
+            metadata={},
+        )
+    )
+    _COMPONENT_NAME: str = "rerun.components.GeoLineString"
 
     @staticmethod
     def _native_to_pa_array(data: GeoLineStringArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string_ext.py
@@ -35,16 +35,16 @@ class GeoLineStringExt:
             if len(data) == 0:
                 inners = []
             elif data.ndim == 2:
-                inners = [DVec2DBatch(data).as_arrow_array().storage]
+                inners = [DVec2DBatch(data).as_arrow_array()]
             else:
                 o = 0
                 offsets = [o] + [o := next_offset(o, arr) for arr in data]
-                inner = DVec2DBatch(data.reshape(-1)).as_arrow_array().storage
+                inner = DVec2DBatch(data.reshape(-1)).as_arrow_array()
                 return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         # pure-object
         elif isinstance(data, GeoLineString):
-            inners = [DVec2DBatch(data.lat_lon).as_arrow_array().storage]
+            inners = [DVec2DBatch(data.lat_lon).as_arrow_array()]
 
         # sequences
         elif isinstance(data, Sequence):
@@ -56,7 +56,7 @@ class GeoLineStringExt:
                 if isinstance(data[0], Sequence) and len(data[0]) > 0 and isinstance(data[0][0], numbers.Number):
                     if len(data[0]) == 2:  # type: ignore[arg-type]
                         # If any of the following elements are not sequence of length 2, DVec2DBatch should raise an error.
-                        inners = [DVec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                        inners = [DVec2DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                     else:
                         raise ValueError(
                             "Expected a sequence of sequences of 2D vectors, but the inner sequence length was not equal to 2."
@@ -64,7 +64,7 @@ class GeoLineStringExt:
                 # It could be a sequence of the style `[np.array([0, 0]), np.array([1, 1])]` which is a single strip.
                 elif isinstance(data[0], np.ndarray) and data[0].shape == (2,):
                     # If any of the following elements are not np arrays of shape 2, DVec2DBatch should raise an error.
-                    inners = [DVec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                    inners = [DVec2DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                 # .. otherwise assume that it's several strips.
                 else:
 
@@ -78,13 +78,13 @@ class GeoLineStringExt:
                                 )
                             return DVec2DBatch(strip)
 
-                    inners = [to_dvec2D_batch(strip).as_arrow_array().storage for strip in data]
+                    inners = [to_dvec2D_batch(strip).as_arrow_array() for strip in data]
         else:
-            inners = [DVec2DBatch(data).storage]
+            inners = [DVec2DBatch(data)]
 
         if len(inners) == 0:
             offsets = pa.array([0], type=pa.int32())
-            inner = DVec2DBatch([]).as_arrow_array().storage
+            inner = DVec2DBatch([]).as_arrow_array()
             return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         o = 0

--- a/rerun_py/rerun_sdk/rerun/components/half_size2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size2d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["HalfSize2D", "HalfSize2DBatch", "HalfSize2DType"]
+__all__ = ["HalfSize2D", "HalfSize2DBatch"]
 
 
 class HalfSize2D(datatypes.Vec2D, ComponentMixin):
@@ -31,12 +31,8 @@ class HalfSize2D(datatypes.Vec2D, ComponentMixin):
     pass
 
 
-class HalfSize2DType(datatypes.Vec2DType):
-    _TYPE_NAME: str = "rerun.components.HalfSize2D"
-
-
 class HalfSize2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = HalfSize2DType()
+    _COMPONENT_NAME: str = "rerun.components.HalfSize2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/half_size3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size3d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["HalfSize3D", "HalfSize3DBatch", "HalfSize3DType"]
+__all__ = ["HalfSize3D", "HalfSize3DBatch"]
 
 
 class HalfSize3D(datatypes.Vec3D, ComponentMixin):
@@ -31,12 +31,8 @@ class HalfSize3D(datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class HalfSize3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.HalfSize3D"
-
-
 class HalfSize3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = HalfSize3DType()
+    _COMPONENT_NAME: str = "rerun.components.HalfSize3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_buffer.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ImageBuffer", "ImageBufferBatch", "ImageBufferType"]
+__all__ = ["ImageBuffer", "ImageBufferBatch"]
 
 
 class ImageBuffer(datatypes.Blob, ComponentMixin):
@@ -28,12 +28,8 @@ class ImageBuffer(datatypes.Blob, ComponentMixin):
     pass
 
 
-class ImageBufferType(datatypes.BlobType):
-    _TYPE_NAME: str = "rerun.components.ImageBuffer"
-
-
 class ImageBufferBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ImageBufferType()
+    _COMPONENT_NAME: str = "rerun.components.ImageBuffer"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_format.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_format.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ImageFormat", "ImageFormatBatch", "ImageFormatType"]
+__all__ = ["ImageFormat", "ImageFormatBatch"]
 
 
 class ImageFormat(datatypes.ImageFormat, ComponentMixin):
@@ -24,12 +24,8 @@ class ImageFormat(datatypes.ImageFormat, ComponentMixin):
     pass
 
 
-class ImageFormatType(datatypes.ImageFormatType):
-    _TYPE_NAME: str = "rerun.components.ImageFormat"
-
-
 class ImageFormatBatch(datatypes.ImageFormatBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ImageFormatType()
+    _COMPONENT_NAME: str = "rerun.components.ImageFormat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ImagePlaneDistance", "ImagePlaneDistanceBatch", "ImagePlaneDistanceType"]
+__all__ = ["ImagePlaneDistance", "ImagePlaneDistanceBatch"]
 
 
 class ImagePlaneDistance(datatypes.Float32, ComponentMixin):
@@ -28,12 +28,8 @@ class ImagePlaneDistance(datatypes.Float32, ComponentMixin):
     pass
 
 
-class ImagePlaneDistanceType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.ImagePlaneDistance"
-
-
 class ImagePlaneDistanceBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ImagePlaneDistanceType()
+    _COMPONENT_NAME: str = "rerun.components.ImagePlaneDistance"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["KeypointId", "KeypointIdBatch", "KeypointIdType"]
+__all__ = ["KeypointId", "KeypointIdBatch"]
 
 
 class KeypointId(datatypes.KeypointId, ComponentMixin):
@@ -31,12 +31,8 @@ class KeypointId(datatypes.KeypointId, ComponentMixin):
     pass
 
 
-class KeypointIdType(datatypes.KeypointIdType):
-    _TYPE_NAME: str = "rerun.components.KeypointId"
-
-
 class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
-    _ARROW_TYPE = KeypointIdType()
+    _COMPONENT_NAME: str = "rerun.components.KeypointId"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/lat_lon.py
+++ b/rerun_py/rerun_sdk/rerun/components/lat_lon.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["LatLon", "LatLonBatch", "LatLonType"]
+__all__ = ["LatLon", "LatLonBatch"]
 
 
 class LatLon(datatypes.DVec2D, ComponentMixin):
@@ -24,12 +24,8 @@ class LatLon(datatypes.DVec2D, ComponentMixin):
     pass
 
 
-class LatLonType(datatypes.DVec2DType):
-    _TYPE_NAME: str = "rerun.components.LatLon"
-
-
 class LatLonBatch(datatypes.DVec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = LatLonType()
+    _COMPONENT_NAME: str = "rerun.components.LatLon"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/length.py
+++ b/rerun_py/rerun_sdk/rerun/components/length.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Length", "LengthBatch", "LengthType"]
+__all__ = ["Length", "LengthBatch"]
 
 
 class Length(datatypes.Float32, ComponentMixin):
@@ -29,12 +29,8 @@ class Length(datatypes.Float32, ComponentMixin):
     pass
 
 
-class LengthType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.Length"
-
-
 class LengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = LengthType()
+    _COMPONENT_NAME: str = "rerun.components.Length"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -15,13 +15,12 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 from .line_strip2d_ext import LineStrip2DExt
 
-__all__ = ["LineStrip2D", "LineStrip2DArrayLike", "LineStrip2DBatch", "LineStrip2DLike", "LineStrip2DType"]
+__all__ = ["LineStrip2D", "LineStrip2DArrayLike", "LineStrip2DBatch", "LineStrip2DLike"]
 
 
 @define(init=False)
@@ -60,26 +59,16 @@ else:
 LineStrip2DArrayLike = Union[LineStrip2D, Sequence[LineStrip2DLike], npt.NDArray[np.float32]]
 
 
-class LineStrip2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.LineStrip2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
-                pa.field(
-                    "item",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2),
-                    nullable=False,
-                    metadata={},
-                )
-            ),
-            self._TYPE_NAME,
-        )
-
-
 class LineStrip2DBatch(BaseBatch[LineStrip2DArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = LineStrip2DType()
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2),
+            nullable=False,
+            metadata={},
+        )
+    )
+    _COMPONENT_NAME: str = "rerun.components.LineStrip2D"
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d_ext.py
@@ -28,16 +28,16 @@ class LineStrip2DExt:
             if len(data) == 0:
                 inners = []
             elif data.ndim == 2:
-                inners = [Vec2DBatch(data).as_arrow_array().storage]
+                inners = [Vec2DBatch(data).as_arrow_array()]
             else:
                 o = 0
                 offsets = [o] + [o := next_offset(o, arr) for arr in data]
-                inner = Vec2DBatch(data.reshape(-1)).as_arrow_array().storage
+                inner = Vec2DBatch(data.reshape(-1)).as_arrow_array()
                 return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         # pure-object
         elif isinstance(data, LineStrip2D):
-            inners = [Vec2DBatch(data.points).as_arrow_array().storage]
+            inners = [Vec2DBatch(data.points).as_arrow_array()]
 
         # sequences
         elif isinstance(data, Sequence):
@@ -49,7 +49,7 @@ class LineStrip2DExt:
                 if isinstance(data[0], Sequence) and len(data[0]) > 0 and isinstance(data[0][0], numbers.Number):
                     if len(data[0]) == 2:  # type: ignore[arg-type]
                         # If any of the following elements are not sequence of length 2, Vec2DBatch should raise an error.
-                        inners = [Vec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                        inners = [Vec2DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                     else:
                         raise ValueError(
                             "Expected a sequence of sequences of 2D vectors, but the inner sequence length was not equal to 2."
@@ -57,7 +57,7 @@ class LineStrip2DExt:
                 # It could be a sequence of the style `[np.array([0, 0]), np.array([1, 1])]` which is a single strip.
                 elif isinstance(data[0], np.ndarray) and data[0].shape == (2,):
                     # If any of the following elements are not np arrays of shape 2, Vec2DBatch should raise an error.
-                    inners = [Vec2DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                    inners = [Vec2DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                 # .. otherwise assume that it's several strips.
                 else:
 
@@ -71,13 +71,13 @@ class LineStrip2DExt:
                                 )
                             return Vec2DBatch(strip)
 
-                    inners = [to_vec2d_batch(strip).as_arrow_array().storage for strip in data]
+                    inners = [to_vec2d_batch(strip).as_arrow_array() for strip in data]
         else:
-            inners = [Vec2DBatch(data).storage]
+            inners = [Vec2DBatch(data)]
 
         if len(inners) == 0:
             offsets = pa.array([0], type=pa.int32())
-            inner = Vec2DBatch([]).as_arrow_array().storage
+            inner = Vec2DBatch([]).as_arrow_array()
             return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         o = 0

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -15,13 +15,12 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 from .line_strip3d_ext import LineStrip3DExt
 
-__all__ = ["LineStrip3D", "LineStrip3DArrayLike", "LineStrip3DBatch", "LineStrip3DLike", "LineStrip3DType"]
+__all__ = ["LineStrip3D", "LineStrip3DArrayLike", "LineStrip3DBatch", "LineStrip3DLike"]
 
 
 @define(init=False)
@@ -60,26 +59,16 @@ else:
 LineStrip3DArrayLike = Union[LineStrip3D, Sequence[LineStrip3DLike], npt.NDArray[np.float32]]
 
 
-class LineStrip3DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.LineStrip3D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
-                pa.field(
-                    "item",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                    nullable=False,
-                    metadata={},
-                )
-            ),
-            self._TYPE_NAME,
-        )
-
-
 class LineStrip3DBatch(BaseBatch[LineStrip3DArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = LineStrip3DType()
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+            nullable=False,
+            metadata={},
+        )
+    )
+    _COMPONENT_NAME: str = "rerun.components.LineStrip3D"
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d_ext.py
@@ -28,16 +28,16 @@ class LineStrip3DExt:
             if len(data) == 0:
                 inners = []
             elif data.ndim == 2:
-                inners = [Vec3DBatch(data).as_arrow_array().storage]
+                inners = [Vec3DBatch(data).as_arrow_array()]
             else:
                 o = 0
                 offsets = [o] + [o := next_offset(o, arr) for arr in data]
-                inner = Vec3DBatch(data.reshape(-1)).as_arrow_array().storage
+                inner = Vec3DBatch(data.reshape(-1)).as_arrow_array()
                 return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         # pure-object
         elif isinstance(data, LineStrip3D):
-            inners = [Vec3DBatch(data.points).as_arrow_array().storage]
+            inners = [Vec3DBatch(data.points).as_arrow_array()]
 
         # sequences
         elif isinstance(data, Sequence):
@@ -49,7 +49,7 @@ class LineStrip3DExt:
                 if isinstance(data[0], Sequence) and len(data[0]) > 0 and isinstance(data[0][0], numbers.Number):
                     if len(data[0]) == 3:  # type: ignore[arg-type]
                         # If any of the following elements are not sequence of length 2, Vec2DBatch should raise an error.
-                        inners = [Vec3DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                        inners = [Vec3DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                     else:
                         raise ValueError(
                             "Expected a sequence of sequences of 3D vectors, but the inner sequence length was not equal to 2."
@@ -57,7 +57,7 @@ class LineStrip3DExt:
                 # It could be a sequence of the style `[np.array([0, 0, 0]), np.array([1, 1, 1])]` which is a single strip.
                 elif isinstance(data[0], np.ndarray) and data[0].shape == (3,):
                     # If any of the following elements are not sequence of length 3, Vec3DBatch should raise an error.
-                    inners = [Vec3DBatch(data).as_arrow_array().storage]  # type: ignore[arg-type]
+                    inners = [Vec3DBatch(data).as_arrow_array()]  # type: ignore[arg-type]
                 # .. otherwise assume that it's several strips.
                 else:
 
@@ -71,13 +71,13 @@ class LineStrip3DExt:
                                 )
                             return Vec3DBatch(strip)
 
-                    inners = [to_vec3d_batch(strip).as_arrow_array().storage for strip in data]
+                    inners = [to_vec3d_batch(strip).as_arrow_array() for strip in data]
         else:
-            inners = [Vec3DBatch(data).storage]
+            inners = [Vec3DBatch(data)]
 
         if len(inners) == 0:
             offsets = pa.array([0], type=pa.int32())
-            inner = Vec3DBatch([]).as_arrow_array().storage
+            inner = Vec3DBatch([]).as_arrow_array()
             return pa.ListArray.from_arrays(offsets, inner, type=data_type)
 
         o = 0

--- a/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
+++ b/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
@@ -11,17 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = [
-    "MagnificationFilter",
-    "MagnificationFilterArrayLike",
-    "MagnificationFilterBatch",
-    "MagnificationFilterLike",
-    "MagnificationFilterType",
-]
+__all__ = ["MagnificationFilter", "MagnificationFilterArrayLike", "MagnificationFilterBatch", "MagnificationFilterLike"]
 
 
 from enum import Enum
@@ -70,15 +63,9 @@ MagnificationFilterLike = Union[MagnificationFilter, Literal["Linear", "Nearest"
 MagnificationFilterArrayLike = Union[MagnificationFilterLike, Sequence[MagnificationFilterLike]]
 
 
-class MagnificationFilterType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.MagnificationFilter"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class MagnificationFilterBatch(BaseBatch[MagnificationFilterArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = MagnificationFilterType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.MagnificationFilter"
 
     @staticmethod
     def _native_to_pa_array(data: MagnificationFilterArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -11,11 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = ["MarkerShape", "MarkerShapeArrayLike", "MarkerShapeBatch", "MarkerShapeLike", "MarkerShapeType"]
+__all__ = ["MarkerShape", "MarkerShapeArrayLike", "MarkerShapeBatch", "MarkerShapeLike"]
 
 
 from enum import Enum
@@ -104,15 +103,9 @@ MarkerShapeLike = Union[
 MarkerShapeArrayLike = Union[MarkerShapeLike, Sequence[MarkerShapeLike]]
 
 
-class MarkerShapeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.MarkerShape"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class MarkerShapeBatch(BaseBatch[MarkerShapeArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = MarkerShapeType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.MarkerShape"
 
     @staticmethod
     def _native_to_pa_array(data: MarkerShapeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["MarkerSize", "MarkerSizeBatch", "MarkerSizeType"]
+__all__ = ["MarkerSize", "MarkerSizeBatch"]
 
 
 class MarkerSize(datatypes.Float32, ComponentMixin):
@@ -24,12 +24,8 @@ class MarkerSize(datatypes.Float32, ComponentMixin):
     pass
 
 
-class MarkerSizeType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.MarkerSize"
-
-
 class MarkerSizeBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = MarkerSizeType()
+    _COMPONENT_NAME: str = "rerun.components.MarkerSize"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .media_type_ext import MediaTypeExt
 
-__all__ = ["MediaType", "MediaTypeBatch", "MediaTypeType"]
+__all__ = ["MediaType", "MediaTypeBatch"]
 
 
 class MediaType(MediaTypeExt, datatypes.Utf8, ComponentMixin):
@@ -30,12 +30,8 @@ class MediaType(MediaTypeExt, datatypes.Utf8, ComponentMixin):
     pass
 
 
-class MediaTypeType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.components.MediaType"
-
-
 class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = MediaTypeType()
+    _COMPONENT_NAME: str = "rerun.components.MediaType"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/name.py
+++ b/rerun_py/rerun_sdk/rerun/components/name.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Name", "NameBatch", "NameType"]
+__all__ = ["Name", "NameBatch"]
 
 
 class Name(datatypes.Utf8, ComponentMixin):
@@ -24,12 +24,8 @@ class Name(datatypes.Utf8, ComponentMixin):
     pass
 
 
-class NameType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.components.Name"
-
-
 class NameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = NameType()
+    _COMPONENT_NAME: str = "rerun.components.Name"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/opacity.py
+++ b/rerun_py/rerun_sdk/rerun/components/opacity.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Opacity", "OpacityBatch", "OpacityType"]
+__all__ = ["Opacity", "OpacityBatch"]
 
 
 class Opacity(datatypes.Float32, ComponentMixin):
@@ -29,12 +29,8 @@ class Opacity(datatypes.Float32, ComponentMixin):
     pass
 
 
-class OpacityType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.Opacity"
-
-
 class OpacityBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = OpacityType()
+    _COMPONENT_NAME: str = "rerun.components.Opacity"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["PinholeProjection", "PinholeProjectionBatch", "PinholeProjectionType"]
+__all__ = ["PinholeProjection", "PinholeProjectionBatch"]
 
 
 class PinholeProjection(datatypes.Mat3x3, ComponentMixin):
@@ -38,12 +38,8 @@ class PinholeProjection(datatypes.Mat3x3, ComponentMixin):
     pass
 
 
-class PinholeProjectionType(datatypes.Mat3x3Type):
-    _TYPE_NAME: str = "rerun.components.PinholeProjection"
-
-
 class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _ARROW_TYPE = PinholeProjectionType()
+    _COMPONENT_NAME: str = "rerun.components.PinholeProjection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["PoseRotationAxisAngle", "PoseRotationAxisAngleBatch", "PoseRotationAxisAngleType"]
+__all__ = ["PoseRotationAxisAngle", "PoseRotationAxisAngleBatch"]
 
 
 class PoseRotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
@@ -24,12 +24,8 @@ class PoseRotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
     pass
 
 
-class PoseRotationAxisAngleType(datatypes.RotationAxisAngleType):
-    _TYPE_NAME: str = "rerun.components.PoseRotationAxisAngle"
-
-
 class PoseRotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _ARROW_TYPE = PoseRotationAxisAngleType()
+    _COMPONENT_NAME: str = "rerun.components.PoseRotationAxisAngle"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["PoseRotationQuat", "PoseRotationQuatBatch", "PoseRotationQuatType"]
+__all__ = ["PoseRotationQuat", "PoseRotationQuatBatch"]
 
 
 class PoseRotationQuat(datatypes.Quaternion, ComponentMixin):
@@ -29,12 +29,8 @@ class PoseRotationQuat(datatypes.Quaternion, ComponentMixin):
     pass
 
 
-class PoseRotationQuatType(datatypes.QuaternionType):
-    _TYPE_NAME: str = "rerun.components.PoseRotationQuat"
-
-
 class PoseRotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _ARROW_TYPE = PoseRotationQuatType()
+    _COMPONENT_NAME: str = "rerun.components.PoseRotationQuat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .pose_scale3d_ext import PoseScale3DExt
 
-__all__ = ["PoseScale3D", "PoseScale3DBatch", "PoseScale3DType"]
+__all__ = ["PoseScale3D", "PoseScale3DBatch"]
 
 
 class PoseScale3D(PoseScale3DExt, datatypes.Vec3D, ComponentMixin):
@@ -31,12 +31,8 @@ class PoseScale3D(PoseScale3DExt, datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class PoseScale3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.PoseScale3D"
-
-
 class PoseScale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = PoseScale3DType()
+    _COMPONENT_NAME: str = "rerun.components.PoseScale3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["PoseTransformMat3x3", "PoseTransformMat3x3Batch", "PoseTransformMat3x3Type"]
+__all__ = ["PoseTransformMat3x3", "PoseTransformMat3x3Batch"]
 
 
 class PoseTransformMat3x3(datatypes.Mat3x3, ComponentMixin):
@@ -60,12 +60,8 @@ class PoseTransformMat3x3(datatypes.Mat3x3, ComponentMixin):
     pass
 
 
-class PoseTransformMat3x3Type(datatypes.Mat3x3Type):
-    _TYPE_NAME: str = "rerun.components.PoseTransformMat3x3"
-
-
 class PoseTransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _ARROW_TYPE = PoseTransformMat3x3Type()
+    _COMPONENT_NAME: str = "rerun.components.PoseTransformMat3x3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["PoseTranslation3D", "PoseTranslation3DBatch", "PoseTranslation3DType"]
+__all__ = ["PoseTranslation3D", "PoseTranslation3DBatch"]
 
 
 class PoseTranslation3D(datatypes.Vec3D, ComponentMixin):
@@ -24,12 +24,8 @@ class PoseTranslation3D(datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class PoseTranslation3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.PoseTranslation3D"
-
-
 class PoseTranslation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = PoseTranslation3DType()
+    _COMPONENT_NAME: str = "rerun.components.PoseTranslation3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Position2D", "Position2DBatch", "Position2DType"]
+__all__ = ["Position2D", "Position2DBatch"]
 
 
 class Position2D(datatypes.Vec2D, ComponentMixin):
@@ -24,12 +24,8 @@ class Position2D(datatypes.Vec2D, ComponentMixin):
     pass
 
 
-class Position2DType(datatypes.Vec2DType):
-    _TYPE_NAME: str = "rerun.components.Position2D"
-
-
 class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Position2DType()
+    _COMPONENT_NAME: str = "rerun.components.Position2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Position3D", "Position3DBatch", "Position3DType"]
+__all__ = ["Position3D", "Position3DBatch"]
 
 
 class Position3D(datatypes.Vec3D, ComponentMixin):
@@ -24,12 +24,8 @@ class Position3D(datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class Position3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.Position3D"
-
-
 class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Position3DType()
+    _COMPONENT_NAME: str = "rerun.components.Position3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .radius_ext import RadiusExt
 
-__all__ = ["Radius", "RadiusBatch", "RadiusType"]
+__all__ = ["Radius", "RadiusBatch"]
 
 
 class Radius(RadiusExt, datatypes.Float32, ComponentMixin):
@@ -34,12 +34,8 @@ class Radius(RadiusExt, datatypes.Float32, ComponentMixin):
     pass
 
 
-class RadiusType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.Radius"
-
-
 class RadiusBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = RadiusType()
+    _COMPONENT_NAME: str = "rerun.components.Radius"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/components/range1d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Range1D", "Range1DBatch", "Range1DType"]
+__all__ = ["Range1D", "Range1DBatch"]
 
 
 class Range1D(datatypes.Range1D, ComponentMixin):
@@ -24,12 +24,8 @@ class Range1D(datatypes.Range1D, ComponentMixin):
     pass
 
 
-class Range1DType(datatypes.Range1DType):
-    _TYPE_NAME: str = "rerun.components.Range1D"
-
-
 class Range1DBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Range1DType()
+    _COMPONENT_NAME: str = "rerun.components.Range1D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Resolution", "ResolutionBatch", "ResolutionType"]
+__all__ = ["Resolution", "ResolutionBatch"]
 
 
 class Resolution(datatypes.Vec2D, ComponentMixin):
@@ -28,12 +28,8 @@ class Resolution(datatypes.Vec2D, ComponentMixin):
     pass
 
 
-class ResolutionType(datatypes.Vec2DType):
-    _TYPE_NAME: str = "rerun.components.Resolution"
-
-
 class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ResolutionType()
+    _COMPONENT_NAME: str = "rerun.components.Resolution"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["RotationAxisAngle", "RotationAxisAngleBatch", "RotationAxisAngleType"]
+__all__ = ["RotationAxisAngle", "RotationAxisAngleBatch"]
 
 
 class RotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
@@ -24,12 +24,8 @@ class RotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
     pass
 
 
-class RotationAxisAngleType(datatypes.RotationAxisAngleType):
-    _TYPE_NAME: str = "rerun.components.RotationAxisAngle"
-
-
 class RotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _ARROW_TYPE = RotationAxisAngleType()
+    _COMPONENT_NAME: str = "rerun.components.RotationAxisAngle"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["RotationQuat", "RotationQuatBatch", "RotationQuatType"]
+__all__ = ["RotationQuat", "RotationQuatBatch"]
 
 
 class RotationQuat(datatypes.Quaternion, ComponentMixin):
@@ -29,12 +29,8 @@ class RotationQuat(datatypes.Quaternion, ComponentMixin):
     pass
 
 
-class RotationQuatType(datatypes.QuaternionType):
-    _TYPE_NAME: str = "rerun.components.RotationQuat"
-
-
 class RotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _ARROW_TYPE = RotationQuatType()
+    _COMPONENT_NAME: str = "rerun.components.RotationQuat"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Scalar", "ScalarBatch", "ScalarType"]
+__all__ = ["Scalar", "ScalarBatch"]
 
 
 class Scalar(datatypes.Float64, ComponentMixin):
@@ -28,12 +28,8 @@ class Scalar(datatypes.Float64, ComponentMixin):
     pass
 
 
-class ScalarType(datatypes.Float64Type):
-    _TYPE_NAME: str = "rerun.components.Scalar"
-
-
 class ScalarBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _ARROW_TYPE = ScalarType()
+    _COMPONENT_NAME: str = "rerun.components.Scalar"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/scale3d.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .scale3d_ext import Scale3DExt
 
-__all__ = ["Scale3D", "Scale3DBatch", "Scale3DType"]
+__all__ = ["Scale3D", "Scale3DBatch"]
 
 
 class Scale3D(Scale3DExt, datatypes.Vec3D, ComponentMixin):
@@ -31,12 +31,8 @@ class Scale3D(Scale3DExt, datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class Scale3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.Scale3D"
-
-
 class Scale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Scale3DType()
+    _COMPONENT_NAME: str = "rerun.components.Scale3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/show_labels.py
+++ b/rerun_py/rerun_sdk/rerun/components/show_labels.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ShowLabels", "ShowLabelsBatch", "ShowLabelsType"]
+__all__ = ["ShowLabels", "ShowLabelsBatch"]
 
 
 class ShowLabels(datatypes.Bool, ComponentMixin):
@@ -30,12 +30,8 @@ class ShowLabels(datatypes.Bool, ComponentMixin):
     pass
 
 
-class ShowLabelsType(datatypes.BoolType):
-    _TYPE_NAME: str = "rerun.components.ShowLabels"
-
-
 class ShowLabelsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ShowLabelsType()
+    _COMPONENT_NAME: str = "rerun.components.ShowLabels"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["StrokeWidth", "StrokeWidthBatch", "StrokeWidthType"]
+__all__ = ["StrokeWidth", "StrokeWidthBatch"]
 
 
 class StrokeWidth(datatypes.Float32, ComponentMixin):
@@ -24,12 +24,8 @@ class StrokeWidth(datatypes.Float32, ComponentMixin):
     pass
 
 
-class StrokeWidthType(datatypes.Float32Type):
-    _TYPE_NAME: str = "rerun.components.StrokeWidth"
-
-
 class StrokeWidthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _ARROW_TYPE = StrokeWidthType()
+    _COMPONENT_NAME: str = "rerun.components.StrokeWidth"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TensorData", "TensorDataBatch", "TensorDataType"]
+__all__ = ["TensorData", "TensorDataBatch"]
 
 
 class TensorData(datatypes.TensorData, ComponentMixin):
@@ -33,12 +33,8 @@ class TensorData(datatypes.TensorData, ComponentMixin):
     pass
 
 
-class TensorDataType(datatypes.TensorDataType):
-    _TYPE_NAME: str = "rerun.components.TensorData"
-
-
 class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TensorDataType()
+    _COMPONENT_NAME: str = "rerun.components.TensorData"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TensorDimensionIndexSelection", "TensorDimensionIndexSelectionBatch", "TensorDimensionIndexSelectionType"]
+__all__ = ["TensorDimensionIndexSelection", "TensorDimensionIndexSelectionBatch"]
 
 
 class TensorDimensionIndexSelection(datatypes.TensorDimensionIndexSelection, ComponentMixin):
@@ -24,12 +24,8 @@ class TensorDimensionIndexSelection(datatypes.TensorDimensionIndexSelection, Com
     pass
 
 
-class TensorDimensionIndexSelectionType(datatypes.TensorDimensionIndexSelectionType):
-    _TYPE_NAME: str = "rerun.components.TensorDimensionIndexSelection"
-
-
 class TensorDimensionIndexSelectionBatch(datatypes.TensorDimensionIndexSelectionBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TensorDimensionIndexSelectionType()
+    _COMPONENT_NAME: str = "rerun.components.TensorDimensionIndexSelection"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TensorHeightDimension", "TensorHeightDimensionBatch", "TensorHeightDimensionType"]
+__all__ = ["TensorHeightDimension", "TensorHeightDimensionBatch"]
 
 
 class TensorHeightDimension(datatypes.TensorDimensionSelection, ComponentMixin):
@@ -24,12 +24,8 @@ class TensorHeightDimension(datatypes.TensorDimensionSelection, ComponentMixin):
     pass
 
 
-class TensorHeightDimensionType(datatypes.TensorDimensionSelectionType):
-    _TYPE_NAME: str = "rerun.components.TensorHeightDimension"
-
-
 class TensorHeightDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TensorHeightDimensionType()
+    _COMPONENT_NAME: str = "rerun.components.TensorHeightDimension"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TensorWidthDimension", "TensorWidthDimensionBatch", "TensorWidthDimensionType"]
+__all__ = ["TensorWidthDimension", "TensorWidthDimensionBatch"]
 
 
 class TensorWidthDimension(datatypes.TensorDimensionSelection, ComponentMixin):
@@ -24,12 +24,8 @@ class TensorWidthDimension(datatypes.TensorDimensionSelection, ComponentMixin):
     pass
 
 
-class TensorWidthDimensionType(datatypes.TensorDimensionSelectionType):
-    _TYPE_NAME: str = "rerun.components.TensorWidthDimension"
-
-
 class TensorWidthDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TensorWidthDimensionType()
+    _COMPONENT_NAME: str = "rerun.components.TensorWidthDimension"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Texcoord2D", "Texcoord2DBatch", "Texcoord2DType"]
+__all__ = ["Texcoord2D", "Texcoord2DBatch"]
 
 
 class Texcoord2D(datatypes.Vec2D, ComponentMixin):
@@ -41,12 +41,8 @@ class Texcoord2D(datatypes.Vec2D, ComponentMixin):
     pass
 
 
-class Texcoord2DType(datatypes.Vec2DType):
-    _TYPE_NAME: str = "rerun.components.Texcoord2D"
-
-
 class Texcoord2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Texcoord2DType()
+    _COMPONENT_NAME: str = "rerun.components.Texcoord2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Text", "TextBatch", "TextType"]
+__all__ = ["Text", "TextBatch"]
 
 
 class Text(datatypes.Utf8, ComponentMixin):
@@ -24,12 +24,8 @@ class Text(datatypes.Utf8, ComponentMixin):
     pass
 
 
-class TextType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.components.Text"
-
-
 class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = TextType()
+    _COMPONENT_NAME: str = "rerun.components.Text"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .text_log_level_ext import TextLogLevelExt
 
-__all__ = ["TextLogLevel", "TextLogLevelBatch", "TextLogLevelType"]
+__all__ = ["TextLogLevel", "TextLogLevelBatch"]
 
 
 class TextLogLevel(TextLogLevelExt, datatypes.Utf8, ComponentMixin):
@@ -35,12 +35,8 @@ class TextLogLevel(TextLogLevelExt, datatypes.Utf8, ComponentMixin):
     pass
 
 
-class TextLogLevelType(datatypes.Utf8Type):
-    _TYPE_NAME: str = "rerun.components.TextLogLevel"
-
-
 class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _ARROW_TYPE = TextLogLevelType()
+    _COMPONENT_NAME: str = "rerun.components.TextLogLevel"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TransformMat3x3", "TransformMat3x3Batch", "TransformMat3x3Type"]
+__all__ = ["TransformMat3x3", "TransformMat3x3Batch"]
 
 
 class TransformMat3x3(datatypes.Mat3x3, ComponentMixin):
@@ -60,12 +60,8 @@ class TransformMat3x3(datatypes.Mat3x3, ComponentMixin):
     pass
 
 
-class TransformMat3x3Type(datatypes.Mat3x3Type):
-    _TYPE_NAME: str = "rerun.components.TransformMat3x3"
-
-
 class TransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _ARROW_TYPE = TransformMat3x3Type()
+    _COMPONENT_NAME: str = "rerun.components.TransformMat3x3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_relation.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_relation.py
@@ -11,17 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
 )
 
-__all__ = [
-    "TransformRelation",
-    "TransformRelationArrayLike",
-    "TransformRelationBatch",
-    "TransformRelationLike",
-    "TransformRelationType",
-]
+__all__ = ["TransformRelation", "TransformRelationArrayLike", "TransformRelationBatch", "TransformRelationLike"]
 
 
 from enum import Enum
@@ -75,15 +68,9 @@ TransformRelationLike = Union[
 TransformRelationArrayLike = Union[TransformRelationLike, Sequence[TransformRelationLike]]
 
 
-class TransformRelationType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.components.TransformRelation"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class TransformRelationBatch(BaseBatch[TransformRelationArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = TransformRelationType()
+    _ARROW_DATATYPE = pa.uint8()
+    _COMPONENT_NAME: str = "rerun.components.TransformRelation"
 
     @staticmethod
     def _native_to_pa_array(data: TransformRelationArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/translation3d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Translation3D", "Translation3DBatch", "Translation3DType"]
+__all__ = ["Translation3D", "Translation3DBatch"]
 
 
 class Translation3D(datatypes.Vec3D, ComponentMixin):
@@ -24,12 +24,8 @@ class Translation3D(datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class Translation3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.Translation3D"
-
-
 class Translation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Translation3DType()
+    _COMPONENT_NAME: str = "rerun.components.Translation3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
+++ b/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["TriangleIndices", "TriangleIndicesBatch", "TriangleIndicesType"]
+__all__ = ["TriangleIndices", "TriangleIndicesBatch"]
 
 
 class TriangleIndices(datatypes.UVec3D, ComponentMixin):
@@ -24,12 +24,8 @@ class TriangleIndices(datatypes.UVec3D, ComponentMixin):
     pass
 
 
-class TriangleIndicesType(datatypes.UVec3DType):
-    _TYPE_NAME: str = "rerun.components.TriangleIndices"
-
-
 class TriangleIndicesBatch(datatypes.UVec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = TriangleIndicesType()
+    _COMPONENT_NAME: str = "rerun.components.TriangleIndices"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/value_range.py
+++ b/rerun_py/rerun_sdk/rerun/components/value_range.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["ValueRange", "ValueRangeBatch", "ValueRangeType"]
+__all__ = ["ValueRange", "ValueRangeBatch"]
 
 
 class ValueRange(datatypes.Range1D, ComponentMixin):
@@ -24,12 +24,8 @@ class ValueRange(datatypes.Range1D, ComponentMixin):
     pass
 
 
-class ValueRangeType(datatypes.Range1DType):
-    _TYPE_NAME: str = "rerun.components.ValueRange"
-
-
 class ValueRangeBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ValueRangeType()
+    _COMPONENT_NAME: str = "rerun.components.ValueRange"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector2d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Vector2D", "Vector2DBatch", "Vector2DType"]
+__all__ = ["Vector2D", "Vector2DBatch"]
 
 
 class Vector2D(datatypes.Vec2D, ComponentMixin):
@@ -24,12 +24,8 @@ class Vector2D(datatypes.Vec2D, ComponentMixin):
     pass
 
 
-class Vector2DType(datatypes.Vec2DType):
-    _TYPE_NAME: str = "rerun.components.Vector2D"
-
-
 class Vector2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Vector2DType()
+    _COMPONENT_NAME: str = "rerun.components.Vector2D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -11,7 +11,7 @@ from .._baseclasses import (
     ComponentMixin,
 )
 
-__all__ = ["Vector3D", "Vector3DBatch", "Vector3DType"]
+__all__ = ["Vector3D", "Vector3DBatch"]
 
 
 class Vector3D(datatypes.Vec3D, ComponentMixin):
@@ -24,12 +24,8 @@ class Vector3D(datatypes.Vec3D, ComponentMixin):
     pass
 
 
-class Vector3DType(datatypes.Vec3DType):
-    _TYPE_NAME: str = "rerun.components.Vector3D"
-
-
 class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _ARROW_TYPE = Vector3DType()
+    _COMPONENT_NAME: str = "rerun.components.Vector3D"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .video_timestamp_ext import VideoTimestampExt
 
-__all__ = ["VideoTimestamp", "VideoTimestampBatch", "VideoTimestampType"]
+__all__ = ["VideoTimestamp", "VideoTimestampBatch"]
 
 
 class VideoTimestamp(VideoTimestampExt, datatypes.VideoTimestamp, ComponentMixin):
@@ -25,12 +25,8 @@ class VideoTimestamp(VideoTimestampExt, datatypes.VideoTimestamp, ComponentMixin
     pass
 
 
-class VideoTimestampType(datatypes.VideoTimestampType):
-    _TYPE_NAME: str = "rerun.components.VideoTimestamp"
-
-
 class VideoTimestampBatch(datatypes.VideoTimestampBatch, ComponentBatchMixin):
-    _ARROW_TYPE = VideoTimestampType()
+    _COMPONENT_NAME: str = "rerun.components.VideoTimestamp"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -12,7 +12,7 @@ from .._baseclasses import (
 )
 from .view_coordinates_ext import ViewCoordinatesExt
 
-__all__ = ["ViewCoordinates", "ViewCoordinatesBatch", "ViewCoordinatesType"]
+__all__ = ["ViewCoordinates", "ViewCoordinatesBatch"]
 
 
 class ViewCoordinates(ViewCoordinatesExt, datatypes.ViewCoordinates, ComponentMixin):
@@ -44,12 +44,8 @@ class ViewCoordinates(ViewCoordinatesExt, datatypes.ViewCoordinates, ComponentMi
     pass
 
 
-class ViewCoordinatesType(datatypes.ViewCoordinatesType):
-    _TYPE_NAME: str = "rerun.components.ViewCoordinates"
-
-
 class ViewCoordinatesBatch(datatypes.ViewCoordinatesBatch, ComponentBatchMixin):
-    _ARROW_TYPE = ViewCoordinatesType()
+    _COMPONENT_NAME: str = "rerun.components.ViewCoordinates"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/datatypes/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/__init__.py
@@ -2,151 +2,99 @@
 
 from __future__ import annotations
 
-from .angle import Angle, AngleArrayLike, AngleBatch, AngleLike, AngleType
-from .annotation_info import (
-    AnnotationInfo,
-    AnnotationInfoArrayLike,
-    AnnotationInfoBatch,
-    AnnotationInfoLike,
-    AnnotationInfoType,
-)
-from .blob import Blob, BlobArrayLike, BlobBatch, BlobLike, BlobType
-from .bool import Bool, BoolArrayLike, BoolBatch, BoolLike, BoolType
-from .channel_datatype import (
-    ChannelDatatype,
-    ChannelDatatypeArrayLike,
-    ChannelDatatypeBatch,
-    ChannelDatatypeLike,
-    ChannelDatatypeType,
-)
-from .class_description import (
-    ClassDescription,
-    ClassDescriptionArrayLike,
-    ClassDescriptionBatch,
-    ClassDescriptionLike,
-    ClassDescriptionType,
-)
+from .angle import Angle, AngleArrayLike, AngleBatch, AngleLike
+from .annotation_info import AnnotationInfo, AnnotationInfoArrayLike, AnnotationInfoBatch, AnnotationInfoLike
+from .blob import Blob, BlobArrayLike, BlobBatch, BlobLike
+from .bool import Bool, BoolArrayLike, BoolBatch, BoolLike
+from .channel_datatype import ChannelDatatype, ChannelDatatypeArrayLike, ChannelDatatypeBatch, ChannelDatatypeLike
+from .class_description import ClassDescription, ClassDescriptionArrayLike, ClassDescriptionBatch, ClassDescriptionLike
 from .class_description_map_elem import (
     ClassDescriptionMapElem,
     ClassDescriptionMapElemArrayLike,
     ClassDescriptionMapElemBatch,
     ClassDescriptionMapElemLike,
-    ClassDescriptionMapElemType,
 )
-from .class_id import ClassId, ClassIdArrayLike, ClassIdBatch, ClassIdLike, ClassIdType
-from .color_model import ColorModel, ColorModelArrayLike, ColorModelBatch, ColorModelLike, ColorModelType
-from .dvec2d import DVec2D, DVec2DArrayLike, DVec2DBatch, DVec2DLike, DVec2DType
-from .entity_path import EntityPath, EntityPathArrayLike, EntityPathBatch, EntityPathLike, EntityPathType
-from .float32 import Float32, Float32ArrayLike, Float32Batch, Float32Like, Float32Type
-from .float64 import Float64, Float64ArrayLike, Float64Batch, Float64Like, Float64Type
-from .image_format import ImageFormat, ImageFormatArrayLike, ImageFormatBatch, ImageFormatLike, ImageFormatType
-from .keypoint_id import KeypointId, KeypointIdArrayLike, KeypointIdBatch, KeypointIdLike, KeypointIdType
-from .keypoint_pair import KeypointPair, KeypointPairArrayLike, KeypointPairBatch, KeypointPairLike, KeypointPairType
-from .mat3x3 import Mat3x3, Mat3x3ArrayLike, Mat3x3Batch, Mat3x3Like, Mat3x3Type
-from .mat4x4 import Mat4x4, Mat4x4ArrayLike, Mat4x4Batch, Mat4x4Like, Mat4x4Type
-from .pixel_format import PixelFormat, PixelFormatArrayLike, PixelFormatBatch, PixelFormatLike, PixelFormatType
-from .quaternion import Quaternion, QuaternionArrayLike, QuaternionBatch, QuaternionLike, QuaternionType
-from .range1d import Range1D, Range1DArrayLike, Range1DBatch, Range1DLike, Range1DType
-from .range2d import Range2D, Range2DArrayLike, Range2DBatch, Range2DLike, Range2DType
-from .rgba32 import Rgba32, Rgba32ArrayLike, Rgba32Batch, Rgba32Like, Rgba32Type
+from .class_id import ClassId, ClassIdArrayLike, ClassIdBatch, ClassIdLike
+from .color_model import ColorModel, ColorModelArrayLike, ColorModelBatch, ColorModelLike
+from .dvec2d import DVec2D, DVec2DArrayLike, DVec2DBatch, DVec2DLike
+from .entity_path import EntityPath, EntityPathArrayLike, EntityPathBatch, EntityPathLike
+from .float32 import Float32, Float32ArrayLike, Float32Batch, Float32Like
+from .float64 import Float64, Float64ArrayLike, Float64Batch, Float64Like
+from .image_format import ImageFormat, ImageFormatArrayLike, ImageFormatBatch, ImageFormatLike
+from .keypoint_id import KeypointId, KeypointIdArrayLike, KeypointIdBatch, KeypointIdLike
+from .keypoint_pair import KeypointPair, KeypointPairArrayLike, KeypointPairBatch, KeypointPairLike
+from .mat3x3 import Mat3x3, Mat3x3ArrayLike, Mat3x3Batch, Mat3x3Like
+from .mat4x4 import Mat4x4, Mat4x4ArrayLike, Mat4x4Batch, Mat4x4Like
+from .pixel_format import PixelFormat, PixelFormatArrayLike, PixelFormatBatch, PixelFormatLike
+from .quaternion import Quaternion, QuaternionArrayLike, QuaternionBatch, QuaternionLike
+from .range1d import Range1D, Range1DArrayLike, Range1DBatch, Range1DLike
+from .range2d import Range2D, Range2DArrayLike, Range2DBatch, Range2DLike
+from .rgba32 import Rgba32, Rgba32ArrayLike, Rgba32Batch, Rgba32Like
 from .rotation_axis_angle import (
     RotationAxisAngle,
     RotationAxisAngleArrayLike,
     RotationAxisAngleBatch,
     RotationAxisAngleLike,
-    RotationAxisAngleType,
 )
-from .tensor_buffer import TensorBuffer, TensorBufferArrayLike, TensorBufferBatch, TensorBufferLike, TensorBufferType
-from .tensor_data import TensorData, TensorDataArrayLike, TensorDataBatch, TensorDataLike, TensorDataType
-from .tensor_dimension import (
-    TensorDimension,
-    TensorDimensionArrayLike,
-    TensorDimensionBatch,
-    TensorDimensionLike,
-    TensorDimensionType,
-)
+from .tensor_buffer import TensorBuffer, TensorBufferArrayLike, TensorBufferBatch, TensorBufferLike
+from .tensor_data import TensorData, TensorDataArrayLike, TensorDataBatch, TensorDataLike
+from .tensor_dimension import TensorDimension, TensorDimensionArrayLike, TensorDimensionBatch, TensorDimensionLike
 from .tensor_dimension_index_selection import (
     TensorDimensionIndexSelection,
     TensorDimensionIndexSelectionArrayLike,
     TensorDimensionIndexSelectionBatch,
     TensorDimensionIndexSelectionLike,
-    TensorDimensionIndexSelectionType,
 )
 from .tensor_dimension_selection import (
     TensorDimensionSelection,
     TensorDimensionSelectionArrayLike,
     TensorDimensionSelectionBatch,
     TensorDimensionSelectionLike,
-    TensorDimensionSelectionType,
 )
-from .time_int import TimeInt, TimeIntArrayLike, TimeIntBatch, TimeIntLike, TimeIntType
-from .time_range import TimeRange, TimeRangeArrayLike, TimeRangeBatch, TimeRangeLike, TimeRangeType
+from .time_int import TimeInt, TimeIntArrayLike, TimeIntBatch, TimeIntLike
+from .time_range import TimeRange, TimeRangeArrayLike, TimeRangeBatch, TimeRangeLike
 from .time_range_boundary import (
     TimeRangeBoundary,
     TimeRangeBoundaryArrayLike,
     TimeRangeBoundaryBatch,
     TimeRangeBoundaryLike,
-    TimeRangeBoundaryType,
 )
-from .uint16 import UInt16, UInt16ArrayLike, UInt16Batch, UInt16Like, UInt16Type
-from .uint32 import UInt32, UInt32ArrayLike, UInt32Batch, UInt32Like, UInt32Type
-from .uint64 import UInt64, UInt64ArrayLike, UInt64Batch, UInt64Like, UInt64Type
-from .utf8 import Utf8, Utf8ArrayLike, Utf8Batch, Utf8Like, Utf8Type
-from .uuid import Uuid, UuidArrayLike, UuidBatch, UuidLike, UuidType
-from .uvec2d import UVec2D, UVec2DArrayLike, UVec2DBatch, UVec2DLike, UVec2DType
-from .uvec3d import UVec3D, UVec3DArrayLike, UVec3DBatch, UVec3DLike, UVec3DType
-from .uvec4d import UVec4D, UVec4DArrayLike, UVec4DBatch, UVec4DLike, UVec4DType
-from .vec2d import Vec2D, Vec2DArrayLike, Vec2DBatch, Vec2DLike, Vec2DType
-from .vec3d import Vec3D, Vec3DArrayLike, Vec3DBatch, Vec3DLike, Vec3DType
-from .vec4d import Vec4D, Vec4DArrayLike, Vec4DBatch, Vec4DLike, Vec4DType
-from .video_timestamp import (
-    VideoTimestamp,
-    VideoTimestampArrayLike,
-    VideoTimestampBatch,
-    VideoTimestampLike,
-    VideoTimestampType,
-)
-from .view_coordinates import (
-    ViewCoordinates,
-    ViewCoordinatesArrayLike,
-    ViewCoordinatesBatch,
-    ViewCoordinatesLike,
-    ViewCoordinatesType,
-)
-from .visible_time_range import (
-    VisibleTimeRange,
-    VisibleTimeRangeArrayLike,
-    VisibleTimeRangeBatch,
-    VisibleTimeRangeLike,
-    VisibleTimeRangeType,
-)
+from .uint16 import UInt16, UInt16ArrayLike, UInt16Batch, UInt16Like
+from .uint32 import UInt32, UInt32ArrayLike, UInt32Batch, UInt32Like
+from .uint64 import UInt64, UInt64ArrayLike, UInt64Batch, UInt64Like
+from .utf8 import Utf8, Utf8ArrayLike, Utf8Batch, Utf8Like
+from .uuid import Uuid, UuidArrayLike, UuidBatch, UuidLike
+from .uvec2d import UVec2D, UVec2DArrayLike, UVec2DBatch, UVec2DLike
+from .uvec3d import UVec3D, UVec3DArrayLike, UVec3DBatch, UVec3DLike
+from .uvec4d import UVec4D, UVec4DArrayLike, UVec4DBatch, UVec4DLike
+from .vec2d import Vec2D, Vec2DArrayLike, Vec2DBatch, Vec2DLike
+from .vec3d import Vec3D, Vec3DArrayLike, Vec3DBatch, Vec3DLike
+from .vec4d import Vec4D, Vec4DArrayLike, Vec4DBatch, Vec4DLike
+from .video_timestamp import VideoTimestamp, VideoTimestampArrayLike, VideoTimestampBatch, VideoTimestampLike
+from .view_coordinates import ViewCoordinates, ViewCoordinatesArrayLike, ViewCoordinatesBatch, ViewCoordinatesLike
+from .visible_time_range import VisibleTimeRange, VisibleTimeRangeArrayLike, VisibleTimeRangeBatch, VisibleTimeRangeLike
 
 __all__ = [
     "Angle",
     "AngleArrayLike",
     "AngleBatch",
     "AngleLike",
-    "AngleType",
     "AnnotationInfo",
     "AnnotationInfoArrayLike",
     "AnnotationInfoBatch",
     "AnnotationInfoLike",
-    "AnnotationInfoType",
     "Blob",
     "BlobArrayLike",
     "BlobBatch",
     "BlobLike",
-    "BlobType",
     "Bool",
     "BoolArrayLike",
     "BoolBatch",
     "BoolLike",
-    "BoolType",
     "ChannelDatatype",
     "ChannelDatatypeArrayLike",
     "ChannelDatatypeBatch",
     "ChannelDatatypeLike",
-    "ChannelDatatypeType",
     "ClassDescription",
     "ClassDescriptionArrayLike",
     "ClassDescriptionBatch",
@@ -155,103 +103,82 @@ __all__ = [
     "ClassDescriptionMapElemArrayLike",
     "ClassDescriptionMapElemBatch",
     "ClassDescriptionMapElemLike",
-    "ClassDescriptionMapElemType",
-    "ClassDescriptionType",
     "ClassId",
     "ClassIdArrayLike",
     "ClassIdBatch",
     "ClassIdLike",
-    "ClassIdType",
     "ColorModel",
     "ColorModelArrayLike",
     "ColorModelBatch",
     "ColorModelLike",
-    "ColorModelType",
     "DVec2D",
     "DVec2DArrayLike",
     "DVec2DBatch",
     "DVec2DLike",
-    "DVec2DType",
     "EntityPath",
     "EntityPathArrayLike",
     "EntityPathBatch",
     "EntityPathLike",
-    "EntityPathType",
     "Float32",
     "Float32ArrayLike",
     "Float32Batch",
     "Float32Like",
-    "Float32Type",
     "Float64",
     "Float64ArrayLike",
     "Float64Batch",
     "Float64Like",
-    "Float64Type",
     "ImageFormat",
     "ImageFormatArrayLike",
     "ImageFormatBatch",
     "ImageFormatLike",
-    "ImageFormatType",
     "KeypointId",
     "KeypointIdArrayLike",
     "KeypointIdBatch",
     "KeypointIdLike",
-    "KeypointIdType",
     "KeypointPair",
     "KeypointPairArrayLike",
     "KeypointPairBatch",
     "KeypointPairLike",
-    "KeypointPairType",
     "Mat3x3",
     "Mat3x3ArrayLike",
     "Mat3x3Batch",
     "Mat3x3Like",
-    "Mat3x3Type",
     "Mat4x4",
     "Mat4x4ArrayLike",
     "Mat4x4Batch",
     "Mat4x4Like",
-    "Mat4x4Type",
     "PixelFormat",
     "PixelFormatArrayLike",
     "PixelFormatBatch",
     "PixelFormatLike",
-    "PixelFormatType",
     "Quaternion",
     "QuaternionArrayLike",
     "QuaternionBatch",
     "QuaternionLike",
-    "QuaternionType",
     "Range1D",
     "Range1DArrayLike",
     "Range1DBatch",
     "Range1DLike",
-    "Range1DType",
     "Range2D",
     "Range2DArrayLike",
     "Range2DBatch",
     "Range2DLike",
-    "Range2DType",
     "Rgba32",
     "Rgba32ArrayLike",
     "Rgba32Batch",
     "Rgba32Like",
-    "Rgba32Type",
     "RotationAxisAngle",
     "RotationAxisAngleArrayLike",
     "RotationAxisAngleBatch",
     "RotationAxisAngleLike",
-    "RotationAxisAngleType",
     "TensorBuffer",
     "TensorBufferArrayLike",
     "TensorBufferBatch",
     "TensorBufferLike",
-    "TensorBufferType",
     "TensorData",
     "TensorDataArrayLike",
     "TensorDataBatch",
     "TensorDataLike",
-    "TensorDataType",
     "TensorDimension",
     "TensorDimensionArrayLike",
     "TensorDimensionBatch",
@@ -259,19 +186,15 @@ __all__ = [
     "TensorDimensionIndexSelectionArrayLike",
     "TensorDimensionIndexSelectionBatch",
     "TensorDimensionIndexSelectionLike",
-    "TensorDimensionIndexSelectionType",
     "TensorDimensionLike",
     "TensorDimensionSelection",
     "TensorDimensionSelectionArrayLike",
     "TensorDimensionSelectionBatch",
     "TensorDimensionSelectionLike",
-    "TensorDimensionSelectionType",
-    "TensorDimensionType",
     "TimeInt",
     "TimeIntArrayLike",
     "TimeIntBatch",
     "TimeIntLike",
-    "TimeIntType",
     "TimeRange",
     "TimeRangeArrayLike",
     "TimeRangeBatch",
@@ -279,77 +202,61 @@ __all__ = [
     "TimeRangeBoundaryArrayLike",
     "TimeRangeBoundaryBatch",
     "TimeRangeBoundaryLike",
-    "TimeRangeBoundaryType",
     "TimeRangeLike",
-    "TimeRangeType",
     "UInt16",
     "UInt16ArrayLike",
     "UInt16Batch",
     "UInt16Like",
-    "UInt16Type",
     "UInt32",
     "UInt32ArrayLike",
     "UInt32Batch",
     "UInt32Like",
-    "UInt32Type",
     "UInt64",
     "UInt64ArrayLike",
     "UInt64Batch",
     "UInt64Like",
-    "UInt64Type",
     "UVec2D",
     "UVec2DArrayLike",
     "UVec2DBatch",
     "UVec2DLike",
-    "UVec2DType",
     "UVec3D",
     "UVec3DArrayLike",
     "UVec3DBatch",
     "UVec3DLike",
-    "UVec3DType",
     "UVec4D",
     "UVec4DArrayLike",
     "UVec4DBatch",
     "UVec4DLike",
-    "UVec4DType",
     "Utf8",
     "Utf8ArrayLike",
     "Utf8Batch",
     "Utf8Like",
-    "Utf8Type",
     "Uuid",
     "UuidArrayLike",
     "UuidBatch",
     "UuidLike",
-    "UuidType",
     "Vec2D",
     "Vec2DArrayLike",
     "Vec2DBatch",
     "Vec2DLike",
-    "Vec2DType",
     "Vec3D",
     "Vec3DArrayLike",
     "Vec3DBatch",
     "Vec3DLike",
-    "Vec3DType",
     "Vec4D",
     "Vec4DArrayLike",
     "Vec4DBatch",
     "Vec4DLike",
-    "Vec4DType",
     "VideoTimestamp",
     "VideoTimestampArrayLike",
     "VideoTimestampBatch",
     "VideoTimestampLike",
-    "VideoTimestampType",
     "ViewCoordinates",
     "ViewCoordinatesArrayLike",
     "ViewCoordinatesBatch",
     "ViewCoordinatesLike",
-    "ViewCoordinatesType",
     "VisibleTimeRange",
     "VisibleTimeRangeArrayLike",
     "VisibleTimeRangeBatch",
     "VisibleTimeRangeLike",
-    "VisibleTimeRangeType",
 ]

--- a/rerun_py/rerun_sdk/rerun/datatypes/angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/angle.py
@@ -14,11 +14,10 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .angle_ext import AngleExt
 
-__all__ = ["Angle", "AngleArrayLike", "AngleBatch", "AngleLike", "AngleType"]
+__all__ = ["Angle", "AngleArrayLike", "AngleBatch", "AngleLike"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ else:
 AngleArrayLike = Union[Angle, Sequence[AngleLike], npt.ArrayLike, Sequence[float], Sequence[int]]
 
 
-class AngleType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Angle"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
-
-
 class AngleBatch(BaseBatch[AngleArrayLike]):
-    _ARROW_TYPE = AngleType()
+    _ARROW_DATATYPE = pa.float32()
 
     @staticmethod
     def _native_to_pa_array(data: AngleArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info.py
@@ -13,17 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .annotation_info_ext import AnnotationInfoExt
 
-__all__ = [
-    "AnnotationInfo",
-    "AnnotationInfoArrayLike",
-    "AnnotationInfoBatch",
-    "AnnotationInfoLike",
-    "AnnotationInfoType",
-]
+__all__ = ["AnnotationInfo", "AnnotationInfoArrayLike", "AnnotationInfoBatch", "AnnotationInfoLike"]
 
 
 def _annotation_info__label__special_field_converter_override(x: datatypes.Utf8Like | None) -> datatypes.Utf8 | None:
@@ -106,23 +99,12 @@ AnnotationInfoArrayLike = Union[
 ]
 
 
-class AnnotationInfoType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.AnnotationInfo"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("id", pa.uint16(), nullable=False, metadata={}),
-                pa.field("label", pa.utf8(), nullable=True, metadata={}),
-                pa.field("color", pa.uint32(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class AnnotationInfoBatch(BaseBatch[AnnotationInfoArrayLike]):
-    _ARROW_TYPE = AnnotationInfoType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("id", pa.uint16(), nullable=False, metadata={}),
+        pa.field("label", pa.utf8(), nullable=True, metadata={}),
+        pa.field("color", pa.uint32(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationInfoArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/annotation_info_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/annotation_info_ext.py
@@ -17,7 +17,7 @@ class AnnotationInfoExt:
 
     @staticmethod
     def native_to_pa_array_override(data: AnnotationInfoArrayLike, data_type: pa.DataType) -> pa.Array:
-        from . import AnnotationInfo, Rgba32Type, Utf8Type
+        from . import AnnotationInfo, Rgba32Batch, Utf8Batch
 
         if isinstance(data, AnnotationInfo):
             data = [data]
@@ -32,8 +32,8 @@ class AnnotationInfoExt:
 
         # Note: we can't use from_similar here because we need to handle optional values
         # fortunately these are fairly simple types
-        label_array = pa.array(labels, type=Utf8Type().storage_type)
-        color_array = pa.array(colors, type=Rgba32Type().storage_type)
+        label_array = pa.array(labels, type=Utf8Batch._ARROW_DATATYPE)
+        color_array = pa.array(colors, type=Rgba32Batch._ARROW_DATATYPE)
 
         return pa.StructArray.from_arrays(
             arrays=[id_array, label_array, color_array],

--- a/rerun_py/rerun_sdk/rerun/datatypes/blob.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/blob.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint8,
 )
 from .blob_ext import BlobExt
 
-__all__ = ["Blob", "BlobArrayLike", "BlobBatch", "BlobLike", "BlobType"]
+__all__ = ["Blob", "BlobArrayLike", "BlobBatch", "BlobLike"]
 
 
 @define(init=False)
@@ -49,17 +48,8 @@ else:
 BlobArrayLike = Union[Blob, Sequence[BlobLike], bytes, npt.NDArray[np.uint8]]
 
 
-class BlobType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Blob"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={})), self._TYPE_NAME
-        )
-
-
 class BlobBatch(BaseBatch[BlobArrayLike]):
-    _ARROW_TYPE = BlobType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}))
 
     @staticmethod
     def _native_to_pa_array(data: BlobArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/blob_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/blob_ext.py
@@ -23,7 +23,7 @@ class BlobExt:
 
         # someone or something is building things manually, let them!
         if isinstance(data, BlobBatch):
-            return data.as_arrow_array().storage
+            return data.as_arrow_array()
 
         # pure-numpy fast path
         elif isinstance(data, np.ndarray):

--- a/rerun_py/rerun_sdk/rerun/datatypes/bool.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/bool.py
@@ -13,10 +13,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["Bool", "BoolArrayLike", "BoolBatch", "BoolLike", "BoolType"]
+__all__ = ["Bool", "BoolArrayLike", "BoolBatch", "BoolLike"]
 
 
 @define(init=False)
@@ -46,15 +45,8 @@ BoolArrayLike = Union[
 ]
 
 
-class BoolType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Bool"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.bool_(), self._TYPE_NAME)
-
-
 class BoolBatch(BaseBatch[BoolArrayLike]):
-    _ARROW_TYPE = BoolType()
+    _ARROW_DATATYPE = pa.bool_()
 
     @staticmethod
     def _native_to_pa_array(data: BoolArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/channel_datatype.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/channel_datatype.py
@@ -11,17 +11,10 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .channel_datatype_ext import ChannelDatatypeExt
 
-__all__ = [
-    "ChannelDatatype",
-    "ChannelDatatypeArrayLike",
-    "ChannelDatatypeBatch",
-    "ChannelDatatypeLike",
-    "ChannelDatatypeType",
-]
+__all__ = ["ChannelDatatype", "ChannelDatatypeArrayLike", "ChannelDatatypeBatch", "ChannelDatatypeLike"]
 
 
 from enum import Enum
@@ -119,15 +112,8 @@ ChannelDatatypeLike = Union[
 ChannelDatatypeArrayLike = Union[ChannelDatatypeLike, Sequence[ChannelDatatypeLike]]
 
 
-class ChannelDatatypeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ChannelDatatype"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ChannelDatatypeBatch(BaseBatch[ChannelDatatypeArrayLike]):
-    _ARROW_TYPE = ChannelDatatypeType()
+    _ARROW_DATATYPE = pa.uint8()
 
     @staticmethod
     def _native_to_pa_array(data: ChannelDatatypeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description.py
@@ -13,17 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .class_description_ext import ClassDescriptionExt
 
-__all__ = [
-    "ClassDescription",
-    "ClassDescriptionArrayLike",
-    "ClassDescriptionBatch",
-    "ClassDescriptionLike",
-    "ClassDescriptionType",
-]
+__all__ = ["ClassDescription", "ClassDescriptionArrayLike", "ClassDescriptionBatch", "ClassDescriptionLike"]
 
 
 @define(init=False)
@@ -84,15 +77,23 @@ ClassDescriptionArrayLike = Union[
 ]
 
 
-class ClassDescriptionType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ClassDescription"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
+class ClassDescriptionBatch(BaseBatch[ClassDescriptionArrayLike]):
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "info",
             pa.struct([
+                pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                pa.field("color", pa.uint32(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "keypoint_annotations",
+            pa.list_(
                 pa.field(
-                    "info",
+                    "item",
                     pa.struct([
                         pa.field("id", pa.uint16(), nullable=False, metadata={}),
                         pa.field("label", pa.utf8(), nullable=True, metadata={}),
@@ -100,47 +101,28 @@ class ClassDescriptionType(BaseExtensionType):
                     ]),
                     nullable=False,
                     metadata={},
-                ),
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "keypoint_connections",
+            pa.list_(
                 pa.field(
-                    "keypoint_annotations",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.struct([
-                                pa.field("id", pa.uint16(), nullable=False, metadata={}),
-                                pa.field("label", pa.utf8(), nullable=True, metadata={}),
-                                pa.field("color", pa.uint32(), nullable=True, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
+                    "item",
+                    pa.struct([
+                        pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                        pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
+                    ]),
                     nullable=False,
                     metadata={},
-                ),
-                pa.field(
-                    "keypoint_connections",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.struct([
-                                pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
-                                pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
-class ClassDescriptionBatch(BaseBatch[ClassDescriptionArrayLike]):
-    _ARROW_TYPE = ClassDescriptionType()
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_ext.py
@@ -115,7 +115,7 @@ class ClassDescriptionExt:
         annotations = [item.keypoint_annotations for item in descs]
         connections = [item.keypoint_connections for item in descs]
 
-        infos_array = AnnotationInfoBatch(infos).as_arrow_array().storage
+        infos_array = AnnotationInfoBatch(infos).as_arrow_array()
 
         annotation_offsets = list(
             itertools.chain([0], itertools.accumulate(len(ann) if ann else 0 for ann in annotations))
@@ -124,7 +124,7 @@ class ClassDescriptionExt:
         # annotation_null_map = pa.array([ann is None for ann in annotations], type=pa.bool_())
         # concat_annotations = list(itertools.chain.from_iterable(ann for ann in annotations if ann is not None))
         concat_annotations = list(itertools.chain.from_iterable(annotations))
-        annotation_values_array = AnnotationInfoBatch(concat_annotations).as_arrow_array().storage
+        annotation_values_array = AnnotationInfoBatch(concat_annotations).as_arrow_array()
         # annotations_array = pa.ListArray.from_arrays(annotation_offsets,
         #                                              annotation_values_array,
         #                                              mask=annotation_null_map)
@@ -139,7 +139,7 @@ class ClassDescriptionExt:
         # connection_null_map = pa.array([con is None for con in connections], type=pa.bool_())
         # concat_connections = list(itertools.chain.from_iterable(con for con in connections if con is not None))
         concat_connections = list(itertools.chain.from_iterable(connections))
-        connection_values_array = KeypointPairBatch(concat_connections).as_arrow_array().storage
+        connection_values_array = KeypointPairBatch(concat_connections).as_arrow_array()
         # connection_array = pa.ListArray.from_arrays(connections_offsets,
         #                                             connection_values_array,
         #                                             mask=connection_null_map)

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem.py
@@ -13,7 +13,6 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .class_description_map_elem_ext import ClassDescriptionMapElemExt
 
@@ -22,7 +21,6 @@ __all__ = [
     "ClassDescriptionMapElemArrayLike",
     "ClassDescriptionMapElemBatch",
     "ClassDescriptionMapElemLike",
-    "ClassDescriptionMapElemType",
 ]
 
 
@@ -83,19 +81,27 @@ ClassDescriptionMapElemArrayLike = Union[
 ]
 
 
-class ClassDescriptionMapElemType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ClassDescriptionMapElem"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
+class ClassDescriptionMapElemBatch(BaseBatch[ClassDescriptionMapElemArrayLike]):
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
+        pa.field(
+            "class_description",
             pa.struct([
-                pa.field("class_id", pa.uint16(), nullable=False, metadata={}),
                 pa.field(
-                    "class_description",
+                    "info",
                     pa.struct([
+                        pa.field("id", pa.uint16(), nullable=False, metadata={}),
+                        pa.field("label", pa.utf8(), nullable=True, metadata={}),
+                        pa.field("color", pa.uint32(), nullable=True, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "keypoint_annotations",
+                    pa.list_(
                         pa.field(
-                            "info",
+                            "item",
                             pa.struct([
                                 pa.field("id", pa.uint16(), nullable=False, metadata={}),
                                 pa.field("label", pa.utf8(), nullable=True, metadata={}),
@@ -103,51 +109,32 @@ class ClassDescriptionMapElemType(BaseExtensionType):
                             ]),
                             nullable=False,
                             metadata={},
-                        ),
+                        )
+                    ),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "keypoint_connections",
+                    pa.list_(
                         pa.field(
-                            "keypoint_annotations",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.struct([
-                                        pa.field("id", pa.uint16(), nullable=False, metadata={}),
-                                        pa.field("label", pa.utf8(), nullable=True, metadata={}),
-                                        pa.field("color", pa.uint32(), nullable=True, metadata={}),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
+                            "item",
+                            pa.struct([
+                                pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+                                pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
+                            ]),
                             nullable=False,
                             metadata={},
-                        ),
-                        pa.field(
-                            "keypoint_connections",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.struct([
-                                        pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
-                                        pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
-                            nullable=False,
-                            metadata={},
-                        ),
-                    ]),
+                        )
+                    ),
                     nullable=False,
                     metadata={},
                 ),
             ]),
-            self._TYPE_NAME,
-        )
-
-
-class ClassDescriptionMapElemBatch(BaseBatch[ClassDescriptionMapElemArrayLike]):
-    _ARROW_TYPE = ClassDescriptionMapElemType()
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: ClassDescriptionMapElemArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_description_map_elem_ext.py
@@ -41,8 +41,8 @@ class ClassDescriptionMapElemExt:
         ids = [item.class_id for item in map_items]
         class_descriptions = [item.class_description for item in map_items]
 
-        id_array = ClassIdBatch(ids).as_arrow_array().storage
-        desc_array = ClassDescriptionBatch(class_descriptions).as_arrow_array().storage
+        id_array = ClassIdBatch(ids).as_arrow_array()
+        desc_array = ClassDescriptionBatch(class_descriptions).as_arrow_array()
 
         return pa.StructArray.from_arrays(
             arrays=[id_array, desc_array],

--- a/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/class_id.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["ClassId", "ClassIdArrayLike", "ClassIdBatch", "ClassIdLike", "ClassIdType"]
+__all__ = ["ClassId", "ClassIdArrayLike", "ClassIdBatch", "ClassIdLike"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ else:
 ClassIdArrayLike = Union[ClassId, Sequence[ClassIdLike], int, npt.ArrayLike]
 
 
-class ClassIdType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ClassId"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint16(), self._TYPE_NAME)
-
-
 class ClassIdBatch(BaseBatch[ClassIdArrayLike]):
-    _ARROW_TYPE = ClassIdType()
+    _ARROW_DATATYPE = pa.uint16()
 
     @staticmethod
     def _native_to_pa_array(data: ClassIdArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/color_model.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/color_model.py
@@ -11,10 +11,9 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["ColorModel", "ColorModelArrayLike", "ColorModelBatch", "ColorModelLike", "ColorModelType"]
+__all__ = ["ColorModel", "ColorModelArrayLike", "ColorModelBatch", "ColorModelLike"]
 
 
 from enum import Enum
@@ -67,15 +66,8 @@ ColorModelLike = Union[ColorModel, Literal["BGR", "BGRA", "L", "RGB", "RGBA", "b
 ColorModelArrayLike = Union[ColorModelLike, Sequence[ColorModelLike]]
 
 
-class ColorModelType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ColorModel"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ColorModelBatch(BaseBatch[ColorModelArrayLike]):
-    _ARROW_TYPE = ColorModelType()
+    _ARROW_DATATYPE = pa.uint8()
 
     @staticmethod
     def _native_to_pa_array(data: ColorModelArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/dvec2d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float64,
 )
 from .dvec2d_ext import DVec2DExt
 
-__all__ = ["DVec2D", "DVec2DArrayLike", "DVec2DBatch", "DVec2DLike", "DVec2DType"]
+__all__ = ["DVec2D", "DVec2DArrayLike", "DVec2DBatch", "DVec2DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ DVec2DArrayLike = Union[
 ]
 
 
-class DVec2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.DVec2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2), self._TYPE_NAME
-        )
-
-
 class DVec2DBatch(BaseBatch[DVec2DArrayLike]):
-    _ARROW_TYPE = DVec2DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2)
 
     @staticmethod
     def _native_to_pa_array(data: DVec2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/entity_path.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["EntityPath", "EntityPathArrayLike", "EntityPathBatch", "EntityPathLike", "EntityPathType"]
+__all__ = ["EntityPath", "EntityPathArrayLike", "EntityPathBatch", "EntityPathLike"]
 
 
 @define(init=False)
@@ -47,15 +46,8 @@ else:
 EntityPathArrayLike = Union[EntityPath, Sequence[EntityPathLike], Sequence[str]]
 
 
-class EntityPathType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.EntityPath"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
-
-
 class EntityPathBatch(BaseBatch[EntityPathArrayLike]):
-    _ARROW_TYPE = EntityPathType()
+    _ARROW_DATATYPE = pa.utf8()
 
     @staticmethod
     def _native_to_pa_array(data: EntityPathArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/float32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float32.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["Float32", "Float32ArrayLike", "Float32Batch", "Float32Like", "Float32Type"]
+__all__ = ["Float32", "Float32ArrayLike", "Float32Batch", "Float32Like"]
 
 
 @define(init=False)
@@ -53,15 +52,8 @@ Float32ArrayLike = Union[
 ]
 
 
-class Float32Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Float32"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
-
-
 class Float32Batch(BaseBatch[Float32ArrayLike]):
-    _ARROW_TYPE = Float32Type()
+    _ARROW_DATATYPE = pa.float32()
 
     @staticmethod
     def _native_to_pa_array(data: Float32ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/float64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/float64.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["Float64", "Float64ArrayLike", "Float64Batch", "Float64Like", "Float64Type"]
+__all__ = ["Float64", "Float64ArrayLike", "Float64Batch", "Float64Like"]
 
 
 @define(init=False)
@@ -53,15 +52,8 @@ Float64ArrayLike = Union[
 ]
 
 
-class Float64Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Float64"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float64(), self._TYPE_NAME)
-
-
 class Float64Batch(BaseBatch[Float64ArrayLike]):
-    _ARROW_TYPE = Float64Type()
+    _ARROW_DATATYPE = pa.float64()
 
     @staticmethod
     def _native_to_pa_array(data: Float64ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/image_format.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/image_format.py
@@ -14,11 +14,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .image_format_ext import ImageFormatExt
 
-__all__ = ["ImageFormat", "ImageFormatArrayLike", "ImageFormatBatch", "ImageFormatLike", "ImageFormatType"]
+__all__ = ["ImageFormat", "ImageFormatArrayLike", "ImageFormatBatch", "ImageFormatLike"]
 
 
 @define(init=False)
@@ -114,25 +113,14 @@ ImageFormatArrayLike = Union[
 ]
 
 
-class ImageFormatType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ImageFormat"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("width", pa.uint32(), nullable=False, metadata={}),
-                pa.field("height", pa.uint32(), nullable=False, metadata={}),
-                pa.field("pixel_format", pa.uint8(), nullable=True, metadata={}),
-                pa.field("color_model", pa.uint8(), nullable=True, metadata={}),
-                pa.field("channel_datatype", pa.uint8(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class ImageFormatBatch(BaseBatch[ImageFormatArrayLike]):
-    _ARROW_TYPE = ImageFormatType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("width", pa.uint32(), nullable=False, metadata={}),
+        pa.field("height", pa.uint32(), nullable=False, metadata={}),
+        pa.field("pixel_format", pa.uint8(), nullable=True, metadata={}),
+        pa.field("color_model", pa.uint8(), nullable=True, metadata={}),
+        pa.field("channel_datatype", pa.uint8(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: ImageFormatArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -145,9 +133,9 @@ class ImageFormatBatch(BaseBatch[ImageFormatArrayLike]):
             [
                 pa.array(np.asarray([x.width for x in data], dtype=np.uint32)),
                 pa.array(np.asarray([x.height for x in data], dtype=np.uint32)),
-                PixelFormatBatch([x.pixel_format for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                ColorModelBatch([x.color_model for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                ChannelDatatypeBatch([x.channel_datatype for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                PixelFormatBatch([x.pixel_format for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                ColorModelBatch([x.color_model for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                ChannelDatatypeBatch([x.channel_datatype for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_id.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["KeypointId", "KeypointIdArrayLike", "KeypointIdBatch", "KeypointIdLike", "KeypointIdType"]
+__all__ = ["KeypointId", "KeypointIdArrayLike", "KeypointIdBatch", "KeypointIdLike"]
 
 
 @define(init=False)
@@ -58,15 +57,8 @@ else:
 KeypointIdArrayLike = Union[KeypointId, Sequence[KeypointIdLike], int, npt.ArrayLike]
 
 
-class KeypointIdType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.KeypointId"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint16(), self._TYPE_NAME)
-
-
 class KeypointIdBatch(BaseBatch[KeypointIdArrayLike]):
-    _ARROW_TYPE = KeypointIdType()
+    _ARROW_DATATYPE = pa.uint16()
 
     @staticmethod
     def _native_to_pa_array(data: KeypointIdArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair.py
@@ -13,11 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .keypoint_pair_ext import KeypointPairExt
 
-__all__ = ["KeypointPair", "KeypointPairArrayLike", "KeypointPairBatch", "KeypointPairLike", "KeypointPairType"]
+__all__ = ["KeypointPair", "KeypointPairArrayLike", "KeypointPairBatch", "KeypointPairLike"]
 
 
 def _keypoint_pair__keypoint0__special_field_converter_override(x: datatypes.KeypointIdLike) -> datatypes.KeypointId:
@@ -76,22 +75,11 @@ KeypointPairArrayLike = Union[
 ]
 
 
-class KeypointPairType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.KeypointPair"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
-                pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class KeypointPairBatch(BaseBatch[KeypointPairArrayLike]):
-    _ARROW_TYPE = KeypointPairType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("keypoint0", pa.uint16(), nullable=False, metadata={}),
+        pa.field("keypoint1", pa.uint16(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: KeypointPairArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/keypoint_pair_ext.py
@@ -38,8 +38,8 @@ class KeypointPairExt:
         keypoint0 = [pair.keypoint0 for pair in keypoints]
         keypoint1 = [pair.keypoint1 for pair in keypoints]
 
-        keypoint0_array = KeypointIdBatch(keypoint0).as_arrow_array().storage
-        keypoint1_array = KeypointIdBatch(keypoint1).as_arrow_array().storage
+        keypoint0_array = KeypointIdBatch(keypoint0).as_arrow_array()
+        keypoint1_array = KeypointIdBatch(keypoint1).as_arrow_array()
 
         return pa.StructArray.from_arrays(
             arrays=[keypoint0_array, keypoint1_array],

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat3x3.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .mat3x3_ext import Mat3x3Ext
 
-__all__ = ["Mat3x3", "Mat3x3ArrayLike", "Mat3x3Batch", "Mat3x3Like", "Mat3x3Type"]
+__all__ = ["Mat3x3", "Mat3x3ArrayLike", "Mat3x3Batch", "Mat3x3Like"]
 
 
 @define(init=False)
@@ -81,17 +80,8 @@ else:
 Mat3x3ArrayLike = Union[Mat3x3, Sequence[Mat3x3Like], npt.ArrayLike]
 
 
-class Mat3x3Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Mat3x3"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9), self._TYPE_NAME
-        )
-
-
 class Mat3x3Batch(BaseBatch[Mat3x3ArrayLike]):
-    _ARROW_TYPE = Mat3x3Type()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 9)
 
     @staticmethod
     def _native_to_pa_array(data: Mat3x3ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/mat4x4.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .mat4x4_ext import Mat4x4Ext
 
-__all__ = ["Mat4x4", "Mat4x4ArrayLike", "Mat4x4Batch", "Mat4x4Like", "Mat4x4Type"]
+__all__ = ["Mat4x4", "Mat4x4ArrayLike", "Mat4x4Batch", "Mat4x4Like"]
 
 
 @define(init=False)
@@ -86,17 +85,8 @@ Mat4x4ArrayLike = Union[
 ]
 
 
-class Mat4x4Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Mat4x4"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 16), self._TYPE_NAME
-        )
-
-
 class Mat4x4Batch(BaseBatch[Mat4x4ArrayLike]):
-    _ARROW_TYPE = Mat4x4Type()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 16)
 
     @staticmethod
     def _native_to_pa_array(data: Mat4x4ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/pixel_format.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/pixel_format.py
@@ -11,10 +11,9 @@ import pyarrow as pa
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["PixelFormat", "PixelFormatArrayLike", "PixelFormatBatch", "PixelFormatLike", "PixelFormatType"]
+__all__ = ["PixelFormat", "PixelFormatArrayLike", "PixelFormatBatch", "PixelFormatLike"]
 
 
 from enum import Enum
@@ -185,15 +184,8 @@ PixelFormatLike = Union[
 PixelFormatArrayLike = Union[PixelFormatLike, Sequence[PixelFormatLike]]
 
 
-class PixelFormatType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.PixelFormat"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class PixelFormatBatch(BaseBatch[PixelFormatArrayLike]):
-    _ARROW_TYPE = PixelFormatType()
+    _ARROW_DATATYPE = pa.uint8()
 
     @staticmethod
     def _native_to_pa_array(data: PixelFormatArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/quaternion.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .quaternion_ext import QuaternionExt
 
-__all__ = ["Quaternion", "QuaternionArrayLike", "QuaternionBatch", "QuaternionLike", "QuaternionType"]
+__all__ = ["Quaternion", "QuaternionArrayLike", "QuaternionBatch", "QuaternionLike"]
 
 
 @define(init=False)
@@ -48,17 +47,8 @@ QuaternionArrayLike = Union[
 ]
 
 
-class QuaternionType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Quaternion"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), self._TYPE_NAME
-        )
-
-
 class QuaternionBatch(BaseBatch[QuaternionArrayLike]):
-    _ARROW_TYPE = QuaternionType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4)
 
     @staticmethod
     def _native_to_pa_array(data: QuaternionArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range1d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float64,
 )
 from .range1d_ext import Range1DExt
 
-__all__ = ["Range1D", "Range1DArrayLike", "Range1DBatch", "Range1DLike", "Range1DType"]
+__all__ = ["Range1D", "Range1DArrayLike", "Range1DBatch", "Range1DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ Range1DArrayLike = Union[
 ]
 
 
-class Range1DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Range1D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2), self._TYPE_NAME
-        )
-
-
 class Range1DBatch(BaseBatch[Range1DArrayLike]):
-    _ARROW_TYPE = Range1DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2)
 
     @staticmethod
     def _native_to_pa_array(data: Range1DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/range2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/range2d.py
@@ -13,10 +13,9 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["Range2D", "Range2DArrayLike", "Range2DBatch", "Range2DLike", "Range2DType"]
+__all__ = ["Range2D", "Range2DArrayLike", "Range2DBatch", "Range2DLike"]
 
 
 def _range2d__x_range__special_field_converter_override(x: datatypes.Range1DLike) -> datatypes.Range1D:
@@ -71,32 +70,21 @@ Range2DArrayLike = Union[
 ]
 
 
-class Range2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Range2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field(
-                    "x_range",
-                    pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "y_range",
-                    pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class Range2DBatch(BaseBatch[Range2DArrayLike]):
-    _ARROW_TYPE = Range2DType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "x_range",
+            pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "y_range",
+            pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={}), 2),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: Range2DArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -107,8 +95,8 @@ class Range2DBatch(BaseBatch[Range2DArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                Range1DBatch([x.x_range for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                Range1DBatch([x.y_range for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                Range1DBatch([x.x_range for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                Range1DBatch([x.y_range for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rgba32.py
@@ -14,11 +14,10 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .rgba32_ext import Rgba32Ext
 
-__all__ = ["Rgba32", "Rgba32ArrayLike", "Rgba32Batch", "Rgba32Like", "Rgba32Type"]
+__all__ = ["Rgba32", "Rgba32ArrayLike", "Rgba32Batch", "Rgba32Like"]
 
 
 @define(init=False)
@@ -63,15 +62,8 @@ else:
 Rgba32ArrayLike = Union[Rgba32, Sequence[Rgba32Like], int, npt.ArrayLike]
 
 
-class Rgba32Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Rgba32"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint32(), self._TYPE_NAME)
-
-
 class Rgba32Batch(BaseBatch[Rgba32ArrayLike]):
-    _ARROW_TYPE = Rgba32Type()
+    _ARROW_DATATYPE = pa.uint32()
 
     @staticmethod
     def _native_to_pa_array(data: Rgba32ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/rotation_axis_angle.py
@@ -13,17 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .rotation_axis_angle_ext import RotationAxisAngleExt
 
-__all__ = [
-    "RotationAxisAngle",
-    "RotationAxisAngleArrayLike",
-    "RotationAxisAngleBatch",
-    "RotationAxisAngleLike",
-    "RotationAxisAngleType",
-]
+__all__ = ["RotationAxisAngle", "RotationAxisAngleArrayLike", "RotationAxisAngleBatch", "RotationAxisAngleLike"]
 
 
 def _rotation_axis_angle__axis__special_field_converter_override(x: datatypes.Vec3DLike) -> datatypes.Vec3D:
@@ -63,27 +56,16 @@ RotationAxisAngleArrayLike = Union[
 ]
 
 
-class RotationAxisAngleType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.RotationAxisAngle"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field(
-                    "axis",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field("angle", pa.float32(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class RotationAxisAngleBatch(BaseBatch[RotationAxisAngleArrayLike]):
-    _ARROW_TYPE = RotationAxisAngleType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "axis",
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field("angle", pa.float32(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: RotationAxisAngleArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -94,8 +76,8 @@ class RotationAxisAngleBatch(BaseBatch[RotationAxisAngleArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                Vec3DBatch([x.axis for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                AngleBatch([x.angle for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                Vec3DBatch([x.axis for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                AngleBatch([x.angle for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_buffer.py
@@ -14,11 +14,10 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .tensor_buffer_ext import TensorBufferExt
 
-__all__ = ["TensorBuffer", "TensorBufferArrayLike", "TensorBufferBatch", "TensorBufferLike", "TensorBufferType"]
+__all__ = ["TensorBuffer", "TensorBufferArrayLike", "TensorBufferBatch", "TensorBufferLike"]
 
 
 @define
@@ -119,87 +118,41 @@ else:
     TensorBufferArrayLike = Any
 
 
-class TensorBufferType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TensorBuffer"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.dense_union([
-                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                pa.field(
-                    "U8",
-                    pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "U16",
-                    pa.list_(pa.field("item", pa.uint16(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "U32",
-                    pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "U64",
-                    pa.list_(pa.field("item", pa.uint64(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "I8",
-                    pa.list_(pa.field("item", pa.int8(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "I16",
-                    pa.list_(pa.field("item", pa.int16(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "I32",
-                    pa.list_(pa.field("item", pa.int32(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "I64",
-                    pa.list_(pa.field("item", pa.int64(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "F16",
-                    pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "F32",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "F64",
-                    pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TensorBufferBatch(BaseBatch[TensorBufferArrayLike]):
-    _ARROW_TYPE = TensorBufferType()
+    _ARROW_DATATYPE = pa.dense_union([
+        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+        pa.field(
+            "U8", pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "U16", pa.list_(pa.field("item", pa.uint16(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "U32", pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "U64", pa.list_(pa.field("item", pa.uint64(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field("I8", pa.list_(pa.field("item", pa.int8(), nullable=False, metadata={})), nullable=False, metadata={}),
+        pa.field(
+            "I16", pa.list_(pa.field("item", pa.int16(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "I32", pa.list_(pa.field("item", pa.int32(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "I64", pa.list_(pa.field("item", pa.int64(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "F16", pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "F32", pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+        pa.field(
+            "F64", pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={})), nullable=False, metadata={}
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TensorBufferArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data.py
@@ -14,11 +14,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .tensor_data_ext import TensorDataExt
 
-__all__ = ["TensorData", "TensorDataArrayLike", "TensorDataBatch", "TensorDataLike", "TensorDataType"]
+__all__ = ["TensorData", "TensorDataArrayLike", "TensorDataBatch", "TensorDataLike"]
 
 
 def _tensor_data__buffer__special_field_converter_override(x: datatypes.TensorBufferLike) -> datatypes.TensorBuffer:
@@ -66,110 +65,99 @@ else:
 TensorDataArrayLike = Union[TensorData, Sequence[TensorDataLike], npt.ArrayLike]
 
 
-class TensorDataType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TensorData"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
+class TensorDataBatch(BaseBatch[TensorDataArrayLike]):
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "shape",
+            pa.list_(
                 pa.field(
-                    "shape",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.struct([
-                                pa.field("size", pa.uint64(), nullable=False, metadata={}),
-                                pa.field("name", pa.utf8(), nullable=True, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
+                    "item",
+                    pa.struct([
+                        pa.field("size", pa.uint64(), nullable=False, metadata={}),
+                        pa.field("name", pa.utf8(), nullable=True, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "buffer",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field(
+                    "U8",
+                    pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={})),
                     nullable=False,
                     metadata={},
                 ),
                 pa.field(
-                    "buffer",
-                    pa.dense_union([
-                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                        pa.field(
-                            "U8",
-                            pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "U16",
-                            pa.list_(pa.field("item", pa.uint16(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "U32",
-                            pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "U64",
-                            pa.list_(pa.field("item", pa.uint64(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "I8",
-                            pa.list_(pa.field("item", pa.int8(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "I16",
-                            pa.list_(pa.field("item", pa.int16(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "I32",
-                            pa.list_(pa.field("item", pa.int32(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "I64",
-                            pa.list_(pa.field("item", pa.int64(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "F16",
-                            pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "F32",
-                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "F64",
-                            pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                    ]),
+                    "U16",
+                    pa.list_(pa.field("item", pa.uint16(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "U32",
+                    pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "U64",
+                    pa.list_(pa.field("item", pa.uint64(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "I8",
+                    pa.list_(pa.field("item", pa.int8(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "I16",
+                    pa.list_(pa.field("item", pa.int16(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "I32",
+                    pa.list_(pa.field("item", pa.int32(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "I64",
+                    pa.list_(pa.field("item", pa.int64(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "F16",
+                    pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "F32",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "F64",
+                    pa.list_(pa.field("item", pa.float64(), nullable=False, metadata={})),
                     nullable=False,
                     metadata={},
                 ),
             ]),
-            self._TYPE_NAME,
-        )
-
-
-class TensorDataBatch(BaseBatch[TensorDataArrayLike]):
-    _ARROW_TYPE = TensorDataType()
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TensorDataArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_data_ext.py
@@ -189,9 +189,9 @@ class TensorDataExt:
 
 
 def _build_shape_array(dims: list[TensorDimension]) -> pa.Array:
-    from . import TensorDimensionType
+    from . import TensorDimensionBatch
 
-    data_type = TensorDimensionType().storage_type
+    data_type = TensorDimensionBatch._ARROW_DATATYPE
 
     array = np.asarray([d.size for d in dims], dtype=np.uint64).flatten()
     names = pa.array([d.name for d in dims], mask=[d is None for d in dims], type=data_type.field("name").type)
@@ -224,9 +224,9 @@ DTYPE_MAP: Final[dict[npt.DTypeLike, str]] = {
 
 
 def _build_buffer_array(buffer: TensorBufferLike) -> pa.Array:
-    from . import TensorBuffer, TensorBufferType
+    from . import TensorBuffer, TensorBufferBatch
 
-    data_type = TensorBufferType().storage_type
+    data_type = TensorBufferBatch._ARROW_DATATYPE
 
     if isinstance(buffer, TensorBuffer):
         buffer = buffer.inner

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension.py
@@ -12,19 +12,12 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     str_or_none,
 )
 
-__all__ = [
-    "TensorDimension",
-    "TensorDimensionArrayLike",
-    "TensorDimensionBatch",
-    "TensorDimensionLike",
-    "TensorDimensionType",
-]
+__all__ = ["TensorDimension", "TensorDimensionArrayLike", "TensorDimensionBatch", "TensorDimensionLike"]
 
 
 @define(init=False)
@@ -65,22 +58,11 @@ TensorDimensionArrayLike = Union[
 ]
 
 
-class TensorDimensionType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TensorDimension"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("size", pa.uint64(), nullable=False, metadata={}),
-                pa.field("name", pa.utf8(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TensorDimensionBatch(BaseBatch[TensorDimensionArrayLike]):
-    _ARROW_TYPE = TensorDimensionType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("size", pa.uint64(), nullable=False, metadata={}),
+        pa.field("name", pa.utf8(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension_index_selection.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension_index_selection.py
@@ -13,7 +13,6 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 __all__ = [
@@ -21,7 +20,6 @@ __all__ = [
     "TensorDimensionIndexSelectionArrayLike",
     "TensorDimensionIndexSelectionBatch",
     "TensorDimensionIndexSelectionLike",
-    "TensorDimensionIndexSelectionType",
 ]
 
 
@@ -67,22 +65,11 @@ TensorDimensionIndexSelectionArrayLike = Union[
 ]
 
 
-class TensorDimensionIndexSelectionType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TensorDimensionIndexSelection"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("dimension", pa.uint32(), nullable=False, metadata={}),
-                pa.field("index", pa.uint64(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TensorDimensionIndexSelectionBatch(BaseBatch[TensorDimensionIndexSelectionArrayLike]):
-    _ARROW_TYPE = TensorDimensionIndexSelectionType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("dimension", pa.uint32(), nullable=False, metadata={}),
+        pa.field("index", pa.uint64(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionIndexSelectionArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension_selection.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/tensor_dimension_selection.py
@@ -13,7 +13,6 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .tensor_dimension_selection_ext import TensorDimensionSelectionExt
 
@@ -22,7 +21,6 @@ __all__ = [
     "TensorDimensionSelectionArrayLike",
     "TensorDimensionSelectionBatch",
     "TensorDimensionSelectionLike",
-    "TensorDimensionSelectionType",
 ]
 
 
@@ -53,22 +51,11 @@ TensorDimensionSelectionArrayLike = Union[
 ]
 
 
-class TensorDimensionSelectionType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TensorDimensionSelection"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("dimension", pa.uint32(), nullable=False, metadata={}),
-                pa.field("invert", pa.bool_(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TensorDimensionSelectionBatch(BaseBatch[TensorDimensionSelectionArrayLike]):
-    _ARROW_TYPE = TensorDimensionSelectionType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("dimension", pa.uint32(), nullable=False, metadata={}),
+        pa.field("invert", pa.bool_(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TensorDimensionSelectionArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_int.py
@@ -14,11 +14,10 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .time_int_ext import TimeIntExt
 
-__all__ = ["TimeInt", "TimeIntArrayLike", "TimeIntBatch", "TimeIntLike", "TimeIntType"]
+__all__ = ["TimeInt", "TimeIntArrayLike", "TimeIntBatch", "TimeIntLike"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ TimeIntArrayLike = Union[
 ]
 
 
-class TimeIntType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TimeInt"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.int64(), self._TYPE_NAME)
-
-
 class TimeIntBatch(BaseBatch[TimeIntArrayLike]):
-    _ARROW_TYPE = TimeIntType()
+    _ARROW_DATATYPE = pa.int64()
 
     @staticmethod
     def _native_to_pa_array(data: TimeIntArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range.py
@@ -13,10 +13,9 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["TimeRange", "TimeRangeArrayLike", "TimeRangeBatch", "TimeRangeLike", "TimeRangeType"]
+__all__ = ["TimeRange", "TimeRangeArrayLike", "TimeRangeBatch", "TimeRangeLike"]
 
 
 def _time_range__start__special_field_converter_override(
@@ -75,42 +74,31 @@ TimeRangeArrayLike = Union[
 ]
 
 
-class TimeRangeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TimeRange"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field(
-                    "start",
-                    pa.dense_union([
-                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                        pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
-                        pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
-                        pa.field("Infinite", pa.null(), nullable=True, metadata={}),
-                    ]),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "end",
-                    pa.dense_union([
-                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                        pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
-                        pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
-                        pa.field("Infinite", pa.null(), nullable=True, metadata={}),
-                    ]),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TimeRangeBatch(BaseBatch[TimeRangeArrayLike]):
-    _ARROW_TYPE = TimeRangeType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "start",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
+                pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
+                pa.field("Infinite", pa.null(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "end",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
+                pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
+                pa.field("Infinite", pa.null(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TimeRangeArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -121,8 +109,8 @@ class TimeRangeBatch(BaseBatch[TimeRangeArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                TimeRangeBoundaryBatch([x.start for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                TimeRangeBoundaryBatch([x.end for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                TimeRangeBoundaryBatch([x.start for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                TimeRangeBoundaryBatch([x.end for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/time_range_boundary.py
@@ -13,17 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .time_range_boundary_ext import TimeRangeBoundaryExt
 
-__all__ = [
-    "TimeRangeBoundary",
-    "TimeRangeBoundaryArrayLike",
-    "TimeRangeBoundaryBatch",
-    "TimeRangeBoundaryLike",
-    "TimeRangeBoundaryType",
-]
+__all__ = ["TimeRangeBoundary", "TimeRangeBoundaryArrayLike", "TimeRangeBoundaryBatch", "TimeRangeBoundaryLike"]
 
 
 @define
@@ -78,24 +71,13 @@ else:
     TimeRangeBoundaryArrayLike = Any
 
 
-class TimeRangeBoundaryType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.TimeRangeBoundary"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.dense_union([
-                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
-                pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
-                pa.field("Infinite", pa.null(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class TimeRangeBoundaryBatch(BaseBatch[TimeRangeBoundaryArrayLike]):
-    _ARROW_TYPE = TimeRangeBoundaryType()
+    _ARROW_DATATYPE = pa.dense_union([
+        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+        pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
+        pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
+        pa.field("Infinite", pa.null(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: TimeRangeBoundaryArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -145,8 +127,8 @@ class TimeRangeBoundaryBatch(BaseBatch[TimeRangeBoundaryArrayLike]):
         ]
         children = [
             pa.nulls(num_nulls),
-            TimeIntBatch(variant_cursor_relative).as_arrow_array().storage,
-            TimeIntBatch(variant_absolute).as_arrow_array().storage,
+            TimeIntBatch(variant_cursor_relative).as_arrow_array(),
+            TimeIntBatch(variant_absolute).as_arrow_array(),
             pa.nulls(variant_infinite),
         ]
 

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint16.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint16.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["UInt16", "UInt16ArrayLike", "UInt16Batch", "UInt16Like", "UInt16Type"]
+__all__ = ["UInt16", "UInt16ArrayLike", "UInt16Batch", "UInt16Like"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ else:
 UInt16ArrayLike = Union[UInt16, Sequence[UInt16Like], int, npt.NDArray[np.uint16]]
 
 
-class UInt16Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UInt16"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint16(), self._TYPE_NAME)
-
-
 class UInt16Batch(BaseBatch[UInt16ArrayLike]):
-    _ARROW_TYPE = UInt16Type()
+    _ARROW_DATATYPE = pa.uint16()
 
     @staticmethod
     def _native_to_pa_array(data: UInt16ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint32.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["UInt32", "UInt32ArrayLike", "UInt32Batch", "UInt32Like", "UInt32Type"]
+__all__ = ["UInt32", "UInt32ArrayLike", "UInt32Batch", "UInt32Like"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ else:
 UInt32ArrayLike = Union[UInt32, Sequence[UInt32Like], int, npt.NDArray[np.uint32]]
 
 
-class UInt32Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UInt32"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint32(), self._TYPE_NAME)
-
-
 class UInt32Batch(BaseBatch[UInt32ArrayLike]):
-    _ARROW_TYPE = UInt32Type()
+    _ARROW_DATATYPE = pa.uint32()
 
     @staticmethod
     def _native_to_pa_array(data: UInt32ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uint64.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["UInt64", "UInt64ArrayLike", "UInt64Batch", "UInt64Like", "UInt64Type"]
+__all__ = ["UInt64", "UInt64ArrayLike", "UInt64Batch", "UInt64Like"]
 
 
 @define(init=False)
@@ -51,15 +50,8 @@ else:
 UInt64ArrayLike = Union[UInt64, Sequence[UInt64Like], int, npt.NDArray[np.uint64]]
 
 
-class UInt64Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UInt64"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint64(), self._TYPE_NAME)
-
-
 class UInt64Batch(BaseBatch[UInt64ArrayLike]):
-    _ARROW_TYPE = UInt64Type()
+    _ARROW_DATATYPE = pa.uint64()
 
     @staticmethod
     def _native_to_pa_array(data: UInt64ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/utf8.py
@@ -14,10 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["Utf8", "Utf8ArrayLike", "Utf8Batch", "Utf8Like", "Utf8Type"]
+__all__ = ["Utf8", "Utf8ArrayLike", "Utf8Batch", "Utf8Like"]
 
 
 @define(init=False)
@@ -47,15 +46,8 @@ else:
 Utf8ArrayLike = Union[Utf8, Sequence[Utf8Like], str, Sequence[str], npt.ArrayLike]
 
 
-class Utf8Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Utf8"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
-
-
 class Utf8Batch(BaseBatch[Utf8ArrayLike]):
-    _ARROW_TYPE = Utf8Type()
+    _ARROW_DATATYPE = pa.utf8()
 
     @staticmethod
     def _native_to_pa_array(data: Utf8ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uuid.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint8,
 )
 from .uuid_ext import UuidExt
 
-__all__ = ["Uuid", "UuidArrayLike", "UuidBatch", "UuidLike", "UuidType"]
+__all__ = ["Uuid", "UuidArrayLike", "UuidBatch", "UuidLike"]
 
 
 @define(init=False)
@@ -62,17 +61,8 @@ UuidArrayLike = Union[
 ]
 
 
-class UuidType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Uuid"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 16), self._TYPE_NAME
-        )
-
-
 class UuidBatch(BaseBatch[UuidArrayLike]):
-    _ARROW_TYPE = UuidType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 16)
 
     @staticmethod
     def _native_to_pa_array(data: UuidArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec2d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint32,
 )
 from .uvec2d_ext import UVec2DExt
 
-__all__ = ["UVec2D", "UVec2DArrayLike", "UVec2DBatch", "UVec2DLike", "UVec2DType"]
+__all__ = ["UVec2D", "UVec2DArrayLike", "UVec2DBatch", "UVec2DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ UVec2DArrayLike = Union[
 ]
 
 
-class UVec2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UVec2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 2), self._TYPE_NAME
-        )
-
-
 class UVec2DBatch(BaseBatch[UVec2DArrayLike]):
-    _ARROW_TYPE = UVec2DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 2)
 
     @staticmethod
     def _native_to_pa_array(data: UVec2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec3d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint32,
 )
 from .uvec3d_ext import UVec3DExt
 
-__all__ = ["UVec3D", "UVec3DArrayLike", "UVec3DBatch", "UVec3DLike", "UVec3DType"]
+__all__ = ["UVec3D", "UVec3DArrayLike", "UVec3DBatch", "UVec3DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ UVec3DArrayLike = Union[
 ]
 
 
-class UVec3DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UVec3D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 3), self._TYPE_NAME
-        )
-
-
 class UVec3DBatch(BaseBatch[UVec3DArrayLike]):
-    _ARROW_TYPE = UVec3DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 3)
 
     @staticmethod
     def _native_to_pa_array(data: UVec3DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/uvec4d.py
@@ -14,13 +14,12 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint32,
 )
 
-__all__ = ["UVec4D", "UVec4DArrayLike", "UVec4DBatch", "UVec4DLike", "UVec4DType"]
+__all__ = ["UVec4D", "UVec4DArrayLike", "UVec4DBatch", "UVec4DLike"]
 
 
 @define(init=False)
@@ -50,17 +49,8 @@ UVec4DArrayLike = Union[
 ]
 
 
-class UVec4DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.UVec4D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 4), self._TYPE_NAME
-        )
-
-
 class UVec4DBatch(BaseBatch[UVec4DArrayLike]):
-    _ARROW_TYPE = UVec4DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint32(), nullable=False, metadata={}), 4)
 
     @staticmethod
     def _native_to_pa_array(data: UVec4DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec2d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .vec2d_ext import Vec2DExt
 
-__all__ = ["Vec2D", "Vec2DArrayLike", "Vec2DBatch", "Vec2DLike", "Vec2DType"]
+__all__ = ["Vec2D", "Vec2DArrayLike", "Vec2DBatch", "Vec2DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ Vec2DArrayLike = Union[
 ]
 
 
-class Vec2DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Vec2D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2), self._TYPE_NAME
-        )
-
-
 class Vec2DBatch(BaseBatch[Vec2DArrayLike]):
-    _ARROW_TYPE = Vec2DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 2)
 
     @staticmethod
     def _native_to_pa_array(data: Vec2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec3d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .vec3d_ext import Vec3DExt
 
-__all__ = ["Vec3D", "Vec3DArrayLike", "Vec3DBatch", "Vec3DLike", "Vec3DType"]
+__all__ = ["Vec3D", "Vec3DArrayLike", "Vec3DBatch", "Vec3DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ Vec3DArrayLike = Union[
 ]
 
 
-class Vec3DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Vec3D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3), self._TYPE_NAME
-        )
-
-
 class Vec3DBatch(BaseBatch[Vec3DArrayLike]):
-    _ARROW_TYPE = Vec3DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3)
 
     @staticmethod
     def _native_to_pa_array(data: Vec3DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/vec4d.py
@@ -14,14 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_float32,
 )
 from .vec4d_ext import Vec4DExt
 
-__all__ = ["Vec4D", "Vec4DArrayLike", "Vec4DBatch", "Vec4DLike", "Vec4DType"]
+__all__ = ["Vec4D", "Vec4DArrayLike", "Vec4DBatch", "Vec4DLike"]
 
 
 @define(init=False)
@@ -51,17 +50,8 @@ Vec4DArrayLike = Union[
 ]
 
 
-class Vec4DType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.Vec4D"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4), self._TYPE_NAME
-        )
-
-
 class Vec4DBatch(BaseBatch[Vec4DArrayLike]):
-    _ARROW_TYPE = Vec4DType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 4)
 
     @staticmethod
     def _native_to_pa_array(data: Vec4DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/video_timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/video_timestamp.py
@@ -14,16 +14,9 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = [
-    "VideoTimestamp",
-    "VideoTimestampArrayLike",
-    "VideoTimestampBatch",
-    "VideoTimestampLike",
-    "VideoTimestampType",
-]
+__all__ = ["VideoTimestamp", "VideoTimestampArrayLike", "VideoTimestampBatch", "VideoTimestampLike"]
 
 
 @define(init=False)
@@ -76,15 +69,8 @@ VideoTimestampArrayLike = Union[
 ]
 
 
-class VideoTimestampType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.VideoTimestamp"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.int64(), self._TYPE_NAME)
-
-
 class VideoTimestampBatch(BaseBatch[VideoTimestampArrayLike]):
-    _ARROW_TYPE = VideoTimestampType()
+    _ARROW_DATATYPE = pa.int64()
 
     @staticmethod
     def _native_to_pa_array(data: VideoTimestampArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/view_coordinates.py
@@ -14,20 +14,13 @@ from attrs import define, field
 
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .._converters import (
     to_np_uint8,
 )
 from .view_coordinates_ext import ViewCoordinatesExt
 
-__all__ = [
-    "ViewCoordinates",
-    "ViewCoordinatesArrayLike",
-    "ViewCoordinatesBatch",
-    "ViewCoordinatesLike",
-    "ViewCoordinatesType",
-]
+__all__ = ["ViewCoordinates", "ViewCoordinatesArrayLike", "ViewCoordinatesBatch", "ViewCoordinatesLike"]
 
 
 @define(init=False)
@@ -85,17 +78,8 @@ else:
 ViewCoordinatesArrayLike = Union[ViewCoordinates, Sequence[ViewCoordinatesLike], npt.ArrayLike]
 
 
-class ViewCoordinatesType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.ViewCoordinates"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 3), self._TYPE_NAME
-        )
-
-
 class ViewCoordinatesBatch(BaseBatch[ViewCoordinatesArrayLike]):
-    _ARROW_TYPE = ViewCoordinatesType()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 3)
 
     @staticmethod
     def _native_to_pa_array(data: ViewCoordinatesArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/datatypes/visible_time_range.py
@@ -13,17 +13,10 @@ from attrs import define, field
 from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from .visible_time_range_ext import VisibleTimeRangeExt
 
-__all__ = [
-    "VisibleTimeRange",
-    "VisibleTimeRangeArrayLike",
-    "VisibleTimeRangeBatch",
-    "VisibleTimeRangeLike",
-    "VisibleTimeRangeType",
-]
+__all__ = ["VisibleTimeRange", "VisibleTimeRangeArrayLike", "VisibleTimeRangeBatch", "VisibleTimeRangeLike"]
 
 
 def _visible_time_range__timeline__special_field_converter_override(x: datatypes.Utf8Like) -> datatypes.Utf8:
@@ -57,50 +50,39 @@ VisibleTimeRangeArrayLike = Union[
 ]
 
 
-class VisibleTimeRangeType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.datatypes.VisibleTimeRange"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
+class VisibleTimeRangeBatch(BaseBatch[VisibleTimeRangeArrayLike]):
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("timeline", pa.utf8(), nullable=False, metadata={}),
+        pa.field(
+            "range",
             pa.struct([
-                pa.field("timeline", pa.utf8(), nullable=False, metadata={}),
                 pa.field(
-                    "range",
-                    pa.struct([
-                        pa.field(
-                            "start",
-                            pa.dense_union([
-                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
-                                pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
-                                pa.field("Infinite", pa.null(), nullable=True, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "end",
-                            pa.dense_union([
-                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
-                                pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
-                                pa.field("Infinite", pa.null(), nullable=True, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        ),
+                    "start",
+                    pa.dense_union([
+                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                        pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
+                        pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
+                        pa.field("Infinite", pa.null(), nullable=True, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "end",
+                    pa.dense_union([
+                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                        pa.field("CursorRelative", pa.int64(), nullable=False, metadata={}),
+                        pa.field("Absolute", pa.int64(), nullable=False, metadata={}),
+                        pa.field("Infinite", pa.null(), nullable=True, metadata={}),
                     ]),
                     nullable=False,
                     metadata={},
                 ),
             ]),
-            self._TYPE_NAME,
-        )
-
-
-class VisibleTimeRangeBatch(BaseBatch[VisibleTimeRangeArrayLike]):
-    _ARROW_TYPE = VisibleTimeRangeType()
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: VisibleTimeRangeArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -111,8 +93,8 @@ class VisibleTimeRangeBatch(BaseBatch[VisibleTimeRangeArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                Utf8Batch([x.timeline for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                TimeRangeBatch([x.range for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                Utf8Batch([x.timeline for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                TimeRangeBatch([x.range for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -434,8 +434,7 @@ impl FromPyObject<'_> for ComponentLike {
             Ok(Self(component_str))
         } else if let Ok(component_str) = component
             .getattr("_BATCH_TYPE")
-            .and_then(|batch_type| batch_type.getattr("_ARROW_TYPE"))
-            .and_then(|arrow_type| arrow_type.getattr("_TYPE_NAME"))
+            .and_then(|batch_type| batch_type.getattr("_COMPONENT_NAME"))
             .and_then(|type_name| type_name.extract::<String>())
         {
             Ok(Self(component_str))

--- a/rerun_py/tests/test_types/components/__init__.py
+++ b/rerun_py/tests/test_types/components/__init__.py
@@ -2,71 +2,29 @@
 
 from __future__ import annotations
 
-from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1Batch, AffixFuzzer1Type
-from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2Batch, AffixFuzzer2Type
-from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3Batch, AffixFuzzer3Type
-from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4Batch, AffixFuzzer4Type
-from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5Batch, AffixFuzzer5Type
-from .affix_fuzzer6 import AffixFuzzer6, AffixFuzzer6Batch, AffixFuzzer6Type
-from .affix_fuzzer7 import AffixFuzzer7, AffixFuzzer7ArrayLike, AffixFuzzer7Batch, AffixFuzzer7Like, AffixFuzzer7Type
-from .affix_fuzzer8 import AffixFuzzer8, AffixFuzzer8ArrayLike, AffixFuzzer8Batch, AffixFuzzer8Like, AffixFuzzer8Type
-from .affix_fuzzer9 import AffixFuzzer9, AffixFuzzer9ArrayLike, AffixFuzzer9Batch, AffixFuzzer9Like, AffixFuzzer9Type
-from .affix_fuzzer10 import (
-    AffixFuzzer10,
-    AffixFuzzer10ArrayLike,
-    AffixFuzzer10Batch,
-    AffixFuzzer10Like,
-    AffixFuzzer10Type,
-)
-from .affix_fuzzer11 import (
-    AffixFuzzer11,
-    AffixFuzzer11ArrayLike,
-    AffixFuzzer11Batch,
-    AffixFuzzer11Like,
-    AffixFuzzer11Type,
-)
-from .affix_fuzzer12 import (
-    AffixFuzzer12,
-    AffixFuzzer12ArrayLike,
-    AffixFuzzer12Batch,
-    AffixFuzzer12Like,
-    AffixFuzzer12Type,
-)
-from .affix_fuzzer13 import (
-    AffixFuzzer13,
-    AffixFuzzer13ArrayLike,
-    AffixFuzzer13Batch,
-    AffixFuzzer13Like,
-    AffixFuzzer13Type,
-)
-from .affix_fuzzer14 import AffixFuzzer14, AffixFuzzer14Batch, AffixFuzzer14Type
-from .affix_fuzzer15 import AffixFuzzer15, AffixFuzzer15Batch, AffixFuzzer15Type
-from .affix_fuzzer16 import (
-    AffixFuzzer16,
-    AffixFuzzer16ArrayLike,
-    AffixFuzzer16Batch,
-    AffixFuzzer16Like,
-    AffixFuzzer16Type,
-)
-from .affix_fuzzer17 import (
-    AffixFuzzer17,
-    AffixFuzzer17ArrayLike,
-    AffixFuzzer17Batch,
-    AffixFuzzer17Like,
-    AffixFuzzer17Type,
-)
-from .affix_fuzzer18 import (
-    AffixFuzzer18,
-    AffixFuzzer18ArrayLike,
-    AffixFuzzer18Batch,
-    AffixFuzzer18Like,
-    AffixFuzzer18Type,
-)
-from .affix_fuzzer19 import AffixFuzzer19, AffixFuzzer19Batch, AffixFuzzer19Type
-from .affix_fuzzer20 import AffixFuzzer20, AffixFuzzer20Batch, AffixFuzzer20Type
-from .affix_fuzzer21 import AffixFuzzer21, AffixFuzzer21Batch, AffixFuzzer21Type
-from .affix_fuzzer22 import AffixFuzzer22, AffixFuzzer22Batch, AffixFuzzer22Type
-from .affix_fuzzer23 import AffixFuzzer23, AffixFuzzer23Batch, AffixFuzzer23Type
+from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1Batch
+from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2Batch
+from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3Batch
+from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4Batch
+from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5Batch
+from .affix_fuzzer6 import AffixFuzzer6, AffixFuzzer6Batch
+from .affix_fuzzer7 import AffixFuzzer7, AffixFuzzer7ArrayLike, AffixFuzzer7Batch, AffixFuzzer7Like
+from .affix_fuzzer8 import AffixFuzzer8, AffixFuzzer8ArrayLike, AffixFuzzer8Batch, AffixFuzzer8Like
+from .affix_fuzzer9 import AffixFuzzer9, AffixFuzzer9ArrayLike, AffixFuzzer9Batch, AffixFuzzer9Like
+from .affix_fuzzer10 import AffixFuzzer10, AffixFuzzer10ArrayLike, AffixFuzzer10Batch, AffixFuzzer10Like
+from .affix_fuzzer11 import AffixFuzzer11, AffixFuzzer11ArrayLike, AffixFuzzer11Batch, AffixFuzzer11Like
+from .affix_fuzzer12 import AffixFuzzer12, AffixFuzzer12ArrayLike, AffixFuzzer12Batch, AffixFuzzer12Like
+from .affix_fuzzer13 import AffixFuzzer13, AffixFuzzer13ArrayLike, AffixFuzzer13Batch, AffixFuzzer13Like
+from .affix_fuzzer14 import AffixFuzzer14, AffixFuzzer14Batch
+from .affix_fuzzer15 import AffixFuzzer15, AffixFuzzer15Batch
+from .affix_fuzzer16 import AffixFuzzer16, AffixFuzzer16ArrayLike, AffixFuzzer16Batch, AffixFuzzer16Like
+from .affix_fuzzer17 import AffixFuzzer17, AffixFuzzer17ArrayLike, AffixFuzzer17Batch, AffixFuzzer17Like
+from .affix_fuzzer18 import AffixFuzzer18, AffixFuzzer18ArrayLike, AffixFuzzer18Batch, AffixFuzzer18Like
+from .affix_fuzzer19 import AffixFuzzer19, AffixFuzzer19Batch
+from .affix_fuzzer20 import AffixFuzzer20, AffixFuzzer20Batch
+from .affix_fuzzer21 import AffixFuzzer21, AffixFuzzer21Batch
+from .affix_fuzzer22 import AffixFuzzer22, AffixFuzzer22Batch
+from .affix_fuzzer23 import AffixFuzzer23, AffixFuzzer23Batch
 
 __all__ = [
     "AffixFuzzer1",
@@ -74,88 +32,65 @@ __all__ = [
     "AffixFuzzer10ArrayLike",
     "AffixFuzzer10Batch",
     "AffixFuzzer10Like",
-    "AffixFuzzer10Type",
     "AffixFuzzer11",
     "AffixFuzzer11ArrayLike",
     "AffixFuzzer11Batch",
     "AffixFuzzer11Like",
-    "AffixFuzzer11Type",
     "AffixFuzzer12",
     "AffixFuzzer12ArrayLike",
     "AffixFuzzer12Batch",
     "AffixFuzzer12Like",
-    "AffixFuzzer12Type",
     "AffixFuzzer13",
     "AffixFuzzer13ArrayLike",
     "AffixFuzzer13Batch",
     "AffixFuzzer13Like",
-    "AffixFuzzer13Type",
     "AffixFuzzer14",
     "AffixFuzzer14Batch",
-    "AffixFuzzer14Type",
     "AffixFuzzer15",
     "AffixFuzzer15Batch",
-    "AffixFuzzer15Type",
     "AffixFuzzer16",
     "AffixFuzzer16ArrayLike",
     "AffixFuzzer16Batch",
     "AffixFuzzer16Like",
-    "AffixFuzzer16Type",
     "AffixFuzzer17",
     "AffixFuzzer17ArrayLike",
     "AffixFuzzer17Batch",
     "AffixFuzzer17Like",
-    "AffixFuzzer17Type",
     "AffixFuzzer18",
     "AffixFuzzer18ArrayLike",
     "AffixFuzzer18Batch",
     "AffixFuzzer18Like",
-    "AffixFuzzer18Type",
     "AffixFuzzer19",
     "AffixFuzzer19Batch",
-    "AffixFuzzer19Type",
     "AffixFuzzer1Batch",
-    "AffixFuzzer1Type",
     "AffixFuzzer2",
     "AffixFuzzer20",
     "AffixFuzzer20Batch",
-    "AffixFuzzer20Type",
     "AffixFuzzer21",
     "AffixFuzzer21Batch",
-    "AffixFuzzer21Type",
     "AffixFuzzer22",
     "AffixFuzzer22Batch",
-    "AffixFuzzer22Type",
     "AffixFuzzer23",
     "AffixFuzzer23Batch",
-    "AffixFuzzer23Type",
     "AffixFuzzer2Batch",
-    "AffixFuzzer2Type",
     "AffixFuzzer3",
     "AffixFuzzer3Batch",
-    "AffixFuzzer3Type",
     "AffixFuzzer4",
     "AffixFuzzer4Batch",
-    "AffixFuzzer4Type",
     "AffixFuzzer5",
     "AffixFuzzer5Batch",
-    "AffixFuzzer5Type",
     "AffixFuzzer6",
     "AffixFuzzer6Batch",
-    "AffixFuzzer6Type",
     "AffixFuzzer7",
     "AffixFuzzer7ArrayLike",
     "AffixFuzzer7Batch",
     "AffixFuzzer7Like",
-    "AffixFuzzer7Type",
     "AffixFuzzer8",
     "AffixFuzzer8ArrayLike",
     "AffixFuzzer8Batch",
     "AffixFuzzer8Like",
-    "AffixFuzzer8Type",
     "AffixFuzzer9",
     "AffixFuzzer9ArrayLike",
     "AffixFuzzer9Batch",
     "AffixFuzzer9Like",
-    "AffixFuzzer9Type",
 ]

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer1", "AffixFuzzer1Batch", "AffixFuzzer1Type"]
+__all__ = ["AffixFuzzer1", "AffixFuzzer1Batch"]
 
 
 class AffixFuzzer1(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer1(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer1Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer1"
-
-
 class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer1Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer1"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
@@ -21,7 +20,7 @@ from rerun._converters import (
     str_or_none,
 )
 
-__all__ = ["AffixFuzzer10", "AffixFuzzer10ArrayLike", "AffixFuzzer10Batch", "AffixFuzzer10Like", "AffixFuzzer10Type"]
+__all__ = ["AffixFuzzer10", "AffixFuzzer10ArrayLike", "AffixFuzzer10Batch", "AffixFuzzer10Like"]
 
 
 @define(init=False)
@@ -44,15 +43,9 @@ AffixFuzzer10ArrayLike = Union[
 ]
 
 
-class AffixFuzzer10Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer10"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
-
-
 class AffixFuzzer10Batch(BaseBatch[AffixFuzzer10ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer10Type()
+    _ARROW_DATATYPE = pa.utf8()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer10"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer10ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
@@ -21,7 +20,7 @@ from rerun._converters import (
     to_np_float32,
 )
 
-__all__ = ["AffixFuzzer11", "AffixFuzzer11ArrayLike", "AffixFuzzer11Batch", "AffixFuzzer11Like", "AffixFuzzer11Type"]
+__all__ = ["AffixFuzzer11", "AffixFuzzer11ArrayLike", "AffixFuzzer11Batch", "AffixFuzzer11Like"]
 
 
 @define(init=False)
@@ -48,17 +47,9 @@ AffixFuzzer11ArrayLike = Union[
 ]
 
 
-class AffixFuzzer11Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer11"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})), self._TYPE_NAME
-        )
-
-
 class AffixFuzzer11Batch(BaseBatch[AffixFuzzer11ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer11Type()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}))
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer11"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer11ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
-__all__ = ["AffixFuzzer12", "AffixFuzzer12ArrayLike", "AffixFuzzer12Batch", "AffixFuzzer12Like", "AffixFuzzer12Type"]
+__all__ = ["AffixFuzzer12", "AffixFuzzer12ArrayLike", "AffixFuzzer12Batch", "AffixFuzzer12Like"]
 
 
 @define(init=False)
@@ -39,17 +38,9 @@ AffixFuzzer12ArrayLike = Union[
 ]
 
 
-class AffixFuzzer12Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer12"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})), self._TYPE_NAME
-        )
-
-
 class AffixFuzzer12Batch(BaseBatch[AffixFuzzer12ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer12Type()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer12"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer12ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
-__all__ = ["AffixFuzzer13", "AffixFuzzer13ArrayLike", "AffixFuzzer13Batch", "AffixFuzzer13Like", "AffixFuzzer13Type"]
+__all__ = ["AffixFuzzer13", "AffixFuzzer13ArrayLike", "AffixFuzzer13Batch", "AffixFuzzer13Like"]
 
 
 @define(init=False)
@@ -39,17 +38,9 @@ AffixFuzzer13ArrayLike = Union[
 ]
 
 
-class AffixFuzzer13Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer13"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})), self._TYPE_NAME
-        )
-
-
 class AffixFuzzer13Batch(BaseBatch[AffixFuzzer13ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer13Type()
+    _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer13"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer13ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer14", "AffixFuzzer14Batch", "AffixFuzzer14Type"]
+__all__ = ["AffixFuzzer14", "AffixFuzzer14Batch"]
 
 
 class AffixFuzzer14(datatypes.AffixFuzzer3, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer14(datatypes.AffixFuzzer3, ComponentMixin):
     pass
 
 
-class AffixFuzzer14Type(datatypes.AffixFuzzer3Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer14"
-
-
 class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer14Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer14"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer15", "AffixFuzzer15Batch", "AffixFuzzer15Type"]
+__all__ = ["AffixFuzzer15", "AffixFuzzer15Batch"]
 
 
 class AffixFuzzer15(datatypes.AffixFuzzer3, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer15(datatypes.AffixFuzzer3, ComponentMixin):
     pass
 
 
-class AffixFuzzer15Type(datatypes.AffixFuzzer3Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer15"
-
-
 class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer15Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer15"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -11,14 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer16", "AffixFuzzer16ArrayLike", "AffixFuzzer16Batch", "AffixFuzzer16Like", "AffixFuzzer16Type"]
+__all__ = ["AffixFuzzer16", "AffixFuzzer16ArrayLike", "AffixFuzzer16Batch", "AffixFuzzer16Like"]
 
 
 @define(init=False)
@@ -41,79 +40,69 @@ AffixFuzzer16ArrayLike = Union[
 ]
 
 
-class AffixFuzzer16Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer16"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
+class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin):
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
                 pa.field(
-                    "item",
-                    pa.dense_union([
-                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                    "craziness",
+                    pa.list_(
                         pa.field(
-                            "craziness",
-                            pa.list_(
+                            "item",
+                            pa.struct([
+                                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                                 pa.field(
-                                    "item",
-                                    pa.struct([
-                                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
-                                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
-                                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
-                                        pa.field(
-                                            "many_floats_optional",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                                            nullable=True,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "many_strings_required",
-                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "many_strings_optional",
-                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                            nullable=True,
-                                            metadata={},
-                                        ),
-                                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "almost_flattened_scalar",
-                                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                    ]),
+                                    "many_floats_optional",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field(
+                                    "many_strings_required",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                     nullable=False,
                                     metadata={},
-                                )
-                            ),
+                                ),
+                                pa.field(
+                                    "many_strings_optional",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                                pa.field(
+                                    "almost_flattened_scalar",
+                                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                    nullable=False,
+                                    metadata={},
+                                ),
+                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                            ]),
                             nullable=False,
                             metadata={},
-                        ),
-                        pa.field(
-                            "fixed_size_shenanigans",
-                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-                    ]),
+                        )
+                    ),
                     nullable=False,
                     metadata={},
-                )
-            ),
-            self._TYPE_NAME,
+                ),
+                pa.field(
+                    "fixed_size_shenanigans",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
         )
-
-
-class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer16Type()
+    )
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer16"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer16ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -11,14 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer17", "AffixFuzzer17ArrayLike", "AffixFuzzer17Batch", "AffixFuzzer17Like", "AffixFuzzer17Type"]
+__all__ = ["AffixFuzzer17", "AffixFuzzer17ArrayLike", "AffixFuzzer17Batch", "AffixFuzzer17Like"]
 
 
 @define(init=False)
@@ -41,79 +40,69 @@ AffixFuzzer17ArrayLike = Union[
 ]
 
 
-class AffixFuzzer17Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer17"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
+class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin):
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
                 pa.field(
-                    "item",
-                    pa.dense_union([
-                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+                    "craziness",
+                    pa.list_(
                         pa.field(
-                            "craziness",
-                            pa.list_(
+                            "item",
+                            pa.struct([
+                                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                                 pa.field(
-                                    "item",
-                                    pa.struct([
-                                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
-                                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
-                                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
-                                        pa.field(
-                                            "many_floats_optional",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                                            nullable=True,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "many_strings_required",
-                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "many_strings_optional",
-                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                            nullable=True,
-                                            metadata={},
-                                        ),
-                                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "almost_flattened_scalar",
-                                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                    ]),
+                                    "many_floats_optional",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field(
+                                    "many_strings_required",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                                     nullable=False,
                                     metadata={},
-                                )
-                            ),
+                                ),
+                                pa.field(
+                                    "many_strings_optional",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                                pa.field(
+                                    "almost_flattened_scalar",
+                                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                    nullable=False,
+                                    metadata={},
+                                ),
+                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                            ]),
                             nullable=False,
                             metadata={},
-                        ),
-                        pa.field(
-                            "fixed_size_shenanigans",
-                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-                    ]),
+                        )
+                    ),
                     nullable=False,
                     metadata={},
-                )
-            ),
-            self._TYPE_NAME,
+                ),
+                pa.field(
+                    "fixed_size_shenanigans",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
         )
-
-
-class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer17Type()
+    )
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer17"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer17ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -11,14 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer18", "AffixFuzzer18ArrayLike", "AffixFuzzer18Batch", "AffixFuzzer18Like", "AffixFuzzer18Type"]
+__all__ = ["AffixFuzzer18", "AffixFuzzer18ArrayLike", "AffixFuzzer18Batch", "AffixFuzzer18Like"]
 
 
 @define(init=False)
@@ -41,19 +40,76 @@ AffixFuzzer18ArrayLike = Union[
 ]
 
 
-class AffixFuzzer18Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer18"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
+class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin):
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                 pa.field(
-                    "item",
+                    "single_required",
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
                         pa.field(
-                            "single_required",
+                            "craziness",
+                            pa.list_(
+                                pa.field(
+                                    "item",
+                                    pa.struct([
+                                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
+                                        pa.field(
+                                            "many_floats_optional",
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                                            nullable=True,
+                                            metadata={},
+                                        ),
+                                        pa.field(
+                                            "many_strings_required",
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                            nullable=False,
+                                            metadata={},
+                                        ),
+                                        pa.field(
+                                            "many_strings_optional",
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                            nullable=True,
+                                            metadata={},
+                                        ),
+                                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                                        pa.field(
+                                            "almost_flattened_scalar",
+                                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                            nullable=False,
+                                            metadata={},
+                                        ),
+                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                                    ]),
+                                    nullable=False,
+                                    metadata={},
+                                )
+                            ),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field(
+                            "fixed_size_shenanigans",
+                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "many_required",
+                    pa.list_(
+                        pa.field(
+                            "item",
                             pa.dense_union([
                                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
@@ -120,116 +176,17 @@ class AffixFuzzer18Type(BaseExtensionType):
                             ]),
                             nullable=False,
                             metadata={},
-                        ),
-                        pa.field(
-                            "many_required",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.dense_union([
-                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "craziness",
-                                            pa.list_(
-                                                pa.field(
-                                                    "item",
-                                                    pa.struct([
-                                                        pa.field(
-                                                            "single_float_optional",
-                                                            pa.float32(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_required",
-                                                            pa.utf8(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_optional",
-                                                            pa.utf8(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_floats_optional",
-                                                            pa.list_(
-                                                                pa.field(
-                                                                    "item", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_required",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_optional",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "flattened_scalar",
-                                                            pa.float32(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "almost_flattened_scalar",
-                                                            pa.struct([
-                                                                pa.field(
-                                                                    "value", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ]),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                )
-                                            ),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
-                            nullable=False,
-                            metadata={},
-                        ),
-                    ]),
+                        )
+                    ),
                     nullable=False,
                     metadata={},
-                )
-            ),
-            self._TYPE_NAME,
+                ),
+            ]),
+            nullable=False,
+            metadata={},
         )
-
-
-class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer18Type()
+    )
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer18"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer18ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer19", "AffixFuzzer19Batch", "AffixFuzzer19Type"]
+__all__ = ["AffixFuzzer19", "AffixFuzzer19Batch"]
 
 
 class AffixFuzzer19(datatypes.AffixFuzzer5, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer19(datatypes.AffixFuzzer5, ComponentMixin):
     pass
 
 
-class AffixFuzzer19Type(datatypes.AffixFuzzer5Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer19"
-
-
 class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer19Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer19"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer2", "AffixFuzzer2Batch", "AffixFuzzer2Type"]
+__all__ = ["AffixFuzzer2", "AffixFuzzer2Batch"]
 
 
 class AffixFuzzer2(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer2(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer2Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer2"
-
-
 class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer2Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer2"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer20", "AffixFuzzer20Batch", "AffixFuzzer20Type"]
+__all__ = ["AffixFuzzer20", "AffixFuzzer20Batch"]
 
 
 class AffixFuzzer20(datatypes.AffixFuzzer20, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer20(datatypes.AffixFuzzer20, ComponentMixin):
     pass
 
 
-class AffixFuzzer20Type(datatypes.AffixFuzzer20Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer20"
-
-
 class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer20Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer20"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer21", "AffixFuzzer21Batch", "AffixFuzzer21Type"]
+__all__ = ["AffixFuzzer21", "AffixFuzzer21Batch"]
 
 
 class AffixFuzzer21(datatypes.AffixFuzzer21, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer21(datatypes.AffixFuzzer21, ComponentMixin):
     pass
 
 
-class AffixFuzzer21Type(datatypes.AffixFuzzer21Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer21"
-
-
 class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer21Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer21"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer22.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer22", "AffixFuzzer22Batch", "AffixFuzzer22Type"]
+__all__ = ["AffixFuzzer22", "AffixFuzzer22Batch"]
 
 
 class AffixFuzzer22(datatypes.AffixFuzzer22, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer22(datatypes.AffixFuzzer22, ComponentMixin):
     pass
 
 
-class AffixFuzzer22Type(datatypes.AffixFuzzer22Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer22"
-
-
 class AffixFuzzer22Batch(datatypes.AffixFuzzer22Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer22Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer22"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer23.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer23.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer23", "AffixFuzzer23Batch", "AffixFuzzer23Type"]
+__all__ = ["AffixFuzzer23", "AffixFuzzer23Batch"]
 
 
 class AffixFuzzer23(datatypes.MultiEnum, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer23(datatypes.MultiEnum, ComponentMixin):
     pass
 
 
-class AffixFuzzer23Type(datatypes.MultiEnumType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer23"
-
-
 class AffixFuzzer23Batch(datatypes.MultiEnumBatch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer23Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer23"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer3", "AffixFuzzer3Batch", "AffixFuzzer3Type"]
+__all__ = ["AffixFuzzer3", "AffixFuzzer3Batch"]
 
 
 class AffixFuzzer3(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer3(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer3Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer3"
-
-
 class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer3Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer3"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer4", "AffixFuzzer4Batch", "AffixFuzzer4Type"]
+__all__ = ["AffixFuzzer4", "AffixFuzzer4Batch"]
 
 
 class AffixFuzzer4(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer4(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer4Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer4"
-
-
 class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer4Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer4"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer5", "AffixFuzzer5Batch", "AffixFuzzer5Type"]
+__all__ = ["AffixFuzzer5", "AffixFuzzer5Batch"]
 
 
 class AffixFuzzer5(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer5(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer5Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer5"
-
-
 class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer5Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer5"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -12,7 +12,7 @@ from rerun._baseclasses import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer6", "AffixFuzzer6Batch", "AffixFuzzer6Type"]
+__all__ = ["AffixFuzzer6", "AffixFuzzer6Batch"]
 
 
 class AffixFuzzer6(datatypes.AffixFuzzer1, ComponentMixin):
@@ -23,12 +23,8 @@ class AffixFuzzer6(datatypes.AffixFuzzer1, ComponentMixin):
     pass
 
 
-class AffixFuzzer6Type(datatypes.AffixFuzzer1Type):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer6"
-
-
 class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer6Type()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer6"
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -11,14 +11,13 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer7", "AffixFuzzer7ArrayLike", "AffixFuzzer7Batch", "AffixFuzzer7Like", "AffixFuzzer7Type"]
+__all__ = ["AffixFuzzer7", "AffixFuzzer7ArrayLike", "AffixFuzzer7Batch", "AffixFuzzer7Like"]
 
 
 @define(init=False)
@@ -41,56 +40,46 @@ AffixFuzzer7ArrayLike = Union[
 ]
 
 
-class AffixFuzzer7Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer7"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.list_(
+class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
+    _ARROW_DATATYPE = pa.list_(
+        pa.field(
+            "item",
+            pa.struct([
+                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                 pa.field(
-                    "item",
-                    pa.struct([
-                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
-                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
-                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
-                        pa.field(
-                            "many_floats_optional",
-                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                            nullable=True,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "many_strings_required",
-                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field(
-                            "many_strings_optional",
-                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                            nullable=True,
-                            metadata={},
-                        ),
-                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                        pa.field(
-                            "almost_flattened_scalar",
-                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-                            nullable=False,
-                            metadata={},
-                        ),
-                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                    ]),
+                    "many_floats_optional",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                    nullable=True,
+                    metadata={},
+                ),
+                pa.field(
+                    "many_strings_required",
+                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                     nullable=False,
                     metadata={},
-                )
-            ),
-            self._TYPE_NAME,
+                ),
+                pa.field(
+                    "many_strings_optional",
+                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                    nullable=True,
+                    metadata={},
+                ),
+                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                pa.field(
+                    "almost_flattened_scalar",
+                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
         )
-
-
-class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer7Type()
+    )
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer7"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer7ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
@@ -21,7 +20,7 @@ from rerun._converters import (
     float_or_none,
 )
 
-__all__ = ["AffixFuzzer8", "AffixFuzzer8ArrayLike", "AffixFuzzer8Batch", "AffixFuzzer8Like", "AffixFuzzer8Type"]
+__all__ = ["AffixFuzzer8", "AffixFuzzer8ArrayLike", "AffixFuzzer8Batch", "AffixFuzzer8Like"]
 
 
 @define(init=False)
@@ -48,15 +47,9 @@ AffixFuzzer8ArrayLike = Union[
 ]
 
 
-class AffixFuzzer8Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer8"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
-
-
 class AffixFuzzer8Batch(BaseBatch[AffixFuzzer8ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer8Type()
+    _ARROW_DATATYPE = pa.float32()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer8"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer8ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -13,12 +13,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
     ComponentBatchMixin,
     ComponentMixin,
 )
 
-__all__ = ["AffixFuzzer9", "AffixFuzzer9ArrayLike", "AffixFuzzer9Batch", "AffixFuzzer9Like", "AffixFuzzer9Type"]
+__all__ = ["AffixFuzzer9", "AffixFuzzer9ArrayLike", "AffixFuzzer9Batch", "AffixFuzzer9Like"]
 
 
 @define(init=False)
@@ -47,15 +46,9 @@ AffixFuzzer9ArrayLike = Union[
 ]
 
 
-class AffixFuzzer9Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.components.AffixFuzzer9"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
-
-
 class AffixFuzzer9Batch(BaseBatch[AffixFuzzer9ArrayLike], ComponentBatchMixin):
-    _ARROW_TYPE = AffixFuzzer9Type()
+    _ARROW_DATATYPE = pa.utf8()
+    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer9"
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer9ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/__init__.py
+++ b/rerun_py/tests/test_types/datatypes/__init__.py
@@ -2,126 +2,81 @@
 
 from __future__ import annotations
 
-from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1ArrayLike, AffixFuzzer1Batch, AffixFuzzer1Like, AffixFuzzer1Type
-from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2ArrayLike, AffixFuzzer2Batch, AffixFuzzer2Like, AffixFuzzer2Type
-from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3ArrayLike, AffixFuzzer3Batch, AffixFuzzer3Like, AffixFuzzer3Type
-from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4ArrayLike, AffixFuzzer4Batch, AffixFuzzer4Like, AffixFuzzer4Type
-from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5ArrayLike, AffixFuzzer5Batch, AffixFuzzer5Like, AffixFuzzer5Type
-from .affix_fuzzer20 import (
-    AffixFuzzer20,
-    AffixFuzzer20ArrayLike,
-    AffixFuzzer20Batch,
-    AffixFuzzer20Like,
-    AffixFuzzer20Type,
-)
-from .affix_fuzzer21 import (
-    AffixFuzzer21,
-    AffixFuzzer21ArrayLike,
-    AffixFuzzer21Batch,
-    AffixFuzzer21Like,
-    AffixFuzzer21Type,
-)
-from .affix_fuzzer22 import (
-    AffixFuzzer22,
-    AffixFuzzer22ArrayLike,
-    AffixFuzzer22Batch,
-    AffixFuzzer22Like,
-    AffixFuzzer22Type,
-)
-from .enum_test import EnumTest, EnumTestArrayLike, EnumTestBatch, EnumTestLike, EnumTestType
-from .flattened_scalar import (
-    FlattenedScalar,
-    FlattenedScalarArrayLike,
-    FlattenedScalarBatch,
-    FlattenedScalarLike,
-    FlattenedScalarType,
-)
-from .multi_enum import MultiEnum, MultiEnumArrayLike, MultiEnumBatch, MultiEnumLike, MultiEnumType
+from .affix_fuzzer1 import AffixFuzzer1, AffixFuzzer1ArrayLike, AffixFuzzer1Batch, AffixFuzzer1Like
+from .affix_fuzzer2 import AffixFuzzer2, AffixFuzzer2ArrayLike, AffixFuzzer2Batch, AffixFuzzer2Like
+from .affix_fuzzer3 import AffixFuzzer3, AffixFuzzer3ArrayLike, AffixFuzzer3Batch, AffixFuzzer3Like
+from .affix_fuzzer4 import AffixFuzzer4, AffixFuzzer4ArrayLike, AffixFuzzer4Batch, AffixFuzzer4Like
+from .affix_fuzzer5 import AffixFuzzer5, AffixFuzzer5ArrayLike, AffixFuzzer5Batch, AffixFuzzer5Like
+from .affix_fuzzer20 import AffixFuzzer20, AffixFuzzer20ArrayLike, AffixFuzzer20Batch, AffixFuzzer20Like
+from .affix_fuzzer21 import AffixFuzzer21, AffixFuzzer21ArrayLike, AffixFuzzer21Batch, AffixFuzzer21Like
+from .affix_fuzzer22 import AffixFuzzer22, AffixFuzzer22ArrayLike, AffixFuzzer22Batch, AffixFuzzer22Like
+from .enum_test import EnumTest, EnumTestArrayLike, EnumTestBatch, EnumTestLike
+from .flattened_scalar import FlattenedScalar, FlattenedScalarArrayLike, FlattenedScalarBatch, FlattenedScalarLike
+from .multi_enum import MultiEnum, MultiEnumArrayLike, MultiEnumBatch, MultiEnumLike
 from .primitive_component import (
     PrimitiveComponent,
     PrimitiveComponentArrayLike,
     PrimitiveComponentBatch,
     PrimitiveComponentLike,
-    PrimitiveComponentType,
 )
-from .string_component import (
-    StringComponent,
-    StringComponentArrayLike,
-    StringComponentBatch,
-    StringComponentLike,
-    StringComponentType,
-)
-from .valued_enum import ValuedEnum, ValuedEnumArrayLike, ValuedEnumBatch, ValuedEnumLike, ValuedEnumType
+from .string_component import StringComponent, StringComponentArrayLike, StringComponentBatch, StringComponentLike
+from .valued_enum import ValuedEnum, ValuedEnumArrayLike, ValuedEnumBatch, ValuedEnumLike
 
 __all__ = [
     "AffixFuzzer1",
     "AffixFuzzer1ArrayLike",
     "AffixFuzzer1Batch",
     "AffixFuzzer1Like",
-    "AffixFuzzer1Type",
     "AffixFuzzer2",
     "AffixFuzzer20",
     "AffixFuzzer20ArrayLike",
     "AffixFuzzer20Batch",
     "AffixFuzzer20Like",
-    "AffixFuzzer20Type",
     "AffixFuzzer21",
     "AffixFuzzer21ArrayLike",
     "AffixFuzzer21Batch",
     "AffixFuzzer21Like",
-    "AffixFuzzer21Type",
     "AffixFuzzer22",
     "AffixFuzzer22ArrayLike",
     "AffixFuzzer22Batch",
     "AffixFuzzer22Like",
-    "AffixFuzzer22Type",
     "AffixFuzzer2ArrayLike",
     "AffixFuzzer2Batch",
     "AffixFuzzer2Like",
-    "AffixFuzzer2Type",
     "AffixFuzzer3",
     "AffixFuzzer3ArrayLike",
     "AffixFuzzer3Batch",
     "AffixFuzzer3Like",
-    "AffixFuzzer3Type",
     "AffixFuzzer4",
     "AffixFuzzer4ArrayLike",
     "AffixFuzzer4Batch",
     "AffixFuzzer4Like",
-    "AffixFuzzer4Type",
     "AffixFuzzer5",
     "AffixFuzzer5ArrayLike",
     "AffixFuzzer5Batch",
     "AffixFuzzer5Like",
-    "AffixFuzzer5Type",
     "EnumTest",
     "EnumTestArrayLike",
     "EnumTestBatch",
     "EnumTestLike",
-    "EnumTestType",
     "FlattenedScalar",
     "FlattenedScalarArrayLike",
     "FlattenedScalarBatch",
     "FlattenedScalarLike",
-    "FlattenedScalarType",
     "MultiEnum",
     "MultiEnumArrayLike",
     "MultiEnumBatch",
     "MultiEnumLike",
-    "MultiEnumType",
     "PrimitiveComponent",
     "PrimitiveComponentArrayLike",
     "PrimitiveComponentBatch",
     "PrimitiveComponentLike",
-    "PrimitiveComponentType",
     "StringComponent",
     "StringComponentArrayLike",
     "StringComponentBatch",
     "StringComponentLike",
-    "StringComponentType",
     "ValuedEnum",
     "ValuedEnumArrayLike",
     "ValuedEnumBatch",
     "ValuedEnumLike",
-    "ValuedEnumType",
 ]

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer1.py
@@ -13,7 +13,6 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from rerun._converters import (
     bool_or_none,
@@ -24,7 +23,7 @@ from rerun._converters import (
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer1", "AffixFuzzer1ArrayLike", "AffixFuzzer1Batch", "AffixFuzzer1Like", "AffixFuzzer1Type"]
+__all__ = ["AffixFuzzer1", "AffixFuzzer1ArrayLike", "AffixFuzzer1Batch", "AffixFuzzer1Like"]
 
 
 def _affix_fuzzer1__almost_flattened_scalar__special_field_converter_override(
@@ -85,49 +84,38 @@ AffixFuzzer1ArrayLike = Union[
 ]
 
 
-class AffixFuzzer1Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer1"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
-                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
-                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
-                pa.field(
-                    "many_floats_optional",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                    nullable=True,
-                    metadata={},
-                ),
-                pa.field(
-                    "many_strings_required",
-                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field(
-                    "many_strings_optional",
-                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                    nullable=True,
-                    metadata={},
-                ),
-                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                pa.field(
-                    "almost_flattened_scalar",
-                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class AffixFuzzer1Batch(BaseBatch[AffixFuzzer1ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer1Type()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
+        pa.field(
+            "many_floats_optional",
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+            nullable=True,
+            metadata={},
+        ),
+        pa.field(
+            "many_strings_required",
+            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "many_strings_optional",
+            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+            nullable=True,
+            metadata={},
+        ),
+        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+        pa.field(
+            "almost_flattened_scalar",
+            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer1ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer2.py
@@ -13,13 +13,12 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from rerun._converters import (
     float_or_none,
 )
 
-__all__ = ["AffixFuzzer2", "AffixFuzzer2ArrayLike", "AffixFuzzer2Batch", "AffixFuzzer2Like", "AffixFuzzer2Type"]
+__all__ = ["AffixFuzzer2", "AffixFuzzer2ArrayLike", "AffixFuzzer2Batch", "AffixFuzzer2Like"]
 
 
 @define(init=False)
@@ -44,15 +43,8 @@ AffixFuzzer2ArrayLike = Union[
 ]
 
 
-class AffixFuzzer2Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer2"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.float32(), self._TYPE_NAME)
-
-
 class AffixFuzzer2Batch(BaseBatch[AffixFuzzer2ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer2Type()
+    _ARROW_DATATYPE = pa.float32()
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer2ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer20.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer20", "AffixFuzzer20ArrayLike", "AffixFuzzer20Batch", "AffixFuzzer20Like", "AffixFuzzer20Type"]
+__all__ = ["AffixFuzzer20", "AffixFuzzer20ArrayLike", "AffixFuzzer20Batch", "AffixFuzzer20Like"]
 
 
 def _affix_fuzzer20__p__special_field_converter_override(
@@ -54,22 +53,11 @@ AffixFuzzer20ArrayLike = Union[
 ]
 
 
-class AffixFuzzer20Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer20"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("p", pa.uint32(), nullable=False, metadata={}),
-                pa.field("s", pa.utf8(), nullable=False, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class AffixFuzzer20Batch(BaseBatch[AffixFuzzer20ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer20Type()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("p", pa.uint32(), nullable=False, metadata={}),
+        pa.field("s", pa.utf8(), nullable=False, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer20ArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -80,8 +68,8 @@ class AffixFuzzer20Batch(BaseBatch[AffixFuzzer20ArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                PrimitiveComponentBatch([x.p for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                StringComponentBatch([x.s for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                PrimitiveComponentBatch([x.p for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                StringComponentBatch([x.s for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer21.py
@@ -13,13 +13,12 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from rerun._converters import (
     to_np_float16,
 )
 
-__all__ = ["AffixFuzzer21", "AffixFuzzer21ArrayLike", "AffixFuzzer21Batch", "AffixFuzzer21Like", "AffixFuzzer21Type"]
+__all__ = ["AffixFuzzer21", "AffixFuzzer21ArrayLike", "AffixFuzzer21Batch", "AffixFuzzer21Like"]
 
 
 @define(init=False)
@@ -41,27 +40,16 @@ AffixFuzzer21ArrayLike = Union[
 ]
 
 
-class AffixFuzzer21Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer21"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("single_half", pa.float16(), nullable=False, metadata={}),
-                pa.field(
-                    "many_halves",
-                    pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class AffixFuzzer21Batch(BaseBatch[AffixFuzzer21ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer21Type()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("single_half", pa.float16(), nullable=False, metadata={}),
+        pa.field(
+            "many_halves",
+            pa.list_(pa.field("item", pa.float16(), nullable=False, metadata={})),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer21ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer22.py
@@ -13,13 +13,12 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 from rerun._converters import (
     to_np_uint8,
 )
 
-__all__ = ["AffixFuzzer22", "AffixFuzzer22ArrayLike", "AffixFuzzer22Batch", "AffixFuzzer22Like", "AffixFuzzer22Type"]
+__all__ = ["AffixFuzzer22", "AffixFuzzer22ArrayLike", "AffixFuzzer22Batch", "AffixFuzzer22Like"]
 
 
 @define(init=False)
@@ -44,26 +43,15 @@ AffixFuzzer22ArrayLike = Union[
 ]
 
 
-class AffixFuzzer22Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer22"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field(
-                    "fixed_sized_native",
-                    pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 4),
-                    nullable=False,
-                    metadata={},
-                )
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class AffixFuzzer22Batch(BaseBatch[AffixFuzzer22ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer22Type()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "fixed_sized_native",
+            pa.list_(pa.field("item", pa.uint8(), nullable=False, metadata={}), 4),
+            nullable=False,
+            metadata={},
+        )
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer22ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer3.py
@@ -13,12 +13,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer3", "AffixFuzzer3ArrayLike", "AffixFuzzer3Batch", "AffixFuzzer3Like", "AffixFuzzer3Type"]
+__all__ = ["AffixFuzzer3", "AffixFuzzer3ArrayLike", "AffixFuzzer3Batch", "AffixFuzzer3Like"]
 
 
 @define
@@ -60,72 +59,61 @@ else:
     AffixFuzzer3ArrayLike = Any
 
 
-class AffixFuzzer3Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer3"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.dense_union([
-                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+class AffixFuzzer3Batch(BaseBatch[AffixFuzzer3ArrayLike]):
+    _ARROW_DATATYPE = pa.dense_union([
+        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
+        pa.field(
+            "craziness",
+            pa.list_(
                 pa.field(
-                    "craziness",
-                    pa.list_(
+                    "item",
+                    pa.struct([
+                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
                         pa.field(
-                            "item",
-                            pa.struct([
-                                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
-                                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
-                                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
-                                pa.field(
-                                    "many_floats_optional",
-                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
-                                    nullable=True,
-                                    metadata={},
-                                ),
-                                pa.field(
-                                    "many_strings_required",
-                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                                pa.field(
-                                    "many_strings_optional",
-                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                    nullable=True,
-                                    metadata={},
-                                ),
-                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                                pa.field(
-                                    "almost_flattened_scalar",
-                                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                            ]),
+                            "many_floats_optional",
+                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                            nullable=True,
+                            metadata={},
+                        ),
+                        pa.field(
+                            "many_strings_required",
+                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
                             nullable=False,
                             metadata={},
-                        )
-                    ),
+                        ),
+                        pa.field(
+                            "many_strings_optional",
+                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                            nullable=True,
+                            metadata={},
+                        ),
+                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                        pa.field(
+                            "almost_flattened_scalar",
+                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                    ]),
                     nullable=False,
                     metadata={},
-                ),
-                pa.field(
-                    "fixed_size_shenanigans",
-                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                    nullable=False,
-                    metadata={},
-                ),
-                pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
-class AffixFuzzer3Batch(BaseBatch[AffixFuzzer3ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer3Type()
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "fixed_size_shenanigans",
+            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer3ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer4.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer4", "AffixFuzzer4ArrayLike", "AffixFuzzer4Batch", "AffixFuzzer4Like", "AffixFuzzer4Type"]
+__all__ = ["AffixFuzzer4", "AffixFuzzer4ArrayLike", "AffixFuzzer4Batch", "AffixFuzzer4Like"]
 
 
 @define
@@ -50,16 +49,73 @@ else:
     AffixFuzzer4ArrayLike = Any
 
 
-class AffixFuzzer4Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer4"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
+class AffixFuzzer4Batch(BaseBatch[AffixFuzzer4ArrayLike]):
+    _ARROW_DATATYPE = pa.dense_union([
+        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+        pa.field(
+            "single_required",
             pa.dense_union([
                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
                 pa.field(
-                    "single_required",
+                    "craziness",
+                    pa.list_(
+                        pa.field(
+                            "item",
+                            pa.struct([
+                                pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
+                                pa.field(
+                                    "many_floats_optional",
+                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field(
+                                    "many_strings_required",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                    nullable=False,
+                                    metadata={},
+                                ),
+                                pa.field(
+                                    "many_strings_optional",
+                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                    nullable=True,
+                                    metadata={},
+                                ),
+                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                                pa.field(
+                                    "almost_flattened_scalar",
+                                    pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                    nullable=False,
+                                    metadata={},
+                                ),
+                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                            ]),
+                            nullable=False,
+                            metadata={},
+                        )
+                    ),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "fixed_size_shenanigans",
+                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+            ]),
+            nullable=False,
+            metadata={},
+        ),
+        pa.field(
+            "many_required",
+            pa.list_(
+                pa.field(
+                    "item",
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                         pa.field("degrees", pa.float32(), nullable=False, metadata={}),
@@ -116,90 +172,12 @@ class AffixFuzzer4Type(BaseExtensionType):
                     ]),
                     nullable=False,
                     metadata={},
-                ),
-                pa.field(
-                    "many_required",
-                    pa.list_(
-                        pa.field(
-                            "item",
-                            pa.dense_union([
-                                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                pa.field(
-                                    "craziness",
-                                    pa.list_(
-                                        pa.field(
-                                            "item",
-                                            pa.struct([
-                                                pa.field(
-                                                    "single_float_optional", pa.float32(), nullable=True, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "single_string_required", pa.utf8(), nullable=False, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "single_string_optional", pa.utf8(), nullable=True, metadata={}
-                                                ),
-                                                pa.field(
-                                                    "many_floats_optional",
-                                                    pa.list_(
-                                                        pa.field("item", pa.float32(), nullable=False, metadata={})
-                                                    ),
-                                                    nullable=True,
-                                                    metadata={},
-                                                ),
-                                                pa.field(
-                                                    "many_strings_required",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                                    nullable=False,
-                                                    metadata={},
-                                                ),
-                                                pa.field(
-                                                    "many_strings_optional",
-                                                    pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
-                                                    nullable=True,
-                                                    metadata={},
-                                                ),
-                                                pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
-                                                pa.field(
-                                                    "almost_flattened_scalar",
-                                                    pa.struct([
-                                                        pa.field("value", pa.float32(), nullable=False, metadata={})
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                ),
-                                                pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                            ]),
-                                            nullable=False,
-                                            metadata={},
-                                        )
-                                    ),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                                pa.field(
-                                    "fixed_size_shenanigans",
-                                    pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                    nullable=False,
-                                    metadata={},
-                                ),
-                                pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-                            ]),
-                            nullable=False,
-                            metadata={},
-                        )
-                    ),
-                    nullable=False,
-                    metadata={},
-                ),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
-class AffixFuzzer4Batch(BaseBatch[AffixFuzzer4ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer4Type()
+                )
+            ),
+            nullable=False,
+            metadata={},
+        ),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer4ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/datatypes/affix_fuzzer5.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 from .. import datatypes
 
-__all__ = ["AffixFuzzer5", "AffixFuzzer5ArrayLike", "AffixFuzzer5Batch", "AffixFuzzer5Like", "AffixFuzzer5Type"]
+__all__ = ["AffixFuzzer5", "AffixFuzzer5ArrayLike", "AffixFuzzer5Batch", "AffixFuzzer5Like"]
 
 
 def _affix_fuzzer5__single_optional_union__special_field_converter_override(
@@ -50,19 +49,76 @@ AffixFuzzer5ArrayLike = Union[
 ]
 
 
-class AffixFuzzer5Type(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.AffixFuzzer5"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
+class AffixFuzzer5Batch(BaseBatch[AffixFuzzer5ArrayLike]):
+    _ARROW_DATATYPE = pa.struct([
+        pa.field(
+            "single_optional_union",
+            pa.dense_union([
+                pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                 pa.field(
-                    "single_optional_union",
+                    "single_required",
                     pa.dense_union([
                         pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
+                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
                         pa.field(
-                            "single_required",
+                            "craziness",
+                            pa.list_(
+                                pa.field(
+                                    "item",
+                                    pa.struct([
+                                        pa.field("single_float_optional", pa.float32(), nullable=True, metadata={}),
+                                        pa.field("single_string_required", pa.utf8(), nullable=False, metadata={}),
+                                        pa.field("single_string_optional", pa.utf8(), nullable=True, metadata={}),
+                                        pa.field(
+                                            "many_floats_optional",
+                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={})),
+                                            nullable=True,
+                                            metadata={},
+                                        ),
+                                        pa.field(
+                                            "many_strings_required",
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                            nullable=False,
+                                            metadata={},
+                                        ),
+                                        pa.field(
+                                            "many_strings_optional",
+                                            pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={})),
+                                            nullable=True,
+                                            metadata={},
+                                        ),
+                                        pa.field("flattened_scalar", pa.float32(), nullable=False, metadata={}),
+                                        pa.field(
+                                            "almost_flattened_scalar",
+                                            pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]),
+                                            nullable=False,
+                                            metadata={},
+                                        ),
+                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
+                                    ]),
+                                    nullable=False,
+                                    metadata={},
+                                )
+                            ),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field(
+                            "fixed_size_shenanigans",
+                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
+                            nullable=False,
+                            metadata={},
+                        ),
+                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
+                    ]),
+                    nullable=False,
+                    metadata={},
+                ),
+                pa.field(
+                    "many_required",
+                    pa.list_(
+                        pa.field(
+                            "item",
                             pa.dense_union([
                                 pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
                                 pa.field("degrees", pa.float32(), nullable=False, metadata={}),
@@ -129,116 +185,16 @@ class AffixFuzzer5Type(BaseExtensionType):
                             ]),
                             nullable=False,
                             metadata={},
-                        ),
-                        pa.field(
-                            "many_required",
-                            pa.list_(
-                                pa.field(
-                                    "item",
-                                    pa.dense_union([
-                                        pa.field("_null_markers", pa.null(), nullable=True, metadata={}),
-                                        pa.field("degrees", pa.float32(), nullable=False, metadata={}),
-                                        pa.field(
-                                            "craziness",
-                                            pa.list_(
-                                                pa.field(
-                                                    "item",
-                                                    pa.struct([
-                                                        pa.field(
-                                                            "single_float_optional",
-                                                            pa.float32(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_required",
-                                                            pa.utf8(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "single_string_optional",
-                                                            pa.utf8(),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_floats_optional",
-                                                            pa.list_(
-                                                                pa.field(
-                                                                    "item", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_required",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "many_strings_optional",
-                                                            pa.list_(
-                                                                pa.field("item", pa.utf8(), nullable=False, metadata={})
-                                                            ),
-                                                            nullable=True,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "flattened_scalar",
-                                                            pa.float32(),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field(
-                                                            "almost_flattened_scalar",
-                                                            pa.struct([
-                                                                pa.field(
-                                                                    "value", pa.float32(), nullable=False, metadata={}
-                                                                )
-                                                            ]),
-                                                            nullable=False,
-                                                            metadata={},
-                                                        ),
-                                                        pa.field("from_parent", pa.bool_(), nullable=True, metadata={}),
-                                                    ]),
-                                                    nullable=False,
-                                                    metadata={},
-                                                )
-                                            ),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field(
-                                            "fixed_size_shenanigans",
-                                            pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}), 3),
-                                            nullable=False,
-                                            metadata={},
-                                        ),
-                                        pa.field("empty_variant", pa.null(), nullable=True, metadata={}),
-                                    ]),
-                                    nullable=False,
-                                    metadata={},
-                                )
-                            ),
-                            nullable=False,
-                            metadata={},
-                        ),
-                    ]),
-                    nullable=True,
+                        )
+                    ),
+                    nullable=False,
                     metadata={},
-                )
+                ),
             ]),
-            self._TYPE_NAME,
+            nullable=True,
+            metadata={},
         )
-
-
-class AffixFuzzer5Batch(BaseBatch[AffixFuzzer5ArrayLike]):
-    _ARROW_TYPE = AffixFuzzer5Type()
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer5ArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -249,7 +205,7 @@ class AffixFuzzer5Batch(BaseBatch[AffixFuzzer5ArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                AffixFuzzer4Batch([x.single_optional_union for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                AffixFuzzer4Batch([x.single_optional_union for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/tests/test_types/datatypes/enum_test.py
+++ b/rerun_py/tests/test_types/datatypes/enum_test.py
@@ -10,10 +10,9 @@ from typing import Literal, Sequence, Union
 import pyarrow as pa
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["EnumTest", "EnumTestArrayLike", "EnumTestBatch", "EnumTestLike", "EnumTestType"]
+__all__ = ["EnumTest", "EnumTestArrayLike", "EnumTestBatch", "EnumTestLike"]
 
 
 from enum import Enum
@@ -69,15 +68,8 @@ EnumTestLike = Union[
 EnumTestArrayLike = Union[EnumTestLike, Sequence[EnumTestLike]]
 
 
-class EnumTestType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.EnumTest"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class EnumTestBatch(BaseBatch[EnumTestArrayLike]):
-    _ARROW_TYPE = EnumTestType()
+    _ARROW_DATATYPE = pa.uint8()
 
     @staticmethod
     def _native_to_pa_array(data: EnumTestArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/flattened_scalar.py
+++ b/rerun_py/tests/test_types/datatypes/flattened_scalar.py
@@ -13,16 +13,9 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = [
-    "FlattenedScalar",
-    "FlattenedScalarArrayLike",
-    "FlattenedScalarBatch",
-    "FlattenedScalarLike",
-    "FlattenedScalarType",
-]
+__all__ = ["FlattenedScalar", "FlattenedScalarArrayLike", "FlattenedScalarBatch", "FlattenedScalarLike"]
 
 
 @define(init=False)
@@ -53,17 +46,8 @@ FlattenedScalarArrayLike = Union[
 ]
 
 
-class FlattenedScalarType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.FlattenedScalar"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self, pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})]), self._TYPE_NAME
-        )
-
-
 class FlattenedScalarBatch(BaseBatch[FlattenedScalarArrayLike]):
-    _ARROW_TYPE = FlattenedScalarType()
+    _ARROW_DATATYPE = pa.struct([pa.field("value", pa.float32(), nullable=False, metadata={})])
 
     @staticmethod
     def _native_to_pa_array(data: FlattenedScalarArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/multi_enum.py
+++ b/rerun_py/tests/test_types/datatypes/multi_enum.py
@@ -11,12 +11,11 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
 from .. import datatypes
 
-__all__ = ["MultiEnum", "MultiEnumArrayLike", "MultiEnumBatch", "MultiEnumLike", "MultiEnumType"]
+__all__ = ["MultiEnum", "MultiEnumArrayLike", "MultiEnumBatch", "MultiEnumLike"]
 
 
 @define(init=False)
@@ -55,22 +54,11 @@ MultiEnumArrayLike = Union[
 ]
 
 
-class MultiEnumType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.MultiEnum"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(
-            self,
-            pa.struct([
-                pa.field("value1", pa.uint8(), nullable=False, metadata={}),
-                pa.field("value2", pa.uint8(), nullable=True, metadata={}),
-            ]),
-            self._TYPE_NAME,
-        )
-
-
 class MultiEnumBatch(BaseBatch[MultiEnumArrayLike]):
-    _ARROW_TYPE = MultiEnumType()
+    _ARROW_DATATYPE = pa.struct([
+        pa.field("value1", pa.uint8(), nullable=False, metadata={}),
+        pa.field("value2", pa.uint8(), nullable=True, metadata={}),
+    ])
 
     @staticmethod
     def _native_to_pa_array(data: MultiEnumArrayLike, data_type: pa.DataType) -> pa.Array:
@@ -81,8 +69,8 @@ class MultiEnumBatch(BaseBatch[MultiEnumArrayLike]):
 
         return pa.StructArray.from_arrays(
             [
-                EnumTestBatch([x.value1 for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
-                ValuedEnumBatch([x.value2 for x in data]).as_arrow_array().storage,  # type: ignore[misc, arg-type]
+                EnumTestBatch([x.value1 for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
+                ValuedEnumBatch([x.value2 for x in data]).as_arrow_array(),  # type: ignore[misc, arg-type]
             ],
             fields=list(data_type),
         )

--- a/rerun_py/tests/test_types/datatypes/primitive_component.py
+++ b/rerun_py/tests/test_types/datatypes/primitive_component.py
@@ -13,16 +13,9 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = [
-    "PrimitiveComponent",
-    "PrimitiveComponentArrayLike",
-    "PrimitiveComponentBatch",
-    "PrimitiveComponentLike",
-    "PrimitiveComponentType",
-]
+__all__ = ["PrimitiveComponent", "PrimitiveComponentArrayLike", "PrimitiveComponentBatch", "PrimitiveComponentLike"]
 
 
 @define(init=False)
@@ -53,15 +46,8 @@ PrimitiveComponentArrayLike = Union[
 ]
 
 
-class PrimitiveComponentType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.PrimitiveComponent"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint32(), self._TYPE_NAME)
-
-
 class PrimitiveComponentBatch(BaseBatch[PrimitiveComponentArrayLike]):
-    _ARROW_TYPE = PrimitiveComponentType()
+    _ARROW_DATATYPE = pa.uint32()
 
     @staticmethod
     def _native_to_pa_array(data: PrimitiveComponentArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/string_component.py
+++ b/rerun_py/tests/test_types/datatypes/string_component.py
@@ -13,16 +13,9 @@ import pyarrow as pa
 from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = [
-    "StringComponent",
-    "StringComponentArrayLike",
-    "StringComponentBatch",
-    "StringComponentLike",
-    "StringComponentType",
-]
+__all__ = ["StringComponent", "StringComponentArrayLike", "StringComponentBatch", "StringComponentLike"]
 
 
 @define(init=False)
@@ -49,15 +42,8 @@ StringComponentArrayLike = Union[
 ]
 
 
-class StringComponentType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.StringComponent"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.utf8(), self._TYPE_NAME)
-
-
 class StringComponentBatch(BaseBatch[StringComponentArrayLike]):
-    _ARROW_TYPE = StringComponentType()
+    _ARROW_DATATYPE = pa.utf8()
 
     @staticmethod
     def _native_to_pa_array(data: StringComponentArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/datatypes/valued_enum.py
+++ b/rerun_py/tests/test_types/datatypes/valued_enum.py
@@ -10,10 +10,9 @@ from typing import Literal, Sequence, Union
 import pyarrow as pa
 from rerun._baseclasses import (
     BaseBatch,
-    BaseExtensionType,
 )
 
-__all__ = ["ValuedEnum", "ValuedEnumArrayLike", "ValuedEnumBatch", "ValuedEnumLike", "ValuedEnumType"]
+__all__ = ["ValuedEnum", "ValuedEnumArrayLike", "ValuedEnumBatch", "ValuedEnumLike"]
 
 
 from enum import Enum
@@ -59,15 +58,8 @@ ValuedEnumLike = Union[ValuedEnum, Literal["One", "TheAnswer", "Three", "Two", "
 ValuedEnumArrayLike = Union[ValuedEnumLike, Sequence[ValuedEnumLike]]
 
 
-class ValuedEnumType(BaseExtensionType):
-    _TYPE_NAME: str = "rerun.testing.datatypes.ValuedEnum"
-
-    def __init__(self) -> None:
-        pa.ExtensionType.__init__(self, pa.uint8(), self._TYPE_NAME)
-
-
 class ValuedEnumBatch(BaseBatch[ValuedEnumArrayLike]):
-    _ARROW_TYPE = ValuedEnumType()
+    _ARROW_DATATYPE = pa.uint8()
 
     @staticmethod
     def _native_to_pa_array(data: ValuedEnumArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/unit/test_image_encoded.py
+++ b/rerun_py/tests/unit/test_image_encoded.py
@@ -27,7 +27,7 @@ def test_image_encoded_png() -> None:
 
         assert type(img) is rr.EncodedImage
         assert img.media_type is not None
-        media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+        media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
         assert media_type_arrow == "image/png"
 
@@ -47,7 +47,7 @@ def test_image_encoded_jpg() -> None:
 
         assert type(img) is rr.EncodedImage
         assert img.media_type is not None
-        media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+        media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
         assert media_type_arrow == "image/jpeg"
 
@@ -67,7 +67,7 @@ def test_image_encoded_mono_jpg() -> None:
 
         assert type(img) is rr.EncodedImage
         assert img.media_type is not None
-        media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+        media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
         assert media_type_arrow == "image/jpeg"
 
@@ -85,7 +85,7 @@ def test_image_encoded_jpg_from_bytes() -> None:
 
     assert type(img) is rr.EncodedImage
     assert img.media_type is not None
-    media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+    media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
     assert media_type_arrow == "image/jpeg"
 
@@ -97,7 +97,7 @@ def test_image_encoded_jpg_from_bytes() -> None:
 
     assert type(img) is rr.EncodedImage
     assert img.media_type is not None
-    media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+    media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
     assert media_type_arrow == "image/jpeg"
 
@@ -115,7 +115,7 @@ def test_image_encoded_mono_jpg_from_bytes() -> None:
 
     assert type(img) is rr.EncodedImage
     assert img.media_type is not None
-    media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+    media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
     assert media_type_arrow == "image/jpeg"
 
@@ -128,7 +128,7 @@ def test_image_encoded_mono_jpg_from_bytes() -> None:
 
     assert type(img) is rr.EncodedImage
     assert img.media_type is not None
-    media_type_arrow = img.media_type.as_arrow_array().storage[0].as_py()
+    media_type_arrow = img.media_type.as_arrow_array()[0].as_py()
 
     assert media_type_arrow == "image/jpeg"
 
@@ -154,7 +154,7 @@ def test_image_encoded_nv12() -> None:
 
     assert type(img) is rr.Image
 
-    image_format_arrow = img.format.as_arrow_array().storage[0].as_py()
+    image_format_arrow = img.format.as_arrow_array()[0].as_py()
 
     image_format = rr.components.ImageFormat(
         width=image_format_arrow["width"],
@@ -169,5 +169,5 @@ def test_image_encoded_nv12() -> None:
     assert image_format.pixel_format == rr.PixelFormat.NV12
 
     assert img.draw_order is not None
-    draw_order_arrow = img.draw_order.as_arrow_array().storage[0].as_py()
+    draw_order_arrow = img.draw_order.as_arrow_array()[0].as_py()
     assert draw_order_arrow == 42

--- a/rerun_py/tests/unit/test_tensor.py
+++ b/rerun_py/tests/unit/test_tensor.py
@@ -50,7 +50,7 @@ def tensor_data_expected() -> Any:
 
 def compare_tensors(left: Any, right: Any, check_fields: list[int]) -> None:
     for field in check_fields:
-        assert left.as_arrow_array().storage.field(field) == right.as_arrow_array().storage.field(field)
+        assert left.as_arrow_array().field(field) == right.as_arrow_array().field(field)
 
 
 def test_tensor() -> None:

--- a/rerun_py/tests/unit/test_utf8list.py
+++ b/rerun_py/tests/unit/test_utf8list.py
@@ -51,11 +51,11 @@ def test_utf8list() -> None:
 
     # A component delegating through to the underlying datatype should behave the same
     assert (
-        components.VisualizerOverrides(single_string).as_arrow_array().storage
-        == datatypes.Utf8ListBatch(array_of_array_of_single_string).as_arrow_array().storage
+        components.VisualizerOverrides(single_string).as_arrow_array()
+        == datatypes.Utf8ListBatch(array_of_array_of_single_string).as_arrow_array()
     )
 
     assert (
-        components.VisualizerOverrides(list_with_two_strings).as_arrow_array().storage
-        == datatypes.Utf8ListBatch(list_of_list_with_two_strings).as_arrow_array().storage
+        components.VisualizerOverrides(list_with_two_strings).as_arrow_array()
+        == datatypes.Utf8ListBatch(list_of_list_with_two_strings).as_arrow_array()
     )


### PR DESCRIPTION
* Do not generate, instantiate, nor carry Arrow extensions around: we do not need them, ever. We rely on chunk metadata for everything meta-esque.
* Do not let datatypes pretend that they have semantics. They do not need names.
* Clean everything accordingly.

---

* DNM: requires #8151 

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8153?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8153?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8153)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.