### PR TITLE
Remove hack for setting `ExternalImageSource::VideoFrame` in wasm video processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5870,7 +5870,6 @@ dependencies = [
  "web-time",
  "wgpu",
  "wgpu-core",
- "wgpu-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,7 +325,6 @@ wgpu = { version = "23.0", default-features = false, features = [
   "fragile-send-sync-non-atomic-wasm",
 ] }
 wgpu-core = "23.0"
-wgpu-types = "23.0"
 xshell = "0.2"
 zip = { version = "0.6", default-features = false } # We're stuck on 0.6 because https://crates.io/crates/protoc-prebuilt is still using 0.6
 

--- a/crates/viewer/re_renderer/Cargo.toml
+++ b/crates/viewer/re_renderer/Cargo.toml
@@ -81,7 +81,6 @@ type-map.workspace = true
 web-time.workspace = true
 wgpu.workspace = true
 wgpu-core.workspace = true                                           # Needed for error handling when wgpu-core implemented backend is used.
-wgpu-types.workspace = true
 
 # optional
 arrow2 = { workspace = true, optional = true }

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -189,7 +189,7 @@ fn copy_web_video_frame_to_texture(
         // Careful: `web_sys::VideoFrame` has a custom `clone` method:
         // https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/clone
         // We instead just want to clone the js value!
-        source: wgpu::ExternalImageSource::VideoFrame(Clone::clone(frame)),
+        source: wgpu::ExternalImageSource::VideoFrame(JsValue::clone(frame)),
         origin: wgpu::Origin2d { x: 0, y: 0 },
         flip_y: false,
     };

--- a/crates/viewer/re_renderer/src/video/chunk_decoder.rs
+++ b/crates/viewer/re_renderer/src/video/chunk_decoder.rs
@@ -188,8 +188,8 @@ fn copy_web_video_frame_to_texture(
     let source = wgpu::ImageCopyExternalImage {
         // Careful: `web_sys::VideoFrame` has a custom `clone` method:
         // https://developer.mozilla.org/en-US/docs/Web/API/VideoFrame/clone
-        // We instead just want to clone the js value!
-        source: wgpu::ExternalImageSource::VideoFrame(JsValue::clone(frame)),
+        // We instead just want to clone the js value wrapped in VideoFrame!
+        source: wgpu::ExternalImageSource::VideoFrame(Clone::clone(frame)),
         origin: wgpu::Origin2d { x: 0, y: 0 },
         flip_y: false,
     };

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -18,7 +18,7 @@ pub enum VideoPlayerError {
     #[error("The decoder is lagging behind")]
     EmptyBuffer,
 
-    #[error("Video seems to be empty, no segments have been found.")]
+    #[error("Video is empty.")]
     EmptyVideo,
 
     /// e.g. unsupported codec

--- a/crates/viewer/re_renderer/src/video/mod.rs
+++ b/crates/viewer/re_renderer/src/video/mod.rs
@@ -18,7 +18,7 @@ pub enum VideoPlayerError {
     #[error("The decoder is lagging behind")]
     EmptyBuffer,
 
-    #[error("Video seems to be empty, no segments have beem found.")]
+    #[error("Video seems to be empty, no segments have been found.")]
     EmptyVideo,
 
     /// e.g. unsupported codec


### PR DESCRIPTION
Thanks to @jprochazk pushing a fix upstream & us now being on wgpu 23, we no longer need this hack

Gave it a spin locally to verify that video still plays on the web player.