### PR TITLE
World grid part 1/2: add world grid renderer to `re_renderer`

### DIFF
--- a/crates/viewer/re_renderer/shader/screen_triangle.wgsl
+++ b/crates/viewer/re_renderer/shader/screen_triangle.wgsl
@@ -15,3 +15,4 @@ fn main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     out.texcoord.y = 1.0 - out.texcoord.y;
     return out;
 }
+

--- a/crates/viewer/re_renderer/shader/screen_triangle_vertex.wgsl
+++ b/crates/viewer/re_renderer/shader/screen_triangle_vertex.wgsl
@@ -1,5 +1,3 @@
-#import <./types.wgsl>
-
 struct VertexOutput {
     // Mark output position as invariant so it's safe to use it with depth test Equal.
     // Without @invariant, different usages in different render pipelines might optimize differently,

--- a/crates/viewer/re_renderer/shader/utils/interpolation.wgsl
+++ b/crates/viewer/re_renderer/shader/utils/interpolation.wgsl
@@ -1,0 +1,11 @@
+//! Additional interpolation functions.
+
+// Like smoothstep, but linear. 1D.
+fn linearstep(edge0: f32, edge1: f32, x: f32) -> f32 {
+    return saturate((x - edge0) / (edge1 - edge0));
+}
+
+// Like smoothstep, but linear. 2D.
+fn linearstep2(edge0: vec2f, edge1: vec2f, x: vec2f) -> vec2f {
+    return saturate((x - edge0) / (edge1 - edge0));
+}

--- a/crates/viewer/re_renderer/shader/utils/plane.wgsl
+++ b/crates/viewer/re_renderer/shader/utils/plane.wgsl
@@ -1,0 +1,9 @@
+struct Plane {
+    normal: vec3f,
+    distance: f32,
+}
+
+/// How far away is a given point from the plane?
+fn distance_to_plane(plane: Plane, point: vec3f) -> f32 {
+    return dot(plane.normal, point) + plane.distance;
+}

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -101,7 +101,7 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     //
     // Note that `1/plane_unit_pixel_derivative` would give us more literal pixels per line,
     // but we actually want to know how dense the lines get here so we use `1/width_in_grid_units` instead,
-    // such that a line density of 1.0 means roughtly "100% lines" and 10.0 means "Every 10 pixels there is a lines".
+    // such that a line density of 1.0 means roughly "100% lines" and 10.0 means "Every 10 pixels there is a lines".
     // Empirically (== making the fade a hard cut and taking screenshot), this works out pretty accurately!
     //
     // Tried smoothstep here, but didn't feel right even with lots of range tweaking.
@@ -127,7 +127,7 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     // X and Y are combined like akin to premultiplied alpha operations.
     let intensity_combined = saturate(cardinal_and_regular.x * (1.0 - cardinal_and_regular.y) + cardinal_and_regular.y);
 
-    // Fade on accute viewing angles.
+    // Fade on acute viewing angles.
     var view_direction_up_component: f32;
     switch (config.orientation) {
         case ORIENTATION_XZ: {

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -10,7 +10,7 @@ struct WorldGridUniformBuffer {
     spacing: f32,
 
     /// How thick the lines are in UI units.
-    thickness_ui: f32,
+    radius_ui: f32,
 }
 
 @group(1) @binding(0)
@@ -29,7 +29,7 @@ struct VertexOutput {
     scaled_world_plane_position: vec2f,
 };
 
-const PLANE_SCALE: f32 = 100000.0;
+const PLANE_SCALE: f32 = 10000.0;
 
 // Spans a large quad where centered around the camera.
 //
@@ -61,14 +61,20 @@ fn main_vs(@builtin(vertex_index) v_idx: u32) -> VertexOutput {
     }
 
     out.position = frame.projection_from_world * vec4f(world_position, 1.0);
-    out.scaled_world_plane_position = plane_position * config.spacing * 0.1; // TODO: artificial scaling factor.
+    out.scaled_world_plane_position = plane_position / config.spacing; // TODO: artificial scaling factor.
 
     return out;
 }
 
+// Like smoothstep, but linear.
+// Used for anti-aliasing. Smoothstep works as well, but is very subtly worse.
+fn linearstep(edge0: vec2f, edge1: vec2f, x: vec2f) -> vec2f {
+    return clamp((x - edge0) / (edge1 - edge0), vec2f(0.0), vec2f(1.0));
+}
+
 @fragment
 fn main_fs(in: VertexOutput) -> @location(0) vec4f {
-    // Takes inspiration from https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8
+    // The basics are very well explained by Ben Golus here: https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8
     // We're not actually implementing the "pristine grid shader" which is a world space grid,
     // but rather the pixel space grid, which is a lot simpler, but happens to be also described very well in this article.
 
@@ -77,19 +83,24 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
 
     // Figure out the how wide the lines are in this "draw space".
     let plane_unit_pixel_derivative = fwidthFine(in.scaled_world_plane_position);
-    let width_in_pixels = config.thickness_ui * frame.pixels_from_point;
+    let width_in_pixels = 1.0;//config.radius_ui * frame.pixels_from_point;
     let width_in_grid_units = width_in_pixels * plane_unit_pixel_derivative;
 
-    let line_anti_alias = plane_unit_pixel_derivative * 1.5;
-    let intensity = smoothstep(width_in_grid_units + line_anti_alias, width_in_grid_units - line_anti_alias, distance_to_grid_line);
+    let line_anti_alias = plane_unit_pixel_derivative;
+    var intensity = linearstep(width_in_grid_units + line_anti_alias, width_in_grid_units - line_anti_alias, distance_to_grid_line);
+
+    // Fade lines that get too close to each other.
+    // If the plane unit derivative is high it must mean that this is happening!
+    // TODO: this value is tuned empirically for thin lines, for thicker lines this needs to be adjusted.
+    intensity *= saturate(smoothstep(0.35, 0.0, max(width_in_grid_units.x, width_in_grid_units.y)));
+
+    // Fade on accute viewing angles.
+    // TODO:
 
     // Combine both lines.
     // This is like a premultiplied alpha operation combination.
     let intensity_combined = intensity.x * (1.0 - intensity.y) + intensity.y;
 
-    // Fade in the distance.
-
-    // Fade lines that get too close.
 
     return config.color * intensity_combined;
 }

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -1,0 +1,95 @@
+#import <./global_bindings.wgsl>
+
+struct WorldGridUniformBuffer {
+    color: vec4f,
+
+    /// A value of [`super::GridPlane`]
+    orientation: u32,
+
+    /// How far apart the closest sets of lines are.
+    spacing: f32,
+
+    /// How thick the lines are in UI units.
+    thickness_ui: f32,
+}
+
+@group(1) @binding(0)
+var<uniform> config: WorldGridUniformBuffer;
+
+// See world_grid::GridPlane
+const ORIENTATION_XZ: u32 = 0;
+const ORIENTATION_YZ: u32 = 1;
+const ORIENTATION_XY: u32 = 2;
+
+struct VertexOutput {
+    @builtin(position)
+    position: vec4f,
+
+    @location(0)
+    scaled_world_plane_position: vec2f,
+};
+
+const PLANE_SCALE: f32 = 100000.0;
+
+// Spans a large quad where centered around the camera.
+//
+// This gives us the "canvas" to drawn the grid on.
+// Compared to a fullscreen pass, we get the z value (and thus early z testing) for free,
+// as well as never covering the screen above the horizon.
+@vertex
+fn main_vs(@builtin(vertex_index) v_idx: u32) -> VertexOutput {
+    var out: VertexOutput;
+
+    var plane_position = (vec2f(f32(v_idx / 2u), f32(v_idx % 2u)) * 2.0 - 1.0) * PLANE_SCALE;
+    var world_position: vec3f;
+    switch (config.orientation) {
+        case ORIENTATION_XZ: {
+            plane_position += frame.camera_position.xz;
+            world_position = vec3f(plane_position.x, 0.0, plane_position.y);
+        }
+        case ORIENTATION_YZ: {
+            plane_position += frame.camera_position.yz;
+            world_position = vec3f(0.0, plane_position.x, plane_position.y);
+        }
+        case ORIENTATION_XY: {
+            plane_position += frame.camera_position.xy;
+            world_position = vec3f(plane_position.x, plane_position.y, 0.0);
+        }
+        default: {
+            world_position = vec3f(0.0);
+        }
+    }
+
+    out.position = frame.projection_from_world * vec4f(world_position, 1.0);
+    out.scaled_world_plane_position = plane_position * config.spacing * 0.1; // TODO: artificial scaling factor.
+
+    return out;
+}
+
+@fragment
+fn main_fs(in: VertexOutput) -> @location(0) vec4f {
+    // Takes inspiration from https://bgolus.medium.com/the-best-darn-grid-shader-yet-727f9278b9d8
+    // We're not actually implementing the "pristine grid shader" which is a world space grid,
+    // but rather the pixel space grid, which is a lot simpler, but happens to be also described very well in this article.
+
+    // Distance to a grid line in x and y ranging from 0 to 1.
+    let distance_to_grid_line = 1.0 - abs(fract(in.scaled_world_plane_position) * 2.0 - 1.0);
+
+    // Figure out the how wide the lines are in this "draw space".
+    let plane_unit_pixel_derivative = fwidthFine(in.scaled_world_plane_position);
+    let width_in_pixels = config.thickness_ui * frame.pixels_from_point;
+    let width_in_grid_units = width_in_pixels * plane_unit_pixel_derivative;
+
+    let line_anti_alias = plane_unit_pixel_derivative * 1.5;
+    let intensity = smoothstep(width_in_grid_units + line_anti_alias, width_in_grid_units - line_anti_alias, distance_to_grid_line);
+
+    // Combine both lines.
+    // This is like a premultiplied alpha operation combination.
+    let intensity_combined = intensity.x * (1.0 - intensity.y) + intensity.y;
+
+    // Fade in the distance.
+
+    // Fade lines that get too close.
+
+    return config.color * intensity_combined;
+}

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -76,7 +76,7 @@ fn linearstep2(edge0: vec2f, edge1: vec2f, x: vec2f) -> vec2f {
 }
 
 // Distance to a grid line in x and y ranging from 0 to 1.
-fn distance_to_grid_line(scaled_world_plane_position: vec2f) -> vec2f {
+fn calc_distance_to_grid_line(scaled_world_plane_position: vec2f) -> vec2f {
     return 1.0 - abs(fract(scaled_world_plane_position) * 2.0 - 1.0);
 }
 
@@ -87,7 +87,7 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     // but rather the pixel space grid, which is a lot simpler, but happens to be also described very well in this article.
 
     // Distance to a grid line in x and y ranging from 0 to 1.
-    let distance_to_grid_line = distance_to_grid_line(in.scaled_world_plane_position);
+    let distance_to_grid_line = calc_distance_to_grid_line(in.scaled_world_plane_position);
 
     // Figure out the how wide the lines are in this "draw space".
     let plane_unit_pixel_derivative = fwidthFine(in.scaled_world_plane_position);
@@ -113,7 +113,7 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     // Experimented previously with more levels of cardinal lines, but it gets too busy:
     // It seems that if we want to go down this path, we should ensure that there's only two levels of lines on screen at a time.
     const CARDINAL_LINE_FACTOR: f32 = 10.0;
-    let distance_to_grid_line_cardinal = distance_to_grid_line(in.scaled_world_plane_position * (1.0 / CARDINAL_LINE_FACTOR));
+    let distance_to_grid_line_cardinal = calc_distance_to_grid_line(in.scaled_world_plane_position * (1.0 / CARDINAL_LINE_FACTOR));
     var cardinal_line_intensity = linearstep2(width_in_grid_units + line_anti_alias, width_in_grid_units - line_anti_alias,
                                               distance_to_grid_line_cardinal * CARDINAL_LINE_FACTOR);
     let cardinal_grid_closeness_fade = linearstep(2.0, 10.0, line_density * CARDINAL_LINE_FACTOR); // Fade cardinal lines a little bit earlier (because it looks nicer)

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -17,8 +17,8 @@ struct WorldGridUniformBuffer {
 var<uniform> config: WorldGridUniformBuffer;
 
 // See world_grid::GridPlane
-const ORIENTATION_XZ: u32 = 0;
-const ORIENTATION_YZ: u32 = 1;
+const ORIENTATION_YZ: u32 = 0;
+const ORIENTATION_ZX: u32 = 1;
 const ORIENTATION_XY: u32 = 2;
 
 struct VertexOutput {

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -29,7 +29,12 @@ struct VertexOutput {
     scaled_world_plane_position: vec2f,
 };
 
-const PLANE_SCALE: f32 = 10000.0;
+// We have to make up some world space geometry which then necessarily gets a limited size.
+// Putting a too high number here makes things break down because of floating point inaccuracies.
+// But arguably at that point we're potentially doomed either way since precision will break down in other parts of the rendering as well.
+//
+// This is the main drawback of the plane approach over the screen space filling one.
+const PLANE_GEOMETRY_SIZE: f32 = 100000.0;
 
 // Spans a large quad where centered around the camera.
 //
@@ -40,7 +45,7 @@ const PLANE_SCALE: f32 = 10000.0;
 fn main_vs(@builtin(vertex_index) v_idx: u32) -> VertexOutput {
     var out: VertexOutput;
 
-    var plane_position = (vec2f(f32(v_idx / 2u), f32(v_idx % 2u)) * 2.0 - 1.0) * PLANE_SCALE;
+    var plane_position = (vec2f(f32(v_idx / 2u), f32(v_idx % 2u)) * 2.0 - 1.0) * PLANE_GEOMETRY_SIZE;
     var world_position: vec3f;
     switch (config.orientation) {
         case ORIENTATION_XZ: {

--- a/crates/viewer/re_renderer/shader/world_grid.wgsl
+++ b/crates/viewer/re_renderer/shader/world_grid.wgsl
@@ -105,20 +105,35 @@ fn main_fs(in: VertexOutput) -> @location(0) vec4f {
     cardinal_line_intensity *= cardinal_grid_closeness_fade;
 
     // Fade on accute viewing angles.
-    // TODO:
+    var view_direction_up_component: f32;
+    switch (config.orientation) {
+        case ORIENTATION_XZ: {
+            view_direction_up_component = frame.camera_forward.y;
+        }
+        case ORIENTATION_YZ: {
+            view_direction_up_component = frame.camera_forward.x;
+        }
+        case ORIENTATION_XY: {
+            view_direction_up_component = frame.camera_forward.z;
+        }
+        default: {
+            view_direction_up_component = 0.0;
+        }
+    }
+    let view_angle_fade = smoothstep(0.0, 0.25, abs(view_direction_up_component)); // Empirical values.
 
     // Combine all lines.
     //
     // Lerp for cardinal & regular.
     // This way we don't break anti-aliasing (as addition would!), mute the regular lines, and make cardinals weaker when there's no regular to support them.
-    let cardinal_and_regular = mix(intensity_regular, cardinal_line_intensity, 0.6);
+    let cardinal_and_regular = mix(intensity_regular, cardinal_line_intensity, 0.6) * view_angle_fade;
     // X and Y are combined like akin to premultiplied alpha operations.
     let intensity_combined = saturate(cardinal_and_regular.x * (1.0 - cardinal_and_regular.y) + cardinal_and_regular.y);
-
 
     return config.color * intensity_combined;
 
     // Debugging visualizations:
+    //return vec4f(view_angle_fade);
     //return vec4f(intensity_combined);
     //return vec4f(grid_closeness_fade, cardinal_grid_closeness_fade, 0.0, 1.0);
 }

--- a/crates/viewer/re_renderer/src/draw_phases/mod.rs
+++ b/crates/viewer/re_renderer/src/draw_phases/mod.rs
@@ -32,6 +32,9 @@ pub enum DrawPhase {
     /// Background, rendering where depth wasn't written.
     Background,
 
+    /// Transparent objects, performing reads of the depth buffer, but no writes.
+    Transparent,
+
     /// Everything that can be picked with GPU based picking.
     ///
     /// This should be everything in the `Opaque` phase.

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -31,6 +31,9 @@ pub(crate) use compositor::CompositorDrawData;
 mod debug_overlay;
 pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayError, DebugOverlayRenderer};
 
+mod world_grid;
+pub use world_grid::{GridPlane, WorldGridConfiguration, WorldGridDrawData, WorldGridRenderer};
+
 pub mod gpu_data {
     pub use super::lines::gpu_data::{LineStripInfo, LineVertex};
     pub use super::point_cloud::gpu_data::PositionRadius;

--- a/crates/viewer/re_renderer/src/renderer/mod.rs
+++ b/crates/viewer/re_renderer/src/renderer/mod.rs
@@ -32,7 +32,7 @@ mod debug_overlay;
 pub use debug_overlay::{DebugOverlayDrawData, DebugOverlayError, DebugOverlayRenderer};
 
 mod world_grid;
-pub use world_grid::{GridPlane, WorldGridConfiguration, WorldGridDrawData, WorldGridRenderer};
+pub use world_grid::{WorldGridConfiguration, WorldGridDrawData, WorldGridRenderer};
 
 pub mod gpu_data {
     pub use super::lines::gpu_data::{LineStripInfo, LineVertex};

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -55,7 +55,7 @@ mod gpu_data {
         pub spacing: f32,
 
         /// Radius of the lines in UI units.
-        pub radius_ui: f32,
+        pub thickness_ui: f32,
 
         pub _padding: u32,
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 2],
@@ -93,7 +93,7 @@ impl WorldGridDrawData {
                 color: config.color.into(),
                 orientation: config.orientation as u32,
                 spacing: config.spacing,
-                radius_ui: config.thickness_ui * 0.5,
+                thickness_ui: config.thickness_ui,
                 _padding: 0,
                 end_padding: Default::default(),
             },

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -16,10 +16,11 @@ use crate::Rgba;
 use smallvec::smallvec;
 
 /// Determines in which plane the grid is drawn.
+// Order is by index of up-axis.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GridPlane {
-    XZ = 0,
-    YZ = 1,
+    YZ = 0,
+    ZX = 1,
     XY = 2,
 }
 

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -13,7 +13,6 @@ use crate::{
 use super::{DrawData, DrawError, RenderContext, Renderer};
 use crate::Rgba;
 
-use gltf::buffer::View;
 use smallvec::smallvec;
 
 /// Determines in which plane the grid is drawn.

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -66,12 +66,7 @@ pub struct WorldGridRenderer {
     bind_group_layout: GpuBindGroupLayoutHandle,
 }
 
-/// Debug overlay for quick & dirty display of texture contents.
-///
-/// Executed as part of the composition draw phase in order to allow "direct" output to the screen.
-///
-/// Do *not* use this in production!
-/// See also `debug_overlay.wgsl` - you are encouraged to edit this shader for your concrete debugging needs!
+/// Draw data for a world grid renderer.
 #[derive(Clone)]
 pub struct WorldGridDrawData {
     bind_group: GpuBindGroup,

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -54,8 +54,8 @@ mod gpu_data {
         /// How far apart the closest sets of lines are.
         pub spacing: f32,
 
-        /// How thick the lines are in UI units.
-        pub thickness_ui: f32,
+        /// Radius of the lines in UI units.
+        pub radius_ui: f32,
 
         pub _padding: u32,
         pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 2],
@@ -93,7 +93,7 @@ impl WorldGridDrawData {
                 color: config.color.into(),
                 orientation: config.orientation as u32,
                 spacing: config.spacing,
-                thickness_ui: config.thickness_ui,
+                radius_ui: config.thickness_ui * 0.5,
                 _padding: 0,
                 end_padding: Default::default(),
             },

--- a/crates/viewer/re_renderer/src/renderer/world_grid.rs
+++ b/crates/viewer/re_renderer/src/renderer/world_grid.rs
@@ -1,0 +1,208 @@
+use crate::{
+    allocator::create_and_fill_uniform_buffer,
+    draw_phases::DrawPhase,
+    include_shader_module,
+    wgpu_resources::{
+        BindGroupDesc, BindGroupLayoutDesc, GpuBindGroup, GpuBindGroupLayoutHandle,
+        GpuRenderPipelineHandle, GpuRenderPipelinePoolAccessor, PipelineLayoutDesc,
+        RenderPipelineDesc,
+    },
+    ViewBuilder,
+};
+
+use super::{DrawData, DrawError, RenderContext, Renderer};
+use crate::Rgba;
+
+use gltf::buffer::View;
+use smallvec::smallvec;
+
+/// Determines in which plane the grid is drawn.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GridPlane {
+    XZ = 0,
+    YZ = 1,
+    XY = 2,
+}
+
+/// Configuration for the world grid renderer.
+pub struct WorldGridConfiguration {
+    /// The color of the grid lines.
+    pub color: Rgba,
+
+    /// The orientation of the grid lines.
+    pub orientation: GridPlane,
+
+    /// How far apart the closest sets of lines are.
+    pub spacing: f32,
+
+    /// How thick the lines are in UI units.
+    pub thickness_ui: f32,
+}
+
+mod gpu_data {
+    use crate::wgpu_buffer_types;
+
+    /// Keep in sync with `world_grid.wgsl`
+    #[repr(C)]
+    #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+    pub struct WorldGridUniformBuffer {
+        pub color: wgpu_buffer_types::Vec4,
+
+        /// A value of [`super::GridPlane`]
+        pub orientation: u32,
+
+        /// How far apart the closest sets of lines are.
+        pub spacing: f32,
+
+        /// How thick the lines are in UI units.
+        pub thickness_ui: f32,
+
+        pub _padding: u32,
+        pub end_padding: [wgpu_buffer_types::PaddingRow; 16 - 2],
+    }
+}
+
+pub struct WorldGridRenderer {
+    render_pipeline: GpuRenderPipelineHandle,
+    bind_group_layout: GpuBindGroupLayoutHandle,
+}
+
+/// Debug overlay for quick & dirty display of texture contents.
+///
+/// Executed as part of the composition draw phase in order to allow "direct" output to the screen.
+///
+/// Do *not* use this in production!
+/// See also `debug_overlay.wgsl` - you are encouraged to edit this shader for your concrete debugging needs!
+#[derive(Clone)]
+pub struct WorldGridDrawData {
+    bind_group: GpuBindGroup,
+}
+
+impl DrawData for WorldGridDrawData {
+    type Renderer = WorldGridRenderer;
+}
+
+impl WorldGridDrawData {
+    pub fn new(ctx: &RenderContext, config: &WorldGridConfiguration) -> Self {
+        let world_grid_renderer = ctx.renderer::<WorldGridRenderer>();
+
+        let uniform_buffer_binding = create_and_fill_uniform_buffer(
+            ctx,
+            "WorldGridDrawData".into(),
+            gpu_data::WorldGridUniformBuffer {
+                color: config.color.into(),
+                orientation: config.orientation as u32,
+                spacing: config.spacing,
+                thickness_ui: config.thickness_ui,
+                _padding: 0,
+                end_padding: Default::default(),
+            },
+        );
+
+        Self {
+            bind_group: ctx.gpu_resources.bind_groups.alloc(
+                &ctx.device,
+                &ctx.gpu_resources,
+                &BindGroupDesc {
+                    label: "WorldGrid".into(),
+                    entries: smallvec![uniform_buffer_binding],
+                    layout: world_grid_renderer.bind_group_layout,
+                },
+            ),
+        }
+    }
+}
+
+impl Renderer for WorldGridRenderer {
+    type RendererDrawData = WorldGridDrawData;
+
+    fn create_renderer(ctx: &RenderContext) -> Self {
+        re_tracing::profile_function!();
+
+        let bind_group_layout = ctx.gpu_resources.bind_group_layouts.get_or_create(
+            &ctx.device,
+            &BindGroupLayoutDesc {
+                label: "WorldGrid::bind_group_layout".into(),
+                entries: vec![wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT | wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: std::num::NonZeroU64::new(std::mem::size_of::<
+                            gpu_data::WorldGridUniformBuffer,
+                        >()
+                            as _),
+                    },
+                    count: None,
+                }],
+            },
+        );
+
+        let shader_module = ctx
+            .gpu_resources
+            .shader_modules
+            .get_or_create(ctx, &include_shader_module!("../../shader/world_grid.wgsl"));
+        let render_pipeline = ctx.gpu_resources.render_pipelines.get_or_create(
+            ctx,
+            &RenderPipelineDesc {
+                label: "WorldGridDrawData::render_pipeline_regular".into(),
+                pipeline_layout: ctx.gpu_resources.pipeline_layouts.get_or_create(
+                    ctx,
+                    &PipelineLayoutDesc {
+                        label: "WorldGrid".into(),
+                        entries: vec![ctx.global_bindings.layout, bind_group_layout],
+                    },
+                ),
+                vertex_entrypoint: "main_vs".into(),
+                vertex_handle: shader_module,
+                fragment_entrypoint: "main_fs".into(),
+                fragment_handle: shader_module,
+                vertex_buffers: smallvec![],
+                render_targets: smallvec![Some(wgpu::ColorTargetState {
+                    format: ViewBuilder::MAIN_TARGET_COLOR_FORMAT,
+                    blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                primitive: wgpu::PrimitiveState {
+                    // drawn as a (close to) infinite quad
+                    topology: wgpu::PrimitiveTopology::TriangleStrip,
+                    cull_mode: None,
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: ViewBuilder::MAIN_TARGET_DEPTH_FORMAT,
+                    depth_compare: wgpu::CompareFunction::GreaterEqual,
+                    depth_write_enabled: false,
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: ViewBuilder::MAIN_TARGET_DEFAULT_MSAA_STATE,
+            },
+        );
+        Self {
+            render_pipeline,
+            bind_group_layout,
+        }
+    }
+
+    fn draw(
+        &self,
+        render_pipelines: &GpuRenderPipelinePoolAccessor<'_>,
+        _phase: DrawPhase,
+        pass: &mut wgpu::RenderPass<'_>,
+        draw_data: &WorldGridDrawData,
+    ) -> Result<(), DrawError> {
+        let pipeline = render_pipelines.get(self.render_pipeline)?;
+
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(1, &draw_data.bind_group, &[]);
+        pass.draw(0..4, 0..1);
+
+        Ok(())
+    }
+
+    fn participated_phases() -> &'static [DrawPhase] {
+        &[DrawPhase::Transparent]
+    }
+}

--- a/crates/viewer/re_renderer/src/view_builder.rs
+++ b/crates/viewer/re_renderer/src/view_builder.rs
@@ -634,7 +634,11 @@ impl ViewBuilder {
 
             pass.set_bind_group(0, &setup.bind_group_0, &[]);
 
-            for phase in [DrawPhase::Opaque, DrawPhase::Background] {
+            for phase in [
+                DrawPhase::Opaque,
+                DrawPhase::Background,
+                DrawPhase::Transparent,
+            ] {
                 self.draw_phase(&renderers, &pipelines, phase, &mut pass);
             }
         }

--- a/crates/viewer/re_renderer/src/workspace_shaders.rs
+++ b/crates/viewer/re_renderer/src/workspace_shaders.rs
@@ -182,6 +182,12 @@ pub fn init() {
     }
 
     {
+        let virtpath = Path::new("shader/utils/plane.wgsl");
+        let content = include_str!("../shader/utils/plane.wgsl").into();
+        fs.create_file(virtpath, content).unwrap();
+    }
+
+    {
         let virtpath = Path::new("shader/utils/quaternion.wgsl");
         let content = include_str!("../shader/utils/quaternion.wgsl").into();
         fs.create_file(virtpath, content).unwrap();

--- a/crates/viewer/re_renderer/src/workspace_shaders.rs
+++ b/crates/viewer/re_renderer/src/workspace_shaders.rs
@@ -198,4 +198,10 @@ pub fn init() {
         let content = include_str!("../shader/utils/srgb.wgsl").into();
         fs.create_file(virtpath, content).unwrap();
     }
+
+    {
+        let virtpath = Path::new("shader/world_grid.wgsl");
+        let content = include_str!("../shader/world_grid.wgsl").into();
+        fs.create_file(virtpath, content).unwrap();
+    }
 }

--- a/crates/viewer/re_renderer/src/workspace_shaders.rs
+++ b/crates/viewer/re_renderer/src/workspace_shaders.rs
@@ -176,6 +176,12 @@ pub fn init() {
     }
 
     {
+        let virtpath = Path::new("shader/utils/interpolation.wgsl");
+        let content = include_str!("../shader/utils/interpolation.wgsl").into();
+        fs.create_file(virtpath, content).unwrap();
+    }
+
+    {
         let virtpath = Path::new("shader/utils/quaternion.wgsl");
         let content = include_str!("../shader/utils/quaternion.wgsl").into();
         fs.create_file(virtpath, content).unwrap();

--- a/crates/viewer/re_renderer_examples/2d.rs
+++ b/crates/viewer/re_renderer_examples/2d.rs
@@ -63,7 +63,7 @@ impl framework::Example for Render2D {
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_per_point: f32,
-    ) -> Vec<framework::ViewDrawResult> {
+    ) -> anyhow::Result<Vec<framework::ViewDrawResult>> {
         let splits = framework::split_resolution(resolution, 1, 2).collect::<Vec<_>>();
 
         let screen_size = glam::vec2(
@@ -246,8 +246,8 @@ impl framework::Example for Render2D {
                 .add_points_2d(&positions, &sizes, &colors, &picking_ids);
         }
 
-        let line_strip_draw_data = line_strip_builder.into_draw_data().unwrap();
-        let point_draw_data = point_cloud_builder.into_draw_data().unwrap();
+        let line_strip_draw_data = line_strip_builder.into_draw_data()?;
+        let point_draw_data = point_cloud_builder.into_draw_data()?;
 
         let image_scale = 4.0;
         let rectangle_draw_data = RectangleDrawData::new(
@@ -286,10 +286,9 @@ impl framework::Example for Render2D {
                     },
                 },
             ],
-        )
-        .unwrap();
+        )?;
 
-        vec![
+        Ok(vec![
             // 2D view to the left
             {
                 let mut view_builder = ViewBuilder::new(
@@ -362,7 +361,7 @@ impl framework::Example for Render2D {
                     target_location: splits[1].target_location,
                 }
             },
-        ]
+        ])
     }
 
     fn on_key_event(&mut self, _input: winit::event::KeyEvent) {}

--- a/crates/viewer/re_renderer_examples/Cargo.toml
+++ b/crates/viewer/re_renderer_examples/Cargo.toml
@@ -36,6 +36,10 @@ path = "outlines.rs"
 name = "picking"
 path = "picking.rs"
 
+[[bin]]
+name = "world_grid"
+path = "world_grid.rs"
+
 [dependencies]
 re_log = { workspace = true, features = ["setup"] }
 re_math.workspace = true

--- a/crates/viewer/re_renderer_examples/framework.rs
+++ b/crates/viewer/re_renderer_examples/framework.rs
@@ -114,7 +114,9 @@ impl<E: Example + 'static> Application<E> {
         let window = Arc::new(window);
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: supported_backends(),
-            flags: wgpu::InstanceFlags::default(),
+            flags: wgpu::InstanceFlags::default()
+                // Run without validation layers, they can be annoying on shader reload depending on the backend.
+                .intersection(wgpu::InstanceFlags::VALIDATION.complement()),
             dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
             gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
         });
@@ -185,10 +187,9 @@ impl<E: Example + 'static> Application<E> {
         }
 
         let surface_config = wgpu::SurfaceConfiguration {
-            // Not the best setting in general, but nice for quick & easy performance checking.
-            // TODO(andreas): It seems at least on Metal M1 this still does not discard command buffers that come in too fast (even when using `Immediate` explicitly).
-            //                  Quick look into wgpu looks like it does it correctly there. OS limitation? iOS has this limitation, so wouldn't be surprising!
-            present_mode: wgpu::PresentMode::AutoNoVsync,
+            // Use AutoNoVSync if you want to do quick perf checking.
+            // Otherwise, use AutoVsync is much more pleasant to use - laptops don't heat up and desktop won't have annoying coil whine on trivial examples.
+            present_mode: wgpu::PresentMode::AutoVsync,
             format: self.re_ctx.config.output_format_color,
             view_formats: vec![self.re_ctx.config.output_format_color],
             ..self

--- a/crates/viewer/re_renderer_examples/multiview.rs
+++ b/crates/viewer/re_renderer_examples/multiview.rs
@@ -1,8 +1,5 @@
 //! Example with several independent views, using various primitives.
 
-// TODO(#6330): remove unwrap()
-#![allow(clippy::unwrap_used)]
-
 use std::f32::consts::TAU;
 
 use framework::Example;
@@ -29,7 +26,7 @@ fn build_mesh_instances(
     model_mesh_instances: &[GpuMeshInstance],
     mesh_instance_positions_and_colors: &[(glam::Vec3, Color32)],
     seconds_since_startup: f32,
-) -> MeshDrawData {
+) -> anyhow::Result<MeshDrawData> {
     let mesh_instances = mesh_instance_positions_and_colors
         .chunks_exact(model_mesh_instances.len())
         .enumerate()
@@ -53,7 +50,7 @@ fn build_mesh_instances(
             )
         })
         .collect_vec();
-    MeshDrawData::new(re_ctx, &mesh_instances).unwrap()
+    Ok(MeshDrawData::new(re_ctx, &mesh_instances)?)
 }
 
 fn lorenz_points(seconds_since_startup: f32) -> Vec<glam::Vec3> {
@@ -84,14 +81,12 @@ fn lorenz_points(seconds_since_startup: f32) -> Vec<glam::Vec3> {
     .collect()
 }
 
-fn build_lines(re_ctx: &RenderContext, seconds_since_startup: f32) -> LineDrawData {
+fn build_lines(re_ctx: &RenderContext, seconds_since_startup: f32) -> anyhow::Result<LineDrawData> {
     // Calculate some points that look nice for an animated line.
     let lorenz_points = lorenz_points(seconds_since_startup);
 
     let mut builder = LineDrawableBuilder::new(re_ctx);
-    builder
-        .reserve_vertices(lorenz_points.len() + 4 + 1000)
-        .unwrap();
+    builder.reserve_vertices(lorenz_points.len() + 4 + 1000)?;
 
     {
         let mut batch = builder.batch("lines without transform");
@@ -140,7 +135,7 @@ fn build_lines(re_ctx: &RenderContext, seconds_since_startup: f32) -> LineDrawDa
         .radius(Size::new_scene_units(0.1))
         .flags(LineStripFlags::FLAG_CAP_END_TRIANGLE);
 
-    builder.into_draw_data().unwrap()
+    Ok(builder.into_draw_data()?)
 }
 
 enum CameraControl {
@@ -224,26 +219,23 @@ impl Multiview {
         skybox: GenericSkyboxDrawData,
         draw_data: D,
         index: u32,
-    ) -> (ViewBuilder, wgpu::CommandBuffer) {
+    ) -> anyhow::Result<(ViewBuilder, wgpu::CommandBuffer)> {
         let mut view_builder = ViewBuilder::new(re_ctx, target_cfg);
 
         if self
             .take_screenshot_next_frame_for_view
             .map_or(false, |i| i == index)
         {
-            view_builder
-                .schedule_screenshot(re_ctx, READBACK_IDENTIFIER, index)
-                .unwrap();
+            view_builder.schedule_screenshot(re_ctx, READBACK_IDENTIFIER, index)?;
             re_log::info!("Scheduled screenshot for view {}", index);
         }
 
         let command_buffer = view_builder
             .queue_draw(skybox)
             .queue_draw(draw_data)
-            .draw(re_ctx, Rgba::TRANSPARENT)
-            .unwrap();
+            .draw(re_ctx, Rgba::TRANSPARENT)?;
 
-        (view_builder, command_buffer)
+        Ok((view_builder, command_buffer))
     }
 }
 
@@ -311,7 +303,7 @@ impl Example for Multiview {
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_per_point: f32,
-    ) -> Vec<framework::ViewDrawResult> {
+    ) -> anyhow::Result<Vec<framework::ViewDrawResult>> {
         if matches!(self.camera_control, CameraControl::RotateAroundCenter) {
             let seconds_since_startup = time.seconds_since_startup();
             self.camera_position = Vec3::new(
@@ -324,12 +316,11 @@ impl Example for Multiview {
         handle_incoming_screenshots(re_ctx);
 
         let seconds_since_startup = time.seconds_since_startup();
-        let view_from_world =
-            IsoTransform::look_at_rh(self.camera_position, Vec3::ZERO, Vec3::Y).unwrap();
-
+        let view_from_world = IsoTransform::look_at_rh(self.camera_position, Vec3::ZERO, Vec3::Y)
+            .ok_or(anyhow::format_err!("invalid camera"))?;
         let triangle = TestTriangleDrawData::new(re_ctx);
         let skybox = GenericSkyboxDrawData::new(re_ctx, Default::default());
-        let lines = build_lines(re_ctx, seconds_since_startup);
+        let lines = build_lines(re_ctx, seconds_since_startup)?;
 
         let mut builder = PointCloudBuilder::new(re_ctx);
         builder
@@ -342,13 +333,13 @@ impl Example for Multiview {
                 &[],
             );
 
-        let point_cloud = builder.into_draw_data().unwrap();
+        let point_cloud = builder.into_draw_data()?;
         let meshes = build_mesh_instances(
             re_ctx,
             &self.model_mesh_instances,
             &self.mesh_instance_positions_and_colors,
             seconds_since_startup,
-        );
+        )?;
 
         let splits = framework::split_resolution(resolution, 2, 2).collect::<Vec<_>>();
 
@@ -383,7 +374,7 @@ impl Example for Multiview {
                     skybox.clone(),
                     $name,
                     $n,
-                );
+                )?;
                 framework::ViewDrawResult {
                     view_builder,
                     command_buffer,
@@ -401,7 +392,7 @@ impl Example for Multiview {
 
         self.take_screenshot_next_frame_for_view = None;
 
-        draw_results
+        Ok(draw_results)
     }
 
     fn on_key_event(&mut self, input: winit::event::KeyEvent) {

--- a/crates/viewer/re_renderer_examples/outlines.rs
+++ b/crates/viewer/re_renderer_examples/outlines.rs
@@ -1,8 +1,5 @@
 //! Demonstrates outline rendering.
 
-// TODO(#6330): remove unwrap()
-#![allow(clippy::unwrap_used)]
-
 use itertools::Itertools;
 use re_renderer::{
     renderer::GpuMeshInstance,
@@ -45,7 +42,7 @@ impl framework::Example for Outlines {
         resolution: [u32; 2],
         time: &framework::Time,
         pixels_per_point: f32,
-    ) -> Vec<framework::ViewDrawResult> {
+    ) -> anyhow::Result<Vec<framework::ViewDrawResult>> {
         if !self.is_paused {
             self.seconds_since_startup += time.last_frame_duration.as_secs_f32();
         }
@@ -63,7 +60,7 @@ impl framework::Example for Outlines {
                     glam::Vec3::ZERO,
                     glam::Vec3::Y,
                 )
-                .unwrap(),
+                .ok_or(anyhow::format_err!("invalid camera"))?,
                 projection_from_view: Projection::Perspective {
                     vertical_fov: 70.0 * std::f32::consts::TAU / 360.0,
                     near_plane_distance: 0.01,
@@ -128,18 +125,17 @@ impl framework::Example for Outlines {
             re_ctx,
             Default::default(),
         ));
-        view_builder
-            .queue_draw(re_renderer::renderer::MeshDrawData::new(re_ctx, &instances).unwrap());
+        view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(
+            re_ctx, &instances,
+        )?);
 
-        let command_buffer = view_builder
-            .draw(re_ctx, re_renderer::Rgba::TRANSPARENT)
-            .unwrap();
+        let command_buffer = view_builder.draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
 
-        vec![framework::ViewDrawResult {
+        Ok(vec![framework::ViewDrawResult {
             view_builder,
             command_buffer,
             target_location: glam::Vec2::ZERO,
-        }]
+        }])
     }
 
     fn on_key_event(&mut self, input: winit::event::KeyEvent) {

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -97,7 +97,7 @@ impl framework::Example for Outlines {
                 color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
                 spacing: 0.1,
                 thickness_ui: 1.0,
-                orientation: re_renderer::renderer::GridPlane::ZX,
+                plane: re_math::Plane3::ZX,
             },
         ));
         view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -47,8 +47,11 @@ impl framework::Example for Outlines {
             self.seconds_since_startup += time.last_frame_duration.as_secs_f32();
         }
         let seconds_since_startup = self.seconds_since_startup;
-        // TODO(#1426): unify camera logic between examples.
-        let camera_position = glam::vec3(1.0, 3.5, 7.0);
+        let camera_position = glam::vec3(
+            seconds_since_startup.sin(),
+            seconds_since_startup.sin() * 0.5,
+            seconds_since_startup.cos(),
+        ) * 7.0;
 
         let mut view_builder = ViewBuilder::new(
             re_ctx,
@@ -80,8 +83,8 @@ impl framework::Example for Outlines {
             re_ctx,
             &re_renderer::renderer::WorldGridConfiguration {
                 color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
-                spacing: 10.0,
-                thickness_ui: 1.5,
+                spacing: 1.0,
+                thickness_ui: 1.0,
                 orientation: re_renderer::renderer::GridPlane::XZ,
             },
         ));

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -7,7 +7,6 @@
 use re_renderer::{
     renderer::GpuMeshInstance,
     view_builder::{Projection, TargetConfiguration, ViewBuilder},
-    OutlineMaskPreference,
 };
 use winit::event::ElementState;
 

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -3,6 +3,7 @@
 //! Controls:
 //! - Space: Pause
 //! - G: Toggle camera mode
+// TODO(#1426): unify camera logic between examples and add a free camera.
 
 use re_renderer::{
     renderer::GpuMeshInstance,

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -96,7 +96,7 @@ impl framework::Example for Outlines {
                 color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
                 spacing: 0.1,
                 thickness_ui: 1.0,
-                orientation: re_renderer::renderer::GridPlane::XZ,
+                orientation: re_renderer::renderer::GridPlane::ZX,
             },
         ));
         view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(

--- a/crates/viewer/re_renderer_examples/world_grid.rs
+++ b/crates/viewer/re_renderer_examples/world_grid.rs
@@ -1,0 +1,113 @@
+//! Demonstrates world grid rendering.
+
+use itertools::Itertools;
+use re_renderer::{
+    renderer::GpuMeshInstance,
+    view_builder::{Projection, TargetConfiguration, ViewBuilder},
+    Color32, OutlineConfig, OutlineMaskPreference,
+};
+use winit::event::ElementState;
+
+mod framework;
+
+struct Outlines {
+    is_paused: bool,
+    seconds_since_startup: f32,
+    model_mesh_instances: Vec<GpuMeshInstance>,
+}
+
+struct MeshProperties {
+    outline_mask_ids: OutlineMaskPreference,
+    position: glam::Vec3,
+    rotation: glam::Quat,
+}
+
+impl framework::Example for Outlines {
+    fn title() -> &'static str {
+        "Outlines"
+    }
+
+    fn new(re_ctx: &re_renderer::RenderContext) -> Self {
+        Self {
+            is_paused: false,
+            seconds_since_startup: 0.0,
+            model_mesh_instances: crate::framework::load_rerun_mesh(re_ctx)
+                .expect("Failed to load rerun mesh"),
+        }
+    }
+
+    fn draw(
+        &mut self,
+        re_ctx: &re_renderer::RenderContext,
+        resolution: [u32; 2],
+        time: &framework::Time,
+        pixels_per_point: f32,
+    ) -> anyhow::Result<Vec<framework::ViewDrawResult>> {
+        if !self.is_paused {
+            self.seconds_since_startup += time.last_frame_duration.as_secs_f32();
+        }
+        let seconds_since_startup = self.seconds_since_startup;
+        // TODO(#1426): unify camera logic between examples.
+        let camera_position = glam::vec3(1.0, 3.5, 7.0);
+
+        let mut view_builder = ViewBuilder::new(
+            re_ctx,
+            TargetConfiguration {
+                name: "WorldGridDemo".into(),
+                resolution_in_pixel: resolution,
+                view_from_world: re_math::IsoTransform::look_at_rh(
+                    camera_position,
+                    glam::Vec3::ZERO,
+                    glam::Vec3::Y,
+                )
+                .ok_or(anyhow::format_err!("invalid camera"))?,
+                projection_from_view: Projection::Perspective {
+                    vertical_fov: 70.0 * std::f32::consts::TAU / 360.0,
+                    near_plane_distance: 0.01,
+                    aspect_ratio: resolution[0] as f32 / resolution[1] as f32,
+                },
+                pixels_per_point,
+                outline_config: None,
+                ..Default::default()
+            },
+        );
+
+        view_builder.queue_draw(re_renderer::renderer::GenericSkyboxDrawData::new(
+            re_ctx,
+            Default::default(),
+        ));
+        view_builder.queue_draw(re_renderer::renderer::WorldGridDrawData::new(
+            re_ctx,
+            &re_renderer::renderer::WorldGridConfiguration {
+                color: re_renderer::Rgba::from_rgb(0.5, 0.5, 0.5),
+                spacing: 10.0,
+                thickness_ui: 1.5,
+                orientation: re_renderer::renderer::GridPlane::XZ,
+            },
+        ));
+        view_builder.queue_draw(re_renderer::renderer::MeshDrawData::new(
+            re_ctx,
+            &self.model_mesh_instances,
+        )?);
+
+        let command_buffer = view_builder.draw(re_ctx, re_renderer::Rgba::TRANSPARENT)?;
+
+        Ok(vec![framework::ViewDrawResult {
+            view_builder,
+            command_buffer,
+            target_location: glam::Vec2::ZERO,
+        }])
+    }
+
+    fn on_key_event(&mut self, input: winit::event::KeyEvent) {
+        if input.state == ElementState::Pressed
+            && input.logical_key == winit::keyboard::Key::Named(winit::keyboard::NamedKey::Space)
+        {
+            self.is_paused ^= true;
+        }
+    }
+}
+
+fn main() {
+    framework::start::<Outlines>();
+}

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -133,7 +133,7 @@ fn format_with_decimals_in_range(
                     return text;
                 }
             }
-        }>
+        }
         // The value has more precision than we expected.
         // Probably the value was set not by the slider, but from outside.
         // In any case: show the full value

--- a/crates/viewer/re_ui/src/lib.rs
+++ b/crates/viewer/re_ui/src/lib.rs
@@ -133,7 +133,7 @@ fn format_with_decimals_in_range(
                     return text;
                 }
             }
-        }
+        }>
         // The value has more precision than we expected.
         // Probably the value was set not by the slider, but from outside.
         // In any case: show the full value


### PR DESCRIPTION
### Related

This is the first half of

* https://github.com/rerun-io/rerun/issues/872

The second half is here:
* https://github.com/rerun-io/rerun/pull/8234

### What

Implements a "world grid" to be used later in the spatial views of the viewer.
Haven't tested yet how suitable this is for 2D views, might need some adjustments.

## Video

Youtube unfortunately compresses this a lot and Github doesn't let me upload any significant amount of video
(click me)
[![youtube video of world grid v1](http://img.youtube.com/vi/Ho-iGdmJi4Q/0.jpg)](http://www.youtube.com/watch?v=Ho-iGdmJi4Q "World Grid v1")

## Screenshots

Analytical anti-aliasing (shown is what is supposed to be a 1ui unit == 2pixel wide line):
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/702b82ac-2629-4aa5-9304-0cd3c4d87fc5">

Distance has only the cardinal lines (== every tenth line). Those fade eventually as well:
<img width="747" alt="image" src="https://github.com/user-attachments/assets/ebe6b2c9-37e5-4406-8d28-5260cf2940d4">

Fading is based on "how many lines coincide here" which makes fading view dependent rather than distance dependent:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/9bea7a42-9edc-4a7d-be19-9498a1f29fdf">
(this makes this hopefully robust for many usecases)

Grid intersects non-transparent geometry (transparent geometry will be ignored in the future. previous surveying showed that this is common and not a biggy)
<img width="426" alt="image" src="https://github.com/user-attachments/assets/19de2cc9-015d-4fdd-a275-096768119a9e">

Grid fades at acute viewing angles (because empirically and unsurprisingly it looks weird if we don't!)
<img width="1437" alt="image" src="https://github.com/user-attachments/assets/2a05b8e5-9915-4dda-9a54-4db829e22ac3">

Tested image quality to be satisfying on high dpi (ui unit == 2 pixels) and low dpi (ui unit == pixel).

## How does it work

* Draw a large shader generated plane (mostly because setting up vertex buffers is just more hassle 😄 )
    * depth test enabled
    * depth write disabled
    * premultiplied alpha blend
    * make sure we draw this after the background (reminder: we first draw solid, then background)
* Fragment shader looks at 2d coordinate on the plane and decides how "liney" it is
   * using screen space derivatives (ddx/ddy) we figure out how far to go on the plane to achieve a certain line thickness
   * fades:
        * fade if the line density gets too high
        * fade if view angle is too acute relative  
   * ... lot's of details documented in the shader code!

I considered just drawing a screen space triangle, but drawing a plane that moves with the camera has lots of advantages:
* don't have to manipulate depth
    * faster since early z just works
    * less thinking required!
* don't cover things above the horizon - even if only the grid is visible, less pixels will be shaded 

## Known shortcomings

* various hardcoded values around how fading works. Tricky to formalize this better, but likely good enough
    * Doesn't look equally good at all pixel widths, but decent for the range we care
* every tenth line is a "cardinal line", that's nice but it stops there - "infinite" amount of cardinal lines would be nicer
    * Experimented with that but so far didn't get anything that was compelling. Having many order-of-magnitude lines looks way too busy imho, it needs a mechanism that limits that to two.
    * Blender's 2D view does this really well, but in 3D they only do two cardinals as well.

## Try it yourself

Controls:
- Space: Pause
- G: Toggle camera mode

native:
```
cargo run -p re_renderer_examples --bin world_grid
```

web:
```
cargo run-wasm -p re_renderer_examples --bin world_grid
```


## Backend testing matrix

* [x] Metal
* [x] Vulkan
* [x] WebGL
* [x] WebGPU  