### PR TITLE
Use gh-pages hosted rust doc while doc.rs docs are broken

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -112,7 +112,7 @@ High-level documentation for Rerun can be found at [http://rerun.io/docs](http:/
 
 - 🌊 [C++ API docs](https://ref.rerun.io/docs/cpp) are built with `doxygen` and hosted on GitHub. Use `pixi run -e cpp cpp-docs` to build them locally. For details on the C++ doc-system, see [Writing Docs](rerun_cpp/docs/writing_docs.md).
 - 🐍 [Python API docs](https://ref.rerun.io/docs/python) are built via `mkdocs` and hosted on GitHub. For details on the Python doc-system, see [Writing Docs](rerun_py/docs/writing_docs.md).
-- 🦀 [Rust API docs](https://docs.rs/rerun/) are hosted on  <https://docs.rs/rerun/>. You can build them locally with: `cargo doc --all-features --no-deps --open`.
+- 🦀 [Rust API docs](https://ref.rerun.io/docs/rust/stable) are hosted on  <https://ref.rerun.io/docs/rust/stable>. You can build them locally with: `cargo doc --all-features --no-deps --open`.
 
 ## Building for the web
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,7 +313,7 @@ This can both greatly simplify logging code and drastically improve performance 
 API documentation:
 * 🐍 [Python `send_columns` docs](https://ref.rerun.io/docs/python/stable/common/columnar_api/#rerun.send_columns)
 * 🌊 [C++ `send_columns` docs](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#ad17571d51185ce2fc2fc2f5c3070ad65)
-* 🦀 [Rust `send_columns` docs](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.send_columns)
+* 🦀 [Rust `send_columns` docs](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.send_columns)
 
 API usage examples:
 <details>

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You should now be able to run `rerun --help` in any terminal.
 - ⚙️ [Examples](http://rerun.io/examples)
 - 🌊 [C++ API docs](https://ref.rerun.io/docs/cpp)
 - 🐍 [Python API docs](https://ref.rerun.io/docs/python)
-- 🦀 [Rust API docs](https://docs.rs/rerun/)
+- 🦀 [Rust API docs](https://ref.rerun.io/docs/rust/stable)
 - ⁉️ [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 
 

--- a/crates/build/re_types_builder/src/codegen/docs/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/docs/mod.rs
@@ -381,7 +381,9 @@ fn list_links(is_unreleased: bool, page: &mut String, object: &Object) {
 
         putln!(
             page,
-            " * 🦀 [Rust API docs for `{}`](https://docs.rs/rerun/latest/rerun/{}/{}.{}.html{speculative_marker})",
+            // TODO(#8165): docs.rs/rerun is broken right now
+            // " * 🦀 [Rust API docs for `{}`](https://docs.rs/rerun/latest/rerun/{}/{}.{}.html{speculative_marker})",
+            " * 🦀 [Rust API docs for `{}`](https://ref.rerun.io/docs/rust/stable/rerun/{}/{}.{}.html{speculative_marker})",
             object.name,
             object.kind.plural_snake_case(),
             if object.is_struct() { "struct" } else { "enum" },

--- a/crates/top/rerun-cli/README.md
+++ b/crates/top/rerun-cli/README.md
@@ -25,7 +25,9 @@ Run `rerun --help` for more.
 ## What is Rerun?
 - [Examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust)
 - [High-level docs](http://rerun.io/docs)
-- [Rust API docs](https://docs.rs/rerun/)
+<!-- TODO(#8165): docs.rs/rerun is broken right now -->
+<!-- - [Rust API docs](https://docs.rs/rerun/) -->
+- [Rust API docs](https://ref.rerun.io/docs/rust/stable/rerun/)
 - [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 
 

--- a/crates/top/rerun-cli/README.md
+++ b/crates/top/rerun-cli/README.md
@@ -26,7 +26,7 @@ Run `rerun --help` for more.
 - [Examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust)
 - [High-level docs](http://rerun.io/docs)
 <!-- TODO(#8165): docs.rs/rerun is broken right now -->
-<!-- - [Rust API docs](https://docs.rs/rerun/) -->
+<!-- - [Rust API docs](https://ref.rerun.io/docs/rust/stable) -->
 - [Rust API docs](https://ref.rerun.io/docs/rust/stable/rerun/)
 - [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 

--- a/crates/top/rerun/README.md
+++ b/crates/top/rerun/README.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">
   <a href="https://crates.io/crates/rerun">                             <img alt="Latest version" src="https://img.shields.io/crates/v/rerun.svg">                               </a>
-  <a href="https://docs.rs/rerun">                                      <img alt="Documentation"  src="https://docs.rs/rerun/badge.svg">                                         </a>
+  <a href="https://docs.rs/rerun">                                      <img alt="Documentation"  src="https://ref.rerun.io/docs/rust/stablebadge.svg">                                         </a>
   <a href="https://github.com/rerun-io/rerun/blob/main/LICENSE-MIT">    <img alt="MIT"            src="https://img.shields.io/badge/license-MIT-blue.svg">                        </a>
   <a href="https://github.com/rerun-io/rerun/blob/main/LICENSE-APACHE"> <img alt="Apache"         src="https://img.shields.io/badge/license-Apache-blue.svg">                     </a>
   <a href="https://discord.gg/Gcm8BbTaAj">                              <img alt="Rerun Discord"  src="https://img.shields.io/discord/1062300748202921994?label=Rerun%20Discord"> </a>
@@ -33,7 +33,7 @@ rec.log("image", &rerun::archetypes::Image::new(image))?;
 - [Examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust)
 - [High-level docs](http://rerun.io/docs)
 <!-- TODO(#8165): docs.rs/rerun is broken right now -->
-<!-- - [Rust API docs](https://docs.rs/rerun/) -->
+<!-- - [Rust API docs](https://ref.rerun.io/docs/rust/stable) -->
 - [Rust API docs](https://ref.rerun.io/docs/rust/stable/rerun/)
 - [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 

--- a/crates/top/rerun/README.md
+++ b/crates/top/rerun/README.md
@@ -32,7 +32,9 @@ rec.log("image", &rerun::archetypes::Image::new(image))?;
 ## Getting started
 - [Examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust)
 - [High-level docs](http://rerun.io/docs)
-- [Rust API docs](https://docs.rs/rerun/)
+<!-- TODO(#8165): docs.rs/rerun is broken right now -->
+<!-- - [Rust API docs](https://docs.rs/rerun/) -->
+- [Rust API docs](https://ref.rerun.io/docs/rust/stable/rerun/)
 - [Troubleshooting](https://www.rerun.io/docs/getting-started/troubleshooting)
 
 ## Library

--- a/docs/content/concepts/annotation-context.md
+++ b/docs/content/concepts/annotation-context.md
@@ -54,7 +54,7 @@ The Annotation Context is defined as a list of Class Descriptions that define ho
 Annotation contexts are logged with:
 
 * Python: 🐍[`rr.AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes/#rerun.archetypes.AnnotationContext)
-* Rust: 🦀[`rerun::AnnotationContext`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AnnotationContext.html#)
+* Rust: 🦀[`rerun::AnnotationContext`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.AnnotationContext.html#)
 
 snippet: tutorials/annotation-context
 
@@ -72,7 +72,7 @@ By default, Rerun will automatically assign colors to each class id, but by defi
 you can explicitly determine the color of each class.
 
 * Python: [`rr.SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes/#rerun.archetypes.SegmentationImage)
-* Rust: Log a [`rerun::SegmentationImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SegmentationImage.html)
+* Rust: Log a [`rerun::SegmentationImage`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.SegmentationImage.html)
 
 <picture>
   <source media="(max-width: 480px)" srcset="https://static.rerun.io/segmentation_image/f48e7db9a1253f35b55205acd55d4b84ab1d8434/480w.png">

--- a/docs/content/concepts/app-model.md
+++ b/docs/content/concepts/app-model.md
@@ -84,7 +84,7 @@ Dataflow:
 Reference:
 * [SDK operating modes: `connect`](../reference/sdk/operating-modes.md#connect)
 * [🐍 Python `connect`](https://ref.rerun.io/docs/python/0.19.0/common/initialization_functions/#rerun.connect)
-* [🦀 Rust `connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.connect)
+* [🦀 Rust `connect`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html#method.connect)
 * [🌊 C++ `connect`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#aef3377ffaa2441b906d2bac94dd8fc64)
 
 ### Asynchronous workflow
@@ -125,7 +125,7 @@ Dataflow:
 Reference:
 * [SDK operating modes: `save`](../reference/sdk/operating-modes.md#save)
 * [🐍 Python `save`](https://ref.rerun.io/docs/python/0.19.0/common/initialization_functions/#rerun.save)
-* [🦀 Rust `save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.save)
+* [🦀 Rust `save`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html#method.save)
 * [🌊 C++ `save`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a555a7940a076c93d951de5b139d14918)
 
 <!--

--- a/docs/content/concepts/apps-and-recordings.md
+++ b/docs/content/concepts/apps-and-recordings.md
@@ -35,7 +35,7 @@ Different recordings (i.e. different _Recording IDs_) will share the same bluepr
 
 Check out the API to learn more about SDK initialization:
 * [🐍 Python](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.init)
-* [🦀 Rust](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.new)
+* [🦀 Rust](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html#method.new)
 * [🌊 C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#abda6202900fa439fe5c27f7aa0d1105a)
 
 

--- a/docs/content/getting-started/data-in/open-any-file.md
+++ b/docs/content/getting-started/data-in/open-any-file.md
@@ -27,7 +27,7 @@ With the exception of `rrd` files that can be streamed from an HTTP URL (e.g. `r
 
 ## Logging file contents from the SDK
 
-To log the contents of a file from the SDK you can use the `log_file_from_path` and `log_file_from_contents` methods ([C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a8f253422a7adc2a19b89d1538c05bcac), [Python](https://ref.rerun.io/docs/python/stable/common/other_classes_and_functions/#rerun.log_file_from_path), [Rust](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)) and the associated examples ([C++](https://github.com/rerun-io/rerun/blob/main/examples/cpp/log_file/main.cpp), [Python](https://github.com/rerun-io/rerun/blob/main/examples/python/log_file/log_file.py), [Rust](https://github.com/rerun-io/rerun/blob/main/examples/rust/log_file/src/main.rs)).
+To log the contents of a file from the SDK you can use the `log_file_from_path` and `log_file_from_contents` methods ([C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a8f253422a7adc2a19b89d1538c05bcac), [Python](https://ref.rerun.io/docs/python/stable/common/other_classes_and_functions/#rerun.log_file_from_path), [Rust](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_file_from_path)) and the associated examples ([C++](https://github.com/rerun-io/rerun/blob/main/examples/cpp/log_file/main.cpp), [Python](https://github.com/rerun-io/rerun/blob/main/examples/python/log_file/log_file.py), [Rust](https://github.com/rerun-io/rerun/blob/main/examples/rust/log_file/src/main.rs)).
 
 Note: when calling these APIs from the SDK, the data will be loaded by the process running the SDK, not the Viewer!
 

--- a/docs/content/getting-started/data-in/rust.md
+++ b/docs/content/getting-started/data-in/rust.md
@@ -59,9 +59,9 @@ Checkout `rerun --help` for more options.
 
 ## Initializing the SDK
 
-To get going we want to create a [`RecordingStream`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html):
-We can do all of this with the [`rerun::RecordingStreamBuilder::new`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.new) function which allows us to name the dataset we're working on by setting its [`ApplicationId`](https://docs.rs/rerun/latest/rerun/struct.ApplicationId.html).
-We then connect it to the already running Viewer via [`connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html#method.connect), returning the `RecordingStream` upon success.
+To get going we want to create a [`RecordingStream`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html):
+We can do all of this with the [`rerun::RecordingStreamBuilder::new`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html#method.new) function which allows us to name the dataset we're working on by setting its [`ApplicationId`](https://ref.rerun.io/docs/rust/stable/rerun/struct.ApplicationId.html).
+We then connect it to the already running Viewer via [`connect`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html#method.connect), returning the `RecordingStream` upon success.
 
 ```rust
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Among other things, a stable [`ApplicationId`](https://docs.rs/rerun/latest/rerun/struct.ApplicationId.html) will make it so the [Rerun Viewer](../../reference/viewer/overview.md) retains its UI state across runs for this specific dataset, which will make our lives much easier as we iterate.
+Among other things, a stable [`ApplicationId`](https://ref.rerun.io/docs/rust/stable/rerun/struct.ApplicationId.html) will make it so the [Rerun Viewer](../../reference/viewer/overview.md) retains its UI state across runs for this specific dataset, which will make our lives much easier as we iterate.
 
 Check out the reference to learn more about how Rerun deals with [applications and recordings](../../concepts/apps-and-recordings.md).
 
@@ -120,9 +120,7 @@ This tiny snippet of code actually holds much more than meets the eye…
 
 ### Archetypes
 
-<!-- TODO(andreas): UPDATE DOC LINKS -->
-
-The easiest way to log geometric primitives is the use the [`RecordingStream::log`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log) method with one of the built-in archetype class, such as [`Points3D`](https://docs.rs/rerun/latest/0.9.0-alpha.10/struct.Points3D.html). Archetypes take care of building batches
+The easiest way to log geometric primitives is the use the [`RecordingStream::log`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log) method with one of the built-in archetype class, such as [`Points3D`](https://ref.rerun.io/docs/rust/stable/rerun/struct.Points3D.html). Archetypes take care of building batches
 of components that are recognized and correctly displayed by the Rerun viewer.
 
 ### Components
@@ -133,11 +131,9 @@ cases, it's possible to add custom components to archetypes, or even log entirel
 archetypes altogether.
 For more information on how the Rerun data model works, refer to our section on [Entities and Components](../../concepts/entity-component.md).
 
-Notably, the [`RecordingStream::log`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log) method
+Notably, the [`RecordingStream::log`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log) method
 
-<!-- TODO(andreas): UPDATE DOC LINKS -->
-
-will handle any data type that implements the [`AsComponents`](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html) trait, making it easy to add your own data.
+will handle any data type that implements the [`AsComponents`](https://ref.rerun.io/docs/rust/stable/rerun/trait.AsComponents.html) trait, making it easy to add your own data.
 For more information on how to supply your own components see [Use custom data](../../howto/extend/custom-data.md).
 
 ### Entities & hierarchies
@@ -265,7 +261,7 @@ for i in 0..400 {
 }
 ```
 
-First we use [`RecordingStream::set_time_seconds`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.set_time_seconds) to declare our own custom `Timeline` and set the current timestamp.
+First we use [`RecordingStream::set_time_seconds`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.set_time_seconds) to declare our own custom `Timeline` and set the current timestamp.
 You can add as many timelines and timestamps as you want when logging data.
 
 ⚠️ If you run this code as is, the result will be.. surprising: the beads are animating as expected, but everything we've logged until that point is gone! ⚠️
@@ -334,7 +330,7 @@ Sometimes, sending the data over the network is not an option. Maybe you'd like 
 
 Rerun has you covered:
 
--   Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save) to stream all logging data to disk.
+-   Use [`RecordingStream::save`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.save) to stream all logging data to disk.
 -   Visualize it via `rerun path/to/recording.rrd`
 
 You can also save a recording (or a portion of it) as you're visualizing it, directly from the viewer.
@@ -343,7 +339,7 @@ You can also save a recording (or a portion of it) as you're visualizing it, dir
 
 ### Spawning the Viewer from your process
 
-If the Rerun Viewer is [installed](../installing-viewer.md) and available in your `PATH`, you can use [`RecordingStream::spawn`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.spawn) to automatically start a Viewer in a new process and connect to it over TCP.
+If the Rerun Viewer is [installed](../installing-viewer.md) and available in your `PATH`, you can use [`RecordingStream::spawn`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.spawn) to automatically start a Viewer in a new process and connect to it over TCP.
 If an external Viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 ```rust
@@ -357,7 +353,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Alternatively, you can use [`rerun::native_viewer::show`](https://docs.rs/rerun/latest/rerun/native_viewer/fn.show.html) to start a Viewer on the main thread (for platform-compatibility reasons) and feed it data from memory.
+Alternatively, you can use [`rerun::native_viewer::show`](https://ref.rerun.io/docs/rust/stable/rerun/native_viewer/fn.show.html) to start a Viewer on the main thread (for platform-compatibility reasons) and feed it data from memory.
 This requires the `native_viewer` feature to be enabled in `Cargo.toml`:
 
 ```toml

--- a/docs/content/howto/logging/custom-data.md
+++ b/docs/content/howto/logging/custom-data.md
@@ -16,7 +16,7 @@ rr.log(
 )
 ```
 
-You can also create your own component by implementing the `AsComponents` [Python protocol](https://ref.rerun.io/docs/python/0.9.0/common/interfaces/#rerun.AsComponents) or [Rust trait](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html), which means implementing the function, `as_component_batches()`.
+You can also create your own component by implementing the `AsComponents` [Python protocol](https://ref.rerun.io/docs/python/0.9.0/common/interfaces/#rerun.AsComponents) or [Rust trait](https://ref.rerun.io/docs/rust/stable/rerun/trait.AsComponents.html), which means implementing the function, `as_component_batches()`.
 
 ## Remapping to a Rerun archetype
 Let's start with a simple example where you have your own point cloud class that is perfectly representable as a Rerun archetype.

--- a/docs/content/howto/logging/send-columns.md
+++ b/docs/content/howto/logging/send-columns.md
@@ -14,7 +14,7 @@ In contrast to the `log` function, `send_columns` does NOT add any other timelin
 API docs of `send_columns`:
 * [🌊 C++](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#ad17571d51185ce2fc2fc2f5c3070ad65)
 * [🐍 Python](https://ref.rerun.io/docs/python/stable/common/columnar_api/#rerun.send_columns)
-* [🦀 Rust](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.send_columns)
+* [🦀 Rust](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.send_columns)
 
 
 ### Using `send_columns` for logging scalars

--- a/docs/content/howto/visualization/reuse-blueprints.md
+++ b/docs/content/howto/visualization/reuse-blueprints.md
@@ -29,7 +29,7 @@ The interactive way is to import the blueprint file directly into the Rerun view
 
 The programmatic way works by calling `log_file_from_path`:
 * [🐍 Python `log_file_from_path`](https://ref.rerun.io/docs/python/stable/common/logging_functions/#rerun.log_file_from_path)
-* [🦀 Rust `log_file_from_path`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)
+* [🦀 Rust `log_file_from_path`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_file_from_path)
 * [🌊 C++ `log_file_from_path`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a20798d7ea74cce5c8174e5cacd0a2c47)
 
 This method allows you to log any file that contains data that Rerun understands (in this case, blueprint data) as part of your current recording:

--- a/docs/content/reference/data-loaders/overview.md
+++ b/docs/content/reference/data-loaders/overview.md
@@ -35,7 +35,7 @@ The Rerun Viewer/SDK will then automatically load the data streamed to the exter
 </picture>
 
 Like any other `DataLoader`, an external loader will be notified of all file openings, unconditionally.
-To indicate that it does not support a given file, the loader has to exit with a [dedicated status code](https://docs.rs/rerun/latest/rerun/constant.EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE.html).
+To indicate that it does not support a given file, the loader has to exit with a [dedicated status code](https://ref.rerun.io/docs/rust/stable/rerun/constant.EXTERNAL_DATA_LOADER_INCOMPATIBLE_EXIT_CODE.html).
 
 When the Viewer and/or SDK executes an external loader, it will pass to it a set of recommended settings in the form of CLI parameters (in addition to the file path to be loaded, which is passed as the one and only positional argument):
 

--- a/docs/content/reference/dataframes.md
+++ b/docs/content/reference/dataframes.md
@@ -6,7 +6,7 @@ order: 300
 Rerun, at its core, is a database. As such, you can always get your data back in the form of tables (also known as dataframes, or records, or batches...).
 
 This can be achieved in three different ways, depending on your needs:
-* using the dataframe API, currently available in [Python](https://ref.rerun.io/docs/python/stable/common/dataframe/) and [Rust](https://docs.rs/rerun/latest/rerun/dataframe/index.html),
+* using the dataframe API, currently available in [Python](https://ref.rerun.io/docs/python/stable/common/dataframe/) and [Rust](https://ref.rerun.io/docs/rust/stable/rerun/dataframe/index.html),
 * using the [blueprint API](../concepts/blueprint.md) to configure a [dataframe view](types/views/dataframe_view.md) from code,
 * or simply by setting up [dataframe view](types/views/dataframe_view.md) manually in the UI.
 
@@ -28,7 +28,7 @@ snippet: reference/dataframe_query
 Check out the API reference to learn more about all the ways that data can be searched and filtered:
 * [🐍 Python API reference](https://ref.rerun.io/docs/python/stable/common/dataframe/)
   * [Example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/python/dataframe_query/dataframe_query.py)
-* [🦀 Rust API reference](https://docs.rs/rerun/latest/rerun/dataframe/index.html)
+* [🦀 Rust API reference](https://ref.rerun.io/docs/rust/stable/rerun/dataframe/index.html)
   * [Example](https://github.com/rerun-io/rerun/blob/c00a9f649fd4463f91620e8e2eac11355b245ac5/examples/rust/dataframe_query/src/main.rs)
 
 
@@ -61,7 +61,7 @@ snippet: reference/dataframe_view_query_external
 Check out the blueprint API and `log_file_from_path` references to learn more:
 * [🐍 Python blueprint API reference](https://ref.rerun.io/docs/python/stable/common/blueprint_apis/)
 * [🐍 Python `log_file_from_path`](https://ref.rerun.io/docs/python/stable/common/logging_functions/#rerun.log_file_from_path)
-* [🦀 Rust `log_file_from_path`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_file_from_path)
+* [🦀 Rust `log_file_from_path`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_file_from_path)
 * [🌊 C++ `log_file_from_path`](https://ref.rerun.io/docs/cpp/stable/classrerun_1_1RecordingStream.html#a20798d7ea74cce5c8174e5cacd0a2c47)
 
 You can learn more in our [dedicated page about blueprint re-use](../howto/visualization/reuse-blueprints.md).

--- a/docs/content/reference/migration/migration-0-9.md
+++ b/docs/content/reference/migration/migration-0-9.md
@@ -245,21 +245,21 @@ Rust already used a more type oriented interface, so the changes are not as dras
 
 ## Removal of MsgSender
 
-The biggest change that `MsgSender` is gone and all logging happens instead directly on the [`RecordingStream::RecordingStream`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html)
-using its [`log`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log) and [`RecordingStream::log_timeless`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_timeless) functions.
+The biggest change that `MsgSender` is gone and all logging happens instead directly on the [`RecordingStream::RecordingStream`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html)
+using its [`log`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log) and [`RecordingStream::log_timeless`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_timeless) functions.
 
 ## Logging time
 
-The new `log` function logs time implicitly. `log_time` and `log_tick` are always included, as well as any custom timeline set using [`RecordingStream::set_timepoint`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.set_timepoint), or one of the shorthands [`RecordingStream::set_time_sequence`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.set_time_sequence)/[`RecordingStream::set_time_seconds`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.set_time_seconds)/[`RecordingStream::set_time_nanos`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.set_time_nanos)
+The new `log` function logs time implicitly. `log_time` and `log_tick` are always included, as well as any custom timeline set using [`RecordingStream::set_timepoint`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.set_timepoint), or one of the shorthands [`RecordingStream::set_time_sequence`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.set_time_sequence)/[`RecordingStream::set_time_seconds`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.set_time_seconds)/[`RecordingStream::set_time_nanos`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.set_time_nanos)
 
 ## Components -> archetypes
 
-The new log messages consume any type that implements the [`AsComponents`](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html) trait
-which is [implemented by](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html#implementors) all archetypes.
+The new log messages consume any type that implements the [`AsComponents`](https://ref.rerun.io/docs/rust/stable/rerun/trait.AsComponents.html) trait
+which is [implemented by](https://ref.rerun.io/docs/rust/stable/rerun/trait.AsComponents.html#implementors) all archetypes.
 All previously separately logged components have corresponding types and are used in one or more archetypes.
 See the respective API docs as well as the [Archetype Overview](../types/archetypes.md) to learn more and find self-contained code examples.
 
-For continuing to log collections of components without implementing the [`AsComponents`](https://docs.rs/rerun/latest/rerun/trait.AsComponents.html) trait, use [`RecordingStream::log_component_batches`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_component_batches)
+For continuing to log collections of components without implementing the [`AsComponents`](https://ref.rerun.io/docs/rust/stable/rerun/trait.AsComponents.html) trait, use [`RecordingStream::log_component_batches`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_component_batches)
 
 
 
@@ -267,4 +267,4 @@ For continuing to log collections of components without implementing the [`AsCom
 
 Splatting is no longer done explicitly (before `MsgSender::splat`), but automatically inferred whenever
 there is a single component together with larger component batches on the same entity path.
-See also [`RecordingStream::log_component_batches`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.log_component_batches) for more information.
+See also [`RecordingStream::log_component_batches`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.log_component_batches) for more information.

--- a/docs/content/reference/rust.md
+++ b/docs/content/reference/rust.md
@@ -1,5 +1,5 @@
 ---
 title: 🦀 Rust APIs
 order: 2200
-redirect: https://docs.rs/rerun/
+redirect: https://ref.rerun.io/docs/rust/stable
 ---

--- a/docs/content/reference/sdk/operating-modes.md
+++ b/docs/content/reference/sdk/operating-modes.md
@@ -27,7 +27,7 @@ This is the default behavior you get when running all of our C++/Python/Rust exa
 Call [`rr.spawn`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.spawn) once at the start of your program to start a Rerun Viewer in an external process and stream all the data to it via TCP. If an external Viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 #### Rust
-[`RecordingStream::spawn`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.spawn) spawns a new Rerun Viewer process using an executable available in your PATH, then streams all the data to it via TCP. If an external Viewer was already running, `spawn` will connect to that one instead of spawning a new one.
+[`RecordingStream::spawn`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.spawn) spawns a new Rerun Viewer process using an executable available in your PATH, then streams all the data to it via TCP. If an external Viewer was already running, `spawn` will connect to that one instead of spawning a new one.
 
 
 ### Connect
@@ -43,7 +43,7 @@ You will need to start a stand-alone Viewer first by typing `rerun` in your term
 [`rr.connect`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.connect)
 
 #### Rust
-[`RecordingStream::connect`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.connect)
+[`RecordingStream::connect`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.connect)
 
 
 ### Serve
@@ -57,7 +57,7 @@ Not available yet.
 Use [`rr.serve`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.serve).
 
 #### Rust
-[`RecordingStream::serve`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.serve)
+[`RecordingStream::serve`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.serve)
 
 
 ### Save
@@ -75,7 +75,7 @@ Use `RecordingStream::save`.
 Use [`rr.save`](https://ref.rerun.io/docs/python/stable/common/initialization_functions/#rerun.save).
 
 #### Rust
-Use [`RecordingStream::save`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.save).
+Use [`RecordingStream::save`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.save).
 
 
 ### Standard Input/Output
@@ -96,7 +96,7 @@ Check out our [dedicated example](https://github.com/rerun-io/rerun/tree/latest/
 
 #### Rust
 
-Use [`RecordingStream::stdout`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.stdout).
+Use [`RecordingStream::stdout`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.stdout).
 
 Check out our [dedicated example](https://github.com/rerun-io/rerun/tree/latest/examples/rust/stdio/src/main.rs).
 
@@ -106,6 +106,6 @@ Check out our [dedicated example](https://github.com/rerun-io/rerun/tree/latest/
 We provide helpers for both Python & Rust to effortlessly add and properly handle all of these flags in your programs.
 
 - For Python, checkout the [`script_helpers`](https://ref.rerun.io/docs/python/stable/common/script_helpers/) module.
-- For Rust, checkout our [`clap`]() [integration](https://docs.rs/rerun/latest/rerun/clap/index.html).
+- For Rust, checkout our [`clap`]() [integration](https://ref.rerun.io/docs/rust/stable/rerun/clap/index.html).
 
 Have a look at the [official examples](/examples) to see these helpers in action.

--- a/docs/content/reference/types/archetypes/annotation_context.md
+++ b/docs/content/reference/types/archetypes/annotation_context.md
@@ -25,7 +25,7 @@ See also [`datatypes.ClassDescription`](https://rerun.io/docs/reference/types/da
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1AnnotationContext.html)
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AnnotationContext)
- * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AnnotationContext.html)
+ * 🦀 [Rust API docs for `AnnotationContext`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.AnnotationContext.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/arrows2d.md
+++ b/docs/content/reference/types/archetypes/arrows2d.md
@@ -21,7 +21,7 @@ title: "Arrows2D"
 ## API reference links
  * 🌊 [C++ API docs for `Arrows2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows2D.html)
  * 🐍 [Python API docs for `Arrows2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows2D)
- * 🦀 [Rust API docs for `Arrows2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows2D.html)
+ * 🦀 [Rust API docs for `Arrows2D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Arrows2D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/arrows3d.md
+++ b/docs/content/reference/types/archetypes/arrows3d.md
@@ -21,7 +21,7 @@ title: "Arrows3D"
 ## API reference links
  * 🌊 [C++ API docs for `Arrows3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Arrows3D.html)
  * 🐍 [Python API docs for `Arrows3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Arrows3D)
- * 🦀 [Rust API docs for `Arrows3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Arrows3D.html)
+ * 🦀 [Rust API docs for `Arrows3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Arrows3D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/asset3d.md
+++ b/docs/content/reference/types/archetypes/asset3d.md
@@ -26,7 +26,7 @@ an instance of the mesh will be drawn for each transform.
 ## API reference links
  * 🌊 [C++ API docs for `Asset3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Asset3D.html)
  * 🐍 [Python API docs for `Asset3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Asset3D)
- * 🦀 [Rust API docs for `Asset3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Asset3D.html)
+ * 🦀 [Rust API docs for `Asset3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Asset3D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/asset_video.md
+++ b/docs/content/reference/types/archetypes/asset_video.md
@@ -26,7 +26,7 @@ In order to display a video, you also need to log a [`archetypes.VideoFrameRefer
 ## API reference links
  * 🌊 [C++ API docs for `AssetVideo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1AssetVideo.html)
  * 🐍 [Python API docs for `AssetVideo`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.AssetVideo)
- * 🦀 [Rust API docs for `AssetVideo`](https://docs.rs/rerun/latest/rerun/archetypes/struct.AssetVideo.html)
+ * 🦀 [Rust API docs for `AssetVideo`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.AssetVideo.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/bar_chart.md
+++ b/docs/content/reference/types/archetypes/bar_chart.md
@@ -20,7 +20,7 @@ The x values will be the indices of the array, and the bar heights will be the p
 ## API reference links
  * 🌊 [C++ API docs for `BarChart`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1BarChart.html)
  * 🐍 [Python API docs for `BarChart`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.BarChart)
- * 🦀 [Rust API docs for `BarChart`](https://docs.rs/rerun/latest/rerun/archetypes/struct.BarChart.html)
+ * 🦀 [Rust API docs for `BarChart`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.BarChart.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/boxes2d.md
+++ b/docs/content/reference/types/archetypes/boxes2d.md
@@ -21,7 +21,7 @@ title: "Boxes2D"
 ## API reference links
  * 🌊 [C++ API docs for `Boxes2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes2D.html)
  * 🐍 [Python API docs for `Boxes2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes2D)
- * 🦀 [Rust API docs for `Boxes2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes2D.html)
+ * 🦀 [Rust API docs for `Boxes2D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Boxes2D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/boxes3d.md
+++ b/docs/content/reference/types/archetypes/boxes3d.md
@@ -25,7 +25,7 @@ If there's more instance poses than half sizes, the last half size will be repea
 ## API reference links
  * 🌊 [C++ API docs for `Boxes3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Boxes3D.html)
  * 🐍 [Python API docs for `Boxes3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Boxes3D)
- * 🦀 [Rust API docs for `Boxes3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Boxes3D.html)
+ * 🦀 [Rust API docs for `Boxes3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Boxes3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/capsules3d.md
+++ b/docs/content/reference/types/archetypes/capsules3d.md
@@ -26,7 +26,7 @@ instances.
 ## API reference links
  * 🌊 [C++ API docs for `Capsules3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Capsules3D.html)
  * 🐍 [Python API docs for `Capsules3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Capsules3D)
- * 🦀 [Rust API docs for `Capsules3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Capsules3D.html)
+ * 🦀 [Rust API docs for `Capsules3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Capsules3D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/clear.md
+++ b/docs/content/reference/types/archetypes/clear.md
@@ -28,7 +28,7 @@ data (i.e. discontinuous lines).
 ## API reference links
  * 🌊 [C++ API docs for `Clear`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Clear.html)
  * 🐍 [Python API docs for `Clear`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Clear)
- * 🦀 [Rust API docs for `Clear`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Clear.html)
+ * 🦀 [Rust API docs for `Clear`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Clear.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/depth_image.md
+++ b/docs/content/reference/types/archetypes/depth_image.md
@@ -21,7 +21,7 @@ Each pixel corresponds to a depth value in units specified by [`components.Depth
 ## API reference links
  * 🌊 [C++ API docs for `DepthImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DepthImage.html)
  * 🐍 [Python API docs for `DepthImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DepthImage)
- * 🦀 [Rust API docs for `DepthImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DepthImage.html)
+ * 🦀 [Rust API docs for `DepthImage`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.DepthImage.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/disconnected_space.md
+++ b/docs/content/reference/types/archetypes/disconnected_space.md
@@ -22,7 +22,7 @@ This is useful for specifying that a subgraph is independent of the rest of the 
 ## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1DisconnectedSpace.html)
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.DisconnectedSpace)
- * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/archetypes/struct.DisconnectedSpace.html)
+ * 🦀 [Rust API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.DisconnectedSpace.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/ellipsoids3d.md
+++ b/docs/content/reference/types/archetypes/ellipsoids3d.md
@@ -29,7 +29,7 @@ If there's more instance poses than half sizes, the last half size will be repea
 ## API reference links
  * 🌊 [C++ API docs for `Ellipsoids3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Ellipsoids3D.html)
  * 🐍 [Python API docs for `Ellipsoids3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Ellipsoids3D)
- * 🦀 [Rust API docs for `Ellipsoids3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Ellipsoids3D.html)
+ * 🦀 [Rust API docs for `Ellipsoids3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Ellipsoids3D.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/encoded_image.md
+++ b/docs/content/reference/types/archetypes/encoded_image.md
@@ -24,7 +24,7 @@ For images that refer to video frames see [`archetypes.VideoFrameReference`](htt
 ## API reference links
  * 🌊 [C++ API docs for `EncodedImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1EncodedImage.html)
  * 🐍 [Python API docs for `EncodedImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.EncodedImage)
- * 🦀 [Rust API docs for `EncodedImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.EncodedImage.html)
+ * 🦀 [Rust API docs for `EncodedImage`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.EncodedImage.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/geo_line_strings.md
+++ b/docs/content/reference/types/archetypes/geo_line_strings.md
@@ -20,7 +20,7 @@ Also known as "line strips" or "polylines".
 ## API reference links
  * 🌊 [C++ API docs for `GeoLineStrings`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1GeoLineStrings.html)
  * 🐍 [Python API docs for `GeoLineStrings`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.GeoLineStrings)
- * 🦀 [Rust API docs for `GeoLineStrings`](https://docs.rs/rerun/latest/rerun/archetypes/struct.GeoLineStrings.html)
+ * 🦀 [Rust API docs for `GeoLineStrings`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.GeoLineStrings.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/geo_points.md
+++ b/docs/content/reference/types/archetypes/geo_points.md
@@ -20,7 +20,7 @@ Geospatial points with positions expressed in [EPSG:4326](https://epsg.io/4326) 
 ## API reference links
  * 🌊 [C++ API docs for `GeoPoints`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1GeoPoints.html)
  * 🐍 [Python API docs for `GeoPoints`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.GeoPoints)
- * 🦀 [Rust API docs for `GeoPoints`](https://docs.rs/rerun/latest/rerun/archetypes/struct.GeoPoints.html)
+ * 🦀 [Rust API docs for `GeoPoints`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.GeoPoints.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/image.md
+++ b/docs/content/reference/types/archetypes/image.md
@@ -32,7 +32,7 @@ row-major, interleaved-pixel image format.
 ## API reference links
  * 🌊 [C++ API docs for `Image`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Image.html)
  * 🐍 [Python API docs for `Image`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Image)
- * 🦀 [Rust API docs for `Image`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Image.html)
+ * 🦀 [Rust API docs for `Image`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Image.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/instance_poses3d.md
+++ b/docs/content/reference/types/archetypes/instance_poses3d.md
@@ -30,7 +30,7 @@ will draw an object for every pose, a behavior also known as "instancing".
 ## API reference links
  * 🌊 [C++ API docs for `InstancePoses3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1InstancePoses3D.html)
  * 🐍 [Python API docs for `InstancePoses3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.InstancePoses3D)
- * 🦀 [Rust API docs for `InstancePoses3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.InstancePoses3D.html)
+ * 🦀 [Rust API docs for `InstancePoses3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.InstancePoses3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/line_strips2d.md
+++ b/docs/content/reference/types/archetypes/line_strips2d.md
@@ -21,7 +21,7 @@ title: "LineStrips2D"
 ## API reference links
  * 🌊 [C++ API docs for `LineStrips2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips2D.html)
  * 🐍 [Python API docs for `LineStrips2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips2D)
- * 🦀 [Rust API docs for `LineStrips2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips2D.html)
+ * 🦀 [Rust API docs for `LineStrips2D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.LineStrips2D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/line_strips3d.md
+++ b/docs/content/reference/types/archetypes/line_strips3d.md
@@ -21,7 +21,7 @@ title: "LineStrips3D"
 ## API reference links
  * 🌊 [C++ API docs for `LineStrips3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1LineStrips3D.html)
  * 🐍 [Python API docs for `LineStrips3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.LineStrips3D)
- * 🦀 [Rust API docs for `LineStrips3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.LineStrips3D.html)
+ * 🦀 [Rust API docs for `LineStrips3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.LineStrips3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/mesh3d.md
+++ b/docs/content/reference/types/archetypes/mesh3d.md
@@ -26,7 +26,7 @@ an instance of the mesh will be drawn for each transform.
 ## API reference links
  * 🌊 [C++ API docs for `Mesh3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Mesh3D.html)
  * 🐍 [Python API docs for `Mesh3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Mesh3D)
- * 🦀 [Rust API docs for `Mesh3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Mesh3D.html)
+ * 🦀 [Rust API docs for `Mesh3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Mesh3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/pinhole.md
+++ b/docs/content/reference/types/archetypes/pinhole.md
@@ -21,7 +21,7 @@ Camera perspective projection (a.k.a. intrinsics).
 ## API reference links
  * 🌊 [C++ API docs for `Pinhole`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Pinhole.html)
  * 🐍 [Python API docs for `Pinhole`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Pinhole)
- * 🦀 [Rust API docs for `Pinhole`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Pinhole.html)
+ * 🦀 [Rust API docs for `Pinhole`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Pinhole.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/points2d.md
+++ b/docs/content/reference/types/archetypes/points2d.md
@@ -21,7 +21,7 @@ A 2D point cloud with positions and optional colors, radii, labels, etc.
 ## API reference links
  * 🌊 [C++ API docs for `Points2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points2D.html)
  * 🐍 [Python API docs for `Points2D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points2D)
- * 🦀 [Rust API docs for `Points2D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points2D.html)
+ * 🦀 [Rust API docs for `Points2D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Points2D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/points3d.md
+++ b/docs/content/reference/types/archetypes/points3d.md
@@ -21,7 +21,7 @@ A 3D point cloud with positions and optional colors, radii, labels, etc.
 ## API reference links
  * 🌊 [C++ API docs for `Points3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Points3D.html)
  * 🐍 [Python API docs for `Points3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Points3D)
- * 🦀 [Rust API docs for `Points3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Points3D.html)
+ * 🦀 [Rust API docs for `Points3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Points3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/scalar.md
+++ b/docs/content/reference/types/archetypes/scalar.md
@@ -24,7 +24,7 @@ the plot-specific archetypes through the blueprint.
 ## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Scalar.html)
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Scalar)
- * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Scalar.html)
+ * 🦀 [Rust API docs for `Scalar`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Scalar.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/segmentation_image.md
+++ b/docs/content/reference/types/archetypes/segmentation_image.md
@@ -26,7 +26,7 @@ See also [`archetypes.AnnotationContext`](https://rerun.io/docs/reference/types/
 ## API reference links
  * 🌊 [C++ API docs for `SegmentationImage`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SegmentationImage.html)
  * 🐍 [Python API docs for `SegmentationImage`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SegmentationImage)
- * 🦀 [Rust API docs for `SegmentationImage`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SegmentationImage.html)
+ * 🦀 [Rust API docs for `SegmentationImage`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.SegmentationImage.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/series_line.md
+++ b/docs/content/reference/types/archetypes/series_line.md
@@ -20,7 +20,7 @@ when possible. The underlying data needs to be logged to the same entity-path us
 ## API reference links
  * 🌊 [C++ API docs for `SeriesLine`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesLine.html)
  * 🐍 [Python API docs for `SeriesLine`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SeriesLine)
- * 🦀 [Rust API docs for `SeriesLine`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesLine.html)
+ * 🦀 [Rust API docs for `SeriesLine`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.SeriesLine.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/series_point.md
+++ b/docs/content/reference/types/archetypes/series_point.md
@@ -20,7 +20,7 @@ when possible. The underlying data needs to be logged to the same entity-path us
 ## API reference links
  * 🌊 [C++ API docs for `SeriesPoint`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1SeriesPoint.html)
  * 🐍 [Python API docs for `SeriesPoint`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.SeriesPoint)
- * 🦀 [Rust API docs for `SeriesPoint`](https://docs.rs/rerun/latest/rerun/archetypes/struct.SeriesPoint.html)
+ * 🦀 [Rust API docs for `SeriesPoint`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.SeriesPoint.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/tensor.md
+++ b/docs/content/reference/types/archetypes/tensor.md
@@ -19,7 +19,7 @@ An N-dimensional array of numbers.
 ## API reference links
  * 🌊 [C++ API docs for `Tensor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Tensor.html)
  * 🐍 [Python API docs for `Tensor`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Tensor)
- * 🦀 [Rust API docs for `Tensor`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Tensor.html)
+ * 🦀 [Rust API docs for `Tensor`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Tensor.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/text_document.md
+++ b/docs/content/reference/types/archetypes/text_document.md
@@ -20,7 +20,7 @@ Supports raw text and markdown.
 ## API reference links
  * 🌊 [C++ API docs for `TextDocument`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextDocument.html)
  * 🐍 [Python API docs for `TextDocument`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextDocument)
- * 🦀 [Rust API docs for `TextDocument`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextDocument.html)
+ * 🦀 [Rust API docs for `TextDocument`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.TextDocument.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/text_log.md
+++ b/docs/content/reference/types/archetypes/text_log.md
@@ -20,7 +20,7 @@ A log entry in a text log, comprised of a text body and its log level.
 ## API reference links
  * 🌊 [C++ API docs for `TextLog`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1TextLog.html)
  * 🐍 [Python API docs for `TextLog`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.TextLog)
- * 🦀 [Rust API docs for `TextLog`](https://docs.rs/rerun/latest/rerun/archetypes/struct.TextLog.html)
+ * 🦀 [Rust API docs for `TextLog`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.TextLog.html)
 
 ## Example
 

--- a/docs/content/reference/types/archetypes/transform3d.md
+++ b/docs/content/reference/types/archetypes/transform3d.md
@@ -28,7 +28,7 @@ For transforms that affect only a single entity and do not propagate along the e
 ## API reference links
  * 🌊 [C++ API docs for `Transform3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1Transform3D.html)
  * 🐍 [Python API docs for `Transform3D`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.Transform3D)
- * 🦀 [Rust API docs for `Transform3D`](https://docs.rs/rerun/latest/rerun/archetypes/struct.Transform3D.html)
+ * 🦀 [Rust API docs for `Transform3D`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.Transform3D.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/video_frame_reference.md
+++ b/docs/content/reference/types/archetypes/video_frame_reference.md
@@ -24,7 +24,7 @@ See <https://rerun.io/docs/reference/video> for details of what is and isn't sup
 ## API reference links
  * 🌊 [C++ API docs for `VideoFrameReference`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1VideoFrameReference.html)
  * 🐍 [Python API docs for `VideoFrameReference`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.VideoFrameReference)
- * 🦀 [Rust API docs for `VideoFrameReference`](https://docs.rs/rerun/latest/rerun/archetypes/struct.VideoFrameReference.html)
+ * 🦀 [Rust API docs for `VideoFrameReference`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.VideoFrameReference.html)
 
 ## Examples
 

--- a/docs/content/reference/types/archetypes/view_coordinates.md
+++ b/docs/content/reference/types/archetypes/view_coordinates.md
@@ -27,7 +27,7 @@ Make sure that this archetype is logged at or above the origin entity path of yo
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1archetypes_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/archetypes#rerun.archetypes.ViewCoordinates)
- * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/archetypes/struct.ViewCoordinates.html)
+ * 🦀 [Rust API docs for `ViewCoordinates`](https://ref.rerun.io/docs/rust/stable/rerun/archetypes/struct.ViewCoordinates.html)
 
 ## Example
 

--- a/docs/content/reference/types/components/aggregation_policy.md
+++ b/docs/content/reference/types/components/aggregation_policy.md
@@ -39,7 +39,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `AggregationPolicy`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `AggregationPolicy`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AggregationPolicy)
- * 🦀 [Rust API docs for `AggregationPolicy`](https://docs.rs/rerun/latest/rerun/components/enum.AggregationPolicy.html)
+ * 🦀 [Rust API docs for `AggregationPolicy`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.AggregationPolicy.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/albedo_factor.md
+++ b/docs/content/reference/types/components/albedo_factor.md
@@ -17,7 +17,7 @@ uint32
 ## API reference links
  * 🌊 [C++ API docs for `AlbedoFactor`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AlbedoFactor.html)
  * 🐍 [Python API docs for `AlbedoFactor`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AlbedoFactor)
- * 🦀 [Rust API docs for `AlbedoFactor`](https://docs.rs/rerun/latest/rerun/components/struct.AlbedoFactor.html)
+ * 🦀 [Rust API docs for `AlbedoFactor`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.AlbedoFactor.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/annotation_context.md
+++ b/docs/content/reference/types/components/annotation_context.md
@@ -38,7 +38,7 @@ List<Struct {
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationContext`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AnnotationContext.html)
  * 🐍 [Python API docs for `AnnotationContext`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AnnotationContext)
- * 🦀 [Rust API docs for `AnnotationContext`](https://docs.rs/rerun/latest/rerun/components/struct.AnnotationContext.html)
+ * 🦀 [Rust API docs for `AnnotationContext`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.AnnotationContext.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/axis_length.md
+++ b/docs/content/reference/types/components/axis_length.md
@@ -17,7 +17,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `AxisLength`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1AxisLength.html)
  * 🐍 [Python API docs for `AxisLength`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.AxisLength)
- * 🦀 [Rust API docs for `AxisLength`](https://docs.rs/rerun/latest/rerun/components/struct.AxisLength.html)
+ * 🦀 [Rust API docs for `AxisLength`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.AxisLength.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/blob.md
+++ b/docs/content/reference/types/components/blob.md
@@ -17,7 +17,7 @@ List<uint8>
 ## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Blob.html)
  * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Blob)
- * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/latest/rerun/components/struct.Blob.html)
+ * 🦀 [Rust API docs for `Blob`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Blob.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/class_id.md
+++ b/docs/content/reference/types/components/class_id.md
@@ -17,7 +17,7 @@ uint16
 ## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClassId.html)
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClassId)
- * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/components/struct.ClassId.html)
+ * 🦀 [Rust API docs for `ClassId`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ClassId.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/clear_is_recursive.md
+++ b/docs/content/reference/types/components/clear_is_recursive.md
@@ -17,7 +17,7 @@ boolean
 ## API reference links
  * 🌊 [C++ API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ClearIsRecursive.html)
  * 🐍 [Python API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ClearIsRecursive)
- * 🦀 [Rust API docs for `ClearIsRecursive`](https://docs.rs/rerun/latest/rerun/components/struct.ClearIsRecursive.html)
+ * 🦀 [Rust API docs for `ClearIsRecursive`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ClearIsRecursive.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/color.md
+++ b/docs/content/reference/types/components/color.md
@@ -20,7 +20,7 @@ uint32
 ## API reference links
  * 🌊 [C++ API docs for `Color`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Color.html)
  * 🐍 [Python API docs for `Color`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Color)
- * 🦀 [Rust API docs for `Color`](https://docs.rs/rerun/latest/rerun/components/struct.Color.html)
+ * 🦀 [Rust API docs for `Color`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Color.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/colormap.md
+++ b/docs/content/reference/types/components/colormap.md
@@ -63,7 +63,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `Colormap`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `Colormap`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Colormap)
- * 🦀 [Rust API docs for `Colormap`](https://docs.rs/rerun/latest/rerun/components/enum.Colormap.html)
+ * 🦀 [Rust API docs for `Colormap`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.Colormap.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/depth_meter.md
+++ b/docs/content/reference/types/components/depth_meter.md
@@ -24,7 +24,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `DepthMeter`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DepthMeter.html)
  * 🐍 [Python API docs for `DepthMeter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DepthMeter)
- * 🦀 [Rust API docs for `DepthMeter`](https://docs.rs/rerun/latest/rerun/components/struct.DepthMeter.html)
+ * 🦀 [Rust API docs for `DepthMeter`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.DepthMeter.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/disconnected_space.md
+++ b/docs/content/reference/types/components/disconnected_space.md
@@ -22,7 +22,7 @@ boolean
 ## API reference links
  * 🌊 [C++ API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DisconnectedSpace.html)
  * 🐍 [Python API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DisconnectedSpace)
- * 🦀 [Rust API docs for `DisconnectedSpace`](https://docs.rs/rerun/latest/rerun/components/struct.DisconnectedSpace.html)
+ * 🦀 [Rust API docs for `DisconnectedSpace`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.DisconnectedSpace.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/draw_order.md
+++ b/docs/content/reference/types/components/draw_order.md
@@ -22,7 +22,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `DrawOrder`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1DrawOrder.html)
  * 🐍 [Python API docs for `DrawOrder`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.DrawOrder)
- * 🦀 [Rust API docs for `DrawOrder`](https://docs.rs/rerun/latest/rerun/components/struct.DrawOrder.html)
+ * 🦀 [Rust API docs for `DrawOrder`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.DrawOrder.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/entity_path.md
+++ b/docs/content/reference/types/components/entity_path.md
@@ -17,7 +17,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1EntityPath.html)
  * 🐍 [Python API docs for `EntityPath`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.EntityPath)
- * 🦀 [Rust API docs for `EntityPath`](https://docs.rs/rerun/latest/rerun/components/struct.EntityPath.html)
+ * 🦀 [Rust API docs for `EntityPath`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.EntityPath.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/fill_mode.md
+++ b/docs/content/reference/types/components/fill_mode.md
@@ -36,7 +36,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `FillMode`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `FillMode`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.FillMode)
- * 🦀 [Rust API docs for `FillMode`](https://docs.rs/rerun/latest/rerun/components/enum.FillMode.html)
+ * 🦀 [Rust API docs for `FillMode`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.FillMode.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/fill_ratio.md
+++ b/docs/content/reference/types/components/fill_ratio.md
@@ -22,7 +22,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `FillRatio`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1FillRatio.html)
  * 🐍 [Python API docs for `FillRatio`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.FillRatio)
- * 🦀 [Rust API docs for `FillRatio`](https://docs.rs/rerun/latest/rerun/components/struct.FillRatio.html)
+ * 🦀 [Rust API docs for `FillRatio`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.FillRatio.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/gamma_correction.md
+++ b/docs/content/reference/types/components/gamma_correction.md
@@ -23,6 +23,6 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `GammaCorrection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1GammaCorrection.html)
  * 🐍 [Python API docs for `GammaCorrection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.GammaCorrection)
- * 🦀 [Rust API docs for `GammaCorrection`](https://docs.rs/rerun/latest/rerun/components/struct.GammaCorrection.html)
+ * 🦀 [Rust API docs for `GammaCorrection`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.GammaCorrection.html)
 
 

--- a/docs/content/reference/types/components/geo_line_string.md
+++ b/docs/content/reference/types/components/geo_line_string.md
@@ -14,7 +14,7 @@ List<FixedSizeList<2, float64>>
 ## API reference links
  * 🌊 [C++ API docs for `GeoLineString`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1GeoLineString.html)
  * 🐍 [Python API docs for `GeoLineString`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.GeoLineString)
- * 🦀 [Rust API docs for `GeoLineString`](https://docs.rs/rerun/latest/rerun/components/struct.GeoLineString.html)
+ * 🦀 [Rust API docs for `GeoLineString`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.GeoLineString.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/half_size2d.md
+++ b/docs/content/reference/types/components/half_size2d.md
@@ -22,7 +22,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize2D.html)
  * 🐍 [Python API docs for `HalfSize2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSize2D)
- * 🦀 [Rust API docs for `HalfSize2D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSize2D.html)
+ * 🦀 [Rust API docs for `HalfSize2D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.HalfSize2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/half_size3d.md
+++ b/docs/content/reference/types/components/half_size3d.md
@@ -22,7 +22,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `HalfSize3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1HalfSize3D.html)
  * 🐍 [Python API docs for `HalfSize3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.HalfSize3D)
- * 🦀 [Rust API docs for `HalfSize3D`](https://docs.rs/rerun/latest/rerun/components/struct.HalfSize3D.html)
+ * 🦀 [Rust API docs for `HalfSize3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.HalfSize3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/image_buffer.md
+++ b/docs/content/reference/types/components/image_buffer.md
@@ -19,7 +19,7 @@ List<uint8>
 ## API reference links
  * 🌊 [C++ API docs for `ImageBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageBuffer.html)
  * 🐍 [Python API docs for `ImageBuffer`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImageBuffer)
- * 🦀 [Rust API docs for `ImageBuffer`](https://docs.rs/rerun/latest/rerun/components/struct.ImageBuffer.html)
+ * 🦀 [Rust API docs for `ImageBuffer`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ImageBuffer.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/image_format.md
+++ b/docs/content/reference/types/components/image_format.md
@@ -23,7 +23,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `ImageFormat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImageFormat.html)
  * 🐍 [Python API docs for `ImageFormat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImageFormat)
- * 🦀 [Rust API docs for `ImageFormat`](https://docs.rs/rerun/latest/rerun/components/struct.ImageFormat.html)
+ * 🦀 [Rust API docs for `ImageFormat`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ImageFormat.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/image_plane_distance.md
+++ b/docs/content/reference/types/components/image_plane_distance.md
@@ -19,7 +19,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ImagePlaneDistance.html)
  * 🐍 [Python API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ImagePlaneDistance)
- * 🦀 [Rust API docs for `ImagePlaneDistance`](https://docs.rs/rerun/latest/rerun/components/struct.ImagePlaneDistance.html)
+ * 🦀 [Rust API docs for `ImagePlaneDistance`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ImagePlaneDistance.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/keypoint_id.md
+++ b/docs/content/reference/types/components/keypoint_id.md
@@ -17,7 +17,7 @@ uint16
 ## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1KeypointId.html)
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.KeypointId)
- * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/components/struct.KeypointId.html)
+ * 🦀 [Rust API docs for `KeypointId`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.KeypointId.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/lat_lon.md
+++ b/docs/content/reference/types/components/lat_lon.md
@@ -17,7 +17,7 @@ FixedSizeList<2, float64>
 ## API reference links
  * 🌊 [C++ API docs for `LatLon`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LatLon.html)
  * 🐍 [Python API docs for `LatLon`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LatLon)
- * 🦀 [Rust API docs for `LatLon`](https://docs.rs/rerun/latest/rerun/components/struct.LatLon.html)
+ * 🦀 [Rust API docs for `LatLon`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.LatLon.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/length.md
+++ b/docs/content/reference/types/components/length.md
@@ -20,7 +20,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `Length`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Length.html)
  * 🐍 [Python API docs for `Length`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Length)
- * 🦀 [Rust API docs for `Length`](https://docs.rs/rerun/latest/rerun/components/struct.Length.html)
+ * 🦀 [Rust API docs for `Length`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Length.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/line_strip2d.md
+++ b/docs/content/reference/types/components/line_strip2d.md
@@ -25,7 +25,7 @@ List<FixedSizeList<2, float32>>
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip2D.html)
  * 🐍 [Python API docs for `LineStrip2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip2D)
- * 🦀 [Rust API docs for `LineStrip2D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip2D.html)
+ * 🦀 [Rust API docs for `LineStrip2D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.LineStrip2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/line_strip3d.md
+++ b/docs/content/reference/types/components/line_strip3d.md
@@ -25,7 +25,7 @@ List<FixedSizeList<3, float32>>
 ## API reference links
  * 🌊 [C++ API docs for `LineStrip3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1LineStrip3D.html)
  * 🐍 [Python API docs for `LineStrip3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.LineStrip3D)
- * 🦀 [Rust API docs for `LineStrip3D`](https://docs.rs/rerun/latest/rerun/components/struct.LineStrip3D.html)
+ * 🦀 [Rust API docs for `LineStrip3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.LineStrip3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/magnification_filter.md
+++ b/docs/content/reference/types/components/magnification_filter.md
@@ -26,6 +26,6 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `MagnificationFilter`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `MagnificationFilter`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MagnificationFilter)
- * 🦀 [Rust API docs for `MagnificationFilter`](https://docs.rs/rerun/latest/rerun/components/enum.MagnificationFilter.html)
+ * 🦀 [Rust API docs for `MagnificationFilter`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.MagnificationFilter.html)
 
 

--- a/docs/content/reference/types/components/marker_shape.md
+++ b/docs/content/reference/types/components/marker_shape.md
@@ -45,7 +45,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `MarkerShape`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `MarkerShape`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerShape)
- * 🦀 [Rust API docs for `MarkerShape`](https://docs.rs/rerun/latest/rerun/components/enum.MarkerShape.html)
+ * 🦀 [Rust API docs for `MarkerShape`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.MarkerShape.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/marker_size.md
+++ b/docs/content/reference/types/components/marker_size.md
@@ -17,7 +17,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `MarkerSize`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MarkerSize.html)
  * 🐍 [Python API docs for `MarkerSize`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MarkerSize)
- * 🦀 [Rust API docs for `MarkerSize`](https://docs.rs/rerun/latest/rerun/components/struct.MarkerSize.html)
+ * 🦀 [Rust API docs for `MarkerSize`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.MarkerSize.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/media_type.md
+++ b/docs/content/reference/types/components/media_type.md
@@ -20,7 +20,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `MediaType`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1MediaType.html)
  * 🐍 [Python API docs for `MediaType`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.MediaType)
- * 🦀 [Rust API docs for `MediaType`](https://docs.rs/rerun/latest/rerun/components/struct.MediaType.html)
+ * 🦀 [Rust API docs for `MediaType`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.MediaType.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/name.md
+++ b/docs/content/reference/types/components/name.md
@@ -17,7 +17,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `Name`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Name.html)
  * 🐍 [Python API docs for `Name`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Name)
- * 🦀 [Rust API docs for `Name`](https://docs.rs/rerun/latest/rerun/components/struct.Name.html)
+ * 🦀 [Rust API docs for `Name`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Name.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/opacity.md
+++ b/docs/content/reference/types/components/opacity.md
@@ -20,7 +20,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `Opacity`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Opacity.html)
  * 🐍 [Python API docs for `Opacity`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Opacity)
- * 🦀 [Rust API docs for `Opacity`](https://docs.rs/rerun/latest/rerun/components/struct.Opacity.html)
+ * 🦀 [Rust API docs for `Opacity`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Opacity.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pinhole_projection.md
+++ b/docs/content/reference/types/components/pinhole_projection.md
@@ -27,7 +27,7 @@ FixedSizeList<9, float32>
 ## API reference links
  * 🌊 [C++ API docs for `PinholeProjection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PinholeProjection.html)
  * 🐍 [Python API docs for `PinholeProjection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PinholeProjection)
- * 🦀 [Rust API docs for `PinholeProjection`](https://docs.rs/rerun/latest/rerun/components/struct.PinholeProjection.html)
+ * 🦀 [Rust API docs for `PinholeProjection`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PinholeProjection.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pose_rotation_axis_angle.md
+++ b/docs/content/reference/types/components/pose_rotation_axis_angle.md
@@ -20,7 +20,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationAxisAngle.html)
  * 🐍 [Python API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseRotationAxisAngle)
- * 🦀 [Rust API docs for `PoseRotationAxisAngle`](https://docs.rs/rerun/latest/rerun/components/struct.PoseRotationAxisAngle.html)
+ * 🦀 [Rust API docs for `PoseRotationAxisAngle`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PoseRotationAxisAngle.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pose_rotation_quat.md
+++ b/docs/content/reference/types/components/pose_rotation_quat.md
@@ -20,7 +20,7 @@ FixedSizeList<4, float32>
 ## API reference links
  * 🌊 [C++ API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseRotationQuat.html)
  * 🐍 [Python API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseRotationQuat)
- * 🦀 [Rust API docs for `PoseRotationQuat`](https://docs.rs/rerun/latest/rerun/components/struct.PoseRotationQuat.html)
+ * 🦀 [Rust API docs for `PoseRotationQuat`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PoseRotationQuat.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pose_scale3d.md
+++ b/docs/content/reference/types/components/pose_scale3d.md
@@ -21,7 +21,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `PoseScale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseScale3D.html)
  * 🐍 [Python API docs for `PoseScale3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseScale3D)
- * 🦀 [Rust API docs for `PoseScale3D`](https://docs.rs/rerun/latest/rerun/components/struct.PoseScale3D.html)
+ * 🦀 [Rust API docs for `PoseScale3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PoseScale3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pose_transform_mat3x3.md
+++ b/docs/content/reference/types/components/pose_transform_mat3x3.md
@@ -29,7 +29,7 @@ FixedSizeList<9, float32>
 ## API reference links
  * 🌊 [C++ API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTransformMat3x3.html)
  * 🐍 [Python API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseTransformMat3x3)
- * 🦀 [Rust API docs for `PoseTransformMat3x3`](https://docs.rs/rerun/latest/rerun/components/struct.PoseTransformMat3x3.html)
+ * 🦀 [Rust API docs for `PoseTransformMat3x3`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PoseTransformMat3x3.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/pose_translation3d.md
+++ b/docs/content/reference/types/components/pose_translation3d.md
@@ -17,7 +17,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1PoseTranslation3D.html)
  * 🐍 [Python API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.PoseTranslation3D)
- * 🦀 [Rust API docs for `PoseTranslation3D`](https://docs.rs/rerun/latest/rerun/components/struct.PoseTranslation3D.html)
+ * 🦀 [Rust API docs for `PoseTranslation3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.PoseTranslation3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/position2d.md
+++ b/docs/content/reference/types/components/position2d.md
@@ -17,7 +17,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Position2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position2D.html)
  * 🐍 [Python API docs for `Position2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position2D)
- * 🦀 [Rust API docs for `Position2D`](https://docs.rs/rerun/latest/rerun/components/struct.Position2D.html)
+ * 🦀 [Rust API docs for `Position2D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Position2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/position3d.md
+++ b/docs/content/reference/types/components/position3d.md
@@ -17,7 +17,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Position3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Position3D.html)
  * 🐍 [Python API docs for `Position3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Position3D)
- * 🦀 [Rust API docs for `Position3D`](https://docs.rs/rerun/latest/rerun/components/struct.Position3D.html)
+ * 🦀 [Rust API docs for `Position3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Position3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/radius.md
+++ b/docs/content/reference/types/components/radius.md
@@ -24,7 +24,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `Radius`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Radius.html)
  * 🐍 [Python API docs for `Radius`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Radius)
- * 🦀 [Rust API docs for `Radius`](https://docs.rs/rerun/latest/rerun/components/struct.Radius.html)
+ * 🦀 [Rust API docs for `Radius`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Radius.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/range1d.md
+++ b/docs/content/reference/types/components/range1d.md
@@ -17,6 +17,6 @@ FixedSizeList<2, float64>
 ## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Range1D.html)
  * 🐍 [Python API docs for `Range1D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Range1D)
- * 🦀 [Rust API docs for `Range1D`](https://docs.rs/rerun/latest/rerun/components/struct.Range1D.html)
+ * 🦀 [Rust API docs for `Range1D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Range1D.html)
 
 

--- a/docs/content/reference/types/components/resolution.md
+++ b/docs/content/reference/types/components/resolution.md
@@ -19,7 +19,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Resolution`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Resolution.html)
  * 🐍 [Python API docs for `Resolution`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Resolution)
- * 🦀 [Rust API docs for `Resolution`](https://docs.rs/rerun/latest/rerun/components/struct.Resolution.html)
+ * 🦀 [Rust API docs for `Resolution`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Resolution.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/rotation_axis_angle.md
+++ b/docs/content/reference/types/components/rotation_axis_angle.md
@@ -20,7 +20,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationAxisAngle.html)
  * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.RotationAxisAngle)
- * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/latest/rerun/components/struct.RotationAxisAngle.html)
+ * 🦀 [Rust API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.RotationAxisAngle.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/rotation_quat.md
+++ b/docs/content/reference/types/components/rotation_quat.md
@@ -20,7 +20,7 @@ FixedSizeList<4, float32>
 ## API reference links
  * 🌊 [C++ API docs for `RotationQuat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1RotationQuat.html)
  * 🐍 [Python API docs for `RotationQuat`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.RotationQuat)
- * 🦀 [Rust API docs for `RotationQuat`](https://docs.rs/rerun/latest/rerun/components/struct.RotationQuat.html)
+ * 🦀 [Rust API docs for `RotationQuat`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.RotationQuat.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/scalar.md
+++ b/docs/content/reference/types/components/scalar.md
@@ -19,7 +19,7 @@ float64
 ## API reference links
  * 🌊 [C++ API docs for `Scalar`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scalar.html)
  * 🐍 [Python API docs for `Scalar`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scalar)
- * 🦀 [Rust API docs for `Scalar`](https://docs.rs/rerun/latest/rerun/components/struct.Scalar.html)
+ * 🦀 [Rust API docs for `Scalar`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Scalar.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/scale3d.md
+++ b/docs/content/reference/types/components/scale3d.md
@@ -21,7 +21,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Scale3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Scale3D.html)
  * 🐍 [Python API docs for `Scale3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Scale3D)
- * 🦀 [Rust API docs for `Scale3D`](https://docs.rs/rerun/latest/rerun/components/struct.Scale3D.html)
+ * 🦀 [Rust API docs for `Scale3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Scale3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/show_labels.md
+++ b/docs/content/reference/types/components/show_labels.md
@@ -21,7 +21,7 @@ boolean
 ## API reference links
  * 🌊 [C++ API docs for `ShowLabels`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ShowLabels.html)
  * 🐍 [Python API docs for `ShowLabels`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ShowLabels)
- * 🦀 [Rust API docs for `ShowLabels`](https://docs.rs/rerun/latest/rerun/components/struct.ShowLabels.html)
+ * 🦀 [Rust API docs for `ShowLabels`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ShowLabels.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/stroke_width.md
+++ b/docs/content/reference/types/components/stroke_width.md
@@ -17,7 +17,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `StrokeWidth`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1StrokeWidth.html)
  * 🐍 [Python API docs for `StrokeWidth`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.StrokeWidth)
- * 🦀 [Rust API docs for `StrokeWidth`](https://docs.rs/rerun/latest/rerun/components/struct.StrokeWidth.html)
+ * 🦀 [Rust API docs for `StrokeWidth`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.StrokeWidth.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/tensor_data.md
+++ b/docs/content/reference/types/components/tensor_data.md
@@ -43,7 +43,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorData.html)
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorData)
- * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/components/struct.TensorData.html)
+ * 🦀 [Rust API docs for `TensorData`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TensorData.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/components/tensor_dimension_index_selection.md
@@ -20,6 +20,6 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorDimensionIndexSelection.html)
  * 🐍 [Python API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorDimensionIndexSelection)
- * 🦀 [Rust API docs for `TensorDimensionIndexSelection`](https://docs.rs/rerun/latest/rerun/components/struct.TensorDimensionIndexSelection.html)
+ * 🦀 [Rust API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TensorDimensionIndexSelection.html)
 
 

--- a/docs/content/reference/types/components/tensor_height_dimension.md
+++ b/docs/content/reference/types/components/tensor_height_dimension.md
@@ -20,6 +20,6 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorHeightDimension.html)
  * 🐍 [Python API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorHeightDimension)
- * 🦀 [Rust API docs for `TensorHeightDimension`](https://docs.rs/rerun/latest/rerun/components/struct.TensorHeightDimension.html)
+ * 🦀 [Rust API docs for `TensorHeightDimension`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TensorHeightDimension.html)
 
 

--- a/docs/content/reference/types/components/tensor_width_dimension.md
+++ b/docs/content/reference/types/components/tensor_width_dimension.md
@@ -20,6 +20,6 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TensorWidthDimension.html)
  * 🐍 [Python API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TensorWidthDimension)
- * 🦀 [Rust API docs for `TensorWidthDimension`](https://docs.rs/rerun/latest/rerun/components/struct.TensorWidthDimension.html)
+ * 🦀 [Rust API docs for `TensorWidthDimension`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TensorWidthDimension.html)
 
 

--- a/docs/content/reference/types/components/texcoord2d.md
+++ b/docs/content/reference/types/components/texcoord2d.md
@@ -32,7 +32,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Texcoord2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Texcoord2D.html)
  * 🐍 [Python API docs for `Texcoord2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Texcoord2D)
- * 🦀 [Rust API docs for `Texcoord2D`](https://docs.rs/rerun/latest/rerun/components/struct.Texcoord2D.html)
+ * 🦀 [Rust API docs for `Texcoord2D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Texcoord2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/text.md
+++ b/docs/content/reference/types/components/text.md
@@ -17,7 +17,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `Text`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Text.html)
  * 🐍 [Python API docs for `Text`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Text)
- * 🦀 [Rust API docs for `Text`](https://docs.rs/rerun/latest/rerun/components/struct.Text.html)
+ * 🦀 [Rust API docs for `Text`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Text.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/text_log_level.md
+++ b/docs/content/reference/types/components/text_log_level.md
@@ -25,7 +25,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `TextLogLevel`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TextLogLevel.html)
  * 🐍 [Python API docs for `TextLogLevel`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TextLogLevel)
- * 🦀 [Rust API docs for `TextLogLevel`](https://docs.rs/rerun/latest/rerun/components/struct.TextLogLevel.html)
+ * 🦀 [Rust API docs for `TextLogLevel`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TextLogLevel.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/transform_mat3x3.md
+++ b/docs/content/reference/types/components/transform_mat3x3.md
@@ -29,7 +29,7 @@ FixedSizeList<9, float32>
 ## API reference links
  * 🌊 [C++ API docs for `TransformMat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TransformMat3x3.html)
  * 🐍 [Python API docs for `TransformMat3x3`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TransformMat3x3)
- * 🦀 [Rust API docs for `TransformMat3x3`](https://docs.rs/rerun/latest/rerun/components/struct.TransformMat3x3.html)
+ * 🦀 [Rust API docs for `TransformMat3x3`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TransformMat3x3.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/transform_relation.md
+++ b/docs/content/reference/types/components/transform_relation.md
@@ -29,7 +29,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `TransformRelation`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1components.html)
  * 🐍 [Python API docs for `TransformRelation`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TransformRelation)
- * 🦀 [Rust API docs for `TransformRelation`](https://docs.rs/rerun/latest/rerun/components/enum.TransformRelation.html)
+ * 🦀 [Rust API docs for `TransformRelation`](https://ref.rerun.io/docs/rust/stable/rerun/components/enum.TransformRelation.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/translation3d.md
+++ b/docs/content/reference/types/components/translation3d.md
@@ -17,7 +17,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Translation3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Translation3D.html)
  * 🐍 [Python API docs for `Translation3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Translation3D)
- * 🦀 [Rust API docs for `Translation3D`](https://docs.rs/rerun/latest/rerun/components/struct.Translation3D.html)
+ * 🦀 [Rust API docs for `Translation3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Translation3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/triangle_indices.md
+++ b/docs/content/reference/types/components/triangle_indices.md
@@ -17,7 +17,7 @@ FixedSizeList<3, uint32>
 ## API reference links
  * 🌊 [C++ API docs for `TriangleIndices`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1TriangleIndices.html)
  * 🐍 [Python API docs for `TriangleIndices`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.TriangleIndices)
- * 🦀 [Rust API docs for `TriangleIndices`](https://docs.rs/rerun/latest/rerun/components/struct.TriangleIndices.html)
+ * 🦀 [Rust API docs for `TriangleIndices`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.TriangleIndices.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/value_range.md
+++ b/docs/content/reference/types/components/value_range.md
@@ -17,7 +17,7 @@ FixedSizeList<2, float64>
 ## API reference links
  * 🌊 [C++ API docs for `ValueRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ValueRange.html)
  * 🐍 [Python API docs for `ValueRange`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ValueRange)
- * 🦀 [Rust API docs for `ValueRange`](https://docs.rs/rerun/latest/rerun/components/struct.ValueRange.html)
+ * 🦀 [Rust API docs for `ValueRange`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ValueRange.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/vector2d.md
+++ b/docs/content/reference/types/components/vector2d.md
@@ -17,7 +17,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Vector2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector2D.html)
  * 🐍 [Python API docs for `Vector2D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector2D)
- * 🦀 [Rust API docs for `Vector2D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector2D.html)
+ * 🦀 [Rust API docs for `Vector2D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Vector2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/vector3d.md
+++ b/docs/content/reference/types/components/vector3d.md
@@ -17,7 +17,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Vector3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1Vector3D.html)
  * 🐍 [Python API docs for `Vector3D`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.Vector3D)
- * 🦀 [Rust API docs for `Vector3D`](https://docs.rs/rerun/latest/rerun/components/struct.Vector3D.html)
+ * 🦀 [Rust API docs for `Vector3D`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.Vector3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/video_timestamp.md
+++ b/docs/content/reference/types/components/video_timestamp.md
@@ -17,7 +17,7 @@ int64
 ## API reference links
  * 🌊 [C++ API docs for `VideoTimestamp`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1VideoTimestamp.html)
  * 🐍 [Python API docs for `VideoTimestamp`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.VideoTimestamp)
- * 🦀 [Rust API docs for `VideoTimestamp`](https://docs.rs/rerun/latest/rerun/components/struct.VideoTimestamp.html)
+ * 🦀 [Rust API docs for `VideoTimestamp`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.VideoTimestamp.html)
 
 
 ## Used by

--- a/docs/content/reference/types/components/view_coordinates.md
+++ b/docs/content/reference/types/components/view_coordinates.md
@@ -34,7 +34,7 @@ FixedSizeList<3, uint8>
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1components_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/components#rerun.components.ViewCoordinates)
- * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/components/struct.ViewCoordinates.html)
+ * 🦀 [Rust API docs for `ViewCoordinates`](https://ref.rerun.io/docs/rust/stable/rerun/components/struct.ViewCoordinates.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/angle.md
+++ b/docs/content/reference/types/datatypes/angle.md
@@ -14,7 +14,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `Angle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Angle.html)
  * 🐍 [Python API docs for `Angle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Angle)
- * 🦀 [Rust API docs for `Angle`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Angle.html)
+ * 🦀 [Rust API docs for `Angle`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Angle.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/annotation_info.md
+++ b/docs/content/reference/types/datatypes/annotation_info.md
@@ -37,7 +37,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `AnnotationInfo`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1AnnotationInfo.html)
  * 🐍 [Python API docs for `AnnotationInfo`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.AnnotationInfo)
- * 🦀 [Rust API docs for `AnnotationInfo`](https://docs.rs/rerun/latest/rerun/datatypes/struct.AnnotationInfo.html)
+ * 🦀 [Rust API docs for `AnnotationInfo`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.AnnotationInfo.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/blob.md
+++ b/docs/content/reference/types/datatypes/blob.md
@@ -14,7 +14,7 @@ List<uint8>
 ## API reference links
  * 🌊 [C++ API docs for `Blob`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Blob.html)
  * 🐍 [Python API docs for `Blob`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Blob)
- * 🦀 [Rust API docs for `Blob`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Blob.html)
+ * 🦀 [Rust API docs for `Blob`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Blob.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/bool.md
+++ b/docs/content/reference/types/datatypes/bool.md
@@ -14,7 +14,7 @@ boolean
 ## API reference links
  * 🌊 [C++ API docs for `Bool`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Bool.html)
  * 🐍 [Python API docs for `Bool`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Bool)
- * 🦀 [Rust API docs for `Bool`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Bool.html)
+ * 🦀 [Rust API docs for `Bool`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Bool.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/channel_datatype.md
+++ b/docs/content/reference/types/datatypes/channel_datatype.md
@@ -50,7 +50,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `ChannelDatatype`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)
  * 🐍 [Python API docs for `ChannelDatatype`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ChannelDatatype)
- * 🦀 [Rust API docs for `ChannelDatatype`](https://docs.rs/rerun/latest/rerun/datatypes/enum.ChannelDatatype.html)
+ * 🦀 [Rust API docs for `ChannelDatatype`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/enum.ChannelDatatype.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/class_description.md
+++ b/docs/content/reference/types/datatypes/class_description.md
@@ -58,7 +58,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `ClassDescription`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescription.html)
  * 🐍 [Python API docs for `ClassDescription`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescription)
- * 🦀 [Rust API docs for `ClassDescription`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescription.html)
+ * 🦀 [Rust API docs for `ClassDescription`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.ClassDescription.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/class_description_map_elem.md
+++ b/docs/content/reference/types/datatypes/class_description_map_elem.md
@@ -45,7 +45,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassDescriptionMapElem.html)
  * 🐍 [Python API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassDescriptionMapElem)
- * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassDescriptionMapElem.html)
+ * 🦀 [Rust API docs for `ClassDescriptionMapElem`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.ClassDescriptionMapElem.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/class_id.md
+++ b/docs/content/reference/types/datatypes/class_id.md
@@ -14,7 +14,7 @@ uint16
 ## API reference links
  * 🌊 [C++ API docs for `ClassId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ClassId.html)
  * 🐍 [Python API docs for `ClassId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ClassId)
- * 🦀 [Rust API docs for `ClassId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ClassId.html)
+ * 🦀 [Rust API docs for `ClassId`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.ClassId.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/color_model.md
+++ b/docs/content/reference/types/datatypes/color_model.md
@@ -32,7 +32,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `ColorModel`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)
  * 🐍 [Python API docs for `ColorModel`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ColorModel)
- * 🦀 [Rust API docs for `ColorModel`](https://docs.rs/rerun/latest/rerun/datatypes/enum.ColorModel.html)
+ * 🦀 [Rust API docs for `ColorModel`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/enum.ColorModel.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/dvec2d.md
+++ b/docs/content/reference/types/datatypes/dvec2d.md
@@ -14,7 +14,7 @@ FixedSizeList<2, float64>
 ## API reference links
  * 🌊 [C++ API docs for `DVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1DVec2D.html)
  * 🐍 [Python API docs for `DVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.DVec2D)
- * 🦀 [Rust API docs for `DVec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.DVec2D.html)
+ * 🦀 [Rust API docs for `DVec2D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.DVec2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/entity_path.md
+++ b/docs/content/reference/types/datatypes/entity_path.md
@@ -14,7 +14,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `EntityPath`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1EntityPath.html)
  * 🐍 [Python API docs for `EntityPath`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.EntityPath)
- * 🦀 [Rust API docs for `EntityPath`](https://docs.rs/rerun/latest/rerun/datatypes/struct.EntityPath.html)
+ * 🦀 [Rust API docs for `EntityPath`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.EntityPath.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/float32.md
+++ b/docs/content/reference/types/datatypes/float32.md
@@ -14,7 +14,7 @@ float32
 ## API reference links
  * 🌊 [C++ API docs for `Float32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float32.html)
  * 🐍 [Python API docs for `Float32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float32)
- * 🦀 [Rust API docs for `Float32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Float32.html)
+ * 🦀 [Rust API docs for `Float32`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Float32.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/float64.md
+++ b/docs/content/reference/types/datatypes/float64.md
@@ -14,7 +14,7 @@ float64
 ## API reference links
  * 🌊 [C++ API docs for `Float64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Float64.html)
  * 🐍 [Python API docs for `Float64`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Float64)
- * 🦀 [Rust API docs for `Float64`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Float64.html)
+ * 🦀 [Rust API docs for `Float64`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Float64.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/image_format.md
+++ b/docs/content/reference/types/datatypes/image_format.md
@@ -52,7 +52,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `ImageFormat`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ImageFormat.html)
  * 🐍 [Python API docs for `ImageFormat`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ImageFormat)
- * 🦀 [Rust API docs for `ImageFormat`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ImageFormat.html)
+ * 🦀 [Rust API docs for `ImageFormat`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.ImageFormat.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/keypoint_id.md
+++ b/docs/content/reference/types/datatypes/keypoint_id.md
@@ -14,7 +14,7 @@ uint16
 ## API reference links
  * 🌊 [C++ API docs for `KeypointId`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointId.html)
  * 🐍 [Python API docs for `KeypointId`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointId)
- * 🦀 [Rust API docs for `KeypointId`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointId.html)
+ * 🦀 [Rust API docs for `KeypointId`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.KeypointId.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/keypoint_pair.md
+++ b/docs/content/reference/types/datatypes/keypoint_pair.md
@@ -28,7 +28,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `KeypointPair`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1KeypointPair.html)
  * 🐍 [Python API docs for `KeypointPair`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.KeypointPair)
- * 🦀 [Rust API docs for `KeypointPair`](https://docs.rs/rerun/latest/rerun/datatypes/struct.KeypointPair.html)
+ * 🦀 [Rust API docs for `KeypointPair`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.KeypointPair.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/mat3x3.md
+++ b/docs/content/reference/types/datatypes/mat3x3.md
@@ -23,7 +23,7 @@ FixedSizeList<9, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Mat3x3`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat3x3.html)
  * 🐍 [Python API docs for `Mat3x3`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat3x3)
- * 🦀 [Rust API docs for `Mat3x3`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat3x3.html)
+ * 🦀 [Rust API docs for `Mat3x3`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Mat3x3.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/mat4x4.md
+++ b/docs/content/reference/types/datatypes/mat4x4.md
@@ -24,6 +24,6 @@ FixedSizeList<16, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Mat4x4`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Mat4x4.html)
  * 🐍 [Python API docs for `Mat4x4`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Mat4x4)
- * 🦀 [Rust API docs for `Mat4x4`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Mat4x4.html)
+ * 🦀 [Rust API docs for `Mat4x4`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Mat4x4.html)
 
 

--- a/docs/content/reference/types/datatypes/pixel_format.md
+++ b/docs/content/reference/types/datatypes/pixel_format.md
@@ -105,7 +105,7 @@ uint8
 ## API reference links
  * 🌊 [C++ API docs for `PixelFormat`](https://ref.rerun.io/docs/cpp/stable/namespacererun_1_1datatypes.html)
  * 🐍 [Python API docs for `PixelFormat`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.PixelFormat)
- * 🦀 [Rust API docs for `PixelFormat`](https://docs.rs/rerun/latest/rerun/datatypes/enum.PixelFormat.html)
+ * 🦀 [Rust API docs for `PixelFormat`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/enum.PixelFormat.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/quaternion.md
+++ b/docs/content/reference/types/datatypes/quaternion.md
@@ -17,7 +17,7 @@ FixedSizeList<4, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Quaternion`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Quaternion.html)
  * 🐍 [Python API docs for `Quaternion`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Quaternion)
- * 🦀 [Rust API docs for `Quaternion`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Quaternion.html)
+ * 🦀 [Rust API docs for `Quaternion`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Quaternion.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/range1d.md
+++ b/docs/content/reference/types/datatypes/range1d.md
@@ -14,7 +14,7 @@ FixedSizeList<2, float64>
 ## API reference links
  * 🌊 [C++ API docs for `Range1D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range1D.html)
  * 🐍 [Python API docs for `Range1D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Range1D)
- * 🦀 [Rust API docs for `Range1D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Range1D.html)
+ * 🦀 [Rust API docs for `Range1D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Range1D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/range2d.md
+++ b/docs/content/reference/types/datatypes/range2d.md
@@ -28,6 +28,6 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `Range2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Range2D.html)
  * 🐍 [Python API docs for `Range2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Range2D)
- * 🦀 [Rust API docs for `Range2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Range2D.html)
+ * 🦀 [Rust API docs for `Range2D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Range2D.html)
 
 

--- a/docs/content/reference/types/datatypes/rgba32.md
+++ b/docs/content/reference/types/datatypes/rgba32.md
@@ -17,7 +17,7 @@ uint32
 ## API reference links
  * 🌊 [C++ API docs for `Rgba32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Rgba32.html)
  * 🐍 [Python API docs for `Rgba32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Rgba32)
- * 🦀 [Rust API docs for `Rgba32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Rgba32.html)
+ * 🦀 [Rust API docs for `Rgba32`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Rgba32.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/rotation_axis_angle.md
+++ b/docs/content/reference/types/datatypes/rotation_axis_angle.md
@@ -32,7 +32,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1RotationAxisAngle.html)
  * 🐍 [Python API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.RotationAxisAngle)
- * 🦀 [Rust API docs for `RotationAxisAngle`](https://docs.rs/rerun/latest/rerun/datatypes/struct.RotationAxisAngle.html)
+ * 🦀 [Rust API docs for `RotationAxisAngle`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.RotationAxisAngle.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/tensor_buffer.md
+++ b/docs/content/reference/types/datatypes/tensor_buffer.md
@@ -85,7 +85,7 @@ DenseUnion {
 ## API reference links
  * 🌊 [C++ API docs for `TensorBuffer`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorBuffer.html)
  * 🐍 [Python API docs for `TensorBuffer`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorBuffer)
- * 🦀 [Rust API docs for `TensorBuffer`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TensorBuffer.html)
+ * 🦀 [Rust API docs for `TensorBuffer`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/enum.TensorBuffer.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/tensor_data.md
+++ b/docs/content/reference/types/datatypes/tensor_data.md
@@ -51,7 +51,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorData`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorData.html)
  * 🐍 [Python API docs for `TensorData`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorData)
- * 🦀 [Rust API docs for `TensorData`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorData.html)
+ * 🦀 [Rust API docs for `TensorData`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TensorData.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/tensor_dimension.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension.md
@@ -28,7 +28,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimension`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimension.html)
  * 🐍 [Python API docs for `TensorDimension`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimension)
- * 🦀 [Rust API docs for `TensorDimension`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimension.html)
+ * 🦀 [Rust API docs for `TensorDimension`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TensorDimension.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_index_selection.md
@@ -30,7 +30,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimensionIndexSelection.html)
  * 🐍 [Python API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimensionIndexSelection)
- * 🦀 [Rust API docs for `TensorDimensionIndexSelection`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimensionIndexSelection.html)
+ * 🦀 [Rust API docs for `TensorDimensionIndexSelection`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TensorDimensionIndexSelection.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/tensor_dimension_selection.md
+++ b/docs/content/reference/types/datatypes/tensor_dimension_selection.md
@@ -28,7 +28,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TensorDimensionSelection`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TensorDimensionSelection.html)
  * 🐍 [Python API docs for `TensorDimensionSelection`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TensorDimensionSelection)
- * 🦀 [Rust API docs for `TensorDimensionSelection`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TensorDimensionSelection.html)
+ * 🦀 [Rust API docs for `TensorDimensionSelection`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TensorDimensionSelection.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/time_int.md
+++ b/docs/content/reference/types/datatypes/time_int.md
@@ -14,7 +14,7 @@ int64
 ## API reference links
  * 🌊 [C++ API docs for `TimeInt`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeInt.html)
  * 🐍 [Python API docs for `TimeInt`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TimeInt)
- * 🦀 [Rust API docs for `TimeInt`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeInt.html)
+ * 🦀 [Rust API docs for `TimeInt`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TimeInt.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/time_range.md
+++ b/docs/content/reference/types/datatypes/time_range.md
@@ -38,7 +38,7 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `TimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRange.html)
  * 🐍 [Python API docs for `TimeRange`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TimeRange)
- * 🦀 [Rust API docs for `TimeRange`](https://docs.rs/rerun/latest/rerun/datatypes/struct.TimeRange.html)
+ * 🦀 [Rust API docs for `TimeRange`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.TimeRange.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/time_range_boundary.md
+++ b/docs/content/reference/types/datatypes/time_range_boundary.md
@@ -35,7 +35,7 @@ DenseUnion {
 ## API reference links
  * 🌊 [C++ API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1TimeRangeBoundary.html)
  * 🐍 [Python API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.TimeRangeBoundary)
- * 🦀 [Rust API docs for `TimeRangeBoundary`](https://docs.rs/rerun/latest/rerun/datatypes/enum.TimeRangeBoundary.html)
+ * 🦀 [Rust API docs for `TimeRangeBoundary`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/enum.TimeRangeBoundary.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/uint16.md
+++ b/docs/content/reference/types/datatypes/uint16.md
@@ -14,6 +14,6 @@ uint16
 ## API reference links
  * 🌊 [C++ API docs for `UInt16`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt16.html)
  * 🐍 [Python API docs for `UInt16`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt16)
- * 🦀 [Rust API docs for `UInt16`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt16.html)
+ * 🦀 [Rust API docs for `UInt16`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UInt16.html)
 
 

--- a/docs/content/reference/types/datatypes/uint32.md
+++ b/docs/content/reference/types/datatypes/uint32.md
@@ -14,6 +14,6 @@ uint32
 ## API reference links
  * 🌊 [C++ API docs for `UInt32`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt32.html)
  * 🐍 [Python API docs for `UInt32`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt32)
- * 🦀 [Rust API docs for `UInt32`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt32.html)
+ * 🦀 [Rust API docs for `UInt32`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UInt32.html)
 
 

--- a/docs/content/reference/types/datatypes/uint64.md
+++ b/docs/content/reference/types/datatypes/uint64.md
@@ -14,6 +14,6 @@ uint64
 ## API reference links
  * 🌊 [C++ API docs for `UInt64`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UInt64.html)
  * 🐍 [Python API docs for `UInt64`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UInt64)
- * 🦀 [Rust API docs for `UInt64`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UInt64.html)
+ * 🦀 [Rust API docs for `UInt64`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UInt64.html)
 
 

--- a/docs/content/reference/types/datatypes/utf8.md
+++ b/docs/content/reference/types/datatypes/utf8.md
@@ -14,7 +14,7 @@ utf8
 ## API reference links
  * 🌊 [C++ API docs for `Utf8`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Utf8.html)
  * 🐍 [Python API docs for `Utf8`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Utf8)
- * 🦀 [Rust API docs for `Utf8`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Utf8.html)
+ * 🦀 [Rust API docs for `Utf8`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Utf8.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/uuid.md
+++ b/docs/content/reference/types/datatypes/uuid.md
@@ -14,6 +14,6 @@ FixedSizeList<16, uint8>
 ## API reference links
  * 🌊 [C++ API docs for `Uuid`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Uuid.html)
  * 🐍 [Python API docs for `Uuid`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Uuid)
- * 🦀 [Rust API docs for `Uuid`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Uuid.html)
+ * 🦀 [Rust API docs for `Uuid`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Uuid.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec2d.md
+++ b/docs/content/reference/types/datatypes/uvec2d.md
@@ -14,6 +14,6 @@ FixedSizeList<2, uint32>
 ## API reference links
  * 🌊 [C++ API docs for `UVec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec2D.html)
  * 🐍 [Python API docs for `UVec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec2D)
- * 🦀 [Rust API docs for `UVec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec2D.html)
+ * 🦀 [Rust API docs for `UVec2D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UVec2D.html)
 
 

--- a/docs/content/reference/types/datatypes/uvec3d.md
+++ b/docs/content/reference/types/datatypes/uvec3d.md
@@ -14,7 +14,7 @@ FixedSizeList<3, uint32>
 ## API reference links
  * 🌊 [C++ API docs for `UVec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec3D.html)
  * 🐍 [Python API docs for `UVec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec3D)
- * 🦀 [Rust API docs for `UVec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec3D.html)
+ * 🦀 [Rust API docs for `UVec3D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UVec3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/uvec4d.md
+++ b/docs/content/reference/types/datatypes/uvec4d.md
@@ -14,6 +14,6 @@ FixedSizeList<4, uint32>
 ## API reference links
  * 🌊 [C++ API docs for `UVec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1UVec4D.html)
  * 🐍 [Python API docs for `UVec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.UVec4D)
- * 🦀 [Rust API docs for `UVec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.UVec4D.html)
+ * 🦀 [Rust API docs for `UVec4D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.UVec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/vec2d.md
+++ b/docs/content/reference/types/datatypes/vec2d.md
@@ -14,7 +14,7 @@ FixedSizeList<2, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Vec2D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec2D.html)
  * 🐍 [Python API docs for `Vec2D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec2D)
- * 🦀 [Rust API docs for `Vec2D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec2D.html)
+ * 🦀 [Rust API docs for `Vec2D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Vec2D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/vec3d.md
+++ b/docs/content/reference/types/datatypes/vec3d.md
@@ -14,7 +14,7 @@ FixedSizeList<3, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Vec3D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec3D.html)
  * 🐍 [Python API docs for `Vec3D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec3D)
- * 🦀 [Rust API docs for `Vec3D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec3D.html)
+ * 🦀 [Rust API docs for `Vec3D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Vec3D.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/vec4d.md
+++ b/docs/content/reference/types/datatypes/vec4d.md
@@ -14,6 +14,6 @@ FixedSizeList<4, float32>
 ## API reference links
  * 🌊 [C++ API docs for `Vec4D`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1Vec4D.html)
  * 🐍 [Python API docs for `Vec4D`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.Vec4D)
- * 🦀 [Rust API docs for `Vec4D`](https://docs.rs/rerun/latest/rerun/datatypes/struct.Vec4D.html)
+ * 🦀 [Rust API docs for `Vec4D`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.Vec4D.html)
 
 

--- a/docs/content/reference/types/datatypes/video_timestamp.md
+++ b/docs/content/reference/types/datatypes/video_timestamp.md
@@ -17,7 +17,7 @@ int64
 ## API reference links
  * 🌊 [C++ API docs for `VideoTimestamp`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1VideoTimestamp.html)
  * 🐍 [Python API docs for `VideoTimestamp`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.VideoTimestamp)
- * 🦀 [Rust API docs for `VideoTimestamp`](https://docs.rs/rerun/latest/rerun/datatypes/struct.VideoTimestamp.html)
+ * 🦀 [Rust API docs for `VideoTimestamp`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.VideoTimestamp.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/view_coordinates.md
+++ b/docs/content/reference/types/datatypes/view_coordinates.md
@@ -31,7 +31,7 @@ FixedSizeList<3, uint8>
 ## API reference links
  * 🌊 [C++ API docs for `ViewCoordinates`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1ViewCoordinates.html)
  * 🐍 [Python API docs for `ViewCoordinates`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.ViewCoordinates)
- * 🦀 [Rust API docs for `ViewCoordinates`](https://docs.rs/rerun/latest/rerun/datatypes/struct.ViewCoordinates.html)
+ * 🦀 [Rust API docs for `ViewCoordinates`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.ViewCoordinates.html)
 
 
 ## Used by

--- a/docs/content/reference/types/datatypes/visible_time_range.md
+++ b/docs/content/reference/types/datatypes/visible_time_range.md
@@ -41,6 +41,6 @@ Struct {
 ## API reference links
  * 🌊 [C++ API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/cpp/stable/structrerun_1_1datatypes_1_1VisibleTimeRange.html)
  * 🐍 [Python API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/python/stable/common/datatypes#rerun.datatypes.VisibleTimeRange)
- * 🦀 [Rust API docs for `VisibleTimeRange`](https://docs.rs/rerun/latest/rerun/datatypes/struct.VisibleTimeRange.html)
+ * 🦀 [Rust API docs for `VisibleTimeRange`](https://ref.rerun.io/docs/rust/stable/rerun/datatypes/struct.VisibleTimeRange.html)
 
 

--- a/examples/rust/external_data_loader/README.md
+++ b/examples/rust/external_data_loader/README.md
@@ -19,6 +19,6 @@ This is an example executable data-loader plugin for the Rerun Viewer.
 It will log Rust source code files as markdown documents.
 To try it out, install it in your $PATH (`cargo install --path . -f`), then open a Rust source file with Rerun (`rerun file.rs`).
 
-Consider using the [`send_columns`](https://docs.rs/rerun/latest/rerun/struct.RecordingStream.html#method.send_columns) API for data loaders that ingest time series data from a file.
+Consider using the [`send_columns`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStream.html#method.send_columns) API for data loaders that ingest time series data from a file.
 This can be much more efficient that the stateful `log` API as it allows bundling
 component data over time into a single call consuming a continuous block of memory.

--- a/examples/rust/revy/README.md
+++ b/examples/rust/revy/README.md
@@ -86,4 +86,4 @@ For more information, check out the [Revy repository](https://github.com/rerun-i
     })
     ```
     This will start a Rerun Viewer in the background and stream the recording data to it.\
-    Check out the [`RecordingStreamBuilder`](https://docs.rs/rerun/latest/rerun/struct.RecordingStreamBuilder.html) docs for other options (saving to file, connecting to a remote viewer, etc).
+    Check out the [`RecordingStreamBuilder`](https://ref.rerun.io/docs/rust/stable/rerun/struct.RecordingStreamBuilder.html) docs for other options (saving to file, connecting to a remote viewer, etc).


### PR DESCRIPTION
### What

Temporary workaround for:
* https://github.com/rerun-io/rerun/issues/8165

Please revert after we published a patch with working doc.rs

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8166?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8166?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8166)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.