### PR TITLE
Views now advertise if they support the visible time range feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6055,8 +6055,6 @@ dependencies = [
  "re_log",
  "re_log_types",
  "re_space_view",
- "re_space_view_spatial",
- "re_space_view_time_series",
  "re_tracing",
  "re_types",
  "re_types_blueprint",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6046,7 +6046,6 @@ dependencies = [
  "egui_tiles",
  "itertools 0.13.0",
  "nohash-hasher",
- "once_cell",
  "re_chunk",
  "re_chunk_store",
  "re_context_menu",

--- a/crates/viewer/re_selection_panel/Cargo.toml
+++ b/crates/viewer/re_selection_panel/Cargo.toml
@@ -39,7 +39,6 @@ re_viewport_blueprint.workspace = true
 egui_tiles.workspace = true
 egui.workspace = true
 itertools.workspace = true
-once_cell.workspace = true
 nohash-hasher.workspace = true
 serde = { workspace = true, features = ["derive"] }
 static_assertions.workspace = true

--- a/crates/viewer/re_selection_panel/Cargo.toml
+++ b/crates/viewer/re_selection_panel/Cargo.toml
@@ -26,8 +26,6 @@ re_data_ui.workspace = true
 re_entity_db.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
-re_space_view_spatial.workspace = true
-re_space_view_time_series.workspace = true
 re_space_view.workspace = true
 re_tracing.workspace = true
 # TODO(jleibs): Remove this once VisualizerOverrides is gone

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -440,7 +440,7 @@ The last rule matching `/world/house` is `+ /world/**`, so it is included.
             let view_ctx = view.bundle_context_with_state(ctx, view_state);
             view_components_defaults_section_ui(&view_ctx, ui, view);
 
-            visible_time_range_ui_for_view(ctx, ui, view, view_state);
+            visible_time_range_ui_for_view(ctx, ui, view, view_class, view_state);
         }
     }
 }

--- a/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
+++ b/crates/viewer/re_selection_panel/src/visible_time_range_ui.rs
@@ -1,47 +1,23 @@
-use std::collections::HashSet;
-
 use egui::{NumExt as _, Ui};
 
 use re_log_types::{EntityPath, ResolvedTimeRange, TimeType, TimelineName};
-use re_space_view_spatial::{SpatialSpaceView2D, SpatialSpaceView3D};
-use re_space_view_time_series::TimeSeriesSpaceView;
 use re_types::{
     blueprint::components::VisibleTimeRange,
     datatypes::{TimeInt, TimeRange, TimeRangeBoundary},
-    Archetype, SpaceViewClassIdentifier,
+    Archetype,
 };
 use re_ui::UiExt as _;
 use re_viewer_context::{QueryRange, SpaceViewClass, SpaceViewState, TimeDragValue, ViewerContext};
 use re_viewport_blueprint::{entity_path_for_view_property, SpaceViewBlueprint};
 
-/// These space views support the Visible History feature.
-static VISIBLE_HISTORY_SUPPORTED_SPACE_VIEWS: once_cell::sync::Lazy<
-    HashSet<SpaceViewClassIdentifier>,
-> = once_cell::sync::Lazy::new(|| {
-    [
-        SpatialSpaceView3D::identifier(),
-        SpatialSpaceView2D::identifier(),
-        TimeSeriesSpaceView::identifier(),
-        // TODO(#7876): replace with `MapSpaceView::identifier()` when we get rid of the cargo feature
-        "Map".into(),
-    ]
-    .map(Into::into)
-    .into()
-});
-
-// TODO(#4145): This method is obviously unfortunate. It's a temporary solution until the Visualizer
-// system is able to report its ability to handle the visible history feature.
-fn space_view_with_visible_history(space_view_class: SpaceViewClassIdentifier) -> bool {
-    VISIBLE_HISTORY_SUPPORTED_SPACE_VIEWS.contains(&space_view_class)
-}
-
 pub fn visible_time_range_ui_for_view(
     ctx: &ViewerContext<'_>,
     ui: &mut Ui,
     view: &SpaceViewBlueprint,
+    view_class: &dyn SpaceViewClass,
     view_state: &dyn SpaceViewState,
 ) {
-    if !space_view_with_visible_history(view.class_identifier()) {
+    if !view_class.supports_visible_time_range() {
         return;
     }
 

--- a/crates/viewer/re_space_view_map/src/map_space_view.rs
+++ b/crates/viewer/re_space_view_map/src/map_space_view.rs
@@ -140,6 +140,10 @@ Displays geospatial primitives on a map.
         SpaceViewClassLayoutPriority::default()
     }
 
+    fn supports_visible_time_range(&self) -> bool {
+        true
+    }
+
     fn spawn_heuristics(&self, ctx: &ViewerContext<'_>) -> SpaceViewSpawnHeuristics {
         re_tracing::profile_function!();
 

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -106,6 +106,10 @@ impl SpaceViewClass for SpatialSpaceView2D {
             })
     }
 
+    fn supports_visible_time_range(&self) -> bool {
+        true
+    }
+
     fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
         re_viewer_context::SpaceViewClassLayoutPriority::High
     }

--- a/crates/viewer/re_space_view_spatial/src/view_3d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_3d.rs
@@ -86,6 +86,10 @@ impl SpaceViewClass for SpatialSpaceView3D {
         None
     }
 
+    fn supports_visible_time_range(&self) -> bool {
+        true
+    }
+
     fn layout_priority(&self) -> re_viewer_context::SpaceViewClassLayoutPriority {
         re_viewer_context::SpaceViewClassLayoutPriority::High
     }

--- a/crates/viewer/re_space_view_time_series/src/space_view_class.rs
+++ b/crates/viewer/re_space_view_time_series/src/space_view_class.rs
@@ -142,6 +142,10 @@ Display time series data in a plot.
         re_viewer_context::SpaceViewClassLayoutPriority::Low
     }
 
+    fn supports_visible_time_range(&self) -> bool {
+        true
+    }
+
     fn default_query_range(&self, _view_state: &dyn SpaceViewState) -> QueryRange {
         QueryRange::TimeRange(TimeRange::EVERYTHING)
     }

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class.rs
@@ -94,6 +94,11 @@ pub trait SpaceViewClass: Send + Sync {
     /// Controls how likely this space view will get a large tile in the ui.
     fn layout_priority(&self) -> SpaceViewClassLayoutPriority;
 
+    /// Controls whether the visible time range UI should be displayed for this view.
+    fn supports_visible_time_range(&self) -> bool {
+        false
+    }
+
     /// Default query range for this space view.
     //TODO(#6918): also provide ViewerContext and SpaceViewId, to enable reading view properties.
     fn default_query_range(&self, _state: &dyn SpaceViewState) -> QueryRange {


### PR DESCRIPTION
### What

- Fixes #4145

This allows removing the dependency of `re_selection_panel` on views just to get some id.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8169?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/8169?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/8169)
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.