### PR TITLE
Add `map_view` to the default features and improve how the `nasm` feature is handled and documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ rr.log("path/to/points", rr.Points3D(positions, colors=colors))
 
 ### Installing the Rerun Viewer binary
 To stream log data over the network or load our `.rrd` data files you also need the `rerun` binary.
-It can be installed with `pip install rerun-sdk` or with `cargo install rerun-cli --locked`.
+It can be installed with `pip install rerun-sdk` or with `cargo install rerun-cli --locked --features nasm` (see note bellow).
 Note that only the Python SDK comes bundled with the Viewer whereas C++ & Rust always rely on a separate install.
+
+**Note**: the `nasm` Cargo feature requires the [`nasm`](https://www.nasm.us) CLI to be installed and available in your path.
+Alternatively, you may skip enabling this feature, but this may result in inferior video decoding performance.
 
 You should now be able to run `rerun --help` in any terminal.
 

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -48,6 +48,13 @@ default = ["native_viewer", "web_viewer", "map_view"]
 # - This list is not exhaustive and will unexpectedly grow in the future.
 #
 # If you insist on adding a feature here, please make sure you address all the concerns above.
+#
+# `nasm`
+# ------
+#
+# This requires external build tools (the `nasm` cli) and would break any build on a system without it. Mitigation: a
+# warning with instructions is printed when building `rerun-cli` in release mode without the `nasm` feature (see
+# `build.rs`).
 
 ## The features we enable when we build the pre-built binaries during our releases.
 ## This may enable features that require extra build tools that not everyone has.

--- a/crates/top/rerun-cli/Cargo.toml
+++ b/crates/top/rerun-cli/Cargo.toml
@@ -35,11 +35,23 @@ doc = false
 ## so we have all the bells and wistles here, except those that may require extra tools
 ## (like "nasm").
 ## That is: `cargo install rerun-cli --locked` should work for _everyone_.
-default = ["native_viewer", "web_viewer"]
+default = ["native_viewer", "web_viewer", "map_view"]
+
+
+# !!!IMPORTANT!!!
+#
+# Do you _really_ want to add features in `release` that are not in `default`?
+#
+# Here are some reasons not to:
+# - These features will be missing from the `cargo install rerun-cli` command our users will inevitably use.
+# - These features will not be picked up in places where we cannot use the `release` feature set (e.g. rerun_js).
+# - This list is not exhaustive and will unexpectedly grow in the future.
+#
+# If you insist on adding a feature here, please make sure you address all the concerns above.
 
 ## The features we enable when we build the pre-built binaries during our releases.
-## This may enable features that require extra build tools that not everyone heas.
-release = ["default", "nasm", "map_view"]
+## This may enable features that require extra build tools that not everyone has.
+release = ["default", "nasm"]
 
 ## Enable faster native video decoding with assembly.
 ## You need to install [nasm](https://nasm.us/) to compile with this feature.
@@ -51,7 +63,6 @@ native_viewer = ["rerun/native_viewer"]
 
 ## Support the map view.
 ## This adds a lot of extra dependencies.
-#TODO(#7876): remove this feature when we have fewer dependencies
 map_view = ["rerun/map_view"]
 
 ## Enable the gRPC Rerun Data Platform data source.

--- a/crates/top/rerun-cli/README.md
+++ b/crates/top/rerun-cli/README.md
@@ -13,9 +13,12 @@
 </h1>
 
 ## Rerun command-line tool
-You can install the binary with `cargo install rerun-cli --locked`
+You can install the binary with `cargo install rerun-cli --locked --features nasm`.
 
-This can act either as a server, a viewer, or both, depending on which options you use when you start it.
+**Note**: this requires the [`nasm`](https://www.nasm.us) CLI to be installed and available in your path.
+Alternatively, you may skip enabling the `nasm` feature, but this may result in inferior video decoding performance.
+
+The `rerun` CLI can act either as a server, a viewer, or both, depending on which options you use when you start it.
 
 Running `rerun` with no arguments will start the viewer, waiting for an SDK to connect to it over TCP.
 

--- a/crates/top/rerun-cli/build.rs
+++ b/crates/top/rerun-cli/build.rs
@@ -1,3 +1,14 @@
 fn main() {
     re_build_tools::export_build_info_vars_for_crate("rerun-cli");
+
+    // Warn about not using the `nasm` feature in a release build.
+    let is_release = std::env::var("PROFILE").unwrap() == "release";
+    let has_nasm_feature = std::env::var("CARGO_FEATURE_NASM").is_ok();
+    if is_release && !has_nasm_feature {
+        println!(
+            "cargo:warning=Rerun is compiled in release mode without the `nasm` feature activated. \
+            Enabling the `nasm` feature is recommended for better video decoding performance. \
+            This requires that the `nasm` CLI is installed and available in the current PATH."
+        );
+    }
 }

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -31,6 +31,7 @@ default = [
   "glam",
   "image",
   "log",
+  "map_view",
   "sdk",
   "server",
 ]
@@ -85,7 +86,6 @@ native_viewer = ["dep:re_viewer"]
 
 ## Support the map view.
 ## This adds a lot of extra dependencies.
-#TODO(#7876): remove this feature when we have fewer dependencies
 map_view = ["re_viewer?/map_view"]
 
 ## Enable the gRPC Rerun Data Platform data source.

--- a/crates/top/rerun/README.md
+++ b/crates/top/rerun/README.md
@@ -41,14 +41,16 @@ You can add the `rerun` crate to your project with `cargo add rerun`.
 To get started, see [the examples](https://github.com/rerun-io/rerun/tree/latest/examples/rust).
 
 ## Binary
-You can install the binary with `cargo install rerun-cli --locked`
+You can install the binary with `cargo install rerun-cli --locked --features nasm`.
 
-This can act either as a server, a viewer, or both, depending on which options you use when you start it.
+**Note**: this requires the [`nasm`](https://www.nasm.us) CLI to be installed and available in your path.
+Alternatively, you may skip enabling the `nasm` feature, but this may result in inferior video decoding performance.
+
+The `rerun` CLI can act either as a server, a viewer, or both, depending on which options you use when you start it.
 
 Running `rerun` with no arguments will start the viewer, waiting for an SDK to connect to it over TCP.
 
 Run `rerun --help` for more.
-
 
 ### Running a web viewer
 The web viewer is an experimental feature, but you can try it out with:

--- a/crates/viewer/re_viewer/data/quick_start_guides/cpp_connect.md
+++ b/crates/viewer/re_viewer/data/quick_start_guides/cpp_connect.md
@@ -4,8 +4,11 @@
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
-* Via cargo: `cargo install rerun-cli --locked`
+* Via cargo: `cargo install rerun-cli --locked --features nasm` (see note bellow)
 * Via pip: `pip install rerun-sdk`
+
+**Note**: the `nasm` Cargo feature requires the [`nasm`](https://www.nasm.us) CLI to be installed and available in your path.
+Alternatively, you may skip enabling this feature, but this may result in inferior video decoding performance.
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/crates/viewer/re_viewer/data/quick_start_guides/cpp_spawn.md
+++ b/crates/viewer/re_viewer/data/quick_start_guides/cpp_spawn.md
@@ -4,8 +4,11 @@
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
-* Via cargo: `cargo install rerun-cli --locked`
+* Via cargo: `cargo install rerun-cli --locked --features nasm` (see note bellow)
 * Via pip: `pip install rerun-sdk`
+
+**Note**: the `nasm` Cargo feature requires the [`nasm`](https://www.nasm.us) CLI to be installed and available in your path.
+Alternatively, you may skip enabling this feature, but this may result in inferior video decoding performance.
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -1308,7 +1308,6 @@ impl App {
                         .archetype_reflection_from_short_name(&archetype_name)
                     {
                         for &view_type in archetype.view_types {
-                            // TODO(#7876): remove once `map_view` feature is gone
                             if !cfg!(feature = "map_view") && view_type == "MapView" {
                                 re_log::warn_once!("Found map-related archetype, but viewer was not compiled with the `map_view` feature.");
                             }

--- a/deny.toml
+++ b/deny.toml
@@ -43,7 +43,6 @@ deny = [
   { name = "egui_glow" },   # We use wgpu
   { name = "openssl-sys" }, # We prefer rustls
   { name = "openssl" },     # We prefer rustls
-  # { name = "reqwest" },   # We prefer ureq - less dependencies TODO(#7876): reenable that when `walkers` is updated
 ]
 skip = [
   { name = "ahash" },          # Popular crate + fast release schedule = lots of crates still using old versions

--- a/pixi.toml
+++ b/pixi.toml
@@ -175,13 +175,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view,grpc --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view,grpc --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -197,7 +197,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,map_view,grpc --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends_on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -31,7 +31,7 @@ function buildWebViewer(mode) {
       "cargo run -p re_dev_tools -- build-web-viewer",
       modeFlags,
       "--target no-modules-base",
-      "--features map_view,grpc",
+      "--features grpc",
       "-o rerun_js/web-viewer",
     ].join(" "),
   );


### PR DESCRIPTION
### Related

* Related to #7876 

### What

This PR:
- adds the `map_view` feature to `default`
- removes everywhere the `map_view` was explicitly added that is no longer necessary
- prints a warning when building in release mode with the `nasm` feature disabled (which is still the default)
- document that `nasm` thing everywhere we talk about `cargo install rerun-cli`
- tries to make people think before they add stuff to the `release` feature instead of the `default` feature
