### PR TITLE
Fix a drag-and-drop display regression

### DIFF
--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -335,10 +335,6 @@ impl ListItem {
             style_response.hovered = true;
         }
 
-        if egui::DragAndDrop::has_any_payload(ui.ctx()) {
-            //style_response.hovered = false;
-        }
-
         let mut collapse_response = None;
 
         let visuals = ui.style().interact_selectable(&style_response, selected);

--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -2,10 +2,7 @@
 
 use egui::{NumExt, Response, Shape, Ui};
 
-use crate::{
-    list_item::{ContentContext, DesiredWidth, LayoutInfoStack, ListItemContent},
-    ContextExt as _,
-};
+use crate::list_item::{ContentContext, DesiredWidth, LayoutInfoStack, ListItemContent};
 use crate::{DesignTokens, UiExt as _};
 
 struct ListItemResponse {
@@ -338,6 +335,10 @@ impl ListItem {
             style_response.hovered = true;
         }
 
+        if egui::DragAndDrop::has_any_payload(ui.ctx()) {
+            //style_response.hovered = false;
+        }
+
         let mut collapse_response = None;
 
         let visuals = ui.style().interact_selectable(&style_response, selected);
@@ -389,13 +390,20 @@ impl ListItem {
             if drag_target {
                 ui.painter().set(
                     background_frame,
-                    Shape::rect_stroke(bg_rect_to_paint, 0.0, ui.ctx().hover_stroke()),
+                    Shape::rect_stroke(
+                        bg_rect_to_paint.expand(-1.0),
+                        0.0,
+                        egui::Stroke::new(1.0, ui.visuals().selection.bg_fill),
+                    ),
                 );
             }
 
             let bg_fill = force_background.or_else(|| {
                 if !drag_target && interactive {
-                    if !response.hovered() && ui.rect_contains_pointer(bg_rect) {
+                    if !response.hovered()
+                        && ui.rect_contains_pointer(bg_rect)
+                        && !egui::DragAndDrop::has_any_payload(ui.ctx())
+                    {
                         // if some part of the content is active and hovered, our background should
                         // become dimmer
                         Some(visuals.bg_fill)


### PR DESCRIPTION
### Related

* Closes #8204

### What

This PR fix a display regression introduced in 0.17

#### 0.16

https://github.com/user-attachments/assets/6855b0e0-b5d7-415d-9ea5-e8d51d3111fa

#### 0.17

Note the busy hover highlight and the confusing target-container white frame.

https://github.com/user-attachments/assets/08085dca-3150-4f01-9d51-c3e981c08651

#### This PR


https://github.com/user-attachments/assets/c100b858-4d97-45f2-85a2-ea17e3f9d0c5


