### PR TITLE
Fix last remaining C++ warnings

### DIFF
--- a/rerun_cpp/src/rerun/recording_stream.cpp
+++ b/rerun_cpp/src/rerun/recording_stream.cpp
@@ -7,6 +7,7 @@
 
 #include <arrow/buffer.h>
 
+#include <cassert>
 #include <string> // to_string
 #include <vector>
 
@@ -18,6 +19,9 @@ namespace rerun {
 
             case StoreKind::Blueprint:
                 return RR_STORE_KIND_BLUEPRINT;
+
+            default:
+                assert(false && "unreachable");
         }
 
         // This should never happen since if we missed a switch case we'll get a warning on

--- a/tests/cpp/plot_dashboard_stress/main.cpp
+++ b/tests/cpp/plot_dashboard_stress/main.cpp
@@ -147,9 +147,14 @@ int main(int argc, char** argv) {
 
     std::vector<size_t> offsets;
     if (temporal_batch_size.has_value()) {
+// GCC wrongfully thinks that `temporal_batch_size` might be uninit, even though we've
+// literally checked for that in the line above?!
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
         for (size_t i = 0; i < num_points_per_series; i += *temporal_batch_size) {
             offsets.push_back(i);
         }
+#pragma GCC diagnostic pop
     } else {
         offsets.resize(sim_times.size());
         std::iota(offsets.begin(), offsets.end(), 0);


### PR DESCRIPTION
This fixes the last two remaining warnings I get when `pixi run cpp-build-all`.

* One of them is just a switch I forgot in https://github.com/rerun-io/rerun/pull/8057.
* The other is just GCC being weird... I dunno man.

---

* [x] :seal: 