### PR TITLE
Fix typo in archetypes.md

### DIFF
--- a/docs/content/reference/types/archetypes.md
+++ b/docs/content/reference/types/archetypes.md
@@ -7,7 +7,7 @@ order: 1
 Archetypes are bundles of components for which the Rerun viewer has first-class
 built-in support. When logged, each archetype also includes an _indicator component_ which captures
 the intent of the logging code and triggers the activation of the corresponding visualizers. See
-[Entities and Compponents](../../concepts/entity-component.md) and
+[Entities and Components](../../concepts/entity-component.md) and
 [Visualizers and Overrides](../../concepts/visualizers-and-overrides.md) for more information.
 
 This page lists all built-in archetypes.


### PR DESCRIPTION
### Related

N/A

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

Really just a typo

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
