### PR TITLE
Fix doc build - run `cargo metadata` with `--offline` & `--no-deps`

### DIFF
--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -289,7 +289,12 @@ pub fn cargo_metadata() -> anyhow::Result<cargo_metadata::Metadata> {
         "Can't get metadata during crate publishing - it would create a Cargo.lock file"
     );
 
-    Ok(cargo_metadata::MetadataCommand::new().exec()?)
+    Ok(cargo_metadata::MetadataCommand::new()
+        .no_deps()
+        // Make sure this works without a connection, since docs.rs won't have one either.
+        // See https://github.com/rerun-io/rerun/issues/8165
+        .other_options(vec!["--offline".to_owned()])
+        .exec()?)
 }
 
 /// Returns a list of all the enabled features of the given package.

--- a/crates/build/re_build_tools/src/lib.rs
+++ b/crates/build/re_build_tools/src/lib.rs
@@ -293,7 +293,7 @@ pub fn cargo_metadata() -> anyhow::Result<cargo_metadata::Metadata> {
         .no_deps()
         // Make sure this works without a connection, since docs.rs won't have one either.
         // See https://github.com/rerun-io/rerun/issues/8165
-        .other_options(vec!["--offline".to_owned()])
+        .other_options(vec!["--frozen".to_owned()])
         .exec()?)
 }
 


### PR DESCRIPTION
### What

* solves https://github.com/rerun-io/rerun/issues/8165
(don't close ticket yet, have to confirm that docs.rs actually works)

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8168?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8168?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8168)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.