### PR TITLE
End-to-end tagging: Python

### DIFF
--- a/crates/build/re_types_builder/src/codegen/python/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/python/mod.rs
@@ -409,6 +409,7 @@ impl PythonCodeGenerator {
                 Archetype,
                 BaseBatch,
                 ComponentBatchMixin,
+                ComponentDescriptor,
                 ComponentMixin,
             )
             from {rerun_path}_converters import (
@@ -1926,7 +1927,7 @@ fn quote_arrow_support_from_obj(
             r#"
             class {extension_batch}{batch_superclass_decl}:
                 _ARROW_DATATYPE = {datatype}
-                _COMPONENT_NAME: str = "{fqname}"
+                _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("{fqname}")
 
                 @staticmethod
                 def _native_to_pa_array(data: {many_aliases}, data_type: pa.DataType) -> pa.Array:
@@ -1939,7 +1940,7 @@ fn quote_arrow_support_from_obj(
         unindent(&format!(
             r#"
             class {extension_batch}{batch_superclass_decl}:
-                _COMPONENT_NAME: str = "{fqname}"
+                _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("{fqname}")
             "#
         ))
     }

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -284,23 +284,7 @@ impl Chunk {
                     .collect();
                 timelines == rhs_timelines
             }
-            // TODO(cmc): we cannot compare tags yet, need to support Python & C++ first
-            // && *components == rhs.components
-            && {
-                let lhs_components_no_tags: ChunkComponents = components
-                    .clone()
-                    .into_iter_flattened()
-                    .map(|(descr, list_array)| (ComponentDescriptor::new(descr.component_name), list_array))
-                    .collect();
-                let rhs_components_no_tags: ChunkComponents = rhs
-                    .components
-                    .clone()
-                    .into_iter_flattened()
-                    .map(|(descr, list_array)| (ComponentDescriptor::new(descr.component_name), list_array))
-                    .collect();
-
-                lhs_components_no_tags == rhs_components_no_tags
-            }
+            && *components == rhs.components
     }
 
     /// Check for equality while ignoring possible `Extension` type information

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.py
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import rerun as rr  # pip install rerun-sdk
+
+rr.init("rerun_example_descriptors_builtin_archetype")
+rr.spawn()
+
+rr.log("data", rr.Points3D([[1, 2, 3]], radii=[0.3, 0.2, 0.1]), static=True)
+
+# The tags are indirectly checked by the Rust version (have a look over there for more info).

--- a/docs/snippets/all/descriptors/descr_builtin_component.py
+++ b/docs/snippets/all/descriptors/descr_builtin_component.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import rerun as rr  # pip install rerun-sdk
+
+rr.init("rerun_example_descriptors_builtin_component")
+rr.spawn()
+
+rr.log("data", [rr.components.Position3DBatch([1, 2, 3])], static=True)
+
+# The tags are indirectly checked by the Rust version (have a look over there for more info).

--- a/docs/snippets/all/descriptors/descr_custom_archetype.py
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import numpy.typing as npt
+import pyarrow as pa
+import rerun as rr  # pip install rerun-sdk
+
+
+class CustomPosition3DBatch(rr.ComponentBatchLike):
+    def __init__(self: Any, positions: npt.ArrayLike) -> None:
+        self.position = rr.components.Position3DBatch(positions)
+
+    def component_descriptor(self) -> rr.ComponentDescriptor:
+        return rr.ComponentDescriptor(
+            "user.CustomPosition3D",
+            archetype_name="user.CustomPoints3D",
+            archetype_field_name="custom_positions",
+        )
+
+    def as_arrow_array(self) -> pa.Array:
+        return self.position.as_arrow_array()
+
+
+class CustomPoints3D(rr.AsComponents):
+    def __init__(self: Any, positions: npt.ArrayLike, colors: npt.ArrayLike) -> None:
+        self.positions = CustomPosition3DBatch(positions)
+        self.colors = rr.components.ColorBatch(colors)
+
+    def as_component_batches(self) -> Iterable[rr.ComponentBatchLike]:
+        return (
+            [rr.IndicatorComponentBatch("user.CustomPoints3D")]
+            + [
+                rr.DescribedComponentBatch(
+                    self.positions,
+                    self.positions.component_descriptor().or_with_overrides(
+                        archetype_name="user.CustomPoints3D", archetype_field_name="custom_positions"
+                    ),
+                )
+            ]
+            + [
+                rr.DescribedComponentBatch(
+                    self.colors,
+                    self.colors.component_descriptor().or_with_overrides(
+                        archetype_name="user.CustomPoints3D", archetype_field_name="colors"
+                    ),
+                )
+            ]
+        )
+
+
+rr.init("rerun_example_descriptors_custom_archetype")
+rr.spawn()
+
+rr.log("data", CustomPoints3D([[1, 2, 3]], [0xFF00FFFF]), static=True)
+
+# The tags are indirectly checked by the Rust version (have a look over there for more info).

--- a/docs/snippets/all/descriptors/descr_custom_component.py
+++ b/docs/snippets/all/descriptors/descr_custom_component.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy.typing as npt
+import pyarrow as pa
+import rerun as rr  # pip install rerun-sdk
+
+
+class CustomPosition3DBatch(rr.ComponentBatchLike):
+    def __init__(self: Any, positions: npt.ArrayLike) -> None:
+        self.position = rr.components.Position3DBatch(positions)
+
+    def component_descriptor(self) -> rr.ComponentDescriptor:
+        return rr.ComponentDescriptor(
+            "user.CustomPosition3D",
+            archetype_name="user.CustomArchetype",
+            archetype_field_name="custom_positions",
+        )
+
+    def as_arrow_array(self) -> pa.Array:
+        return self.position.as_arrow_array()
+
+
+rr.init("rerun_example_descriptors_custom_component")
+rr.spawn()
+
+rr.log("data", [CustomPosition3DBatch([[1, 2, 3]])], static=True)
+
+# The tags are indirectly checked by the Rust version (have a look over there for more info).

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -54,23 +54,10 @@
   "cpp",
   "rust",
 ]
