### PR TITLE
Pin to cargo deny 0.16.1 to avoid MSRV issue

### DIFF
--- a/scripts/ci/rust_checks.py
+++ b/scripts/ci/rust_checks.py
@@ -156,7 +156,9 @@ def cargo_deny(timings: list[Timing]) -> None:
     # Note: running just `cargo deny check` without a `--target` can result in
     # false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
     # Installing is quite quick if it's already installed.
-    timings.append(run_cargo("install", "--locked cargo-deny"))
+    #
+    # `cargo-deny` 0.16.2 raises MSRV 1.81.0, we're not there yet.
+    timings.append(run_cargo("install", "--locked cargo-deny@0.16.1"))
     timings.append(run_cargo("deny", "--all-features --log-level error --target aarch64-apple-darwin check"))
     timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-gnu check"))
     timings.append(run_cargo("deny", "--all-features --log-level error --target i686-pc-windows-msvc check"))


### PR DESCRIPTION
### What

Causes our ci to fail because we're on an older Rust version than what is required by 0.16.2

I'm pretty sure this happened unintentionally, see:
* https://github.com/EmbarkStudios/cargo-deny/issues/720

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8158?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8158?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8158)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.