### PR TITLE
Fix duplicate egui id in the stream trees

### DIFF
--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -548,7 +548,7 @@ impl TimePanel {
                 }
 
                 // Show "/" on top?
-                let show_root = true;
+                let show_root = self.source == TimePanelSource::Recording;
 
                 if show_root {
                     self.show_tree(
@@ -632,7 +632,12 @@ impl TimePanel {
 
         // Globally unique id - should only be one of these in view at one time.
         // We do this so that we can support "collapse/expand all" command.
-        let id = egui::Id::new(CollapseScope::StreamsTree.entity(tree.path.clone()));
+        let id = egui::Id::new(match self.source {
+            TimePanelSource::Recording => CollapseScope::StreamsTree.entity(tree.path.clone()),
+            TimePanelSource::Blueprint => {
+                CollapseScope::BlueprintStreamsTree.entity(tree.path.clone())
+            }
+        });
 
         let list_item::ShowCollapsingResponse {
             item_response: response,

--- a/crates/viewer/re_viewer_context/src/collapsed_id.rs
+++ b/crates/viewer/re_viewer_context/src/collapsed_id.rs
@@ -9,9 +9,13 @@ use crate::{ContainerId, SpaceViewId};
 
 /// The various scopes for which we want to track collapsed state.
 #[derive(Debug, Clone, Copy, Hash)]
+#[allow(clippy::enum_variant_names)]
 pub enum CollapseScope {
     /// Stream tree from the time panel
     StreamsTree,
+
+    /// The stream tree from the blueprint debug time panel
+    BlueprintStreamsTree,
 
     /// Blueprint tree from the blueprint panel
     BlueprintTree,


### PR DESCRIPTION
### Related

* Fixes #8202
* Related #8202

### What

This PR fixes the above bug _twice_:
1) use a different id for the blueprint streams tree (including the root item)
2) do not show the root time for the blueprint streams tree to begin with

(1) should make the collapsing state management more robust. The motivation for (2) is that in the context of the blueprint streams tree, the root item is just lost space as we never log anything there.

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/26d6af86-1530-4cd8-8697-5e15967b1538">
