### PR TITLE
Improve performance of time panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,6 +6271,7 @@ dependencies = [
  "criterion",
  "egui",
  "itertools 0.13.0",
+ "once_cell",
  "rand",
  "re_chunk_store",
  "re_context_menu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6271,6 +6271,7 @@ dependencies = [
  "criterion",
  "egui",
  "itertools 0.13.0",
+ "nohash-hasher",
  "once_cell",
  "rand",
  "re_chunk_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6280,6 +6280,7 @@ dependencies = [
  "re_entity_db",
  "re_format",
  "re_int_histogram",
+ "re_log",
  "re_log_types",
  "re_tracing",
  "re_types",

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use itertools::Itertools;
 use re_chunk::Chunk;
 use re_log_types::StoreId;
 

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use itertools::Itertools;
 use re_chunk::Chunk;
 use re_log_types::StoreId;
 
@@ -93,7 +94,8 @@ pub struct ChunkCompactionReport {
 impl PartialEq for ChunkCompactionReport {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {
-        self.compacted_chunks == rhs.compacted_chunks && self.new_chunk.id() == rhs.new_chunk.id()
+        self.compacted_chunks.keys().eq(rhs.compacted_chunks.keys())
+            && self.new_chunk.id() == rhs.new_chunk.id()
     }
 }
 

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -85,7 +85,7 @@ impl ChunkStoreDiffKind {
 #[derive(Debug, Clone)]
 pub struct ChunkCompactionReport {
     /// The chunks that were merged into a new chunk.
-    pub compacted_chunks: BTreeMap<ChunkId, Arc<Chunk>>,
+    pub srcs: BTreeMap<ChunkId, Arc<Chunk>>,
 
     /// The new chunk that was created as the result of the compaction.
     pub new_chunk: Arc<Chunk>,
@@ -94,8 +94,7 @@ pub struct ChunkCompactionReport {
 impl PartialEq for ChunkCompactionReport {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {
-        self.compacted_chunks.keys().eq(rhs.compacted_chunks.keys())
-            && self.new_chunk.id() == rhs.new_chunk.id()
+        self.srcs.keys().eq(rhs.srcs.keys()) && self.new_chunk.id() == rhs.new_chunk.id()
     }
 }
 

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -80,6 +80,23 @@ impl ChunkStoreDiffKind {
     }
 }
 
+/// Reports which [`Chunk`]s were merged into a new [`Chunk`] during a compaction.
+#[derive(Debug, Clone)]
+pub struct ChunkCompactionReport {
+    /// The chunks that were merged into a new chunk.
+    pub compacted_chunks: BTreeMap<ChunkId, Arc<Chunk>>,
+
+    /// The new chunk that was created as the result of the compaction.
+    pub new_chunk: Arc<Chunk>,
+}
+
+impl PartialEq for ChunkCompactionReport {
+    #[inline]
+    fn eq(&self, rhs: &Self) -> bool {
+        self.compacted_chunks == rhs.compacted_chunks && self.new_chunk.id() == rhs.new_chunk.id()
+    }
+}
+
 /// Describes an atomic change in the Rerun [`ChunkStore`]: a chunk has been added or deleted.
 ///
 /// From a query model standpoint, the [`ChunkStore`] _always_ operates one chunk at a time:
@@ -120,14 +137,15 @@ pub struct ChunkStoreDiff {
     // deallocated.
     pub chunk: Arc<Chunk>,
 
-    /// Reports which [`Chunk`]s were merged into a new [`ChunkId`] (srcs, dst) during a compaction.
+    /// Reports which [`Chunk`]s were merged into a new [`Chunk`] during a compaction.
     ///
     /// This is only specified if an addition to the store triggered a compaction.
     /// When that happens, it is guaranteed that [`ChunkStoreDiff::chunk`] will be present in the
     /// set of source chunks below, since it was compacted on arrival.
     ///
-    /// A corollary to that is that the destination [`ChunkId`] must have never been seen before.
-    pub compacted: Option<(BTreeMap<ChunkId, Arc<Chunk>>, ChunkId)>,
+    /// A corollary to that is that the destination [`Chunk`] must have never been seen before,
+    /// i.e. it's [`ChunkId`] must have never been seen before.
+    pub compacted: Option<ChunkCompactionReport>,
 }
 
 impl PartialEq for ChunkStoreDiff {
@@ -146,10 +164,7 @@ impl Eq for ChunkStoreDiff {}
 
 impl ChunkStoreDiff {
     #[inline]
-    pub fn addition(
-        chunk: Arc<Chunk>,
-        compacted: Option<(BTreeMap<ChunkId, Arc<Chunk>>, ChunkId)>,
-    ) -> Self {
+    pub fn addition(chunk: Arc<Chunk>, compacted: Option<ChunkCompactionReport>) -> Self {
         Self {
             kind: ChunkStoreDiffKind::Addition,
             chunk,

--- a/crates/store/re_chunk_store/src/lib.rs
+++ b/crates/store/re_chunk_store/src/lib.rs
@@ -29,7 +29,9 @@ pub use self::dataframe::{
     IndexRange, IndexValue, QueryExpression, SparseFillStrategy, TimeColumnDescriptor,
     TimeColumnSelector, ViewContentsSelector,
 };
-pub use self::events::{ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent};
+pub use self::events::{
+    ChunkCompactionReport, ChunkStoreDiff, ChunkStoreDiffKind, ChunkStoreEvent,
+};
 pub use self::gc::{GarbageCollectionOptions, GarbageCollectionTarget};
 pub use self::stats::{ChunkStoreChunkStats, ChunkStoreStats};
 pub use self::store::{

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -772,8 +772,7 @@ impl ChunkStore {
         query: &RangeQuery,
         entity_path: &EntityPath,
     ) -> Vec<Arc<Chunk>> {
-        // Too small & frequent for profiling scopes.
-        //re_tracing::profile_function!(format!("{query:?}"));
+        re_tracing::profile_function!(format!("{query:?}"));
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -772,7 +772,8 @@ impl ChunkStore {
         query: &RangeQuery,
         entity_path: &EntityPath,
     ) -> Vec<Arc<Chunk>> {
-        re_tracing::profile_function!(format!("{query:?}"));
+        // Too small & frequent for profiling scopes.
+        //re_tracing::profile_function!(format!("{query:?}"));
 
         self.query_id.fetch_add(1, Ordering::Relaxed);
 
@@ -810,7 +811,8 @@ impl ChunkStore {
         query: &RangeQuery,
         temporal_chunk_ids_per_times: impl Iterator<Item = &'a ChunkIdSetPerTime>,
     ) -> Vec<Arc<Chunk>> {
-        re_tracing::profile_function!();
+        // Too small & frequent for profiling scopes.
+        //re_tracing::profile_function!();
 
         temporal_chunk_ids_per_times
             .map(|temporal_chunk_ids_per_time| {

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -314,7 +314,7 @@ impl ChunkStore {
             );
             if let Some(elected_chunk) = &elected_chunk {
                 // NOTE: The chunk that we've just added has been compacted already!
-                let replacements = std::iter::once((non_compacted_chunk.id(), non_compacted_chunk))
+                let srcs = std::iter::once((non_compacted_chunk.id(), non_compacted_chunk))
                     .chain(
                         self.remove_chunk(elected_chunk.id())
                             .into_iter()
@@ -324,7 +324,7 @@ impl ChunkStore {
                     .collect();
 
                 diff.compacted = Some(crate::ChunkCompactionReport {
-                    compacted_chunks: replacements,
+                    srcs,
                     new_chunk: chunk_or_compacted.clone(),
                 });
             }

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -314,7 +314,7 @@ impl ChunkStore {
             );
             if let Some(elected_chunk) = &elected_chunk {
                 // NOTE: The chunk that we've just added has been compacted already!
-                let srcs = std::iter::once((non_compacted_chunk.id(), non_compacted_chunk))
+                let replacements = std::iter::once((non_compacted_chunk.id(), non_compacted_chunk))
                     .chain(
                         self.remove_chunk(elected_chunk.id())
                             .into_iter()
@@ -322,9 +322,11 @@ impl ChunkStore {
                             .map(|diff| (diff.chunk.id(), diff.chunk)),
                     )
                     .collect();
-                let dst = chunk_or_compacted.id();
 
-                diff.compacted = Some((srcs, dst));
+                diff.compacted = Some(crate::ChunkCompactionReport {
+                    compacted_chunks: replacements,
+                    new_chunk: chunk_or_compacted.clone(),
+                });
             }
 
             (chunk_or_compacted, vec![diff])

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -319,7 +319,7 @@ impl ChunkStoreSubscriber for QueryCache {
                         // If a compaction was triggered, make sure to drop the original chunks too.
                         compacted_events.extend(compacted.iter().flat_map(
                             |ChunkCompactionReport {
-                                 compacted_chunks,
+                                 srcs: compacted_chunks,
                                  new_chunk: _,
                              }| compacted_chunks.keys().copied(),
                         ));
@@ -340,7 +340,7 @@ impl ChunkStoreSubscriber for QueryCache {
 
                             // If a compaction was triggered, make sure to drop the original chunks too.
                             if let Some(ChunkCompactionReport {
-                                compacted_chunks,
+                                srcs: compacted_chunks,
                                 new_chunk: _,
                             }) = compacted
                             {
@@ -374,7 +374,7 @@ impl ChunkStoreSubscriber for QueryCache {
                             // If a compaction was triggered, make sure to drop the original chunks too.
                             compacted_events.extend(compacted.iter().flat_map(
                                 |ChunkCompactionReport {
-                                     compacted_chunks,
+                                     srcs: compacted_chunks,
                                      new_chunk: _,
                                  }| {
                                     compacted_chunks.keys().copied()

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -8,7 +8,9 @@ use nohash_hasher::IntSet;
 use parking_lot::RwLock;
 
 use re_chunk::ChunkId;
-use re_chunk_store::{ChunkStoreDiff, ChunkStoreEvent, ChunkStoreHandle, ChunkStoreSubscriber};
+use re_chunk_store::{
+    ChunkCompactionReport, ChunkStoreDiff, ChunkStoreEvent, ChunkStoreHandle, ChunkStoreSubscriber,
+};
 use re_log_types::{EntityPath, ResolvedTimeRange, StoreId, TimeInt, Timeline};
 use re_types_core::{components::ClearIsRecursive, Component as _, ComponentName};
 
@@ -315,11 +317,12 @@ impl ChunkStoreSubscriber for QueryCache {
 
                         compacted_events.insert(chunk.id());
                         // If a compaction was triggered, make sure to drop the original chunks too.
-                        compacted_events.extend(
-                            compacted
-                                .iter()
-                                .flat_map(|(compacted_chunks, _)| compacted_chunks.keys().copied()),
-                        );
+                        compacted_events.extend(compacted.iter().flat_map(
+                            |ChunkCompactionReport {
+                                 compacted_chunks,
+                                 new_chunk: _,
+                             }| compacted_chunks.keys().copied(),
+                        ));
                     }
                 }
 
@@ -336,7 +339,11 @@ impl ChunkStoreSubscriber for QueryCache {
                             let mut data_time_min = time_range.min();
 
                             // If a compaction was triggered, make sure to drop the original chunks too.
-                            if let Some((compacted_chunks, _)) = compacted {
+                            if let Some(ChunkCompactionReport {
+                                compacted_chunks,
+                                new_chunk: _,
+                            }) = compacted
+                            {
                                 for chunk in compacted_chunks.values() {
                                     let data_time_compacted = chunk
                                         .time_range_per_component()
@@ -366,7 +373,12 @@ impl ChunkStoreSubscriber for QueryCache {
                             compacted_events.insert(chunk.id());
                             // If a compaction was triggered, make sure to drop the original chunks too.
                             compacted_events.extend(compacted.iter().flat_map(
-                                |(compacted_chunks, _)| compacted_chunks.keys().copied(),
+                                |ChunkCompactionReport {
+                                     compacted_chunks,
+                                     new_chunk: _,
+                                 }| {
+                                    compacted_chunks.keys().copied()
+                                },
                             ));
                         }
                     }

--- a/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
+++ b/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
@@ -40,13 +40,13 @@ pub struct TransformComponentTracker {
 }
 
 impl TransformComponentTracker {
-    /// Accesses the spatial topology for a given store.
+    /// Accesses the transform component tracking data for a given store.
     #[inline]
     pub fn access<T>(store_id: &StoreId, f: impl FnOnce(&Self) -> T) -> Option<T> {
         ChunkStore::with_subscriber_once(
             TransformComponentTrackerStoreSubscriber::subscription_handle(),
-            move |susbcriber: &TransformComponentTrackerStoreSubscriber| {
-                susbcriber.per_store.get(store_id).map(f)
+            move |subscriber: &TransformComponentTrackerStoreSubscriber| {
+                subscriber.per_store.get(store_id).map(f)
             },
         )
         .flatten()

--- a/crates/viewer/re_time_panel/Cargo.toml
+++ b/crates/viewer/re_time_panel/Cargo.toml
@@ -34,6 +34,7 @@ re_viewport_blueprint.workspace = true
 
 egui.workspace = true
 itertools.workspace = true
+once_cell.workspace = true
 serde.workspace = true
 vec1.workspace = true
 

--- a/crates/viewer/re_time_panel/Cargo.toml
+++ b/crates/viewer/re_time_panel/Cargo.toml
@@ -34,6 +34,7 @@ re_viewport_blueprint.workspace = true
 
 egui.workspace = true
 itertools.workspace = true
+nohash-hasher.workspace = true
 once_cell.workspace = true
 serde.workspace = true
 vec1.workspace = true

--- a/crates/viewer/re_time_panel/Cargo.toml
+++ b/crates/viewer/re_time_panel/Cargo.toml
@@ -26,6 +26,7 @@ re_entity_db.workspace = true
 re_format.workspace = true
 re_int_histogram.workspace = true
 re_log_types.workspace = true
+re_log.workspace = true
 re_tracing.workspace = true
 re_types.workspace = true
 re_ui.workspace = true

--- a/crates/viewer/re_time_panel/src/chunk_statistics_store_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/chunk_statistics_store_subscriber.rs
@@ -1,0 +1,167 @@
+use std::sync::Arc;
+
+use egui::ahash::HashMap;
+use once_cell::sync::OnceCell;
+use re_chunk_store::{
+    Chunk, ChunkId, ChunkStore, ChunkStoreEvent, ChunkStoreSubscriber, ChunkStoreSubscriberHandle,
+};
+use re_log_types::{EntityPath, EntityPathHash, StoreId, Timeline};
+use re_viewer_context::external::nohash_hasher::IntMap; // TODO:
+
+// TODO: not done. unclear if I want this.
+
+/// Recursive statistics for a given timeline & entity.
+#[derive(Default)]
+pub struct EntityTimelineChunks {
+    // TODO: this should be a BTreeMap sorted by lowest time on the given timeline for fast range lookups.
+    pub recursive_chunks: HashMap<ChunkId, Arc<Chunk>>,
+}
+
+// TODO: build up a data-structure that we can retain.
+// pub struct ChunkTimelineStats {
+//     pub chunk_id: ChunkId,
+
+//     /// How many events there are for the given component for the chunk on the timeline this struct is for.
+//     pub num_events_per_component: IntMap<ComponentName, u64>,
+
+//     /// Sum of all items in `Self::num_events_per_component` plus event count of all children
+//     pub num_events_recursive: u64,
+// }
+
+/// Keeps track of various statistics about chunks that are used to draw the data density graph.
+///
+/// The store subscription is only used for invalidating existing data rather than building up
+/// all statistics continuously.
+#[derive(Default)]
+pub struct PathRecursiveChunksPerTimeline {
+    timeline_chunk_stats: IntMap<Timeline, IntMap<EntityPathHash, EntityTimelineChunks>>,
+}
+
+impl PathRecursiveChunksPerTimeline {
+    /// Accesses the chunk
+    #[inline]
+    pub fn access<T>(store_id: &StoreId, f: impl FnOnce(&Self) -> T) -> Option<T> {
+        ChunkStore::with_subscriber_once(
+            PathRecursiveChunksPerTimelineStoreSubscriber::subscription_handle(),
+            move |subscriber: &PathRecursiveChunksPerTimelineStoreSubscriber| {
+                subscriber.per_store.get(store_id).map(f)
+            },
+        )
+        .flatten()
+    }
+
+    pub fn entity_timeline_stats(
+        &self,
+        entity_path: &EntityPath,
+        timeline: Timeline,
+    ) -> Option<&EntityTimelineChunks> {
+        self.timeline_chunk_stats
+            .get(&timeline)?
+            .get(&entity_path.hash())
+    }
+}
+
+#[derive(Default)]
+struct PathRecursiveChunksPerTimelineStoreSubscriber {
+    per_store: HashMap<StoreId, PathRecursiveChunksPerTimeline>,
+}
+
+impl PathRecursiveChunksPerTimelineStoreSubscriber {
+    /// Accesses the global store subscriber.
+    ///
+    /// Lazily registers the subscriber if it hasn't been registered yet.
+    pub fn subscription_handle() -> ChunkStoreSubscriberHandle {
+        static SUBSCRIPTION: OnceCell<ChunkStoreSubscriberHandle> = OnceCell::new();
+        *SUBSCRIPTION.get_or_init(|| ChunkStore::register_subscriber(Box::<Self>::default()))
+    }
+}
+
+impl ChunkStoreSubscriber for PathRecursiveChunksPerTimelineStoreSubscriber {
+    #[inline]
+    fn name(&self) -> String {
+        "rerun.store_subscriber.ChunkStatistics".into()
+    }
+
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn on_events(&mut self, events: &[ChunkStoreEvent]) {
+        re_tracing::profile_function!();
+
+        for event in events {
+            let path_recursive_chunks = self.per_store.entry(event.store_id.clone()).or_default();
+
+            if let Some(re_chunk_store::ChunkCompactionReport {
+                compacted_chunks,
+                new_chunk,
+            }) = &event.diff.compacted
+            {
+                for removed_chunk in compacted_chunks.values() {
+                    remove_chunk(path_recursive_chunks, removed_chunk);
+                }
+                add_chunk(path_recursive_chunks, &new_chunk);
+            } else {
+                match event.diff.kind {
+                    re_chunk_store::ChunkStoreDiffKind::Addition => {
+                        add_chunk(path_recursive_chunks, &event.chunk);
+                    }
+                    re_chunk_store::ChunkStoreDiffKind::Deletion => {
+                        remove_chunk(path_recursive_chunks, &event.chunk);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn add_chunk(path_recursive_chunks: &mut PathRecursiveChunksPerTimeline, chunk: &Arc<Chunk>) {
+    re_tracing::profile_function!();
+
+    for timeline in chunk.timelines().keys() {
+        let chunks_per_entities = path_recursive_chunks
+            .timeline_chunk_stats
+            .entry(timeline.clone())
+            .or_default();
+
+        // Recursively add chunks.
+        let mut next_path = Some(chunk.entity_path().clone());
+        while let Some(path) = next_path {
+            let chunks_per_entity = chunks_per_entities.entry(path.hash()).or_default();
+            chunks_per_entity
+                .recursive_chunks
+                .insert(chunk.id(), chunk.clone());
+            next_path = path.parent();
+        }
+    }
+}
+
+fn remove_chunk(path_recursive_chunks: &mut PathRecursiveChunksPerTimeline, chunk: &Chunk) {
+    re_tracing::profile_function!();
+
+    for timeline in chunk.timelines().keys() {
+        let Some(chunks_per_entities) =
+            path_recursive_chunks.timeline_chunk_stats.get_mut(timeline)
+        else {
+            continue;
+        };
+
+        // Recursively remove chunks.
+        let mut next_path = Some(chunk.entity_path().clone());
+        while let Some(path) = next_path {
+            if let Some(chunks_per_entity) = chunks_per_entities.get_mut(&path.hash()) {
+                chunks_per_entity.recursive_chunks.remove(&chunk.id());
+            }
+            next_path = path.parent();
+        }
+    }
+}
+
+// TODO: add unit tests

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -180,12 +180,11 @@ impl DensityGraph {
         }
 
         // full buckets:
-        for i in (min_bucket.ceil() as i64)..=(max_bucket.floor() as i64) {
-            if let Ok(i) = usize::try_from(i) {
-                if let Some(bucket) = self.buckets.get_mut(i) {
-                    *bucket += count_per_bucket;
-                }
-            }
+        let min_full_bucket_idx = (min_bucket.ceil() as i64).at_least(0) as usize;
+        let max_full_bucket_idx =
+            (max_bucket.floor() as i64).at_most(self.buckets.len() as i64 - 1) as usize;
+        for bucket in &mut self.buckets[min_full_bucket_idx..=max_full_bucket_idx] {
+            *bucket += count_per_bucket;
         }
 
         // last bucket, partially filled:

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -494,8 +494,6 @@ pub fn build_density_graph<'a>(
         }
 
         for (chunk, time_range, num_events_in_chunk) in chunk_ranges {
-            re_tracing::profile_scope!("chunk_range");
-
             let should_render_individual_events = can_render_individual_events
                 && if chunk.is_timeline_sorted(&timeline) {
                     num_events_in_chunk < config.max_events_in_sorted_chunk

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -11,11 +11,7 @@ use egui::{epaint::Vertex, lerp, pos2, remap, Color32, NumExt as _, Rect, Shape}
 
 use re_chunk_store::Chunk;
 use re_chunk_store::RangeQuery;
-use re_log_types::EntityPath;
-use re_log_types::TimeInt;
-use re_log_types::Timeline;
-use re_log_types::{ComponentPath, ResolvedTimeRange};
-use re_types::ComponentName;
+use re_log_types::{ComponentPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_viewer_context::{Item, TimeControl, UiLayout, ViewerContext};
 
 use crate::chunk_statistics_store_subscriber::PathRecursiveChunksPerTimeline;
@@ -450,22 +446,56 @@ pub fn build_density_graph<'a>(
         .time_range_from_x_range((row_rect.left() - MARGIN_X)..=(row_rect.right() + MARGIN_X));
 
     // NOTE: These chunks are guaranteed to have data on the current timeline
-    let mut chunk_ranges: Vec<(Arc<Chunk>, ResolvedTimeRange, u64)> = vec![];
-    let mut total_events = 0;
+    let (chunk_ranges, total_events): (Vec<(Arc<Chunk>, ResolvedTimeRange, u64)>, u64) = {
+        re_tracing::profile_scope!("collect chunks");
 
-    {
-        visit_relevant_chunks(
-            db,
-            &item.entity_path,
-            item.component_name,
-            timeline,
-            visible_time_range,
-            |chunk, time_range, num_events| {
-                chunk_ranges.push((chunk, time_range, num_events));
-                total_events += num_events;
-            },
-        );
-    }
+        let engine = db.storage_engine();
+        let store = engine.store();
+        let query = RangeQuery::new(timeline, visible_time_range);
+
+        if let Some(component_name) = item.component_name {
+            let mut total_num_events = 0;
+            (
+                store
+                    .range_relevant_chunks(&query, &item.entity_path, component_name)
+                    .into_iter()
+                    .filter_map(|chunk| {
+                        let time_range = chunk.timelines().get(&timeline)?.time_range();
+                        chunk
+                            .num_events_for_component(component_name)
+                            .map(|num_events| {
+                                total_num_events += num_events;
+                                (chunk, time_range, num_events)
+                            })
+                    })
+                    .collect(),
+                total_num_events,
+            )
+        } else {
+            PathRecursiveChunksPerTimeline::access(&store.id(), |chunks_per_timeline| {
+                let Some(info) = chunks_per_timeline
+                    .path_recursive_chunks_for_entity_and_timeline(&item.entity_path, timeline)
+                else {
+                    return Default::default();
+                };
+
+                (
+                    info.recursive_chunks_info
+                        .values()
+                        .map(|info| {
+                            (
+                                info.chunk.clone(),
+                                info.resolved_time_range,
+                                info.num_events,
+                            )
+                        })
+                        .collect(),
+                    info.total_num_events,
+                )
+            })
+            .unwrap_or_default()
+        }
+    };
 
     // Small chunk heuristics:
     // We want to render chunks as individual events, but it may be prohibitively expensive
@@ -687,66 +717,6 @@ impl<'a> DensityGraphBuilder<'a> {
                 }
             }
         }
-    }
-}
-
-/// This is a wrapper over `range_relevant_chunks` which also supports querying the entire entity.
-/// Relevant chunks are those which:
-/// - Contain data for `entity_path`
-/// - Contain a `component_name` column (if provided)
-/// - Have data on the given `timeline`
-/// - Have data in the given `time_range`
-///
-/// The does not deduplicates chunks when no `component_name` is provided.
-fn visit_relevant_chunks(
-    db: &re_entity_db::EntityDb,
-    entity_path: &EntityPath,
-    component_name: Option<ComponentName>,
-    timeline: Timeline,
-    time_range: ResolvedTimeRange,
-    mut visitor: impl FnMut(Arc<Chunk>, ResolvedTimeRange, u64),
-) {
-    re_tracing::profile_function!();
-
-    let engine = db.storage_engine();
-    let store = engine.store();
-    let query = RangeQuery::new(timeline, time_range);
-
-    if let Some(component_name) = component_name {
-        // TODO:
-        let chunks = store.range_relevant_chunks(&query, entity_path, component_name);
-
-        for chunk in chunks {
-            let Some(num_events) = chunk.num_events_for_component(component_name) else {
-                continue;
-            };
-
-            let Some(chunk_timeline) = chunk.timelines().get(&timeline) else {
-                continue;
-            };
-
-            visitor(Arc::clone(&chunk), chunk_timeline.time_range(), num_events);
-        }
-    } else {
-        PathRecursiveChunksPerTimeline::access(&store.id(), |chunks_per_timeline| {
-            let Some(stats) = chunks_per_timeline.entity_timeline_stats(entity_path, timeline)
-            else {
-                return;
-            };
-
-            for chunk in stats.recursive_chunks.values() {
-                let Some(chunk_timeline) = chunk.timelines().get(&timeline) else {
-                    debug_assert!(false, "`PathRecursiveChunksPerTimeline` advertised a chunk that for a timeline it doesn't have.");
-                    continue;
-                };
-
-                visitor(
-                    chunk.clone(),
-                    chunk_timeline.time_range(),
-                    chunk.num_events_cumulative(),
-                );
-            }
-        });
     }
 }
 

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -474,7 +474,7 @@ pub fn build_density_graph<'a>(
         } else {
             PathRecursiveChunksPerTimeline::access(&store.id(), |chunks_per_timeline| {
                 let Some(info) = chunks_per_timeline
-                    .path_recursive_chunks_for_entity_and_timeline(&item.entity_path, timeline)
+                    .path_recursive_chunks_for_entity_and_timeline(&item.entity_path, &timeline)
                 else {
                     return Default::default();
                 };

--- a/crates/viewer/re_time_panel/src/data_density_graph.rs
+++ b/crates/viewer/re_time_panel/src/data_density_graph.rs
@@ -14,7 +14,7 @@ use re_chunk_store::RangeQuery;
 use re_log_types::{ComponentPath, ResolvedTimeRange, TimeInt, Timeline};
 use re_viewer_context::{Item, TimeControl, UiLayout, ViewerContext};
 
-use crate::chunk_statistics_store_subscriber::PathRecursiveChunksPerTimeline;
+use crate::recursive_chunks_per_timeline_subscriber::PathRecursiveChunksPerTimeline;
 use crate::TimePanelItem;
 
 use super::time_ranges_ui::TimeRangesUi;

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -6,9 +6,9 @@
 // TODO(#6330): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
-mod chunk_statistics_store_subscriber;
 mod data_density_graph;
 mod paint_ticks;
+mod recursive_chunks_per_timeline_subscriber;
 mod time_axis;
 mod time_control_ui;
 mod time_ranges_ui;

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -6,6 +6,7 @@
 // TODO(#6330): remove unwrap()
 #![allow(clippy::unwrap_used)]
 
+mod chunk_statistics_store_subscriber;
 mod data_density_graph;
 mod paint_ticks;
 mod time_axis;

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -33,6 +33,7 @@ use re_viewer_context::{
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
+use recursive_chunks_per_timeline_subscriber::PathRecursiveChunksPerTimeline;
 use time_axis::TimelineAxis;
 use time_control_ui::TimeControlUi;
 use time_ranges_ui::TimeRangesUi;
@@ -127,6 +128,8 @@ pub struct TimePanel {
 
 impl Default for TimePanel {
     fn default() -> Self {
+        PathRecursiveChunksPerTimeline::ensure_registered();
+
         Self {
             data_density_graph_painter: Default::default(),
             prev_col_width: 400.0,

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -111,7 +111,7 @@ impl ChunkStoreSubscriber for PathRecursiveChunksPerTimelineStoreSubscriber {
             let path_recursive_chunks = self.per_store.entry(event.store_id.clone()).or_default();
 
             if let Some(re_chunk_store::ChunkCompactionReport {
-                compacted_chunks,
+                srcs: compacted_chunks,
                 new_chunk,
             }) = &event.diff.compacted
             {

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -10,15 +10,25 @@ use re_chunk_store::{
 use re_log_types::{EntityPath, EntityPathHash, ResolvedTimeRange, StoreId, Timeline};
 
 /// Cached information about a chunk in the context of a given timeline.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ChunkTimelineInfo {
     pub chunk: Arc<Chunk>,
     pub num_events: u64,
     pub resolved_time_range: ResolvedTimeRange,
 }
 
+#[cfg(test)]
+impl PartialEq for ChunkTimelineInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self.chunk.id() == other.chunk.id()
+            && self.num_events == other.num_events
+            && self.resolved_time_range == other.resolved_time_range
+    }
+}
+
 /// Recursive chunk timeline infos for a given timeline & entity.
-#[derive(Default)]
+#[derive(Debug, Default)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct EntityTimelineChunks {
     /// All chunks used by the entity & timeline, recursive for all children of the entity.
     // TODO(andreas): Sorting this by time range would be great as it would allow us to slice ranges.
@@ -50,10 +60,10 @@ impl PathRecursiveChunksPerTimeline {
     pub fn path_recursive_chunks_for_entity_and_timeline(
         &self,
         entity_path: &EntityPath,
-        timeline: Timeline,
+        timeline: &Timeline,
     ) -> Option<&EntityTimelineChunks> {
         self.chunks_per_timeline_per_entity
-            .get(&timeline)?
+            .get(timeline)?
             .get(&entity_path.hash())
     }
 }
@@ -176,4 +186,167 @@ fn remove_chunk(path_recursive_chunks: &mut PathRecursiveChunksPerTimeline, chun
     }
 }
 
-// TODO: add unit tests
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use re_chunk_store::{Chunk, ChunkStore, ChunkStoreConfig, GarbageCollectionOptions, RowId};
+    use re_log_types::{
+        example_components::MyPoint, ResolvedTimeRange, StoreId, TimeInt, Timeline,
+    };
+
+    use super::{
+        EntityTimelineChunks, PathRecursiveChunksPerTimeline,
+        PathRecursiveChunksPerTimelineStoreSubscriber,
+    };
+
+    #[test]
+    fn path_recursive_chunks_per_timeline() -> anyhow::Result<()> {
+        let mut store = ChunkStore::new(
+            StoreId::random(re_log_types::StoreKind::Recording),
+            ChunkStoreConfig::COMPACTION_DISABLED, // Makes it hard to predict chunks otherwise.
+        );
+        // Initialize the store subscriber. Need to do this ahead of time, otherwise it will miss on events.
+        let _subscriber = PathRecursiveChunksPerTimelineStoreSubscriber::subscription_handle();
+
+        // We use two timelines for which we log events on two entities, at the root and at a grandchild.
+        let t0 = Timeline::new_sequence("time0");
+        let t1 = Timeline::new_sequence("time1");
+        let component_batch = &[MyPoint::new(3.0, 3.0)] as _; // Generic component batch, don't care about the contents.
+
+        // Events at the root path.
+        // 2x: single chunk with two events for both t0 and t1.
+        for i in 1..=2 {
+            store.insert_chunk(&Arc::new(
+                Chunk::builder("/".into())
+                    .with_component_batches(RowId::new(), [(t0, i), (t1, i)], [component_batch])
+                    .with_component_batches(
+                        RowId::new(),
+                        [(t0, i + 2), (t1, i + 2)],
+                        [component_batch],
+                    )
+                    .build()?,
+            ))?;
+        }
+
+        // Events at a child path.
+        // One chunk with one event at t0, one chunk with two events at t1
+        store.insert_chunk(&Arc::new(
+            Chunk::builder("/parent/child".into())
+                .with_component_batches(RowId::new(), [(t0, 0)], [component_batch])
+                .build()?,
+        ))?;
+        store.insert_chunk(&Arc::new(
+            Chunk::builder("/parent/child".into())
+                .with_component_batches(RowId::new(), [(t1, 1)], [component_batch])
+                .with_component_batches(RowId::new(), [(t1, 3)], [component_batch])
+                .build()?,
+        ))?;
+
+        assert_eq!(
+            PathRecursiveChunksPerTimeline::access(&store.id(), |subs| {
+                test_subscriber_status_before_removal(subs, t0, t1)
+            }),
+            Some(Some(()))
+        );
+
+        // Remove only the t0 chunk on "parent/child"
+        store.gc(&GarbageCollectionOptions {
+            protected_time_ranges: [
+                (t0, ResolvedTimeRange::new(1, TimeInt::MAX)),
+                (t1, ResolvedTimeRange::EVERYTHING),
+            ]
+            .into_iter()
+            .collect(),
+            ..GarbageCollectionOptions::gc_everything()
+        });
+
+        assert_eq!(
+            PathRecursiveChunksPerTimeline::access(&store.id(), |subs| {
+                test_subscriber_status_after_t0_child_chunk_removal(subs, t0, t1)
+            }),
+            Some(Some(()))
+        );
+
+        Ok(())
+    }
+
+    fn test_subscriber_status_before_removal(
+        subs: &PathRecursiveChunksPerTimeline,
+        t0: Timeline,
+        t1: Timeline,
+    ) -> Option<()> {
+        // The root accumulates all chunks & events for each timeline.
+        let root_t0 = subs.path_recursive_chunks_for_entity_and_timeline(&"/".into(), &t0)?;
+        assert_eq!(root_t0.recursive_chunks_info.len(), 2 + 1);
+        assert_eq!(root_t0.total_num_events, 2 * 2 + 1);
+        let root_t1 = subs.path_recursive_chunks_for_entity_and_timeline(&"/".into(), &t1)?;
+        assert_eq!(root_t1.recursive_chunks_info.len(), 2 + 1);
+        assert_eq!(root_t1.total_num_events, 2 * 2 + 2);
+
+        let child_t0 =
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent/child".into(), &t0)?;
+        assert_eq!(child_t0.recursive_chunks_info.len(), 1);
+        assert_eq!(child_t0.total_num_events, 1);
+        let child_t1 =
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent/child".into(), &t1)?;
+        assert_eq!(child_t1.recursive_chunks_info.len(), 1);
+        assert_eq!(child_t1.total_num_events, 2);
+
+        test_paths_without_chunks(subs, &child_t0, &child_t1, t0, t1)?;
+
+        Some(())
+    }
+
+    fn test_subscriber_status_after_t0_child_chunk_removal(
+        subs: &PathRecursiveChunksPerTimeline,
+        t0: Timeline,
+        t1: Timeline,
+    ) -> Option<()> {
+        // The root accumulates all chunks & events for each timeline.
+        let root_t0 = subs.path_recursive_chunks_for_entity_and_timeline(&"/".into(), &t0)?;
+        assert_eq!(root_t0.recursive_chunks_info.len(), 2);
+        assert_eq!(root_t0.total_num_events, 2 * 2);
+        let root_t1 = subs.path_recursive_chunks_for_entity_and_timeline(&"/".into(), &t1)?;
+        assert_eq!(root_t1.recursive_chunks_info.len(), 2 + 1);
+        assert_eq!(root_t1.total_num_events, 2 * 2 + 2);
+
+        let child_t0 =
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent/child".into(), &t0)?;
+        assert_eq!(child_t0.recursive_chunks_info.len(), 0);
+        assert_eq!(child_t0.total_num_events, 0);
+        let child_t1 =
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent/child".into(), &t1)?;
+        assert_eq!(child_t1.recursive_chunks_info.len(), 1);
+        assert_eq!(child_t1.total_num_events, 2);
+
+        test_paths_without_chunks(subs, &child_t0, &child_t1, t0, t1)?;
+
+        Some(())
+    }
+
+    fn test_paths_without_chunks(
+        subs: &PathRecursiveChunksPerTimeline,
+        child_t0: &EntityTimelineChunks,
+        child_t1: &EntityTimelineChunks,
+        t0: Timeline,
+        t1: Timeline,
+    ) -> Option<()> {
+        // We only logged at `parent/child`, so we expect all events to `parent` copies over everything `parent/child` has.
+        assert_eq!(
+            child_t0,
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent".into(), &t0)?
+        );
+        assert_eq!(
+            child_t1,
+            subs.path_recursive_chunks_for_entity_and_timeline(&"/parent".into(), &t1)?
+        );
+
+        // No information arbitrary down the tree.
+        assert!(subs
+            .path_recursive_chunks_for_entity_and_timeline(&"/parent/child/grandchild".into(), &t1)
+            .is_none());
+
+        Some(())
+    }
+}

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -182,7 +182,17 @@ fn remove_chunk(path_recursive_chunks: &mut PathRecursiveChunksPerTimeline, chun
                     .remove(&chunk.id())
                     .is_some()
                 {
-                    chunks_per_entity.total_num_events -= chunk.num_events_cumulative();
+                    if let Some(new_total_num_events) = chunks_per_entity
+                        .total_num_events
+                        .checked_sub(chunk.num_events_cumulative())
+                    {
+                        chunks_per_entity.total_num_events = new_total_num_events;
+                    } else {
+                        re_log::error_once!(
+                            "Total number of recursive events for {:?} for went negative",
+                            path
+                        );
+                    }
                 }
             }
             next_path = path.parent();

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -45,6 +45,10 @@ pub struct PathRecursiveChunksPerTimeline {
 }
 
 impl PathRecursiveChunksPerTimeline {
+    pub fn ensure_registered() {
+        PathRecursiveChunksPerTimelineStoreSubscriber::subscription_handle();
+    }
+
     /// Accesses the chunk
     #[inline]
     pub fn access<T>(store_id: &StoreId, f: impl FnOnce(&Self) -> T) -> Option<T> {

--- a/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
+++ b/crates/viewer/re_time_panel/src/recursive_chunks_per_timeline_subscriber.rs
@@ -307,7 +307,7 @@ mod tests {
         assert_eq!(child_t1.recursive_chunks_info.len(), 1);
         assert_eq!(child_t1.total_num_events, 2);
 
-        test_paths_without_chunks(subs, &child_t0, &child_t1, t0, t1)?;
+        test_paths_without_chunks(subs, child_t0, child_t1, t0, t1)?;
 
         Some(())
     }
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(child_t1.recursive_chunks_info.len(), 1);
         assert_eq!(child_t1.total_num_events, 2);
 
-        test_paths_without_chunks(subs, &child_t0, &child_t1, t0, t1)?;
+        test_paths_without_chunks(subs, child_t0, child_t1, t0, t1)?;
 
         Some(())
     }


### PR DESCRIPTION
### Related

* More optimization depends likely on https://github.com/rerun-io/rerun/issues/8221

### What

Make the timepanel faster. Still plenty of room for improvement though.
Achieved by...
* store subscriber to keep track of cumulative chunks needed for a given entity & timeline
    * plus some statistics. less important
* a bit faster `num_events_cumulative_per_unique_time_unsorted`
* improved `DensityGraph::add_range` (this one was surprisingly significant)

### Testing

TL;DR: Minimized timepanel takes less than half the time it use. Other cases are better as well, but more noisy.

----

All testing done on the 2h airtraffic dataset (pre-saved rrd) with all panels hidden and views removed (unless noted otherwise) on my M1 Max. Note that the timeline perf is very dependent on amount of screen real estate - these tests were done maximized on the 14'' Mac's screen.
(Did some throw-away testing on other configs, but these are the ones we're comparing here!)

This round of optimization focused mostly on the "idle" case of having the time panel minimized. There are also some gains for the expanded case, but it's less significant - as illustrated by the profiler screenshots this is largely dominated `num_events_cumulative_per_unique_time` which I hope we can solve with chunk processors (and some untracked overhead I haven't looked into yet).

**Before:**

Frame cpu time without profiler attached hovers around 4.2ms with some outliers.
<img width="169" alt="image" src="https://github.com/user-attachments/assets/0cfead2d-b485-45e8-b864-390cc8acd341">

Attaching the profiler doesn't tell us much since the profiler overhead drowns out everything else:
![image](https://github.com/user-attachments/assets/db688dc3-c0bc-449a-a9d7-cce192cfec30)

Restarting without profiler and expanding the time panel and making it as high as possible gives us about 12ms with frequent spikes beyond 13ms

<img width="1798" alt="image" src="https://github.com/user-attachments/assets/5732a1ed-9911-4dbe-ae15-c52c9d0e4eeb">

Profiler overhead is ironically not _as_ significant. Averaging a few frames tells us the time panel is at 11.5ms
![image](https://github.com/user-attachments/assets/6186da15-faa9-469c-8e80-b12184ae1689)


**After**

Frame cpu time without profiler attached hovers between 1.5ms and 2.8ms, rather unsteady
<img width="124" alt="image" src="https://github.com/user-attachments/assets/9d709888-0b48-4404-a570-417677175202">

Averaging a bunch of frames tells us that the data_density_graph takes now 0.55ms (imho still pretty bad for that it is)
![image](https://github.com/user-attachments/assets/37cf9d75-7023-41d9-967c-7555b6fc0740)

Restarting without profiler and expanding the time panel and making it as high as possible gives us around 11ms

<img width="1798" alt="Screenshot 2024-11-26 at 15 45 20" src="https://github.com/user-attachments/assets/f4eab17f-db0e-4a21-86d9-5ac47560d7d0">

(important: this picture hasn't changed otherwise!)


The time panel now takes 9.4ms (that is definitely still very bad!), profiler overhead is still significant but it's manageable:

![image](https://github.com/user-attachments/assets/0f4375e8-cc76-40c1-9f7f-049e5a4c4640)



