### PR TITLE
Improve the unknown view class text

### DIFF
--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -1,10 +1,11 @@
+use re_types::SpaceViewClassIdentifier;
+use re_ui::UiExt;
+
 use crate::{
     SpaceViewClass, SpaceViewClassRegistryError, SpaceViewSpawnHeuristics, SpaceViewState,
     SpaceViewSystemExecutionError, SpaceViewSystemRegistrator, SystemExecutionOutput, ViewQuery,
     ViewerContext,
 };
-use re_types::SpaceViewClassIdentifier;
-use re_ui::UiExt;
 
 /// A placeholder space view class that can be used when the actual class is not registered.
 #[derive(Default)]

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -24,15 +24,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
     }
 
     fn help_markdown(&self, _egui_ctx: &egui::Context) -> String {
-        "The space view class was not recognized.\n\n\
-        \
-        This happens if either the blueprint specifies an invalid space view class or this version \
-        of the viewer does not know about \
-        this type.\n\n\
-        \
-        **Note**: some views may require a specific Cargo feature to be enabled. In particular, \
-        the map view requires the `map_view` feature."
-            .to_owned()
+        "Placeholder view for unknown space view class".to_owned()
     }
 
     fn on_register(
@@ -56,7 +48,7 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
 
     fn ui(
         &self,
-        ctx: &ViewerContext<'_>,
+        _ctx: &ViewerContext<'_>,
         ui: &mut egui::Ui,
         _state: &mut dyn SpaceViewState,
         _query: &ViewQuery<'_>,
@@ -67,7 +59,15 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
             ..Default::default()
         }
         .show(ui, |ui| {
-            ui.markdown_ui(&self.help_markdown(ctx.egui_ctx));
+            ui.warning_label("Unknown space view class");
+
+            ui.markdown_ui(
+                "This happens if either the blueprint specifies an invalid space view class or \
+                this version of the viewer does not know about this type.\n\n\
+                \
+                **Note**: some views may require a specific Cargo feature to be enabled. In \
+                particular, the map view requires the `map_view` feature.",
+            );
         });
 
         Ok(())

--- a/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/space_view_class_placeholder.rs
@@ -24,7 +24,15 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
     }
 
     fn help_markdown(&self, _egui_ctx: &egui::Context) -> String {
-        "The space view class was not recognized.\n\nThis happens if either the blueprint specifies an invalid space view class or this version of the viewer does not know about this type.".to_owned()
+        "The space view class was not recognized.\n\n\
+        \
+        This happens if either the blueprint specifies an invalid space view class or this version \
+        of the viewer does not know about \
+        this type.\n\n\
+        \
+        **Note**: some views may require a specific Cargo feature to be enabled. In particular, \
+        the map view requires the `map_view` feature."
+            .to_owned()
     }
 
     fn on_register(
@@ -54,7 +62,13 @@ impl SpaceViewClass for SpaceViewClassPlaceholder {
         _query: &ViewQuery<'_>,
         _system_output: SystemExecutionOutput,
     ) -> Result<(), SpaceViewSystemExecutionError> {
-        ui.markdown_ui(&self.help_markdown(ctx.egui_ctx));
+        egui::Frame {
+            inner_margin: egui::Margin::same(re_ui::DesignTokens::view_padding()),
+            ..Default::default()
+        }
+        .show(ui, |ui| {
+            ui.markdown_ui(&self.help_markdown(ctx.egui_ctx));
+        });
 
         Ok(())
     }


### PR DESCRIPTION
### Related

- Closes #8052


### What

Update the unknown view ui. Now hints at enabling `map_view` if a map view was expected.

<img width="535" alt="image" src="https://github.com/user-attachments/assets/51d0687b-4705-4d90-a599-a5fce2e2e008">

**Note**: I tried to make that message depend on the actual identifier that was used (to special case `"map"`), but bailed out if it as it messed too much with the view class registrar for my taste.