### PR TITLE
Refactor rerun menu slightly

### DIFF
--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -12,7 +12,7 @@ const SPACING: f32 = 12.0;
 impl App {
     pub fn rerun_menu_button_ui(
         &mut self,
-        frame: &eframe::Frame,
+        render_state: Option<&egui_wgpu::RenderState>,
         _store_context: Option<&StoreContext<'_>>,
         ui: &mut egui::Ui,
     ) {
@@ -27,7 +27,7 @@ impl App {
         ui.menu_image_button(image, |ui| {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend); // no wrapping: make as wide as needed
 
-            ui.menu_button("About", |ui| self.about_rerun_ui(frame, ui));
+            ui.menu_button("About", |ui| self.about_rerun_ui(ui, render_state));
 
             ui.add_space(SPACING);
 
@@ -111,7 +111,7 @@ impl App {
         });
     }
 
-    fn about_rerun_ui(&self, frame: &eframe::Frame, ui: &mut egui::Ui) {
+    fn about_rerun_ui(&self, ui: &mut egui::Ui, render_state: Option<&egui_wgpu::RenderState>) {
         let re_build_info::BuildInfo {
             crate_name,
             features,
@@ -158,7 +158,7 @@ impl App {
 
         ui.label(label);
 
-        if let Some(render_state) = frame.wgpu_render_state() {
+        if let Some(render_state) = render_state {
             render_state_ui(ui, render_state);
         }
     }
@@ -308,7 +308,7 @@ fn render_state_ui(ui: &mut egui::Ui, render_state: &egui_wgpu::RenderState) {
 fn backend_menu_ui(
     command_sender: &re_viewer_context::CommandSender,
     ui: &mut egui::Ui,
-    frame: &eframe::Frame,
+    render_state: Option<&egui_wgpu::RenderState>,
 ) {
     if let Some(backend) = frame
         .wgpu_render_state()

--- a/crates/viewer/re_viewer/src/ui/rerun_menu.rs
+++ b/crates/viewer/re_viewer/src/ui/rerun_menu.rs
@@ -25,90 +25,98 @@ impl App {
             .max_height(desired_icon_height);
 
         ui.menu_image_button(image, |ui| {
-            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend); // no wrapping: make as wide as needed
+            self.rerun_menu_ui(ui, render_state, _store_context);
+        });
+    }
 
-            ui.menu_button("About", |ui| self.about_rerun_ui(ui, render_state));
+    fn rerun_menu_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        render_state: Option<&egui_wgpu::RenderState>,
+        _store_context: Option<&StoreContext<'_>>,
+    ) {
+        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+        // no wrapping: make as wide as needed
 
-            ui.add_space(SPACING);
+        ui.menu_button("About", |ui| self.about_rerun_ui(ui, render_state));
 
-            UICommand::ToggleCommandPalette.menu_button_ui(ui, &self.command_sender);
+        ui.add_space(SPACING);
 
-            ui.add_space(SPACING);
+        UICommand::ToggleCommandPalette.menu_button_ui(ui, &self.command_sender);
 
-            UICommand::Open.menu_button_ui(ui, &self.command_sender);
-            UICommand::Import.menu_button_ui(ui, &self.command_sender);
+        ui.add_space(SPACING);
 
-            self.save_buttons_ui(ui, _store_context);
+        UICommand::Open.menu_button_ui(ui, &self.command_sender);
+        UICommand::Import.menu_button_ui(ui, &self.command_sender);
 
-            UICommand::SaveBlueprint.menu_button_ui(ui, &self.command_sender);
+        self.save_buttons_ui(ui, _store_context);
 
-            UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
+        UICommand::SaveBlueprint.menu_button_ui(ui, &self.command_sender);
 
-            ui.add_space(SPACING);
+        UICommand::CloseCurrentRecording.menu_button_ui(ui, &self.command_sender);
 
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                // On the web the browser controls the zoom
-                let zoom_factor = ui.ctx().zoom_factor();
-                ui.weak(format!("Current zoom: {:.0}%", zoom_factor * 100.0))
-                    .on_hover_text(
-                        "The UI zoom level on top of the operating system's default value",
-                    );
-                UICommand::ZoomIn.menu_button_ui(ui, &self.command_sender);
-                UICommand::ZoomOut.menu_button_ui(ui, &self.command_sender);
-                ui.add_enabled_ui(zoom_factor != 1.0, |ui| {
-                    UICommand::ZoomReset.menu_button_ui(ui, &self.command_sender)
-                });
+        ui.add_space(SPACING);
 
-                UICommand::ToggleFullscreen.menu_button_ui(ui, &self.command_sender);
-
-                ui.add_space(SPACING);
-            }
-
-            {
-                UICommand::ResetViewer.menu_button_ui(ui, &self.command_sender);
-
-                #[cfg(not(target_arch = "wasm32"))]
-                UICommand::OpenProfiler.menu_button_ui(ui, &self.command_sender);
-
-                UICommand::ToggleMemoryPanel.menu_button_ui(ui, &self.command_sender);
-                UICommand::ToggleChunkStoreBrowser.menu_button_ui(ui, &self.command_sender);
-
-                #[cfg(debug_assertions)]
-                UICommand::ToggleEguiDebugPanel.menu_button_ui(ui, &self.command_sender);
-            }
-
-            ui.add_space(SPACING);
-
-            UICommand::Settings.menu_button_ui(ui, &self.command_sender);
-
-            #[cfg(target_arch = "wasm32")]
-            backend_menu_ui(&self.command_sender, ui, frame);
-
-            #[cfg(debug_assertions)]
-            ui.menu_button("Debug", |ui| {
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
-                debug_menu_options_ui(ui, &mut self.state.app_options, &self.command_sender);
-
-                ui.label("egui debug options:");
-                ui.weak(format!(
-                    "pixels_per_point: {:?}",
-                    ui.ctx().pixels_per_point()
-                ));
-                egui_debug_options_ui(ui);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // On the web the browser controls the zoom
+            let zoom_factor = ui.ctx().zoom_factor();
+            ui.weak(format!("Current zoom: {:.0}%", zoom_factor * 100.0))
+                .on_hover_text("The UI zoom level on top of the operating system's default value");
+            UICommand::ZoomIn.menu_button_ui(ui, &self.command_sender);
+            UICommand::ZoomOut.menu_button_ui(ui, &self.command_sender);
+            ui.add_enabled_ui(zoom_factor != 1.0, |ui| {
+                UICommand::ZoomReset.menu_button_ui(ui, &self.command_sender)
             });
 
-            ui.add_space(SPACING);
+            UICommand::ToggleFullscreen.menu_button_ui(ui, &self.command_sender);
 
-            UICommand::OpenWebHelp.menu_button_ui(ui, &self.command_sender);
-            UICommand::OpenRerunDiscord.menu_button_ui(ui, &self.command_sender);
+            ui.add_space(SPACING);
+        }
+
+        {
+            UICommand::ResetViewer.menu_button_ui(ui, &self.command_sender);
 
             #[cfg(not(target_arch = "wasm32"))]
-            {
-                ui.add_space(SPACING);
-                UICommand::Quit.menu_button_ui(ui, &self.command_sender);
-            }
+            UICommand::OpenProfiler.menu_button_ui(ui, &self.command_sender);
+
+            UICommand::ToggleMemoryPanel.menu_button_ui(ui, &self.command_sender);
+            UICommand::ToggleChunkStoreBrowser.menu_button_ui(ui, &self.command_sender);
+
+            #[cfg(debug_assertions)]
+            UICommand::ToggleEguiDebugPanel.menu_button_ui(ui, &self.command_sender);
+        }
+
+        ui.add_space(SPACING);
+
+        UICommand::Settings.menu_button_ui(ui, &self.command_sender);
+
+        #[cfg(target_arch = "wasm32")]
+        backend_menu_ui(&self.command_sender, ui, frame);
+
+        #[cfg(debug_assertions)]
+        ui.menu_button("Debug", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+            debug_menu_options_ui(ui, &mut self.state.app_options, &self.command_sender);
+
+            ui.label("egui debug options:");
+            ui.weak(format!(
+                "pixels_per_point: {:?}",
+                ui.ctx().pixels_per_point()
+            ));
+            egui_debug_options_ui(ui);
         });
+
+        ui.add_space(SPACING);
+
+        UICommand::OpenWebHelp.menu_button_ui(ui, &self.command_sender);
+        UICommand::OpenRerunDiscord.menu_button_ui(ui, &self.command_sender);
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            ui.add_space(SPACING);
+            UICommand::Quit.menu_button_ui(ui, &self.command_sender);
+        }
     }
 
     fn about_rerun_ui(&self, ui: &mut egui::Ui, render_state: Option<&egui_wgpu::RenderState>) {

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -84,7 +84,7 @@ fn top_bar_ui(
     ui: &mut egui::Ui,
     gpu_resource_stats: &WgpuResourcePoolStatistics,
 ) {
-    app.rerun_menu_button_ui(frame, store_context, ui);
+    app.rerun_menu_button_ui(frame.wgpu_render_state(), store_context, ui);
 
     ui.add_space(12.0);
     website_link_ui(ui);


### PR DESCRIPTION
### What
Small refactor. We talked about maybe making a test for this, but in the end we decided to test something else.

### Checklist
* [x] I have read and agree to [Contributor Guide](https://github.com/rerun-io/rerun/blob/main/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/rerun-io/rerun/blob/main/CODE_OF_CONDUCT.md)
* [x] I've included a screenshot or gif (if applicable)
* [x] I have tested the web demo (if applicable):
  * Using examples from latest `main` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json)
  * Using full set of examples from `nightly` build: [rerun.io/viewer](https://rerun.io/viewer/pr/{{pr.number}}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json)
* [x] The PR title and labels are set such as to maximize their usefulness for the next release's CHANGELOG
* [x] If applicable, add a new check to the [release checklist](https://github.com/rerun-io/rerun/blob/main/tests/python/release_checklist)!
* [x] If have noted any breaking changes to the log API in `CHANGELOG.md` and the migration guide

- [PR Build Summary](https://build.rerun.io/pr/{{pr.number}})
- [Recent benchmark results](https://build.rerun.io/graphs/crates.html)
- [Wasm size tracking](https://build.rerun.io/graphs/sizes.html)

To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.

To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
