### PR TITLE
Fix: simplify viewport tree after dragging a tile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6769,7 +6769,6 @@ dependencies = [
  "image",
  "itertools 0.13.0",
  "nohash-hasher",
- "parking_lot",
  "rayon",
  "re_context_menu",
  "re_entity_db",

--- a/crates/viewer/re_viewport/Cargo.toml
+++ b/crates/viewer/re_viewport/Cargo.toml
@@ -44,5 +44,4 @@ glam.workspace = true
 image = { workspace = true, default-features = false, features = ["png"] }
 itertools.workspace = true
 nohash-hasher.workspace = true
-parking_lot.workspace = true
 rayon.workspace = true

--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -460,6 +460,7 @@ struct TilesDelegate<'a, 'b> {
 
     /// The user edited the tree.
     edited: bool,
+
     /// The user edited the tree by drag-dropping a tile.
     tile_dropped: bool,
 }


### PR DESCRIPTION

### Related
* Fixed bug introduced in https://github.com/rerun-io/rerun/pull/8241


### What

Before we would be left with empty containers.
