### PR TITLE
Fix web viewer feature flags

### DIFF
--- a/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
@@ -74,6 +74,7 @@ pub fn build(
     debug_symbols: bool,
     target: Target,
     build_dir: &Utf8Path,
+    no_default_features: bool,
     features: &String,
 ) -> anyhow::Result<()> {
     std::env::set_current_dir(workspace_root())?;
@@ -118,7 +119,11 @@ pub fn build(
             "--lib",
             "--target=wasm32-unknown-unknown",
             &format!("--target-dir={}", target_wasm_dir.as_str()),
-            "--no-default-features",
+            if no_default_features {
+                "--no-default-features"
+            } else {
+                ""
+            },
             &format!("--features={features}"),
         ]);
         if profile == Profile::Release {

--- a/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/lib.rs
@@ -119,13 +119,13 @@ pub fn build(
             "--lib",
             "--target=wasm32-unknown-unknown",
             &format!("--target-dir={}", target_wasm_dir.as_str()),
-            if no_default_features {
-                "--no-default-features"
-            } else {
-                ""
-            },
-            &format!("--features={features}"),
         ]);
+        if no_default_features {
+            cmd.arg("--no-default-features");
+        }
+        if !features.is_empty() {
+            cmd.arg(&format!("--features={features}"));
+        }
         if profile == Profile::Release {
             cmd.arg("--release");
         }

--- a/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
@@ -38,6 +38,10 @@ pub struct Args {
     /// comma-separated list of features to pass on to `re_viewer`
     #[argh(option, short = 'F', long = "features", default = "default_features()")]
     features: String,
+
+    /// whether to exclude defualt features from `re_viewer` wasm build
+    #[argh(option, long = "no-default-features", default = "false")]
+    no_default_features: bool,
 }
 
 fn default_features() -> String {
@@ -62,6 +66,7 @@ pub fn main(args: Args) -> anyhow::Result<()> {
         args.debug_symbols,
         args.target,
         &build_dir,
+        args.no_default_features,
         &args.features,
     )
 }

--- a/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
@@ -40,7 +40,7 @@ pub struct Args {
     features: String,
 
     /// whether to exclude default features from `re_viewer` wasm build
-    #[argh(option, long = "no-default-features", default = "false")]
+    #[argh(switch, long = "no-default-features")]
     no_default_features: bool,
 }
 

--- a/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
+++ b/crates/build/re_dev_tools/src/build_web_viewer/mod.rs
@@ -39,7 +39,7 @@ pub struct Args {
     #[argh(option, short = 'F', long = "features", default = "default_features()")]
     features: String,
 
-    /// whether to exclude defualt features from `re_viewer` wasm build
+    /// whether to exclude default features from `re_viewer` wasm build
     #[argh(option, long = "no-default-features", default = "false")]
     no_default_features: bool,
 }

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -32,7 +32,7 @@ crate-type = ["cdylib", "rlib"]
 
 
 [features]
-default = ["analytics"]
+default = ["analytics", "map_view"]
 
 ## Enable telemetry using our analytics SDK.
 analytics = ["dep:re_analytics"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -175,13 +175,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -197,7 +197,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends_on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.

--- a/pixi.toml
+++ b/pixi.toml
@@ -175,13 +175,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -189,7 +189,7 @@ rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p 
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features --features web_viewer --release -- --web-viewer", depends_on = [
+rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features --features web_viewer,map_view,grpc --release -- --web-viewer", depends_on = [
   "rerun-build-web-release",
 ] }
 
@@ -197,7 +197,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --no-default-features --features analytics,grpc,map_view --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends_on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.

--- a/pixi.toml
+++ b/pixi.toml
@@ -175,13 +175,13 @@ rerun-web = { cmd = "cargo run --package rerun-cli --no-default-features --featu
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug"
+rerun-build-web = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --debug"
 
 # Compile the web-viewer wasm and the cli.
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
+rerun-build-web-cli = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --debug && cargo build --package rerun-cli --no-default-features --features web_viewer"
 
 # Compile and run the web-viewer in release mode via rerun-cli.
 #
@@ -197,7 +197,7 @@ rerun-web-release = { cmd = "cargo run --package rerun-cli --no-default-features
 #
 # This installs the `wasm32-unknown-unknown` rust target if it's not already installed.
 # (this looks heavy but takes typically below 0.1s!)
-rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc --release -g"
+rerun-build-web-release = "rustup target add wasm32-unknown-unknown && cargo run -p re_dev_tools -- build-web-viewer --features analytics,grpc,map_view --release -g"
 
 rs-check = { cmd = "rustup target add wasm32-unknown-unknown && python scripts/ci/rust_checks.py", depends_on = [
   "rerun-build-web", # The checks require the web viewer wasm to be around.

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -31,7 +31,8 @@ function buildWebViewer(mode) {
       "cargo run -p re_dev_tools -- build-web-viewer",
       modeFlags,
       "--target no-modules-base",
-      "--features grpc",
+      "--no-default-features",
+      "--features grpc,map_view",
       "-o rerun_js/web-viewer",
     ].join(" "),
   );

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -32,7 +32,7 @@ function buildWebViewer(mode) {
       modeFlags,
       "--target no-modules-base",
       "--no-default-features",
-      "--features grpc,map_view",
+      "--features grpc,map_view", // no `analytics`
       "-o rerun_js/web-viewer",
     ].join(" "),
   );

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -32,7 +32,7 @@ function buildWebViewer(mode) {
       modeFlags,
       "--target no-modules-base",
       "--no-default-features",
-      "--features grpc,map_view",
+      "--features grpc",
       "-o rerun_js/web-viewer",
     ].join(" "),
   );

--- a/rerun_js/web-viewer/build-wasm.mjs
+++ b/rerun_js/web-viewer/build-wasm.mjs
@@ -32,7 +32,7 @@ function buildWebViewer(mode) {
       modeFlags,
       "--target no-modules-base",
       "--no-default-features",
-      "--features grpc",
+      "--features grpc,map_view",
       "-o rerun_js/web-viewer",
     ].join(" "),
   );


### PR DESCRIPTION
### Related

* Closes #8294

### What

* `build-web-viewer` now propagates `--no-default-features`, and doesn't include it by default
* Made `map_view` a default feature in `re_viewer`