-"descriptors/descr_builtin_archetype" = [ # Python and C++ not yet supported (next PRs)
-  "py",
-]
-"descriptors/descr_builtin_component" = [ # Python and C++ not yet supported (next PRs)
-  "py",
-]
-"descriptors/descr_custom_archetype" = [ # Python and C++ not yet supported (next PRs)
-  "py",
-]
-"descriptors/descr_custom_component" = [ # Python and C++ not yet supported (next PRs)
-  "py",
-]
-views = [
+"views" = [
   "cpp",  # TODO(#5520): C++ views are not yet implemented
   "rust", # TODO(#5521): Rust views are not yet implemented
 ]
-
 "archetypes/image_advanced" = [
   "cpp",  # Missing examples
   "rust", # Missing examples

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -149,9 +149,11 @@ class Schema:
     def index_columns(self) -> list[IndexColumnDescriptor]:
         """Return a list of all the index columns in the schema."""
         ...
+
     def component_columns(self) -> list[ComponentColumnDescriptor]:
         """Return a list of all the component columns in the schema."""
         ...
+
     def column_for(self, entity_path: str, component: ComponentLike) -> Optional[ComponentColumnDescriptor]:
         """
         Look up the column descriptor for a specific entity path and component.

--- a/rerun_py/rerun_sdk/rerun/__init__.py
+++ b/rerun_py/rerun_sdk/rerun/__init__.py
@@ -34,6 +34,8 @@ from . import (
 )
 from ._baseclasses import (
     ComponentColumn as ComponentColumn,
+    ComponentDescriptor as ComponentDescriptor,
+    DescribedComponentBatch as DescribedComponentBatch,
 )
 from ._image_encoded import (
     ImageEncoded as ImageEncoded,

--- a/rerun_py/rerun_sdk/rerun/blueprint/api.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/api.py
@@ -136,7 +136,7 @@ class SpaceView:
         for default in self.defaults:
             if hasattr(default, "as_component_batches"):
                 stream.log(f"{self.blueprint_path()}/defaults", default, recording=stream)  # type: ignore[attr-defined]
-            elif hasattr(default, "component_name"):
+            elif hasattr(default, "component_descriptor"):
                 stream.log(f"{self.blueprint_path()}/defaults", [default], recording=stream)  # type: ignore[attr-defined]
             else:
                 raise ValueError(f"Provided default: {default} is neither a component nor a component batch.")

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/active_tab.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ActiveTab(datatypes.EntityPath, ComponentMixin):
 
 
 class ActiveTabBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ActiveTab"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ActiveTab")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/apply_latest_at.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ApplyLatestAt(datatypes.Bool, ComponentMixin):
 
 
 class ApplyLatestAtBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ApplyLatestAt"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ApplyLatestAt")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_layout.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class AutoLayout(datatypes.Bool, ComponentMixin):
 
 
 class AutoLayoutBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoLayout"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.AutoLayout")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/auto_space_views.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class AutoSpaceViews(datatypes.Bool, ComponentMixin):
 
 
 class AutoSpaceViewsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.AutoSpaceViews"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.AutoSpaceViews")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/background_kind.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["BackgroundKind", "BackgroundKindArrayLike", "BackgroundKindBatch", "BackgroundKindLike"]
@@ -71,7 +72,7 @@ BackgroundKindArrayLike = Union[BackgroundKindLike, Sequence[BackgroundKindLike]
 
 class BackgroundKindBatch(BaseBatch[BackgroundKindArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.BackgroundKind"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.BackgroundKind")
 
     @staticmethod
     def _native_to_pa_array(data: BackgroundKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/column_share.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ColumnShare(datatypes.Float32, ComponentMixin):
 
 
 class ColumnShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ColumnShare"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ColumnShare")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/component_column_selector.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -25,7 +26,9 @@ class ComponentColumnSelector(blueprint_datatypes.ComponentColumnSelector, Compo
 
 
 class ComponentColumnSelectorBatch(blueprint_datatypes.ComponentColumnSelectorBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ComponentColumnSelector"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
+        "rerun.blueprint.components.ComponentColumnSelector"
+    )
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/container_kind.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["ContainerKind", "ContainerKindArrayLike", "ContainerKindBatch", "ContainerKindLike"]
@@ -64,7 +65,7 @@ ContainerKindArrayLike = Union[ContainerKindLike, Sequence[ContainerKindLike]]
 
 class ContainerKindBatch(BaseBatch[ContainerKindArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ContainerKind"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ContainerKind")
 
     @staticmethod
     def _native_to_pa_array(data: ContainerKindArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/corner2d.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["Corner2D", "Corner2DArrayLike", "Corner2DBatch", "Corner2DLike"]
@@ -66,7 +67,7 @@ Corner2DArrayLike = Union[Corner2DLike, Sequence[Corner2DLike]]
 
 class Corner2DBatch(BaseBatch[Corner2DArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.Corner2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.Corner2D")
 
     @staticmethod
     def _native_to_pa_array(data: Corner2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_by_range.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -25,7 +26,7 @@ class FilterByRange(blueprint_datatypes.FilterByRange, ComponentMixin):
 
 
 class FilterByRangeBatch(blueprint_datatypes.FilterByRangeBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterByRange"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.FilterByRange")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/filter_is_not_null.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -25,7 +26,7 @@ class FilterIsNotNull(blueprint_datatypes.FilterIsNotNull, ComponentMixin):
 
 
 class FilterIsNotNullBatch(blueprint_datatypes.FilterIsNotNullBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.FilterIsNotNull"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.FilterIsNotNull")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_columns.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class GridColumns(datatypes.UInt32, ComponentMixin):
 
 
 class GridColumnsBatch(datatypes.UInt32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.GridColumns"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.GridColumns")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/grid_spacing.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/grid_spacing.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class GridSpacing(datatypes.Float32, ComponentMixin):
 
 
 class GridSpacingBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.GridSpacing"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.GridSpacing")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/included_content.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class IncludedContent(datatypes.EntityPath, ComponentMixin):
 
 
 class IncludedContentBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.IncludedContent"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.IncludedContent")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/interactive.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/interactive.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class Interactive(datatypes.Bool, ComponentMixin):
 
 
 class InteractiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.Interactive"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.Interactive")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/lock_range_during_zoom.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class LockRangeDuringZoom(datatypes.Bool, ComponentMixin):
 
 
 class LockRangeDuringZoomBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.LockRangeDuringZoom"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.LockRangeDuringZoom")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/map_provider.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["MapProvider", "MapProviderArrayLike", "MapProviderBatch", "MapProviderLike"]
@@ -75,7 +76,7 @@ MapProviderArrayLike = Union[MapProviderLike, Sequence[MapProviderLike]]
 
 class MapProviderBatch(BaseBatch[MapProviderArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.MapProvider"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.MapProvider")
 
     @staticmethod
     def _native_to_pa_array(data: MapProviderArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/panel_state.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["PanelState", "PanelStateArrayLike", "PanelStateBatch", "PanelStateLike"]
@@ -59,7 +60,7 @@ PanelStateArrayLike = Union[PanelStateLike, Sequence[PanelStateLike]]
 
 class PanelStateBatch(BaseBatch[PanelStateArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.PanelState"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.PanelState")
 
     @staticmethod
     def _native_to_pa_array(data: PanelStateArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/query_expression.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -36,7 +37,7 @@ class QueryExpression(datatypes.Utf8, ComponentMixin):
 
 
 class QueryExpressionBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.QueryExpression"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.QueryExpression")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/root_container.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class RootContainer(datatypes.Uuid, ComponentMixin):
 
 
 class RootContainerBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.RootContainer"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.RootContainer")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/row_share.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class RowShare(datatypes.Float32, ComponentMixin):
 
 
 class RowShareBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.RowShare"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.RowShare")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/selected_columns.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -25,7 +26,7 @@ class SelectedColumns(blueprint_datatypes.SelectedColumns, ComponentMixin):
 
 
 class SelectedColumnsBatch(blueprint_datatypes.SelectedColumnsBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.SelectedColumns"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.SelectedColumns")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_class.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class SpaceViewClass(datatypes.Utf8, ComponentMixin):
 
 
 class SpaceViewClassBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewClass"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.SpaceViewClass")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_maximized.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class SpaceViewMaximized(datatypes.Uuid, ComponentMixin):
 
 
 class SpaceViewMaximizedBatch(datatypes.UuidBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewMaximized"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.SpaceViewMaximized")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/space_view_origin.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class SpaceViewOrigin(datatypes.EntityPath, ComponentMixin):
 
 
 class SpaceViewOriginBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.SpaceViewOrigin"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.SpaceViewOrigin")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/tensor_dimension_index_slider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -25,7 +26,9 @@ class TensorDimensionIndexSlider(blueprint_datatypes.TensorDimensionIndexSlider,
 
 
 class TensorDimensionIndexSliderBatch(blueprint_datatypes.TensorDimensionIndexSliderBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.TensorDimensionIndexSlider"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
+        "rerun.blueprint.components.TensorDimensionIndexSlider"
+    )
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/timeline_name.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class TimelineName(datatypes.Utf8, ComponentMixin):
 
 
 class TimelineNameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.TimelineName"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.TimelineName")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/view_fit.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from ..._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["ViewFit", "ViewFitArrayLike", "ViewFitBatch", "ViewFitLike"]
@@ -61,7 +62,7 @@ ViewFitArrayLike = Union[ViewFitLike, Sequence[ViewFitLike]]
 
 class ViewFitBatch(BaseBatch[ViewFitArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewFit"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ViewFit")
 
     @staticmethod
     def _native_to_pa_array(data: ViewFitArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/viewer_recommendation_hash.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,9 @@ class ViewerRecommendationHash(datatypes.UInt64, ComponentMixin):
 
 
 class ViewerRecommendationHashBatch(datatypes.UInt64Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ViewerRecommendationHash"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor(
+        "rerun.blueprint.components.ViewerRecommendationHash"
+    )
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Visible(datatypes.Bool, ComponentMixin):
 
 
 class VisibleBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.Visible"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.Visible")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visible_time_range.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class VisibleTimeRange(datatypes.VisibleTimeRange, ComponentMixin):
 
 
 class VisibleTimeRangeBatch(datatypes.VisibleTimeRangeBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.VisibleTimeRange"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisibleTimeRange")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visual_bounds2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .visual_bounds2d_ext import VisualBounds2DExt
@@ -26,7 +27,7 @@ class VisualBounds2D(VisualBounds2DExt, datatypes.Range2D, ComponentMixin):
 
 
 class VisualBounds2DBatch(datatypes.Range2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualBounds2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisualBounds2D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_overrides.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/visualizer_overrides.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from ...blueprint import datatypes as blueprint_datatypes
@@ -36,7 +37,7 @@ class VisualizerOverrides(blueprint_datatypes.Utf8List, ComponentMixin):
 
 
 class VisualizerOverridesBatch(blueprint_datatypes.Utf8ListBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.VisualizerOverrides"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.VisualizerOverrides")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
+++ b/rerun_py/rerun_sdk/rerun/blueprint/components/zoom_level.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from ... import datatypes
 from ..._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ZoomLevel(datatypes.Float64, ComponentMixin):
 
 
 class ZoomLevelBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.blueprint.components.ZoomLevel"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.blueprint.components.ZoomLevel")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
+++ b/rerun_py/rerun_sdk/rerun/components/aggregation_policy.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["AggregationPolicy", "AggregationPolicyArrayLike", "AggregationPolicyBatch", "AggregationPolicyLike"]
@@ -95,7 +96,7 @@ AggregationPolicyArrayLike = Union[AggregationPolicyLike, Sequence[AggregationPo
 
 class AggregationPolicyBatch(BaseBatch[AggregationPolicyArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.AggregationPolicy"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AggregationPolicy")
 
     @staticmethod
     def _native_to_pa_array(data: AggregationPolicyArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
+++ b/rerun_py/rerun_sdk/rerun/components/albedo_factor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class AlbedoFactor(datatypes.Rgba32, ComponentMixin):
 
 
 class AlbedoFactorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.AlbedoFactor"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AlbedoFactor")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/annotation_context.py
+++ b/rerun_py/rerun_sdk/rerun/components/annotation_context.py
@@ -14,6 +14,7 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .annotation_context_ext import AnnotationContextExt
@@ -131,7 +132,7 @@ class AnnotationContextBatch(BaseBatch[AnnotationContextArrayLike], ComponentBat
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.components.AnnotationContext"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AnnotationContext")
 
     @staticmethod
     def _native_to_pa_array(data: AnnotationContextArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/axis_length.py
+++ b/rerun_py/rerun_sdk/rerun/components/axis_length.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class AxisLength(datatypes.Float32, ComponentMixin):
 
 
 class AxisLengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.AxisLength"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.AxisLength")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/blob.py
+++ b/rerun_py/rerun_sdk/rerun/components/blob.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Blob(datatypes.Blob, ComponentMixin):
 
 
 class BlobBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Blob"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Blob")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/class_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/class_id.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ClassId(datatypes.ClassId, ComponentMixin):
 
 
 class ClassIdBatch(datatypes.ClassIdBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ClassId"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ClassId")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
+++ b/rerun_py/rerun_sdk/rerun/components/clear_is_recursive.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .clear_is_recursive_ext import ClearIsRecursiveExt
@@ -26,7 +27,7 @@ class ClearIsRecursive(ClearIsRecursiveExt, datatypes.Bool, ComponentMixin):
 
 
 class ClearIsRecursiveBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ClearIsRecursive"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ClearIsRecursive")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -34,7 +35,7 @@ class Color(datatypes.Rgba32, ComponentMixin):
 
 
 class ColorBatch(datatypes.Rgba32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Color"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Color")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/colormap.py
+++ b/rerun_py/rerun_sdk/rerun/components/colormap.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["Colormap", "ColormapArrayLike", "ColormapBatch", "ColormapLike"]
@@ -133,7 +134,7 @@ ColormapArrayLike = Union[ColormapLike, Sequence[ColormapLike]]
 
 class ColormapBatch(BaseBatch[ColormapArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.Colormap"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Colormap")
 
     @staticmethod
     def _native_to_pa_array(data: ColormapArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/depth_meter.py
+++ b/rerun_py/rerun_sdk/rerun/components/depth_meter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -34,7 +35,7 @@ class DepthMeter(datatypes.Float32, ComponentMixin):
 
 
 class DepthMeterBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.DepthMeter"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.DepthMeter")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
+++ b/rerun_py/rerun_sdk/rerun/components/disconnected_space.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .disconnected_space_ext import DisconnectedSpaceExt
@@ -33,7 +34,7 @@ class DisconnectedSpace(DisconnectedSpaceExt, datatypes.Bool, ComponentMixin):
 
 
 class DisconnectedSpaceBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.DisconnectedSpace"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.DisconnectedSpace")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/draw_order.py
+++ b/rerun_py/rerun_sdk/rerun/components/draw_order.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +33,7 @@ class DrawOrder(datatypes.Float32, ComponentMixin):
 
 
 class DrawOrderBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.DrawOrder"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.DrawOrder")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/entity_path.py
+++ b/rerun_py/rerun_sdk/rerun/components/entity_path.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class EntityPath(datatypes.EntityPath, ComponentMixin):
 
 
 class EntityPathBatch(datatypes.EntityPathBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.EntityPath"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.EntityPath")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/fill_mode.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_mode.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["FillMode", "FillModeArrayLike", "FillModeBatch", "FillModeLike"]
@@ -77,7 +78,7 @@ FillModeArrayLike = Union[FillModeLike, Sequence[FillModeLike]]
 
 class FillModeBatch(BaseBatch[FillModeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.FillMode"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.FillMode")
 
     @staticmethod
     def _native_to_pa_array(data: FillModeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
+++ b/rerun_py/rerun_sdk/rerun/components/fill_ratio.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +33,7 @@ class FillRatio(datatypes.Float32, ComponentMixin):
 
 
 class FillRatioBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.FillRatio"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.FillRatio")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
+++ b/rerun_py/rerun_sdk/rerun/components/gamma_correction.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -33,7 +34,7 @@ class GammaCorrection(datatypes.Float32, ComponentMixin):
 
 
 class GammaCorrectionBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.GammaCorrection"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GammaCorrection")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
+++ b/rerun_py/rerun_sdk/rerun/components/geo_line_string.py
@@ -16,6 +16,7 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .geo_line_string_ext import GeoLineStringExt
@@ -50,7 +51,7 @@ class GeoLineStringBatch(BaseBatch[GeoLineStringArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.components.GeoLineString"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GeoLineString")
 
     @staticmethod
     def _native_to_pa_array(data: GeoLineStringArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/graph_edge.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_edge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class GraphEdge(datatypes.Utf8Pair, ComponentMixin):
 
 
 class GraphEdgeBatch(datatypes.Utf8PairBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.GraphEdge"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphEdge")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/graph_node.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_node.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class GraphNode(datatypes.Utf8, ComponentMixin):
 
 
 class GraphNodeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.GraphNode"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphNode")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/graph_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/graph_type.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["GraphType", "GraphTypeArrayLike", "GraphTypeBatch", "GraphTypeLike"]
@@ -56,7 +57,7 @@ GraphTypeArrayLike = Union[GraphTypeLike, Sequence[GraphTypeLike]]
 
 class GraphTypeBatch(BaseBatch[GraphTypeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.GraphType"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.GraphType")
 
     @staticmethod
     def _native_to_pa_array(data: GraphTypeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/half_size2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +33,7 @@ class HalfSize2D(datatypes.Vec2D, ComponentMixin):
 
 
 class HalfSize2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.HalfSize2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.HalfSize2D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/half_size3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/half_size3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +33,7 @@ class HalfSize3D(datatypes.Vec3D, ComponentMixin):
 
 
 class HalfSize3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.HalfSize3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.HalfSize3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_buffer.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_buffer.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class ImageBuffer(datatypes.Blob, ComponentMixin):
 
 
 class ImageBufferBatch(datatypes.BlobBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ImageBuffer"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImageBuffer")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_format.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_format.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ImageFormat(datatypes.ImageFormat, ComponentMixin):
 
 
 class ImageFormatBatch(datatypes.ImageFormatBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ImageFormat"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImageFormat")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
+++ b/rerun_py/rerun_sdk/rerun/components/image_plane_distance.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class ImagePlaneDistance(datatypes.Float32, ComponentMixin):
 
 
 class ImagePlaneDistanceBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ImagePlaneDistance"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ImagePlaneDistance")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
+++ b/rerun_py/rerun_sdk/rerun/components/keypoint_id.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -32,7 +33,7 @@ class KeypointId(datatypes.KeypointId, ComponentMixin):
 
 
 class KeypointIdBatch(datatypes.KeypointIdBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.KeypointId"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.KeypointId")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/lat_lon.py
+++ b/rerun_py/rerun_sdk/rerun/components/lat_lon.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class LatLon(datatypes.DVec2D, ComponentMixin):
 
 
 class LatLonBatch(datatypes.DVec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.LatLon"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LatLon")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/length.py
+++ b/rerun_py/rerun_sdk/rerun/components/length.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +31,7 @@ class Length(datatypes.Float32, ComponentMixin):
 
 
 class LengthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Length"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Length")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip2d.py
@@ -16,6 +16,7 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .line_strip2d_ext import LineStrip2DExt
@@ -68,7 +69,7 @@ class LineStrip2DBatch(BaseBatch[LineStrip2DArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.components.LineStrip2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LineStrip2D")
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip2DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/line_strip3d.py
@@ -16,6 +16,7 @@ from .. import datatypes
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .line_strip3d_ext import LineStrip3DExt
@@ -68,7 +69,7 @@ class LineStrip3DBatch(BaseBatch[LineStrip3DArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.components.LineStrip3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.LineStrip3D")
 
     @staticmethod
     def _native_to_pa_array(data: LineStrip3DArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
+++ b/rerun_py/rerun_sdk/rerun/components/magnification_filter.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["MagnificationFilter", "MagnificationFilterArrayLike", "MagnificationFilterBatch", "MagnificationFilterLike"]
@@ -65,7 +66,7 @@ MagnificationFilterArrayLike = Union[MagnificationFilterLike, Sequence[Magnifica
 
 class MagnificationFilterBatch(BaseBatch[MagnificationFilterArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.MagnificationFilter"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MagnificationFilter")
 
     @staticmethod
     def _native_to_pa_array(data: MagnificationFilterArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_shape.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_shape.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["MarkerShape", "MarkerShapeArrayLike", "MarkerShapeBatch", "MarkerShapeLike"]
@@ -105,7 +106,7 @@ MarkerShapeArrayLike = Union[MarkerShapeLike, Sequence[MarkerShapeLike]]
 
 class MarkerShapeBatch(BaseBatch[MarkerShapeArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.MarkerShape"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MarkerShape")
 
     @staticmethod
     def _native_to_pa_array(data: MarkerShapeArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/marker_size.py
+++ b/rerun_py/rerun_sdk/rerun/components/marker_size.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class MarkerSize(datatypes.Float32, ComponentMixin):
 
 
 class MarkerSizeBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.MarkerSize"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MarkerSize")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/media_type.py
+++ b/rerun_py/rerun_sdk/rerun/components/media_type.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .media_type_ext import MediaTypeExt
@@ -31,7 +32,7 @@ class MediaType(MediaTypeExt, datatypes.Utf8, ComponentMixin):
 
 
 class MediaTypeBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.MediaType"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.MediaType")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/name.py
+++ b/rerun_py/rerun_sdk/rerun/components/name.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Name(datatypes.Utf8, ComponentMixin):
 
 
 class NameBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Name"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Name")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/opacity.py
+++ b/rerun_py/rerun_sdk/rerun/components/opacity.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +31,7 @@ class Opacity(datatypes.Float32, ComponentMixin):
 
 
 class OpacityBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Opacity"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Opacity")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
+++ b/rerun_py/rerun_sdk/rerun/components/pinhole_projection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -39,7 +40,7 @@ class PinholeProjection(datatypes.Mat3x3, ComponentMixin):
 
 
 class PinholeProjectionBatch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PinholeProjection"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PinholeProjection")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/plane3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/plane3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -35,7 +36,7 @@ class Plane3D(datatypes.Plane3D, ComponentMixin):
 
 
 class Plane3DBatch(datatypes.Plane3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Plane3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Plane3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_axis_angle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class PoseRotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
 
 
 class PoseRotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PoseRotationAxisAngle"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseRotationAxisAngle")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_rotation_quat.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +31,7 @@ class PoseRotationQuat(datatypes.Quaternion, ComponentMixin):
 
 
 class PoseRotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PoseRotationQuat"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseRotationQuat")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_scale3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .pose_scale3d_ext import PoseScale3DExt
@@ -32,7 +33,7 @@ class PoseScale3D(PoseScale3DExt, datatypes.Vec3D, ComponentMixin):
 
 
 class PoseScale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PoseScale3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseScale3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_transform_mat3x3.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -61,7 +62,7 @@ class PoseTransformMat3x3(datatypes.Mat3x3, ComponentMixin):
 
 
 class PoseTransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PoseTransformMat3x3"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseTransformMat3x3")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/pose_translation3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class PoseTranslation3D(datatypes.Vec3D, ComponentMixin):
 
 
 class PoseTranslation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.PoseTranslation3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.PoseTranslation3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Position2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Position2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Position2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Position2D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/position3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/position3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Position3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Position3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Position3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Position3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/radius.py
+++ b/rerun_py/rerun_sdk/rerun/components/radius.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .radius_ext import RadiusExt
@@ -35,7 +36,7 @@ class Radius(RadiusExt, datatypes.Float32, ComponentMixin):
 
 
 class RadiusBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Radius"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Radius")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/range1d.py
+++ b/rerun_py/rerun_sdk/rerun/components/range1d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Range1D(datatypes.Range1D, ComponentMixin):
 
 
 class Range1DBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Range1D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Range1D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/recording_uri.py
+++ b/rerun_py/rerun_sdk/rerun/components/recording_uri.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class RecordingUri(datatypes.Utf8, ComponentMixin):
 
 
 class RecordingUriBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.RecordingUri"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.RecordingUri")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/resolution.py
+++ b/rerun_py/rerun_sdk/rerun/components/resolution.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class Resolution(datatypes.Vec2D, ComponentMixin):
 
 
 class ResolutionBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Resolution"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Resolution")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_axis_angle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class RotationAxisAngle(datatypes.RotationAxisAngle, ComponentMixin):
 
 
 class RotationAxisAngleBatch(datatypes.RotationAxisAngleBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.RotationAxisAngle"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.RotationAxisAngle")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
+++ b/rerun_py/rerun_sdk/rerun/components/rotation_quat.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -30,7 +31,7 @@ class RotationQuat(datatypes.Quaternion, ComponentMixin):
 
 
 class RotationQuatBatch(datatypes.QuaternionBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.RotationQuat"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.RotationQuat")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scalar.py
+++ b/rerun_py/rerun_sdk/rerun/components/scalar.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -29,7 +30,7 @@ class Scalar(datatypes.Float64, ComponentMixin):
 
 
 class ScalarBatch(datatypes.Float64Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Scalar"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Scalar")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/scale3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/scale3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .scale3d_ext import Scale3DExt
@@ -32,7 +33,7 @@ class Scale3D(Scale3DExt, datatypes.Vec3D, ComponentMixin):
 
 
 class Scale3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Scale3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Scale3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/show_labels.py
+++ b/rerun_py/rerun_sdk/rerun/components/show_labels.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -31,7 +32,7 @@ class ShowLabels(datatypes.Bool, ComponentMixin):
 
 
 class ShowLabelsBatch(datatypes.BoolBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ShowLabels"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ShowLabels")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/stroke_width.py
+++ b/rerun_py/rerun_sdk/rerun/components/stroke_width.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class StrokeWidth(datatypes.Float32, ComponentMixin):
 
 
 class StrokeWidthBatch(datatypes.Float32Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.StrokeWidth"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.StrokeWidth")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_data.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_data.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -34,7 +35,7 @@ class TensorData(datatypes.TensorData, ComponentMixin):
 
 
 class TensorDataBatch(datatypes.TensorDataBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TensorData"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorData")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_dimension_index_selection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class TensorDimensionIndexSelection(datatypes.TensorDimensionIndexSelection, Com
 
 
 class TensorDimensionIndexSelectionBatch(datatypes.TensorDimensionIndexSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TensorDimensionIndexSelection"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorDimensionIndexSelection")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_height_dimension.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class TensorHeightDimension(datatypes.TensorDimensionSelection, ComponentMixin):
 
 
 class TensorHeightDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TensorHeightDimension"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorHeightDimension")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
+++ b/rerun_py/rerun_sdk/rerun/components/tensor_width_dimension.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class TensorWidthDimension(datatypes.TensorDimensionSelection, ComponentMixin):
 
 
 class TensorWidthDimensionBatch(datatypes.TensorDimensionSelectionBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TensorWidthDimension"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TensorWidthDimension")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/texcoord2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -42,7 +43,7 @@ class Texcoord2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Texcoord2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Texcoord2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Texcoord2D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text.py
+++ b/rerun_py/rerun_sdk/rerun/components/text.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Text(datatypes.Utf8, ComponentMixin):
 
 
 class TextBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Text"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Text")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/text_log_level.py
+++ b/rerun_py/rerun_sdk/rerun/components/text_log_level.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .text_log_level_ext import TextLogLevelExt
@@ -36,7 +37,7 @@ class TextLogLevel(TextLogLevelExt, datatypes.Utf8, ComponentMixin):
 
 
 class TextLogLevelBatch(datatypes.Utf8Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TextLogLevel"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TextLogLevel")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_mat3x3.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -61,7 +62,7 @@ class TransformMat3x3(datatypes.Mat3x3, ComponentMixin):
 
 
 class TransformMat3x3Batch(datatypes.Mat3x3Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TransformMat3x3"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TransformMat3x3")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/transform_relation.py
+++ b/rerun_py/rerun_sdk/rerun/components/transform_relation.py
@@ -12,6 +12,7 @@ import pyarrow as pa
 from .._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
 )
 
 __all__ = ["TransformRelation", "TransformRelationArrayLike", "TransformRelationBatch", "TransformRelationLike"]
@@ -70,7 +71,7 @@ TransformRelationArrayLike = Union[TransformRelationLike, Sequence[TransformRela
 
 class TransformRelationBatch(BaseBatch[TransformRelationArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.uint8()
-    _COMPONENT_NAME: str = "rerun.components.TransformRelation"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TransformRelation")
 
     @staticmethod
     def _native_to_pa_array(data: TransformRelationArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/rerun_sdk/rerun/components/translation3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/translation3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Translation3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Translation3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Translation3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Translation3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
+++ b/rerun_py/rerun_sdk/rerun/components/triangle_indices.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class TriangleIndices(datatypes.UVec3D, ComponentMixin):
 
 
 class TriangleIndicesBatch(datatypes.UVec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.TriangleIndices"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.TriangleIndices")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/value_range.py
+++ b/rerun_py/rerun_sdk/rerun/components/value_range.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class ValueRange(datatypes.Range1D, ComponentMixin):
 
 
 class ValueRangeBatch(datatypes.Range1DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ValueRange"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ValueRange")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector2d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector2d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Vector2D(datatypes.Vec2D, ComponentMixin):
 
 
 class Vector2DBatch(datatypes.Vec2DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Vector2D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Vector2D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/vector3d.py
+++ b/rerun_py/rerun_sdk/rerun/components/vector3d.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -25,7 +26,7 @@ class Vector3D(datatypes.Vec3D, ComponentMixin):
 
 
 class Vector3DBatch(datatypes.Vec3DBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.Vector3D"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.Vector3D")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
+++ b/rerun_py/rerun_sdk/rerun/components/video_timestamp.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .video_timestamp_ext import VideoTimestampExt
@@ -26,7 +27,7 @@ class VideoTimestamp(VideoTimestampExt, datatypes.VideoTimestamp, ComponentMixin
 
 
 class VideoTimestampBatch(datatypes.VideoTimestampBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.VideoTimestamp"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.VideoTimestamp")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
+++ b/rerun_py/rerun_sdk/rerun/components/view_coordinates.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from .. import datatypes
 from .._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from .view_coordinates_ext import ViewCoordinatesExt
@@ -45,7 +46,7 @@ class ViewCoordinates(ViewCoordinatesExt, datatypes.ViewCoordinates, ComponentMi
 
 
 class ViewCoordinatesBatch(datatypes.ViewCoordinatesBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.components.ViewCoordinates"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.components.ViewCoordinates")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -1,5 +1,7 @@
 //! Methods for handling Arrow datamodel log ingest
 
+use std::borrow::Cow;
+
 use arrow::{
     array::{make_array, ArrayData},
     pyarrow::PyArrowType,
@@ -11,20 +13,49 @@ use arrow2::{
 };
 use pyo3::{
     exceptions::PyRuntimeError,
-    types::{PyAnyMethods as _, PyDict, PyDictMethods, PyString},
+    types::{PyAnyMethods, PyDict, PyDictMethods, PyString},
     Bound, PyAny, PyResult,
 };
 
-use re_chunk::{Chunk, ChunkError, ChunkId, PendingRow, RowId, TimeColumn};
+use re_chunk::{Chunk, ChunkError, ChunkId, PendingRow, RowId, TimeColumn, TransportChunk};
 use re_log_types::TimePoint;
 use re_sdk::{external::nohash_hasher::IntMap, ComponentDescriptor, EntityPath, Timeline};
+
+/// Perform Python-to-Rust conversion for a `ComponentDescriptor`.
+pub fn descriptor_to_rust(component_descr: &Bound<'_, PyAny>) -> PyResult<ComponentDescriptor> {
+    let py = component_descr.py();
+
+    let archetype_name = component_descr.getattr(pyo3::intern!(py, "archetype_name"))?;
+    let archetype_name: Option<Cow<'_, str>> = if !archetype_name.is_none() {
+        Some(archetype_name.extract()?)
+    } else {
+        None
+    };
+
+    let archetype_field_name =
+        component_descr.getattr(pyo3::intern!(py, "archetype_field_name"))?;
+    let archetype_field_name: Option<Cow<'_, str>> = if !archetype_field_name.is_none() {
+        Some(archetype_field_name.extract()?)
+    } else {
+        None
+    };
+
+    let component_name = component_descr.getattr(pyo3::intern!(py, "component_name"))?;
+    let component_name: Cow<'_, str> = component_name.extract()?;
+
+    Ok(ComponentDescriptor {
+        archetype_name: archetype_name.map(|s| s.as_ref().into()),
+        archetype_field_name: archetype_field_name.map(|s| s.as_ref().into()),
+        component_name: component_name.as_ref().into(),
+    })
+}
 
 /// Perform conversion between a pyarrow array to arrow2 types.
 ///
 /// `name` is the name of the Rerun component, and the name of the pyarrow `Field` (column name).
 pub fn array_to_rust(
     arrow_array: &Bound<'_, PyAny>,
-    name: &str,
+    component_descr: &ComponentDescriptor,
 ) -> PyResult<(Box<dyn Array>, Field)> {
     let py_array: PyArrowType<ArrayData> = arrow_array.extract()?;
     let arr1_array = make_array(py_array.0);
@@ -33,34 +64,33 @@ pub fn array_to_rust(
     let arr2_array = arrow2::array::from_data(&data);
 
     let datatype = arr2_array.data_type().to_logical_type().clone();
-    let field = Field::new(name, datatype.clone(), true);
+    let metadata = TransportChunk::field_metadata_component_descriptor(component_descr);
+    let field = Field::new(
+        component_descr.component_name.to_string(),
+        datatype.clone(),
+        true,
+    )
+    .with_metadata(metadata);
 
     Ok((arr2_array, field))
 }
 
 /// Build a [`PendingRow`] given a '**kwargs'-style dictionary of component arrays.
 pub fn build_row_from_components(
-    components: &Bound<'_, PyDict>,
+    components_per_descr: &Bound<'_, PyDict>,
     time_point: &TimePoint,
 ) -> PyResult<PendingRow> {
     // Create row-id as early as possible. It has a timestamp and is used to estimate e2e latency.
     // TODO(emilk): move to before we arrow-serialize the data
     let row_id = RowId::new();
 
-    let (arrays, fields): (Vec<Box<dyn Array>>, Vec<Field>) = itertools::process_results(
-        components.iter().map(|(name, array)| {
-            let py_name = name.downcast::<PyString>()?;
-            let name: std::borrow::Cow<'_, str> = py_name.extract()?;
-            array_to_rust(&array, &name)
-        }),
-        |iter| iter.unzip(),
-    )?;
+    let mut components = IntMap::default();
+    for (component_descr, array) in components_per_descr {
+        let component_descr = descriptor_to_rust(&component_descr)?;
+        let (list_array, _field) = array_to_rust(&array, &component_descr)?;
 
-    let components = arrays
-        .into_iter()
-        .zip(fields)
-        .map(|(value, field)| (ComponentDescriptor::new(field.name), value))
-        .collect();
+        components.insert(component_descr, list_array);
+    }
 
     Ok(PendingRow {
         row_id,
@@ -73,7 +103,7 @@ pub fn build_row_from_components(
 pub fn build_chunk_from_components(
     entity_path: EntityPath,
     timelines: &Bound<'_, PyDict>,
-    components: &Bound<'_, PyDict>,
+    components_per_descr: &Bound<'_, PyDict>,
 ) -> PyResult<Chunk> {
     // Create chunk-id as early as possible. It has a timestamp and is used to estimate e2e latency.
     let chunk_id = ChunkId::new();
@@ -83,7 +113,7 @@ pub fn build_chunk_from_components(
         timelines.iter().map(|(name, array)| {
             let py_name = name.downcast::<PyString>()?;
             let name: std::borrow::Cow<'_, str> = py_name.extract()?;
-            array_to_rust(&array, &name)
+            array_to_rust(&array, &ComponentDescriptor::new(name.to_string()))
         }),
         |iter| iter.unzip(),
     )?;
@@ -122,15 +152,13 @@ pub fn build_chunk_from_components(
 
     // Extract the component data
     let (arrays, fields): (Vec<Box<dyn Array>>, Vec<Field>) = itertools::process_results(
-        components.iter().map(|(name, array)| {
-            let py_name = name.downcast::<PyString>()?;
-            let name: std::borrow::Cow<'_, str> = py_name.extract()?;
-            array_to_rust(&array, &name)
+        components_per_descr.iter().map(|(component_descr, array)| {
+            array_to_rust(&array, &descriptor_to_rust(&component_descr)?)
         }),
         |iter| iter.unzip(),
     )?;
 
-    let components: Result<Vec<_>, ChunkError> = arrays
+    let components: Result<Vec<(ComponentDescriptor, _)>, ChunkError> = arrays
         .into_iter()
         .zip(fields)
         .map(|(value, field)| {

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -434,8 +434,8 @@ impl FromPyObject<'_> for ComponentLike {
             Ok(Self(component_str))
         } else if let Ok(component_str) = component
             .getattr("_BATCH_TYPE")
-            .and_then(|batch_type| batch_type.getattr("_COMPONENT_NAME"))
-            .and_then(|type_name| type_name.extract::<String>())
+            .and_then(|batch_type| batch_type.getattr("_COMPONENT_DESCRIPTOR"))
+            .and_then(|descr| descr.getattr("component_name")?.extract::<String>())
         {
             Ok(Self(component_str))
         } else {

--- a/rerun_py/src/video.rs
+++ b/rerun_py/src/video.rs
@@ -1,6 +1,7 @@
 #![allow(unsafe_op_in_unsafe_fn)] // False positive due to #[pyfunction] macro
 
 use pyo3::{exceptions::PyRuntimeError, pyfunction, Bound, PyAny, PyResult};
+use re_sdk::ComponentDescriptor;
 use re_video::VideoLoadError;
 
 use crate::arrow::array_to_rust;
@@ -17,8 +18,12 @@ pub fn asset_video_read_frame_timestamps_ns(
     video_bytes_arrow_array: &Bound<'_, PyAny>,
     media_type: Option<&str>,
 ) -> PyResult<Vec<i64>> {
-    let video_bytes_arrow_array =
-        array_to_rust(video_bytes_arrow_array, "rerun.components.Blob")?.0;
+    let component_descr = ComponentDescriptor {
+        archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+        archetype_field_name: Some("blob".into()),
+        component_name: "rerun.components.Blob".into(),
+    };
+    let video_bytes_arrow_array = array_to_rust(video_bytes_arrow_array, &component_descr)?.0;
 
     let video_bytes_arrow_uint8_array = video_bytes_arrow_array
         .as_any()

--- a/rerun_py/tests/test_types/components/affix_fuzzer1.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer1.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer1(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer1Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer1"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer1")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer10.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer10.py
@@ -14,6 +14,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -45,7 +46,7 @@ AffixFuzzer10ArrayLike = Union[
 
 class AffixFuzzer10Batch(BaseBatch[AffixFuzzer10ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.utf8()
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer10"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer10")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer10ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer11.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer11.py
@@ -14,6 +14,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -49,7 +50,7 @@ AffixFuzzer11ArrayLike = Union[
 
 class AffixFuzzer11Batch(BaseBatch[AffixFuzzer11ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.float32(), nullable=False, metadata={}))
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer11"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer11")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer11ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer12.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer12.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -40,7 +41,7 @@ AffixFuzzer12ArrayLike = Union[
 
 class AffixFuzzer12Batch(BaseBatch[AffixFuzzer12ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer12"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer12")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer12ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer13.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer13.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -40,7 +41,7 @@ AffixFuzzer13ArrayLike = Union[
 
 class AffixFuzzer13Batch(BaseBatch[AffixFuzzer13ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.list_(pa.field("item", pa.utf8(), nullable=False, metadata={}))
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer13"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer13")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer13ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer14.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer14.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer14(datatypes.AffixFuzzer3, ComponentMixin):
 
 
 class AffixFuzzer14Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer14"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer14")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer15.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer15.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer15(datatypes.AffixFuzzer3, ComponentMixin):
 
 
 class AffixFuzzer15Batch(datatypes.AffixFuzzer3Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer15"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer15")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer16.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer16.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -102,7 +103,7 @@ class AffixFuzzer16Batch(BaseBatch[AffixFuzzer16ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer16"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer16")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer16ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer17.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer17.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -102,7 +103,7 @@ class AffixFuzzer17Batch(BaseBatch[AffixFuzzer17ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer17"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer17")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer17ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer18.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer18.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -186,7 +187,7 @@ class AffixFuzzer18Batch(BaseBatch[AffixFuzzer18ArrayLike], ComponentBatchMixin)
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer18"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer18")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer18ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer19.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer19.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer19(datatypes.AffixFuzzer5, ComponentMixin):
 
 
 class AffixFuzzer19Batch(datatypes.AffixFuzzer5Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer19"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer19")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer2.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer2.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer2(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer2Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer2"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer2")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer20.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer20.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer20(datatypes.AffixFuzzer20, ComponentMixin):
 
 
 class AffixFuzzer20Batch(datatypes.AffixFuzzer20Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer20"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer20")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer21.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer21.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer21(datatypes.AffixFuzzer21, ComponentMixin):
 
 
 class AffixFuzzer21Batch(datatypes.AffixFuzzer21Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer21"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer21")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer22.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer22.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer22(datatypes.AffixFuzzer22, ComponentMixin):
 
 
 class AffixFuzzer22Batch(datatypes.AffixFuzzer22Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer22"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer22")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer23.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer23.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer23(datatypes.MultiEnum, ComponentMixin):
 
 
 class AffixFuzzer23Batch(datatypes.MultiEnumBatch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer23"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer23")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer3.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer3.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer3(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer3Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer3"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer3")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer4.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer4.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer4(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer4Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer4"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer4")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer5.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer5.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer5(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer5Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer5"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer5")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer6.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer6.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from rerun._baseclasses import (
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -24,7 +25,7 @@ class AffixFuzzer6(datatypes.AffixFuzzer1, ComponentMixin):
 
 
 class AffixFuzzer6Batch(datatypes.AffixFuzzer1Batch, ComponentBatchMixin):
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer6"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer6")
 
 
 # This is patched in late to avoid circular dependencies.

--- a/rerun_py/tests/test_types/components/affix_fuzzer7.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer7.py
@@ -12,6 +12,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -79,7 +80,7 @@ class AffixFuzzer7Batch(BaseBatch[AffixFuzzer7ArrayLike], ComponentBatchMixin):
             metadata={},
         )
     )
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer7"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer7")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer7ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer8.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer8.py
@@ -14,6 +14,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 from rerun._converters import (
@@ -49,7 +50,7 @@ AffixFuzzer8ArrayLike = Union[
 
 class AffixFuzzer8Batch(BaseBatch[AffixFuzzer8ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.float32()
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer8"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer8")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer8ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/test_types/components/affix_fuzzer9.py
+++ b/rerun_py/tests/test_types/components/affix_fuzzer9.py
@@ -14,6 +14,7 @@ from attrs import define, field
 from rerun._baseclasses import (
     BaseBatch,
     ComponentBatchMixin,
+    ComponentDescriptor,
     ComponentMixin,
 )
 
@@ -48,7 +49,7 @@ AffixFuzzer9ArrayLike = Union[
 
 class AffixFuzzer9Batch(BaseBatch[AffixFuzzer9ArrayLike], ComponentBatchMixin):
     _ARROW_DATATYPE = pa.utf8()
-    _COMPONENT_NAME: str = "rerun.testing.components.AffixFuzzer9"
+    _COMPONENT_DESCRIPTOR: ComponentDescriptor = ComponentDescriptor("rerun.testing.components.AffixFuzzer9")
 
     @staticmethod
     def _native_to_pa_array(data: AffixFuzzer9ArrayLike, data_type: pa.DataType) -> pa.Array:

--- a/rerun_py/tests/unit/test_any_values.py
+++ b/rerun_py/tests/unit/test_any_values.py
@@ -14,8 +14,8 @@ def test_any_value() -> None:
     foo_batch = batches[0]
     bar_batch = batches[1]
 
-    assert foo_batch.component_name() == "foo"
-    assert bar_batch.component_name() == "bar"
+    assert foo_batch.component_descriptor() == rr.ComponentDescriptor("foo")
+    assert bar_batch.component_descriptor() == rr.ComponentDescriptor("bar")
     assert len(foo_batch.as_arrow_array()) == 3
     assert len(bar_batch.as_arrow_array()) == 1
     assert np.all(foo_batch.as_arrow_array().to_numpy() == np.array([1.0, 2.0, 3.0]))
@@ -28,7 +28,7 @@ def test_any_value_datatypes() -> None:
 
     foo_batch = batches[0]
 
-    assert foo_batch.component_name() == "my_points"
+    assert foo_batch.component_descriptor() == rr.ComponentDescriptor("my_points")
     assert len(foo_batch.as_arrow_array()) == 3
 
 

--- a/rerun_py/tests/unit/test_dataframe.py
+++ b/rerun_py/tests/unit/test_dataframe.py
@@ -108,10 +108,10 @@ class TestDataframe:
         assert schema.index_columns()[1].name == "log_time"
         assert schema.index_columns()[2].name == "my_index"
         assert schema.component_columns()[0].entity_path == "/points"
-        assert schema.component_columns()[0].component_name == "rerun.components.Color"
+        assert schema.component_columns()[0].component_name == "rerun.components.Points3DIndicator"
         assert schema.component_columns()[0].is_static is False
         assert schema.component_columns()[1].entity_path == "/points"
-        assert schema.component_columns()[1].component_name == "rerun.components.Points3DIndicator"
+        assert schema.component_columns()[1].component_name == "rerun.components.Color"
         assert schema.component_columns()[1].is_static is False
         assert schema.component_columns()[2].entity_path == "/points"
         assert schema.component_columns()[2].component_name == "rerun.components.Position3D"
@@ -120,8 +120,11 @@ class TestDataframe:
         assert schema.component_columns()[3].component_name == "rerun.components.Radius"
         assert schema.component_columns()[3].is_static is False
         assert schema.component_columns()[4].entity_path == "/static_text"
-        assert schema.component_columns()[4].component_name == "rerun.components.Text"
+        assert schema.component_columns()[4].component_name == "rerun.components.TextLogIndicator"
         assert schema.component_columns()[4].is_static is True
+        assert schema.component_columns()[5].entity_path == "/static_text"
+        assert schema.component_columns()[5].component_name == "rerun.components.Text"
+        assert schema.component_columns()[5].is_static is True
 
     def test_schema_view(self) -> None:
         schema = self.recording.view(index="my_index", contents="points").schema()


### PR DESCRIPTION
This semantically mimics very closely the way things are done in Rust, minus all technical differences due to the differences between both the languages and the SDKs.
For that reason, everything stated in https://github.com/rerun-io/rerun/pull/8304#issue-2715466746 basically applies as-is.

Pretty happy about it, I must say.

* DNM: requires #8316 
* Part of #7948 