### PR TITLE
End-to-end tagging: Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8024,6 +8024,7 @@ dependencies = [
  "re_build_tools",
  "rerun",
  "rust-format",
+ "similar-asserts",
 ]
 
 [[package]]

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -185,7 +185,7 @@ fn generate_object_file(
     code.push_str("use ::re_types_core::SerializationResult;\n");
     code.push_str("use ::re_types_core::{DeserializationResult, DeserializationError};\n");
     code.push_str("use ::re_types_core::{ComponentDescriptor, ComponentName};\n");
-    code.push_str("use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};\n");
+    code.push_str("use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};\n");
 
     // NOTE: `TokenStream`s discard whitespacing information by definition, so we need to
     // inject some of our own when writing to file… while making sure that don't inject
@@ -1172,7 +1172,7 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
 
             quote! {
                 (#batch).map(|batch| {
-                    ::re_types_core::MaybeOwnedComponentBatch {
+                    ::re_types_core::ComponentBatchCowWithDescriptor {
                         batch: batch.into(),
                         descriptor_override: Some(ComponentDescriptor {
                             archetype_name: Some(#archetype_name.into()),
@@ -1299,9 +1299,9 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
             }
 
             #[inline]
-            fn indicator() -> MaybeOwnedComponentBatch<'static> {
+            fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
                 static INDICATOR: #quoted_indicator_name = #quoted_indicator_name::DEFAULT;
-                MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+                ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
             }
 
             #[inline]
@@ -1352,7 +1352,7 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
         }
 
         impl ::re_types_core::AsComponents for #name {
-            fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+            fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
                 re_tracing::profile_function!();
 
                 use ::re_types_core::Archetype as _;

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -16,7 +16,7 @@ use crate::{
                 should_optimize_buffer_slice_deserialize,
             },
             serializer::quote_arrow_serializer,
-            util::{is_tuple_struct_from_obj, iter_archetype_components, quote_doc_line},
+            util::{is_tuple_struct_from_obj, quote_doc_line},
         },
         Target,
     },
@@ -184,7 +184,7 @@ fn generate_object_file(
     code.push_str("use ::re_types_core::external::arrow2;\n");
     code.push_str("use ::re_types_core::SerializationResult;\n");
     code.push_str("use ::re_types_core::{DeserializationResult, DeserializationError};\n");
-    code.push_str("use ::re_types_core::ComponentName;\n");
+    code.push_str("use ::re_types_core::{ComponentDescriptor, ComponentName};\n");
     code.push_str("use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};\n");
 
     // NOTE: `TokenStream`s discard whitespacing information by definition, so we need to
@@ -354,13 +354,13 @@ fn quote_struct(
         #quoted_deprecation_notice
         #quoted_struct
 
-        #quoted_heap_size_bytes
+        #quoted_trait_impls
 
         #quoted_from_impl
 
-        #quoted_trait_impls
-
         #quoted_builder
+
+        #quoted_heap_size_bytes
     };
 
     tokens
@@ -470,9 +470,9 @@ fn quote_union(
             #(#quoted_fields,)*
         }
 
-        #quoted_heap_size_bytes
-
         #quoted_trait_impls
+
+        #quoted_heap_size_bytes
     };
 
     tokens
@@ -603,6 +603,18 @@ fn quote_enum(
             #(#quoted_fields,)*
         }
 
+        #quoted_trait_impls
+
+        // We implement `Display` to match the `PascalCase` name so that
+        // the enum variants are displayed in the UI exactly how they are displayed in code.
+        impl std::fmt::Display for #name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    #(#display_match_arms,)*
+                }
+            }
+        }
+
         impl ::re_types_core::reflection::Enum for #name {
 
             #[inline]
@@ -629,18 +641,6 @@ fn quote_enum(
                 true
             }
         }
-
-        // We implement `Display` to match the `PascalCase` name so that
-        // the enum variants are displayed in the UI exactly how they are displayed in code.
-        impl std::fmt::Display for #name {
-            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                match self {
-                    #(#display_match_arms,)*
-                }
-            }
-        }
-
-        #quoted_trait_impls
     };
 
     tokens
@@ -1006,14 +1006,16 @@ fn quote_trait_impls_for_datatype_or_component(
         quote! {
             impl ::re_types_core::Component for #name {
                 #[inline]
-                fn name() -> ComponentName {
-                    #fqname.into()
+                fn descriptor() -> ComponentDescriptor {
+                    ComponentDescriptor::new(#fqname)
                 }
             }
         }
     });
 
     quote! {
+        #quoted_impl_component
+
         ::re_types_core::macros::impl_into_cow!(#name);
 
         impl ::re_types_core::Loggable for #name {
@@ -1033,8 +1035,6 @@ fn quote_trait_impls_for_datatype_or_component(
 
             #quoted_from_arrow2
         }
-
-        #quoted_impl_component
     }
 }
 
@@ -1048,40 +1048,70 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
     assert_eq!(kind, &ObjectKind::Archetype);
 
     let display_name = re_case::to_human_case(name);
+    let archetype_name = &obj.fqname;
     let name = format_ident!("{name}");
 
-    fn compute_components(
+    fn compute_component_descriptors(
         obj: &Object,
-        attr: &'static str,
-        extras: impl IntoIterator<Item = String>,
+        requirement_attr_value: &'static str,
     ) -> (usize, TokenStream) {
-        let components = iter_archetype_components(obj, attr)
-            .chain(extras)
-            // Do *not* sort again, we want to preserve the order given by the datatype definition
-            .collect::<Vec<_>>();
+        let descriptors = obj
+            .fields
+            .iter()
+            .filter_map(move |field| {
+                field
+                    .try_get_attr::<String>(requirement_attr_value)
+                    .map(|_| {
+                        let Some(component_name) = field.typ.fqname() else {
+                            panic!("Archetype field must be an object/union or an array/vector of such")
+                        };
 
-        let num_components = components.len();
-        let quoted_components = quote!(#(#components.into(),)*);
+                        let archetype_name = &obj.fqname;
+                        let archetype_field_name = field.snake_case_name();
 
-        (num_components, quoted_components)
+                        quote!(ComponentDescriptor {
+                            archetype_name: Some(#archetype_name.into()),
+                            component_name: #component_name.into(),
+                            archetype_field_name: Some(#archetype_field_name.into()),
+                        })
+                    })
+            })
+            .collect_vec();
+
+        let num_descriptors = descriptors.len();
+        let quoted_descriptors = quote!(#(#descriptors,)*);
+
+        (num_descriptors, quoted_descriptors)
     }
 
     let indicator_name = format!("{}Indicator", obj.name);
-    let indicator_fqname = format!("{}Indicator", obj.fqname).replace("archetypes", "components");
 
     let quoted_indicator_name = format_ident!("{indicator_name}");
     let quoted_indicator_doc =
         format!("Indicator component for the [`{name}`] [`::re_types_core::Archetype`]");
 
-    let (num_required, required) = compute_components(obj, ATTR_RERUN_COMPONENT_REQUIRED, []);
-    let (num_recommended, recommended) =
-        compute_components(obj, ATTR_RERUN_COMPONENT_RECOMMENDED, [indicator_fqname]);
-    let (num_optional, optional) = compute_components(obj, ATTR_RERUN_COMPONENT_OPTIONAL, []);
+    let (num_required_descriptors, required_descriptors) =
+        compute_component_descriptors(obj, ATTR_RERUN_COMPONENT_REQUIRED);
+    let (mut num_recommended_descriptors, mut recommended_descriptors) =
+        compute_component_descriptors(obj, ATTR_RERUN_COMPONENT_RECOMMENDED);
+    let (num_optional_descriptors, optional_descriptors) =
+        compute_component_descriptors(obj, ATTR_RERUN_COMPONENT_OPTIONAL);
+
+    num_recommended_descriptors += 1;
+    recommended_descriptors = quote! {
+        #recommended_descriptors
+        ComponentDescriptor {
+            archetype_name: Some(#archetype_name.into()),
+            component_name: #indicator_name.into(),
+            archetype_field_name: None,
+        },
+    };
 
     let num_components_docstring = quote_doc_line(&format!(
-        "The total number of components in the archetype: {num_required} required, {num_recommended} recommended, {num_optional} optional"
+        "The total number of components in the archetype: {num_required_descriptors} required, {num_recommended_descriptors} recommended, {num_optional_descriptors} optional"
     ));
-    let num_all = num_required + num_recommended + num_optional;
+    let num_all_descriptors =
+        num_required_descriptors + num_recommended_descriptors + num_optional_descriptors;
 
     let quoted_field_names = obj
         .fields
@@ -1099,13 +1129,13 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
 
             // NOTE: The nullability we're dealing with here is the nullability of an entire array of components,
             // not the nullability of individual elements (i.e. instances)!
-            if is_nullable {
+            let batch = if is_nullable {
                 if obj.attrs.has(ATTR_RERUN_LOG_MISSING_AS_EMPTY) {
                     if is_plural {
                         // Always log Option<Vec<C>> as Vec<V>, mapping None to empty batch
                         let component_type = quote_field_type_from_typ(&obj_field.typ, false).0;
                         quote! {
-                            Some((
+                            Some(
                                 if let Some(comp_batch) = &self.#field_name {
                                     (comp_batch as &dyn ComponentBatch)
                                 } else {
@@ -1114,24 +1144,44 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
                                     let empty_batch: &#component_type = EMPTY_BATCH.get_or_init(|| Vec::new());
                                     (empty_batch as &dyn ComponentBatch)
                                 }
-                            ).into())
+                            )
                         }
                     } else {
                         // Always log Option<C>, mapping None to empty batch
-                        quote! { Some((&self.#field_name as &dyn ComponentBatch).into()) }
+                        quote!{ Some(&self.#field_name as &dyn ComponentBatch) }
                     }
                 } else {
                     if is_plural {
                         // Maybe logging an Option<Vec<C>>
-                        quote! { self.#field_name.as_ref().map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()) }
+                        quote!{ self.#field_name.as_ref().map(|comp_batch| (comp_batch as &dyn ComponentBatch)) }
                     } else {
                         // Maybe logging an Option<C>
-                        quote! { self.#field_name.as_ref().map(|comp| (comp as &dyn ComponentBatch).into()) }
+                        quote!{ self.#field_name.as_ref().map(|comp| (comp as &dyn ComponentBatch)) }
                     }
                 }
             } else {
                 // Always logging a Vec<C> or C
-                quote! { Some((&self.#field_name as &dyn ComponentBatch).into()) }
+                quote!{ Some(&self.#field_name as &dyn ComponentBatch) }
+            };
+
+            let Some(component_name) = obj_field.typ.fqname() else {
+                panic!("Archetype field must be an object/union or an array/vector of such")
+            };
+            let archetype_name = &obj.fqname;
+            let archetype_field_name = obj_field.snake_case_name();
+
+            quote! {
+                (#batch).map(|batch| {
+                    ::re_types_core::MaybeOwnedComponentBatch {
+                        batch: batch.into(),
+                        descriptor_override: Some(ComponentDescriptor {
+                            archetype_name: Some(#archetype_name.into()),
+                            archetype_field_name: Some((#archetype_field_name).into()),
+                            component_name: (#component_name).into(),
+                        }),
+                    }
+                })
+
             }
         }))
     };
@@ -1215,21 +1265,21 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
     };
 
     quote! {
-        static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; #num_required]> =
-            once_cell::sync::Lazy::new(|| {[#required]});
+        static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; #num_required_descriptors]> =
+            once_cell::sync::Lazy::new(|| {[#required_descriptors]});
 
-        static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; #num_recommended]> =
-            once_cell::sync::Lazy::new(|| {[#recommended]});
+        static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; #num_recommended_descriptors]> =
+            once_cell::sync::Lazy::new(|| {[#recommended_descriptors]});
 
-        static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; #num_optional]> =
-            once_cell::sync::Lazy::new(|| {[#optional]});
+        static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; #num_optional_descriptors]> =
+            once_cell::sync::Lazy::new(|| {[#optional_descriptors]});
 
-        static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; #num_all]> =
-            once_cell::sync::Lazy::new(|| {[#required #recommended #optional]});
+        static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; #num_all_descriptors]> =
+            once_cell::sync::Lazy::new(|| {[#required_descriptors #recommended_descriptors #optional_descriptors]});
 
         impl #name {
             #num_components_docstring
-            pub const NUM_COMPONENTS: usize = #num_all;
+            pub const NUM_COMPONENTS: usize = #num_all_descriptors;
         }
 
         #[doc = #quoted_indicator_doc]
@@ -1251,27 +1301,27 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
             #[inline]
             fn indicator() -> MaybeOwnedComponentBatch<'static> {
                 static INDICATOR: #quoted_indicator_name = #quoted_indicator_name::DEFAULT;
-                MaybeOwnedComponentBatch::Ref(&INDICATOR)
+                MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
             }
 
             #[inline]
-            fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+            fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
                 REQUIRED_COMPONENTS.as_slice().into()
             }
 
             #[inline]
-            fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]>  {
+            fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]>  {
                 RECOMMENDED_COMPONENTS.as_slice().into()
             }
 
             #[inline]
-            fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]>  {
+            fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]>  {
                 OPTIONAL_COMPONENTS.as_slice().into()
             }
 
             // NOTE: Don't rely on default implementation so that we can keep everything static.
             #[inline]
-            fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]>  {
+            fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]>  {
                 ALL_COMPONENTS.as_slice().into()
             }
 
@@ -1306,7 +1356,6 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
                 re_tracing::profile_function!();
 
                 use ::re_types_core::Archetype as _;
-
                 [#(#all_component_batches,)*].into_iter().flatten().collect()
             }
         }

--- a/crates/build/re_types_builder/src/codegen/rust/util.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/util.rs
@@ -50,25 +50,6 @@ pub fn is_tuple_struct_from_obj(obj: &Object) -> bool {
     is_tuple_struct
 }
 
-pub fn iter_archetype_components<'a>(
-    obj: &'a Object,
-    requirement_attr_value: &'static str,
-) -> impl Iterator<Item = String> + 'a {
-    assert_eq!(ObjectKind::Archetype, obj.kind);
-
-    obj.fields.iter().filter_map(move |field| {
-        field
-            .try_get_attr::<String>(requirement_attr_value)
-            .map(|_| {
-                if let Some(fqname) = field.typ.fqname() {
-                    fqname.to_owned()
-                } else {
-                    panic!("Archetype field must be an object/union or an array/vector of such")
-                }
-            })
-    })
-}
-
 pub fn string_from_quoted(
     reporter: &Reporter,
     acc: &TokenStream,

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -74,7 +74,7 @@ impl ChunkComponents {
     }
 
     #[inline]
-    pub fn get_descriptor(
+    pub fn get_by_descriptor(
         &self,
         component_desc: &ComponentDescriptor,
     ) -> Option<&Arrow2ListArray<i32>> {
@@ -83,7 +83,7 @@ impl ChunkComponents {
     }
 
     #[inline]
-    pub fn get_descriptor_mut(
+    pub fn get_by_descriptor_mut(
         &mut self,
         component_desc: &ComponentDescriptor,
     ) -> Option<&mut Arrow2ListArray<i32>> {

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -14,7 +14,8 @@ use nohash_hasher::IntMap;
 
 use re_log_types::{EntityPath, ResolvedTimeRange, Time, TimeInt, TimePoint, Timeline};
 use re_types_core::{
-    ComponentName, DeserializationError, Loggable, LoggableBatch, SerializationError, SizeBytes,
+    ComponentDescriptor, ComponentName, DeserializationError, Loggable, LoggableBatch,
+    SerializationError, SizeBytes,
 };
 
 use crate::{ChunkId, RowId};
@@ -48,6 +49,109 @@ pub enum ChunkError {
 pub type ChunkResult<T> = Result<T, ChunkError>;
 
 // ---
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ChunkComponents(
+    // TODO(#6576): support non-list based columns?
+    //
+    // NOTE: The extra `ComponentName` layer is needed because it is very common to want to look
+    // for anything matching a `ComponentName`, without any further tags specified.
+    pub IntMap<ComponentName, IntMap<ComponentDescriptor, Arrow2ListArray<i32>>>,
+);
+
+impl ChunkComponents {
+    /// Like `Self::insert`, but automatically infers the [`ComponentName`] layer.
+    #[inline]
+    pub fn insert_descriptor(
+        &mut self,
+        component_desc: ComponentDescriptor,
+        list_array: Arrow2ListArray<i32>,
+    ) {
+        self.0
+            .entry(component_desc.component_name)
+            .or_default()
+            .insert(component_desc, list_array);
+    }
+
+    #[inline]
+    pub fn get_descriptor(
+        &self,
+        component_desc: &ComponentDescriptor,
+    ) -> Option<&Arrow2ListArray<i32>> {
+        self.get(&component_desc.component_name)
+            .and_then(|per_desc| per_desc.get(component_desc))
+    }
+
+    #[inline]
+    pub fn get_descriptor_mut(
+        &mut self,
+        component_desc: &ComponentDescriptor,
+    ) -> Option<&mut Arrow2ListArray<i32>> {
+        self.get_mut(&component_desc.component_name)
+            .and_then(|per_desc| per_desc.get_mut(component_desc))
+    }
+
+    #[inline]
+    pub fn iter_flattened(
+        &self,
+    ) -> impl Iterator<Item = (&ComponentDescriptor, &Arrow2ListArray<i32>)> {
+        self.0.values().flatten()
+    }
+
+    #[inline]
+    pub fn into_iter_flattened(
+        self,
+    ) -> impl Iterator<Item = (ComponentDescriptor, Arrow2ListArray<i32>)> {
+        self.0.into_values().flatten()
+    }
+}
+
+impl std::ops::Deref for ChunkComponents {
+    type Target = IntMap<ComponentName, IntMap<ComponentDescriptor, Arrow2ListArray<i32>>>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ChunkComponents {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl FromIterator<(ComponentDescriptor, Arrow2ListArray<i32>)> for ChunkComponents {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (ComponentDescriptor, Arrow2ListArray<i32>)>>(
+        iter: T,
+    ) -> Self {
+        let mut this = Self::default();
+        {
+            for (component_desc, list_array) in iter {
+                this.entry(component_desc.component_name)
+                    .or_default()
+                    .insert(component_desc, list_array);
+            }
+        }
+        this
+    }
+}
+
+// TODO(cmc): Kinda disgusting but it makes our lives easier during the interim, as long as we're
+// in this weird halfway in-between state where we still have a bunch of things indexed by name only.
+impl FromIterator<(ComponentName, Arrow2ListArray<i32>)> for ChunkComponents {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = (ComponentName, Arrow2ListArray<i32>)>>(iter: T) -> Self {
+        iter.into_iter()
+            .map(|(component_name, list_array)| {
+                let component_desc = ComponentDescriptor::new(component_name);
+                (component_desc, list_array)
+            })
+            .collect()
+    }
+}
 
 /// Dense arrow-based storage of N rows of multi-component multi-temporal data for a specific entity.
 ///
@@ -88,9 +192,7 @@ pub struct Chunk {
     /// Each `ListArray` must be the same length as `row_ids`.
     ///
     /// Sparse so that we can e.g. log a `Position` at one timestamp but not a `Color`.
-    //
-    // TODO(#6576): support non-list based columns?
-    pub(crate) components: IntMap<ComponentName, Arrow2ListArray<i32>>,
+    pub(crate) components: ChunkComponents,
 }
 
 impl PartialEq for Chunk {
@@ -112,6 +214,24 @@ impl PartialEq for Chunk {
             && *row_ids == other.row_ids
             && *timelines == other.timelines
             && *components == other.components
+    }
+}
+
+impl Chunk {
+    /// Returns any list-array that matches the given [`ComponentName`].
+    ///
+    /// This is undefined behavior if there are more than one component with that name.
+    //
+    // TODO(cmc): Kinda disgusting but it makes our lives easier during the interim, as long as we're
+    // in this weird halfway in-between state where we still have a bunch of things indexed by name only.
+    #[inline]
+    pub fn get_first_component(
+        &self,
+        component_name: &ComponentName,
+    ) -> Option<&Arrow2ListArray<i32>> {
+        self.components
+            .get(component_name)
+            .and_then(|per_desc| per_desc.values().next())
     }
 }
 
@@ -192,29 +312,33 @@ impl Chunk {
         );
 
         let components_no_extension: IntMap<_, _> = components
-            .iter()
-            .map(|(name, arr)| {
-                let arr = arrow2::array::ListArray::new(
-                    arr.data_type().to_logical_type().clone(),
-                    arr.offsets().clone(),
-                    arr.values().clone(),
-                    arr.validity().cloned(),
-                );
-                (*name, arr)
+            .values()
+            .flat_map(|per_desc| {
+                per_desc.iter().map(|(component_descr, list_array)| {
+                    let list_array = arrow2::array::ListArray::new(
+                        list_array.data_type().to_logical_type().clone(),
+                        list_array.offsets().clone(),
+                        list_array.values().clone(),
+                        list_array.validity().cloned(),
+                    );
+                    (component_descr.clone(), list_array)
+                })
             })
             .collect();
 
         let other_components_no_extension: IntMap<_, _> = other
             .components
-            .iter()
-            .map(|(name, arr)| {
-                let arr = arrow2::array::ListArray::new(
-                    arr.data_type().to_logical_type().clone(),
-                    arr.offsets().clone(),
-                    arr.values().clone(),
-                    arr.validity().cloned(),
-                );
-                (*name, arr)
+            .values()
+            .flat_map(|per_desc| {
+                per_desc.iter().map(|(component_descr, list_array)| {
+                    let list_array = arrow2::array::ListArray::new(
+                        list_array.data_type().to_logical_type().clone(),
+                        list_array.offsets().clone(),
+                        list_array.values().clone(),
+                        list_array.validity().cloned(),
+                    );
+                    (component_descr.clone(), list_array)
+                })
             })
             .collect();
 
@@ -320,7 +444,8 @@ impl Chunk {
     #[inline]
     pub fn time_range_per_component(
         &self,
-    ) -> IntMap<Timeline, IntMap<ComponentName, ResolvedTimeRange>> {
+    ) -> IntMap<Timeline, IntMap<ComponentName, IntMap<ComponentDescriptor, ResolvedTimeRange>>>
+    {
         re_tracing::profile_function!();
 
         self.timelines
@@ -344,6 +469,7 @@ impl Chunk {
         // Reminder: component columns are sparse, we must take a look at the validity bitmaps.
         self.components
             .values()
+            .flat_map(|per_desc| per_desc.values())
             .map(|list_array| {
                 list_array.validity().map_or_else(
                     || list_array.len() as u64,
@@ -407,16 +533,19 @@ impl Chunk {
         // Raw, potentially duplicated counts (because timestamps aren't necessarily unique).
         let mut counts_raw = vec![0u64; self.num_rows()];
         {
-            self.components.values().for_each(|list_array| {
-                if let Some(validity) = list_array.validity() {
-                    validity
-                        .iter()
-                        .enumerate()
-                        .for_each(|(i, is_valid)| counts_raw[i] += is_valid as u64);
-                } else {
-                    counts_raw.iter_mut().for_each(|count| *count += 1);
-                }
-            });
+            self.components
+                .values()
+                .flat_map(|per_desc| per_desc.values())
+                .for_each(|list_array| {
+                    if let Some(validity) = list_array.validity() {
+                        validity
+                            .iter()
+                            .enumerate()
+                            .for_each(|(i, is_valid)| counts_raw[i] += is_valid as u64);
+                    } else {
+                        counts_raw.iter_mut().for_each(|count| *count += 1);
+                    }
+                });
         }
 
         let mut counts = Vec::with_capacity(counts_raw.len());
@@ -452,25 +581,26 @@ impl Chunk {
 
         // NOTE: This is used on some very hot paths (time panel rendering).
 
-        let result_unordered =
-            self.components
-                .values()
-                .fold(HashMap::default(), |acc, list_array| {
-                    if let Some(validity) = list_array.validity() {
-                        time_column.times().zip(validity.iter()).fold(
-                            acc,
-                            |mut acc, (time, is_valid)| {
-                                *acc.entry(time).or_default() += is_valid as u64;
-                                acc
-                            },
-                        )
-                    } else {
-                        time_column.times().fold(acc, |mut acc, time| {
-                            *acc.entry(time).or_default() += 1;
+        let result_unordered = self
+            .components
+            .values()
+            .flat_map(|per_desc| per_desc.values())
+            .fold(HashMap::default(), |acc, list_array| {
+                if let Some(validity) = list_array.validity() {
+                    time_column.times().zip(validity.iter()).fold(
+                        acc,
+                        |mut acc, (time, is_valid)| {
+                            *acc.entry(time).or_default() += is_valid as u64;
                             acc
-                        })
-                    }
-                });
+                        },
+                    )
+                } else {
+                    time_column.times().fold(acc, |mut acc, time| {
+                        *acc.entry(time).or_default() += 1;
+                        acc
+                    })
+                }
+            });
 
         let mut result = result_unordered.into_iter().collect_vec();
         result.sort_by_key(|val| val.0);
@@ -485,7 +615,7 @@ impl Chunk {
     #[inline]
     pub fn num_events_for_component(&self, component_name: ComponentName) -> Option<u64> {
         // Reminder: component columns are sparse, we must check validity bitmap.
-        self.components.get(&component_name).map(|list_array| {
+        self.get_first_component(&component_name).map(|list_array| {
             list_array.validity().map_or_else(
                 || list_array.len() as u64,
                 |validity| validity.len() as u64 - validity.unset_bits() as u64,
@@ -501,7 +631,9 @@ impl Chunk {
     /// This is crucial for indexing and queries to work properly.
     //
     // TODO(cmc): This needs to be stored in chunk metadata and transported across IPC.
-    pub fn row_id_range_per_component(&self) -> IntMap<ComponentName, (RowId, RowId)> {
+    pub fn row_id_range_per_component(
+        &self,
+    ) -> IntMap<ComponentName, IntMap<ComponentDescriptor, (RowId, RowId)>> {
         re_tracing::profile_function!();
 
         let row_ids = self.row_ids().collect_vec();
@@ -509,43 +641,59 @@ impl Chunk {
         if self.is_sorted() {
             self.components
                 .iter()
-                .filter_map(|(component_name, list_array)| {
-                    let mut row_id_min = None;
-                    let mut row_id_max = None;
+                .map(|(component_name, per_desc)| {
+                    (
+                        *component_name,
+                        per_desc
+                            .iter()
+                            .filter_map(|(component_desc, list_array)| {
+                                let mut row_id_min = None;
+                                let mut row_id_max = None;
 
-                    for (i, &row_id) in row_ids.iter().enumerate() {
-                        if list_array.is_valid(i) {
-                            row_id_min = Some(row_id);
-                        }
-                    }
-                    for (i, &row_id) in row_ids.iter().enumerate().rev() {
-                        if list_array.is_valid(i) {
-                            row_id_max = Some(row_id);
-                        }
-                    }
+                                for (i, &row_id) in row_ids.iter().enumerate() {
+                                    if list_array.is_valid(i) {
+                                        row_id_min = Some(row_id);
+                                    }
+                                }
+                                for (i, &row_id) in row_ids.iter().enumerate().rev() {
+                                    if list_array.is_valid(i) {
+                                        row_id_max = Some(row_id);
+                                    }
+                                }
 
-                    Some((*component_name, (row_id_min?, row_id_max?)))
+                                Some((component_desc.clone(), (row_id_min?, row_id_max?)))
+                            })
+                            .collect(),
+                    )
                 })
                 .collect()
         } else {
             self.components
                 .iter()
-                .filter_map(|(component_name, list_array)| {
-                    let mut row_id_min = Some(RowId::MAX);
-                    let mut row_id_max = Some(RowId::ZERO);
+                .map(|(component_name, per_desc)| {
+                    (
+                        *component_name,
+                        per_desc
+                            .iter()
+                            .filter_map(|(component_desc, list_array)| {
+                                let mut row_id_min = Some(RowId::MAX);
+                                let mut row_id_max = Some(RowId::ZERO);
 
-                    for (i, &row_id) in row_ids.iter().enumerate() {
-                        if list_array.is_valid(i) && Some(row_id) > row_id_min {
-                            row_id_min = Some(row_id);
-                        }
-                    }
-                    for (i, &row_id) in row_ids.iter().enumerate().rev() {
-                        if list_array.is_valid(i) && Some(row_id) < row_id_max {
-                            row_id_max = Some(row_id);
-                        }
-                    }
+                                for (i, &row_id) in row_ids.iter().enumerate() {
+                                    if list_array.is_valid(i) && Some(row_id) > row_id_min {
+                                        row_id_min = Some(row_id);
+                                    }
+                                }
+                                for (i, &row_id) in row_ids.iter().enumerate().rev() {
+                                    if list_array.is_valid(i) && Some(row_id) < row_id_max {
+                                        row_id_max = Some(row_id);
+                                    }
+                                }
 
-                    Some((*component_name, (row_id_min?, row_id_max?)))
+                                Some((component_desc.clone(), (row_id_min?, row_id_max?)))
+                            })
+                            .collect(),
+                    )
                 })
                 .collect()
         }
@@ -594,7 +742,7 @@ impl Chunk {
         is_sorted: Option<bool>,
         row_ids: Arrow2StructArray,
         timelines: IntMap<Timeline, TimeColumn>,
-        components: IntMap<ComponentName, Arrow2ListArray<i32>>,
+        components: ChunkComponents,
     ) -> ChunkResult<Self> {
         let mut chunk = Self {
             id,
@@ -628,7 +776,7 @@ impl Chunk {
         is_sorted: Option<bool>,
         row_ids: &[RowId],
         timelines: IntMap<Timeline, TimeColumn>,
-        components: IntMap<ComponentName, Arrow2ListArray<i32>>,
+        components: ChunkComponents,
     ) -> ChunkResult<Self> {
         re_tracing::profile_function!();
         let row_ids = row_ids
@@ -659,10 +807,10 @@ impl Chunk {
         id: ChunkId,
         entity_path: EntityPath,
         timelines: IntMap<Timeline, TimeColumn>,
-        components: IntMap<ComponentName, Arrow2ListArray<i32>>,
+        components: ChunkComponents,
     ) -> ChunkResult<Self> {
         let count = components
-            .iter()
+            .iter_flattened()
             .next()
             .map_or(0, |(_, list_array)| list_array.len());
 
@@ -690,7 +838,7 @@ impl Chunk {
         entity_path: EntityPath,
         is_sorted: Option<bool>,
         row_ids: Arrow2StructArray,
-        components: IntMap<ComponentName, Arrow2ListArray<i32>>,
+        components: ChunkComponents,
     ) -> ChunkResult<Self> {
         Self::new(
             id,
@@ -723,10 +871,11 @@ impl Chunk {
     #[inline]
     pub fn add_component(
         &mut self,
-        component_name: ComponentName,
+        component_desc: ComponentDescriptor,
         list_array: Arrow2ListArray<i32>,
     ) -> ChunkResult<()> {
-        self.components.insert(component_name, list_array);
+        self.components
+            .insert_descriptor(component_desc, list_array);
         self.sanity_check()
     }
 
@@ -983,7 +1132,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = RowId> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -1064,7 +1213,15 @@ impl Chunk {
     }
 
     #[inline]
-    pub fn components(&self) -> &IntMap<ComponentName, Arrow2ListArray<i32>> {
+    pub fn component_descriptors(&self) -> impl Iterator<Item = ComponentDescriptor> + '_ {
+        self.components
+            .values()
+            .flat_map(|per_desc| per_desc.keys())
+            .cloned()
+    }
+
+    #[inline]
+    pub fn components(&self) -> &ChunkComponents {
         &self.components
     }
 
@@ -1146,46 +1303,57 @@ impl TimeColumn {
     // TODO(cmc): This needs to be stored in chunk metadata and transported across IPC.
     pub fn time_range_per_component(
         &self,
-        components: &IntMap<ComponentName, Arrow2ListArray<i32>>,
-    ) -> IntMap<ComponentName, ResolvedTimeRange> {
+        components: &ChunkComponents,
+    ) -> IntMap<ComponentName, IntMap<ComponentDescriptor, ResolvedTimeRange>> {
         let times = self.times_raw();
         components
             .iter()
-            .filter_map(|(&component_name, list_array)| {
-                if let Some(validity) = list_array.validity() {
-                    // _Potentially_ sparse
+            .map(|(component_name, per_desc)| {
+                (
+                    *component_name,
+                    per_desc
+                        .iter()
+                        .filter_map(|(component_desc, list_array)| {
+                            if let Some(validity) = list_array.validity() {
+                                // Potentially sparse
 
-                    if validity.is_empty() {
-                        return None;
-                    }
+                                if validity.is_empty() {
+                                    return None;
+                                }
 
-                    let is_dense = validity.unset_bits() == 0;
-                    if is_dense {
-                        return Some((component_name, self.time_range));
-                    }
+                                let is_dense = validity.unset_bits() == 0;
+                                if is_dense {
+                                    return Some((component_desc.clone(), self.time_range));
+                                }
 
-                    let mut time_min = TimeInt::MAX;
-                    for (i, time) in times.iter().copied().enumerate() {
-                        if validity.get(i).unwrap_or(false) {
-                            time_min = TimeInt::new_temporal(time);
-                            break;
-                        }
-                    }
+                                let mut time_min = TimeInt::MAX;
+                                for (i, time) in times.iter().copied().enumerate() {
+                                    if validity.get(i).unwrap_or(false) {
+                                        time_min = TimeInt::new_temporal(time);
+                                        break;
+                                    }
+                                }
 
-                    let mut time_max = TimeInt::MIN;
-                    for (i, time) in times.iter().copied().enumerate().rev() {
-                        if validity.get(i).unwrap_or(false) {
-                            time_max = TimeInt::new_temporal(time);
-                            break;
-                        }
-                    }
+                                let mut time_max = TimeInt::MIN;
+                                for (i, time) in times.iter().copied().enumerate().rev() {
+                                    if validity.get(i).unwrap_or(false) {
+                                        time_max = TimeInt::new_temporal(time);
+                                        break;
+                                    }
+                                }
 
-                    Some((component_name, ResolvedTimeRange::new(time_min, time_max)))
-                } else {
-                    // Dense
+                                Some((
+                                    component_desc.clone(),
+                                    ResolvedTimeRange::new(time_min, time_max),
+                                ))
+                            } else {
+                                // Dense
 
-                    Some((component_name, self.time_range))
-                }
+                                Some((component_desc.clone(), self.time_range))
+                            }
+                        })
+                        .collect(),
+                )
             })
             .collect()
     }
@@ -1312,45 +1480,47 @@ impl Chunk {
         }
 
         // Components
-        for (component_name, list_array) in components {
-            if !matches!(list_array.data_type(), arrow2::datatypes::DataType::List(_)) {
-                return Err(ChunkError::Malformed {
-                    reason: format!(
-                        "The outer array in a chunked component batch must be a sparse list, got {:?}",
-                        list_array.data_type(),
-                    ),
-                });
-            }
-            if let arrow2::datatypes::DataType::List(field) = list_array.data_type() {
-                if !field.is_nullable {
+        for (_component_name, per_desc) in components.iter() {
+            for (component_desc, list_array) in per_desc {
+                if !matches!(list_array.data_type(), arrow2::datatypes::DataType::List(_)) {
                     return Err(ChunkError::Malformed {
                         reason: format!(
-                            "The outer array in chunked component batch must be a sparse list, got {:?}",
+                            "The outer array in a chunked component batch must be a sparse list, got {:?}",
                             list_array.data_type(),
                         ),
                     });
                 }
-            }
-            if list_array.len() != row_ids.len() {
-                return Err(ChunkError::Malformed {
-                    reason: format!(
-                        "All component batches in a chunk must have the same number of rows, matching the number of row IDs.\
-                         Found {} row IDs but {} rows for component batch {component_name}",
-                        row_ids.len(), list_array.len(),
-                    ),
-                });
-            }
+                if let arrow2::datatypes::DataType::List(field) = list_array.data_type() {
+                    if !field.is_nullable {
+                        return Err(ChunkError::Malformed {
+                            reason: format!(
+                                "The outer array in chunked component batch must be a sparse list, got {:?}",
+                                list_array.data_type(),
+                            ),
+                        });
+                    }
+                }
+                if list_array.len() != row_ids.len() {
+                    return Err(ChunkError::Malformed {
+                        reason: format!(
+                            "All component batches in a chunk must have the same number of rows, matching the number of row IDs.\
+                             Found {} row IDs but {} rows for component batch {component_desc}",
+                            row_ids.len(), list_array.len(),
+                        ),
+                    });
+                }
 
-            let validity_is_empty = list_array
-                .validity()
-                .map_or(false, |validity| validity.is_empty());
-            if !self.is_empty() && validity_is_empty {
-                return Err(ChunkError::Malformed {
-                    reason: format!(
-                        "All component batches in a chunk must contain at least one non-null entry.\
-                         Found a completely empty column for {component_name}",
-                    ),
-                });
+                let validity_is_empty = list_array
+                    .validity()
+                    .map_or(false, |validity| validity.is_empty());
+                if !self.is_empty() && validity_is_empty {
+                    return Err(ChunkError::Malformed {
+                        reason: format!(
+                            "All component batches in a chunk must contain at least one non-null entry.\
+                             Found a completely empty column for {component_desc}",
+                        ),
+                    });
+                }
             }
         }
 

--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -284,7 +284,23 @@ impl Chunk {
                     .collect();
                 timelines == rhs_timelines
             }
-            && *components == rhs.components
+            // TODO(cmc): we cannot compare tags yet, need to support Python & C++ first
+            // && *components == rhs.components
+            && {
+                let lhs_components_no_tags: ChunkComponents = components
+                    .clone()
+                    .into_iter_flattened()
+                    .map(|(descr, list_array)| (ComponentDescriptor::new(descr.component_name), list_array))
+                    .collect();
+                let rhs_components_no_tags: ChunkComponents = rhs
+                    .components
+                    .clone()
+                    .into_iter_flattened()
+                    .map(|(descr, list_array)| (ComponentDescriptor::new(descr.component_name), list_array))
+                    .collect();
+
+                lhs_components_no_tags == rhs_components_no_tags
+            }
     }
 
     /// Check for equality while ignoring possible `Extension` type information

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -62,7 +62,7 @@ impl Chunk {
         timeline: &Timeline,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = (TimeInt, RowId)> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -128,7 +128,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = TimePoint> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -181,7 +181,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = (usize, usize)> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -213,7 +213,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = Box<dyn Arrow2Array>> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -239,7 +239,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = &[T]> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -284,7 +284,7 @@ impl Chunk {
     where
         [T; N]: bytemuck::Pod,
     {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -346,7 +346,7 @@ impl Chunk {
     where
         [T; N]: bytemuck::Pod,
     {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -428,7 +428,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = Vec<ArrowString>> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -479,7 +479,7 @@ impl Chunk {
         &self,
         component_name: &ComponentName,
     ) -> impl Iterator<Item = Vec<ArrowBuffer<T>>> + '_ {
-        let Some(list_array) = self.components.get(component_name) else {
+        let Some(list_array) = self.get_first_component(component_name) else {
             return Either::Left(std::iter::empty());
         };
 
@@ -697,7 +697,7 @@ impl Chunk {
     pub fn iter_component<C: Component>(
         &self,
     ) -> ChunkComponentIter<C, impl Iterator<Item = (usize, usize)> + '_> {
-        let Some(list_array) = self.components.get(&C::name()) else {
+        let Some(list_array) = self.get_first_component(&C::name()) else {
             return ChunkComponentIter {
                 values: Arc::new(vec![]),
                 offsets: Either::Left(std::iter::empty()),

--- a/crates/store/re_chunk/src/latest_at.rs
+++ b/crates/store/re_chunk/src/latest_at.rs
@@ -77,7 +77,7 @@ impl Chunk {
 
         re_tracing::profile_function!(format!("{query:?}"));
 
-        let Some(component_list_array) = self.components.get(&component_name) else {
+        let Some(component_list_array) = self.get_first_component(&component_name) else {
             return self.emptied();
         };
 

--- a/crates/store/re_chunk/src/lib.rs
+++ b/crates/store/re_chunk/src/lib.rs
@@ -24,7 +24,7 @@ mod batcher;
 mod arrow;
 
 pub use self::builder::{ChunkBuilder, TimeColumnBuilder};
-pub use self::chunk::{Chunk, ChunkError, ChunkResult, TimeColumn};
+pub use self::chunk::{Chunk, ChunkComponents, ChunkError, ChunkResult, TimeColumn};
 pub use self::helpers::{ChunkShared, UnitChunkShared};
 pub use self::id::{ChunkId, RowId};
 pub use self::iter::{ChunkComponentIter, ChunkComponentIterItem, ChunkIndicesIter};
@@ -44,7 +44,7 @@ pub use arrow2::array::Array as Arrow2Array;
 #[doc(no_inline)]
 pub use re_log_types::{EntityPath, TimeInt, TimePoint, Timeline, TimelineName};
 #[doc(no_inline)]
-pub use re_types_core::ComponentName;
+pub use re_types_core::{ArchetypeFieldName, ArchetypeName, ComponentName};
 
 pub mod external {
     pub use arrow2;

--- a/crates/store/re_chunk/src/shuffle.rs
+++ b/crates/store/re_chunk/src/shuffle.rs
@@ -259,7 +259,10 @@ impl Chunk {
         // Reminder: these are all `ListArray`s.
         re_tracing::profile_scope!("components (offsets & data)");
         {
-            for original in components.values_mut() {
+            for original in components
+                .values_mut()
+                .flat_map(|per_desc| per_desc.values_mut())
+            {
                 let sorted_arrays = swaps
                     .iter()
                     .copied()
@@ -359,32 +362,32 @@ mod tests {
                     RowId::new(),
                     [(timeline1, 1000), (timeline2, 42)],
                     [
-                        (MyPoint::name(), Some(&points1 as _)),
-                        (MyColor::name(), Some(&colors1 as _)),
+                        (MyPoint::descriptor(), Some(&points1 as _)),
+                        (MyColor::descriptor(), Some(&colors1 as _)),
                     ],
                 )
                 .with_sparse_component_batches(
                     RowId::new(),
                     [(timeline1, 1001), (timeline2, 43)],
                     [
-                        (MyPoint::name(), None),
-                        (MyColor::name(), Some(&colors2 as _)),
+                        (MyPoint::descriptor(), None),
+                        (MyColor::descriptor(), Some(&colors2 as _)),
                     ],
                 )
                 .with_sparse_component_batches(
                     RowId::new(),
                     [(timeline1, 1002), (timeline2, 44)],
                     [
-                        (MyPoint::name(), Some(&points3 as _)),
-                        (MyColor::name(), None),
+                        (MyPoint::descriptor(), Some(&points3 as _)),
+                        (MyColor::descriptor(), None),
                     ],
                 )
                 .with_sparse_component_batches(
                     RowId::new(),
                     [(timeline1, 1003), (timeline2, 45)],
                     [
-                        (MyPoint::name(), Some(&points4 as _)),
-                        (MyColor::name(), Some(&colors4 as _)),
+                        (MyPoint::descriptor(), Some(&points4 as _)),
+                        (MyColor::descriptor(), Some(&colors4 as _)),
                     ],
                 )
                 .build()?;
@@ -460,32 +463,32 @@ mod tests {
                     row_id1,
                     [(timeline1, 1000), (timeline2, 45)],
                     [
-                        (MyPoint::name(), Some(&points1 as _)),
-                        (MyColor::name(), Some(&colors1 as _)),
+                        (MyPoint::descriptor(), Some(&points1 as _)),
+                        (MyColor::descriptor(), Some(&colors1 as _)),
                     ],
                 )
                 .with_sparse_component_batches(
                     row_id2,
                     [(timeline1, 1001), (timeline2, 44)],
                     [
-                        (MyPoint::name(), None),
-                        (MyColor::name(), Some(&colors2 as _)),
+                        (MyPoint::descriptor(), None),
+                        (MyColor::descriptor(), Some(&colors2 as _)),
                     ],
                 )
                 .with_sparse_component_batches(
                     row_id3,
                     [(timeline1, 1002), (timeline2, 43)],
                     [
-                        (MyPoint::name(), Some(&points3 as _)),
-                        (MyColor::name(), None),
+                        (MyPoint::descriptor(), Some(&points3 as _)),
+                        (MyColor::descriptor(), None),
                     ],
                 )
                 .with_sparse_component_batches(
                     row_id4,
                     [(timeline1, 1003), (timeline2, 42)],
                     [
-                        (MyPoint::name(), Some(&points4 as _)),
-                        (MyColor::name(), Some(&colors4 as _)),
+                        (MyPoint::descriptor(), Some(&points4 as _)),
+                        (MyColor::descriptor(), Some(&colors4 as _)),
                     ],
                 )
                 .build()?;
@@ -553,32 +556,32 @@ mod tests {
                         row_id4,
                         [(timeline1, 1003), (timeline2, 42)],
                         [
-                            (MyPoint::name(), Some(&points4 as _)),
-                            (MyColor::name(), Some(&colors4 as _)),
+                            (MyPoint::descriptor(), Some(&points4 as _)),
+                            (MyColor::descriptor(), Some(&colors4 as _)),
                         ],
                     )
                     .with_sparse_component_batches(
                         row_id3,
                         [(timeline1, 1002), (timeline2, 43)],
                         [
-                            (MyPoint::name(), Some(&points3 as _)),
-                            (MyColor::name(), None),
+                            (MyPoint::descriptor(), Some(&points3 as _)),
+                            (MyColor::descriptor(), None),
                         ],
                     )
                     .with_sparse_component_batches(
                         row_id2,
                         [(timeline1, 1001), (timeline2, 44)],
                         [
-                            (MyPoint::name(), None),
-                            (MyColor::name(), Some(&colors2 as _)),
+                            (MyPoint::descriptor(), None),
+                            (MyColor::descriptor(), Some(&colors2 as _)),
                         ],
                     )
                     .with_sparse_component_batches(
                         row_id1,
                         [(timeline1, 1000), (timeline2, 45)],
                         [
-                            (MyPoint::name(), Some(&points1 as _)),
-                            (MyColor::name(), Some(&colors1 as _)),
+                            (MyPoint::descriptor(), Some(&points1 as _)),
+                            (MyColor::descriptor(), Some(&colors1 as _)),
                         ],
                     )
                     .build()?;

--- a/crates/store/re_chunk/tests/latest_at.rs
+++ b/crates/store/re_chunk/tests/latest_at.rs
@@ -1,19 +1,19 @@
 use arrow2::datatypes::DataType as Arrow2Datatype;
 use nohash_hasher::IntMap;
 
-use re_chunk::{Chunk, ComponentName, LatestAtQuery, RowId, TimePoint, Timeline};
+use re_chunk::{Chunk, LatestAtQuery, RowId, TimePoint, Timeline};
 use re_log_types::example_components::{MyColor, MyLabel, MyPoint};
-use re_types_core::{Component, Loggable};
+use re_types_core::{Component as _, ComponentDescriptor, Loggable as _};
 
 // ---
 
 const ENTITY_PATH: &str = "my/entity";
 
-fn datatypes() -> IntMap<ComponentName, Arrow2Datatype> {
+fn datatypes() -> IntMap<ComponentDescriptor, Arrow2Datatype> {
     [
-        (MyPoint::name(), MyPoint::arrow2_datatype()),
-        (MyColor::name(), MyColor::arrow2_datatype()),
-        (MyLabel::name(), MyLabel::arrow2_datatype()),
+        (MyPoint::descriptor(), MyPoint::arrow2_datatype()),
+        (MyColor::descriptor(), MyColor::arrow2_datatype()),
+        (MyLabel::descriptor(), MyLabel::arrow2_datatype()),
     ]
     .into_iter()
     .collect()
@@ -67,19 +67,19 @@ fn temporal_sorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = chunk.emptied();
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = chunk.emptied();
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
     {
         let query = LatestAtQuery::new(Timeline::new_sequence("frame"), 4);
@@ -89,39 +89,39 @@ fn temporal_sorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
     {
         let query = LatestAtQuery::new(Timeline::new_sequence("frame"), 6);
@@ -131,39 +131,39 @@ fn temporal_sorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint3,
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -217,19 +217,19 @@ fn temporal_unsorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = chunk.emptied();
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = chunk.emptied();
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
     {
         let query = LatestAtQuery::new(Timeline::log_time(), 1050);
@@ -239,39 +239,39 @@ fn temporal_unsorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
     {
         let query = LatestAtQuery::new(Timeline::log_time(), 1100);
@@ -281,39 +281,39 @@ fn temporal_unsorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint3,
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -356,39 +356,39 @@ fn static_sorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -431,39 +431,39 @@ fn static_unsorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -472,15 +472,15 @@ fn static_unsorted() -> anyhow::Result<()> {
 // ---
 
 fn query_and_compare(
-    (component_name, query): (ComponentName, &LatestAtQuery),
+    (component_desc, query): (ComponentDescriptor, &LatestAtQuery),
     chunk: &Chunk,
     expected: &Chunk,
 ) {
     re_log::setup_logging();
 
-    let results = chunk.latest_at(query, component_name);
+    let results = chunk.latest_at(query, component_desc.component_name);
 
-    eprintln!("Query: {component_name} @ {query:?}");
+    eprintln!("Query: {component_desc} @ {query:?}");
     eprintln!("Data:\n{chunk}");
     eprintln!("Expected:\n{expected}");
     eprintln!("Results:\n{results}");

--- a/crates/store/re_chunk/tests/range.rs
+++ b/crates/store/re_chunk/tests/range.rs
@@ -1,22 +1,22 @@
 use arrow2::datatypes::DataType as Arrow2Datatype;
 use nohash_hasher::IntMap;
 
-use re_chunk::{Chunk, ComponentName, RangeQuery, RowId, TimePoint, Timeline};
+use re_chunk::{Chunk, RangeQuery, RowId, TimePoint, Timeline};
 use re_log_types::{
     example_components::{MyColor, MyLabel, MyPoint},
     ResolvedTimeRange,
 };
-use re_types_core::{Component as _, Loggable as _};
+use re_types_core::{Component as _, ComponentDescriptor, Loggable as _};
 
 // ---
 
 const ENTITY_PATH: &str = "my/entity";
 
-fn datatypes() -> IntMap<ComponentName, Arrow2Datatype> {
+fn datatypes() -> IntMap<ComponentDescriptor, Arrow2Datatype> {
     [
-        (MyPoint::name(), MyPoint::arrow2_datatype()),
-        (MyColor::name(), MyColor::arrow2_datatype()),
-        (MyLabel::name(), MyLabel::arrow2_datatype()),
+        (MyPoint::descriptor(), MyPoint::arrow2_datatype()),
+        (MyColor::descriptor(), MyColor::arrow2_datatype()),
+        (MyLabel::descriptor(), MyLabel::arrow2_datatype()),
     ]
     .into_iter()
     .collect()
@@ -73,48 +73,48 @@ fn temporal_sorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .with_sparse_component_batches(
                 row_id3,
                 timepoint3,
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     {
@@ -122,33 +122,33 @@ fn temporal_sorted() -> anyhow::Result<()> {
             RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
 
         let expected = chunk.emptied();
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -202,48 +202,48 @@ fn temporal_unsorted() -> anyhow::Result<()> {
                 row_id1,
                 timepoint1,
                 [
-                    (MyPoint::name(), Some(points1 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points1 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .with_sparse_component_batches(
                 row_id3,
                 timepoint3,
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     {
@@ -251,33 +251,33 @@ fn temporal_unsorted() -> anyhow::Result<()> {
             RangeQuery::with_extras(Timeline::log_time(), ResolvedTimeRange::new(1020, 1050));
 
         let expected = chunk.emptied();
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint2,
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -326,39 +326,39 @@ fn static_sorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -407,39 +407,39 @@ fn static_unsorted() -> anyhow::Result<()> {
                 row_id3,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), Some(points3 as _)),
-                    (MyColor::name(), None),
-                    (MyLabel::name(), None),
+                    (MyPoint::descriptor(), Some(points3 as _)),
+                    (MyColor::descriptor(), None),
+                    (MyLabel::descriptor(), None),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyPoint::name(), &query), &chunk, &expected);
+        query_and_compare((MyPoint::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyColor::name(), &query), &chunk, &expected);
+        query_and_compare((MyColor::descriptor(), &query), &chunk, &expected);
 
         let expected = Chunk::builder_with_id(chunk.id(), ENTITY_PATH.into())
             .with_sparse_component_batches(
                 row_id2,
                 timepoint.clone(),
                 [
-                    (MyPoint::name(), None),
-                    (MyColor::name(), Some(colors2 as _)),
-                    (MyLabel::name(), Some(labels2 as _)),
+                    (MyPoint::descriptor(), None),
+                    (MyColor::descriptor(), Some(colors2 as _)),
+                    (MyLabel::descriptor(), Some(labels2 as _)),
                 ],
             )
             .build_with_datatypes(&datatypes())?;
-        query_and_compare((MyLabel::name(), &query), &chunk, &expected);
+        query_and_compare((MyLabel::descriptor(), &query), &chunk, &expected);
     }
 
     Ok(())
@@ -448,15 +448,15 @@ fn static_unsorted() -> anyhow::Result<()> {
 // ---
 
 fn query_and_compare(
-    (component_name, query): (ComponentName, &RangeQuery),
+    (component_desc, query): (ComponentDescriptor, &RangeQuery),
     chunk: &Chunk,
     expected: &Chunk,
 ) {
     re_log::setup_logging();
 
-    let results = chunk.range(query, component_name);
+    let results = chunk.range(query, component_desc.component_name);
 
-    eprintln!("Query: {component_name} @ {query:?}");
+    eprintln!("Query: {component_desc} @ {query:?}");
     eprintln!("Data:\n{chunk}");
     eprintln!("Expected:\n{expected}");
     eprintln!("Results:\n{results}");

--- a/crates/store/re_chunk_store/src/events.rs
+++ b/crates/store/re_chunk_store/src/events.rs
@@ -263,9 +263,12 @@ mod tests {
                     .entry(event.chunk.entity_path().clone())
                     .or_default() += delta_chunks;
 
-                for (component_name, list_array) in event.chunk.components() {
+                for (component_desc, list_array) in event.chunk.components().iter_flattened() {
                     let delta = event.delta() * list_array.iter().flatten().count() as i64;
-                    *self.component_names.entry(*component_name).or_default() += delta;
+                    *self
+                        .component_names
+                        .entry(component_desc.component_name)
+                        .or_default() += delta;
                 }
 
                 if event.is_static() {

--- a/crates/store/re_chunk_store/src/gc.rs
+++ b/crates/store/re_chunk_store/src/gc.rs
@@ -472,18 +472,20 @@ impl ChunkStore {
             for (timeline, time_range_per_component) in chunk.time_range_per_component() {
                 let chunk_ids_to_be_removed = chunk_ids_to_be_removed.entry(timeline).or_default();
 
-                for (component_name, time_range) in time_range_per_component {
-                    let chunk_ids_to_be_removed =
-                        chunk_ids_to_be_removed.entry(component_name).or_default();
+                for (component_name, per_desc) in time_range_per_component {
+                    for (_component_desc, time_range) in per_desc {
+                        let chunk_ids_to_be_removed =
+                            chunk_ids_to_be_removed.entry(component_name).or_default();
 
-                    chunk_ids_to_be_removed
-                        .entry(time_range.min())
-                        .or_default()
-                        .push(chunk.id());
-                    chunk_ids_to_be_removed
-                        .entry(time_range.max())
-                        .or_default()
-                        .push(chunk.id());
+                        chunk_ids_to_be_removed
+                            .entry(time_range.min())
+                            .or_default()
+                            .push(chunk.id());
+                        chunk_ids_to_be_removed
+                            .entry(time_range.max())
+                            .or_default()
+                            .push(chunk.id());
+                    }
                 }
             }
         }

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -746,6 +746,7 @@ impl ChunkStore {
                         time_column
                             .time_range_per_component(chunk.components())
                             .get(&component_name)
+                            .and_then(|per_desc| per_desc.values().next())
                             .map_or(false, |time_range| time_range.intersects(query.range()))
                     })
             })

--- a/crates/store/re_chunk_store/tests/memory_test.rs
+++ b/crates/store/re_chunk_store/tests/memory_test.rs
@@ -73,7 +73,7 @@ use re_chunk::{
 };
 use re_chunk_store::{ChunkStore, ChunkStoreConfig};
 use re_log_types::{TimePoint, TimeType, Timeline};
-use re_types::{components::Scalar, Component, Loggable};
+use re_types::{components::Scalar, Component as _, Loggable};
 
 /// The memory overhead of storing many scalars in the store.
 #[test]
@@ -104,7 +104,7 @@ fn scalar_memory_overhead() {
 
             let row = PendingRow::new(
                 timepoint,
-                std::iter::once((Scalar::name(), scalars)).collect(),
+                std::iter::once((Scalar::descriptor(), scalars)).collect(),
             );
 
             batcher.push_row(entity_path.clone(), row);

--- a/crates/store/re_chunk_store/tests/reads.rs
+++ b/crates/store/re_chunk_store/tests/reads.rs
@@ -12,32 +12,34 @@ use re_log_types::{
     example_components::{MyColor, MyIndex, MyPoint},
     EntityPath, TimeType, Timeline,
 };
-use re_types::testing::{build_some_large_structs, LargeStruct};
-use re_types::ComponentNameSet;
-use re_types_core::{Component as _, ComponentName};
+use re_types::{
+    testing::{build_some_large_structs, LargeStruct},
+    ComponentDescriptor, ComponentNameSet,
+};
+use re_types_core::Component as _;
 
 // ---
 
 fn query_latest_array(
     store: &ChunkStore,
     entity_path: &EntityPath,
-    component_name: ComponentName,
+    component_desc: &ComponentDescriptor,
     query: &LatestAtQuery,
 ) -> Option<(TimeInt, RowId, Box<dyn Arrow2Array>)> {
     re_tracing::profile_function!();
 
     let ((data_time, row_id), unit) = store
-        .latest_at_relevant_chunks(query, entity_path, component_name)
+        .latest_at_relevant_chunks(query, entity_path, component_desc.component_name)
         .into_iter()
         .filter_map(|chunk| {
             chunk
-                .latest_at(query, component_name)
+                .latest_at(query, component_desc.component_name)
                 .into_unit()
                 .and_then(|chunk| chunk.index(&query.timeline()).map(|index| (index, chunk)))
         })
         .max_by_key(|(index, _chunk)| *index)?;
 
-    unit.component_batch_raw(&component_name)
+    unit.component_batch_raw(&component_desc.component_name)
         .map(|array| (data_time, row_id, array))
 }
 
@@ -53,13 +55,14 @@ fn all_components() -> anyhow::Result<()> {
     let frame2 = TimeInt::new_temporal(2);
 
     let assert_latest_components_at =
-        |store: &ChunkStore, entity_path: &EntityPath, expected: Option<&[ComponentName]>| {
+        |store: &ChunkStore, entity_path: &EntityPath, expected: Option<&[ComponentDescriptor]>| {
             let timeline = Timeline::new("frame_nr", TimeType::Sequence);
 
             let component_names = store.all_components_on_timeline_sorted(&timeline, entity_path);
 
             let expected_component_names = expected.map(|expected| {
-                let expected: ComponentNameSet = expected.iter().copied().collect();
+                let expected: ComponentNameSet =
+                    expected.iter().map(|desc| desc.component_name).collect();
                 expected
             });
 
@@ -75,14 +78,14 @@ fn all_components() -> anyhow::Result<()> {
     );
 
     let components_a = &[
-        MyColor::name(),     // added by test, static
-        LargeStruct::name(), // added by test
+        MyColor::descriptor(),     // added by test, static
+        LargeStruct::descriptor(), // added by test
     ];
 
     let components_b = &[
-        MyColor::name(),     // added by test, static
-        MyPoint::name(),     // added by test
-        LargeStruct::name(), // added by test
+        MyColor::descriptor(),     // added by test, static
+        MyPoint::descriptor(),     // added by test
+        LargeStruct::descriptor(), // added by test
     ];
 
     let chunk = Chunk::builder(entity_path.clone())
@@ -193,60 +196,61 @@ fn latest_at() -> anyhow::Result<()> {
     store.insert_chunk(&chunk4)?;
     store.insert_chunk(&chunk5)?;
 
-    let assert_latest_components = |frame_nr: TimeInt, rows: &[(ComponentName, Option<RowId>)]| {
-        let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
+    let assert_latest_components =
+        |frame_nr: TimeInt, rows: &[(ComponentDescriptor, Option<RowId>)]| {
+            let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
 
-        for (component_name, expected_row_id) in rows {
-            let row_id = query_latest_array(
-                &store,
-                &entity_path,
-                *component_name,
-                &LatestAtQuery::new(timeline_frame_nr, frame_nr),
-            )
-            .map(|(_data_time, row_id, _array)| row_id);
+            for (component_desc, expected_row_id) in rows {
+                let row_id = query_latest_array(
+                    &store,
+                    &entity_path,
+                    component_desc,
+                    &LatestAtQuery::new(timeline_frame_nr, frame_nr),
+                )
+                .map(|(_data_time, row_id, _array)| row_id);
 
-            assert_eq!(*expected_row_id, row_id, "{component_name}");
-        }
-    };
+                assert_eq!(*expected_row_id, row_id, "{component_desc}");
+            }
+        };
 
     assert_latest_components(
         frame0,
         &[
-            (MyColor::name(), Some(row_id5)), // static
-            (MyIndex::name(), None),
-            (MyPoint::name(), None),
+            (MyColor::descriptor(), Some(row_id5)), // static
+            (MyIndex::descriptor(), None),
+            (MyPoint::descriptor(), None),
         ],
     );
     assert_latest_components(
         frame1,
         &[
-            (MyColor::name(), Some(row_id5)), // static
-            (MyIndex::name(), Some(row_id1)),
-            (MyPoint::name(), None),
+            (MyColor::descriptor(), Some(row_id5)), // static
+            (MyIndex::descriptor(), Some(row_id1)),
+            (MyPoint::descriptor(), None),
         ],
     );
     assert_latest_components(
         frame2,
         &[
-            (MyColor::name(), Some(row_id5)),
-            (MyPoint::name(), Some(row_id2)),
-            (MyIndex::name(), Some(row_id2)),
+            (MyColor::descriptor(), Some(row_id5)),
+            (MyPoint::descriptor(), Some(row_id2)),
+            (MyIndex::descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
         frame3,
         &[
-            (MyColor::name(), Some(row_id5)),
-            (MyPoint::name(), Some(row_id3)),
-            (MyIndex::name(), Some(row_id2)),
+            (MyColor::descriptor(), Some(row_id5)),
+            (MyPoint::descriptor(), Some(row_id3)),
+            (MyIndex::descriptor(), Some(row_id2)),
         ],
     );
     assert_latest_components(
         frame4,
         &[
-            (MyColor::name(), Some(row_id5)),
-            (MyPoint::name(), Some(row_id3)),
-            (MyIndex::name(), Some(row_id2)),
+            (MyColor::descriptor(), Some(row_id5)),
+            (MyPoint::descriptor(), Some(row_id3)),
+            (MyIndex::descriptor(), Some(row_id2)),
         ],
     );
 
@@ -310,24 +314,24 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id1_1,
             [build_frame_nr(frame1)],
             [
-                (MyIndex::name(), None),
-                (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
+                (MyIndex::descriptor(), None),
+                (MyPoint::descriptor(), Some(&MyPoint::from_iter(0..1) as _)),
             ],
         )
         .with_sparse_component_batches(
             row_id1_2,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::name(), None),
-                (MyPoint::name(), Some(&MyPoint::from_iter(1..2) as _)),
+                (MyIndex::descriptor(), None),
+                (MyPoint::descriptor(), Some(&MyPoint::from_iter(1..2) as _)),
             ],
         )
         .with_sparse_component_batches(
             row_id1_3,
             [build_frame_nr(frame3)],
             [
-                (MyIndex::name(), Some(&MyIndex::from_iter(2..3) as _)),
-                (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),
+                (MyIndex::descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (MyPoint::descriptor(), Some(&MyPoint::from_iter(2..3) as _)),
             ],
         )
         .build()?;
@@ -345,8 +349,8 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
             row_id2_1,
             [build_frame_nr(frame2)],
             [
-                (MyIndex::name(), Some(&MyIndex::from_iter(2..3) as _)),
-                (MyPoint::name(), Some(&MyPoint::from_iter(1..2) as _)),
+                (MyIndex::descriptor(), Some(&MyIndex::from_iter(2..3) as _)),
+                (MyPoint::descriptor(), Some(&MyPoint::from_iter(1..2) as _)),
             ],
         )
         .build()?;
@@ -363,7 +367,7 @@ fn latest_at_sparse_component_edge_case() -> anyhow::Result<()> {
     let row_id = query_latest_array(
         &store,
         &entity_path,
-        MyIndex::name(),
+        &MyIndex::descriptor(),
         &LatestAtQuery::new(Timeline::new_sequence("frame_nr"), TimeInt::MAX),
     )
     .map(|(_data_time, row_id, _array)| row_id);
@@ -441,22 +445,22 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
         .with_sparse_component_batches(
             row_id1_1,
             [build_frame_nr(frame1)],
-            [(MyPoint::name(), Some(&points1 as _))],
+            [(MyPoint::descriptor(), Some(&points1 as _))],
         )
         .with_sparse_component_batches(
             row_id1_3,
             [build_frame_nr(frame3)],
-            [(MyPoint::name(), Some(&points3 as _))],
+            [(MyPoint::descriptor(), Some(&points3 as _))],
         )
         .with_sparse_component_batches(
             row_id1_5,
             [build_frame_nr(frame5)],
-            [(MyPoint::name(), Some(&points5 as _))],
+            [(MyPoint::descriptor(), Some(&points5 as _))],
         )
         .with_sparse_component_batches(
             row_id1_7,
             [build_frame_nr(frame7)],
-            [(MyPoint::name(), Some(&points7 as _))],
+            [(MyPoint::descriptor(), Some(&points7 as _))],
         )
         .build()?;
 
@@ -470,17 +474,17 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
         .with_sparse_component_batches(
             row_id2_2,
             [build_frame_nr(frame2)],
-            [(MyPoint::name(), Some(&points2 as _))],
+            [(MyPoint::descriptor(), Some(&points2 as _))],
         )
         .with_sparse_component_batches(
             row_id2_3,
             [build_frame_nr(frame3)],
-            [(MyPoint::name(), Some(&points3 as _))],
+            [(MyPoint::descriptor(), Some(&points3 as _))],
         )
         .with_sparse_component_batches(
             row_id2_4,
             [build_frame_nr(frame4)],
-            [(MyPoint::name(), Some(&points4 as _))],
+            [(MyPoint::descriptor(), Some(&points4 as _))],
         )
         .build()?;
 
@@ -494,17 +498,17 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
         .with_sparse_component_batches(
             row_id3_2,
             [build_frame_nr(frame2)],
-            [(MyPoint::name(), Some(&points2 as _))],
+            [(MyPoint::descriptor(), Some(&points2 as _))],
         )
         .with_sparse_component_batches(
             row_id3_4,
             [build_frame_nr(frame4)],
-            [(MyPoint::name(), Some(&points4 as _))],
+            [(MyPoint::descriptor(), Some(&points4 as _))],
         )
         .with_sparse_component_batches(
             row_id3_6,
             [build_frame_nr(frame6)],
-            [(MyPoint::name(), Some(&points6 as _))],
+            [(MyPoint::descriptor(), Some(&points6 as _))],
         )
         .build()?;
 
@@ -524,8 +528,8 @@ fn latest_at_overlapped_chunks() -> anyhow::Result<()> {
         (TimeInt::MAX, row_id1_7), //
     ] {
         let query = LatestAtQuery::new(Timeline::new_sequence("frame_nr"), at);
-        eprintln!("{} @ {query:?}", MyPoint::name());
-        let row_id = query_latest_array(&store, &entity_path, MyPoint::name(), &query)
+        eprintln!("{} @ {query:?}", MyPoint::descriptor());
+        let row_id = query_latest_array(&store, &entity_path, &MyPoint::descriptor(), &query)
             .map(|(_data_time, row_id, _array)| row_id);
         assert_eq!(expected_row_id, row_id.unwrap());
     }
@@ -711,17 +715,18 @@ fn range() -> anyhow::Result<()> {
     #[allow(clippy::type_complexity)]
     let assert_range_components =
         |time_range: ResolvedTimeRange,
-         component_name: ComponentName,
+         component_desc: ComponentDescriptor,
          row_ids_at_times: &[(TimeInt, RowId)]| {
             let timeline_frame_nr = Timeline::new("frame_nr", TimeType::Sequence);
 
             let query = RangeQuery::new(timeline_frame_nr, time_range);
-            let results = store.range_relevant_chunks(&query, &entity_path, component_name);
+            let results =
+                store.range_relevant_chunks(&query, &entity_path, component_desc.component_name);
 
-            eprintln!("================= {component_name} @ {query:?} ===============");
+            eprintln!("================= {component_desc} @ {query:?} ===============");
             let mut results_processed = 0usize;
             for chunk in results {
-                let chunk = chunk.range(&query, component_name);
+                let chunk = chunk.range(&query, component_desc.component_name);
                 eprintln!("{chunk}");
                 for (data_time, row_id) in chunk.iter_indices(&timeline_frame_nr) {
                     let (expected_data_time, expected_row_id) = row_ids_at_times[results_processed];
@@ -740,52 +745,60 @@ fn range() -> anyhow::Result<()> {
 
     assert_range_components(
         ResolvedTimeRange::new(frame1, frame1),
-        MyColor::name(),
-        &[(TimeInt::STATIC, row_id5)],
-    );
-    assert_range_components(ResolvedTimeRange::new(frame1, frame1), MyPoint::name(), &[]);
-    assert_range_components(
-        ResolvedTimeRange::new(frame2, frame2),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
     assert_range_components(
+        ResolvedTimeRange::new(frame1, frame1),
+        MyPoint::descriptor(),
+        &[],
+    );
+    assert_range_components(
         ResolvedTimeRange::new(frame2, frame2),
-        MyPoint::name(),
+        MyColor::descriptor(),
+        &[(TimeInt::STATIC, row_id5)],
+    );
+    assert_range_components(
+        ResolvedTimeRange::new(frame2, frame2),
+        MyPoint::descriptor(),
         &[(frame2, row_id2)],
     );
     assert_range_components(
         ResolvedTimeRange::new(frame3, frame3),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
     assert_range_components(
         ResolvedTimeRange::new(frame3, frame3),
-        MyPoint::name(),
+        MyPoint::descriptor(),
         &[(frame3, row_id3)],
     );
     assert_range_components(
         ResolvedTimeRange::new(frame4, frame4),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
     assert_range_components(
         ResolvedTimeRange::new(frame4, frame4),
-        MyPoint::name(),
+        MyPoint::descriptor(),
         &[(frame4, row_id4_25), (frame4, row_id4_4)],
     );
     assert_range_components(
         ResolvedTimeRange::new(frame5, frame5),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
-    assert_range_components(ResolvedTimeRange::new(frame5, frame5), MyPoint::name(), &[]);
+    assert_range_components(
+        ResolvedTimeRange::new(frame5, frame5),
+        MyPoint::descriptor(),
+        &[],
+    );
 
     // Full range
 
     assert_range_components(
         ResolvedTimeRange::new(frame1, frame5),
-        MyPoint::name(),
+        MyPoint::descriptor(),
         &[
             (frame2, row_id2),
             (frame3, row_id3),
@@ -795,7 +808,7 @@ fn range() -> anyhow::Result<()> {
     );
     assert_range_components(
         ResolvedTimeRange::new(frame1, frame5),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
 
@@ -803,7 +816,7 @@ fn range() -> anyhow::Result<()> {
 
     assert_range_components(
         ResolvedTimeRange::new(TimeInt::MIN, TimeInt::MAX),
-        MyPoint::name(),
+        MyPoint::descriptor(),
         &[
             (frame2, row_id2),
             (frame3, row_id3),
@@ -813,7 +826,7 @@ fn range() -> anyhow::Result<()> {
     );
     assert_range_components(
         ResolvedTimeRange::new(TimeInt::MIN, TimeInt::MAX),
-        MyColor::name(),
+        MyColor::descriptor(),
         &[(TimeInt::STATIC, row_id5)],
     );
 
@@ -934,32 +947,32 @@ fn range_overlapped_chunks() -> anyhow::Result<()> {
         .with_sparse_component_batches(
             row_id1_1,
             [build_frame_nr(frame1)],
-            [(MyPoint::name(), Some(&points1 as _))],
+            [(MyPoint::descriptor(), Some(&points1 as _))],
         )
         .with_sparse_component_batches(
             row_id1_3,
             [build_frame_nr(frame3)],
-            [(MyPoint::name(), Some(&points3 as _))],
+            [(MyPoint::descriptor(), Some(&points3 as _))],
         )
         .with_sparse_component_batches(
             row_id1_5,
             [build_frame_nr(frame5)],
-            [(MyPoint::name(), Some(&points5 as _))],
+            [(MyPoint::descriptor(), Some(&points5 as _))],
         )
         .with_sparse_component_batches(
             row_id1_7_1,
             [build_frame_nr(frame7)],
-            [(MyPoint::name(), Some(&points7_1 as _))],
+            [(MyPoint::descriptor(), Some(&points7_1 as _))],
         )
         .with_sparse_component_batches(
             row_id1_7_2,
             [build_frame_nr(frame7)],
-            [(MyPoint::name(), Some(&points7_2 as _))],
+            [(MyPoint::descriptor(), Some(&points7_2 as _))],
         )
         .with_sparse_component_batches(
             row_id1_7_3,
             [build_frame_nr(frame7)],
-            [(MyPoint::name(), Some(&points7_3 as _))],
+            [(MyPoint::descriptor(), Some(&points7_3 as _))],
         )
         .build()?;
 
@@ -977,17 +990,17 @@ fn range_overlapped_chunks() -> anyhow::Result<()> {
         .with_sparse_component_batches(
             row_id2_2,
             [build_frame_nr(frame2)],
-            [(MyPoint::name(), Some(&points2 as _))],
+            [(MyPoint::descriptor(), Some(&points2 as _))],
         )
         .with_sparse_component_batches(
             row_id2_3,
             [build_frame_nr(frame3)],
-            [(MyPoint::name(), Some(&points3 as _))],
+            [(MyPoint::descriptor(), Some(&points3 as _))],
         )
         .with_sparse_component_batches(
             row_id2_4,
             [build_frame_nr(frame4)],
-            [(MyPoint::name(), Some(&points4 as _))],
+            [(MyPoint::descriptor(), Some(&points4 as _))],
         )
         .build()?;
 

--- a/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
+++ b/crates/store/re_chunk_store/tests/snapshots/memory_test__scalars_on_one_timeline_new.snap
@@ -4,6 +4,6 @@ expression: "[format!(\"{NUM_SCALARS} scalars\"),\n        format!(\"{} in total
 ---
 [
     "1048576 scalars",
-    "37.0 MiB in total",
+    "37.1 MiB in total",
     "37 B per row",
 ]

--- a/crates/store/re_chunk_store/tests/stats.rs
+++ b/crates/store/re_chunk_store/tests/stats.rs
@@ -26,24 +26,24 @@ fn stats() -> anyhow::Result<()> {
                 RowId::new(),
                 [build_frame_nr(TimeInt::new_temporal(0))],
                 [
-                    (MyColor::name(), None),
-                    (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
+                    (MyColor::descriptor(), None),
+                    (MyPoint::descriptor(), Some(&MyPoint::from_iter(0..1) as _)),
                 ],
             )
             .with_sparse_component_batches(
                 RowId::new(),
                 [build_frame_nr(TimeInt::new_temporal(1))],
                 [
-                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
-                    (MyPoint::name(), None),
+                    (MyColor::descriptor(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::descriptor(), None),
                 ],
             )
             .with_sparse_component_batches(
                 RowId::new(),
                 [build_frame_nr(TimeInt::new_temporal(2))],
                 [
-                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
-                    (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),
+                    (MyColor::descriptor(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::descriptor(), Some(&MyPoint::from_iter(2..3) as _)),
                 ],
             )
             .build()?;
@@ -63,8 +63,8 @@ fn stats() -> anyhow::Result<()> {
                 RowId::new(),
                 [build_frame_nr(TimeInt::new_temporal(3))],
                 [
-                    (MyColor::name(), None),
-                    (MyPoint::name(), Some(&MyPoint::from_iter(1..2) as _)),
+                    (MyColor::descriptor(), None),
+                    (MyPoint::descriptor(), Some(&MyPoint::from_iter(1..2) as _)),
                 ],
             )
             .build()?;
@@ -88,24 +88,24 @@ fn stats() -> anyhow::Result<()> {
                 RowId::new(),
                 TimePoint::default(),
                 [
-                    (MyColor::name(), None),
-                    (MyPoint::name(), Some(&MyPoint::from_iter(0..1) as _)),
+                    (MyColor::descriptor(), None),
+                    (MyPoint::descriptor(), Some(&MyPoint::from_iter(0..1) as _)),
                 ],
             )
             .with_sparse_component_batches(
                 RowId::new(),
                 TimePoint::default(),
                 [
-                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
-                    (MyPoint::name(), None),
+                    (MyColor::descriptor(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::descriptor(), None),
                 ],
             )
             .with_sparse_component_batches(
                 RowId::new(),
                 TimePoint::default(),
                 [
-                    (MyColor::name(), Some(&MyColor::from_iter(2..3) as _)),
-                    (MyPoint::name(), Some(&MyPoint::from_iter(2..3) as _)),
+                    (MyColor::descriptor(), Some(&MyColor::from_iter(2..3) as _)),
+                    (MyPoint::descriptor(), Some(&MyPoint::from_iter(2..3) as _)),
                 ],
             )
             .build()?;

--- a/crates/store/re_data_loader/src/loader_archetype.rs
+++ b/crates/store/re_data_loader/src/loader_archetype.rs
@@ -220,10 +220,13 @@ fn load_video(
                 std::iter::once((video_timeline, time_column)).collect(),
                 [
                     (
-                        VideoFrameReference::indicator().name(),
+                        VideoFrameReference::indicator().descriptor().into_owned(),
                         video_frame_reference_indicators_list_array,
                     ),
-                    (video_timestamp_batch.name(), video_timestamp_list_array),
+                    (
+                        video_timestamp_batch.descriptor().into_owned(),
+                        video_timestamp_list_array,
+                    ),
                 ]
                 .into_iter()
                 .collect(),

--- a/crates/store/re_dataframe/src/query.rs
+++ b/crates/store/re_dataframe/src/query.rs
@@ -516,7 +516,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
         fn chunk_filter_recursive_only(chunk: &Chunk) -> Option<Chunk> {
             let list_array = chunk
                 .components()
-                .get_descriptor(&ClearIsRecursive::descriptor())?;
+                .get_by_descriptor(&ClearIsRecursive::descriptor())?;
 
             let values = list_array
                 .values()
@@ -1186,7 +1186,7 @@ impl<E: StorageEngineLike> QueryHandle<E> {
                                 }),
                                 ColumnDescriptor::Time(_) => None,
                             })?;
-                            unit.components().get_descriptor(&component_desc).map(|list_array| list_array.to_boxed())
+                            unit.components().get_by_descriptor(&component_desc).map(|list_array| list_array.to_boxed())
                         }
                     };
 

--- a/crates/store/re_entity_db/src/entity_db.rs
+++ b/crates/store/re_entity_db/src/entity_db.rs
@@ -172,11 +172,11 @@ impl EntityDb {
         entity_path: &EntityPath,
         query: &re_chunk_store::LatestAtQuery,
     ) -> Option<((TimeInt, RowId), C)> {
-        let results = self
-            .storage_engine
-            .read()
-            .cache()
-            .latest_at(query, entity_path, [C::name()]);
+        let results =
+            self.storage_engine
+                .read()
+                .cache()
+                .latest_at(query, entity_path, [&C::descriptor()]);
         results
             .component_mono()
             .map(|value| (results.index(), value))
@@ -196,11 +196,11 @@ impl EntityDb {
         entity_path: &EntityPath,
         query: &re_chunk_store::LatestAtQuery,
     ) -> Option<((TimeInt, RowId), C)> {
-        let results = self
-            .storage_engine
-            .read()
-            .cache()
-            .latest_at(query, entity_path, [C::name()]);
+        let results =
+            self.storage_engine
+                .read()
+                .cache()
+                .latest_at(query, entity_path, [&C::descriptor()]);
         results
             .component_mono_quiet()
             .map(|value| (results.index(), value))

--- a/crates/store/re_entity_db/tests/clear.rs
+++ b/crates/store/re_entity_db/tests/clear.rs
@@ -24,7 +24,7 @@ fn query_latest_component<C: re_types_core::Component>(
     let results = db
         .storage_engine()
         .cache()
-        .latest_at(query, entity_path, [C::name()]);
+        .latest_at(query, entity_path, [C::descriptor()]);
 
     let (data_time, row_id) = results.index();
     let data = results.component_mono::<C>()?;
@@ -125,7 +125,10 @@ fn clears() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id,
                 timepoint,
-                clear.as_component_batches().iter().map(|b| b.as_ref()),
+                clear
+                    .as_component_batches()
+                    .iter()
+                    .map(|b| b as &dyn re_types_core::ComponentBatch),
             )
             .build()?;
 
@@ -163,7 +166,10 @@ fn clears() -> anyhow::Result<()> {
             .with_component_batches(
                 row_id,
                 timepoint,
-                clear.as_component_batches().iter().map(|b| b.as_ref()),
+                clear
+                    .as_component_batches()
+                    .iter()
+                    .map(|b| b as &dyn re_types_core::ComponentBatch),
             )
             .build()?;
 
@@ -348,7 +354,10 @@ fn clears_respect_index_order() -> anyhow::Result<()> {
         .with_component_batches(
             row_id1, // older row id!
             timepoint.clone(),
-            clear.as_component_batches().iter().map(|b| b.as_ref()),
+            clear
+                .as_component_batches()
+                .iter()
+                .map(|b| b as &dyn re_types_core::ComponentBatch),
         )
         .build()?;
 
@@ -372,7 +381,10 @@ fn clears_respect_index_order() -> anyhow::Result<()> {
         .with_component_batches(
             row_id3, // newer row id!
             timepoint.clone(),
-            clear.as_component_batches().iter().map(|b| b.as_ref()),
+            clear
+                .as_component_batches()
+                .iter()
+                .map(|b| b as &dyn re_types_core::ComponentBatch),
         )
         .build()?;
 

--- a/crates/store/re_format_arrow/src/lib.rs
+++ b/crates/store/re_format_arrow/src/lib.rs
@@ -190,7 +190,7 @@ impl std::fmt::Display for DisplayMetadata<'_> {
         f.write_str(
             &metadata
                 .iter()
-                .map(|(key, value)| format!("{prefix}{}: {value:?}", trim_name(key)))
+                .map(|(key, value)| format!("{prefix}{}: {:?}", trim_name(key), trim_name(value)))
                 .collect::<Vec<_>>()
                 .join("\n"),
         )

--- a/crates/store/re_log_types/src/example_components.rs
+++ b/crates/store/re_log_types/src/example_components.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use re_types_core::{Component, ComponentName, DeserializationError, Loggable, SizeBytes};
+use re_types_core::{Component, ComponentDescriptor, DeserializationError, Loggable, SizeBytes};
 
 // ----------------------------------------------------------------------------
 
@@ -24,15 +24,15 @@ impl re_types_core::Archetype for MyPoints {
         "MyPoints"
     }
 
-    fn required_components() -> ::std::borrow::Cow<'static, [re_types_core::ComponentName]> {
-        vec![MyPoint::name()].into()
+    fn required_components() -> ::std::borrow::Cow<'static, [re_types_core::ComponentDescriptor]> {
+        vec![MyPoint::descriptor()].into()
     }
 
-    fn recommended_components() -> std::borrow::Cow<'static, [re_types_core::ComponentName]> {
+    fn recommended_components() -> std::borrow::Cow<'static, [re_types_core::ComponentDescriptor]> {
         vec![
-            re_types_core::ComponentBatch::name(&Self::Indicator::default()),
-            MyColor::name(),
-            MyLabel::name(),
+            re_types_core::ComponentBatch::descriptor(&Self::Indicator::default()).into_owned(),
+            MyColor::descriptor(),
+            MyLabel::descriptor(),
         ]
         .into()
     }
@@ -142,8 +142,8 @@ impl Loggable for MyPoint {
 }
 
 impl Component for MyPoint {
-    fn name() -> ComponentName {
-        "example.MyPoint".into()
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("example.MyPoint")
     }
 }
 
@@ -251,8 +251,8 @@ impl Loggable for MyPoint64 {
 }
 
 impl Component for MyPoint64 {
-    fn name() -> ComponentName {
-        "example.MyPoint64".into()
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("example.MyPoint64")
     }
 }
 
@@ -325,8 +325,8 @@ impl Loggable for MyColor {
 }
 
 impl Component for MyColor {
-    fn name() -> ComponentName {
-        "example.MyColor".into()
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("example.MyColor")
     }
 }
 
@@ -376,8 +376,8 @@ impl Loggable for MyLabel {
 }
 
 impl Component for MyLabel {
-    fn name() -> ComponentName {
-        "example.MyLabel".into()
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("example.MyLabel")
     }
 }
 
@@ -436,7 +436,7 @@ impl Loggable for MyIndex {
 }
 
 impl Component for MyIndex {
-    fn name() -> ComponentName {
-        "example.MyIndex".into()
+    fn descriptor() -> re_types_core::ComponentDescriptor {
+        ComponentDescriptor::new("example.MyIndex")
     }
 }

--- a/crates/store/re_query/benches/latest_at.rs
+++ b/crates/store/re_query/benches/latest_at.rs
@@ -278,7 +278,7 @@ fn query_and_visit_points(caches: &QueryCache, paths: &[EntityPath]) -> Vec<Save
         let results: LatestAtResults = caches.latest_at(
             &query,
             entity_path,
-            Points2D::all_components().iter().copied(), // no generics!
+            Points2D::all_components().iter(), // no generics!
         );
 
         let points = results.component_batch_quiet::<Position2D>().unwrap();
@@ -310,7 +310,7 @@ fn query_and_visit_strings(caches: &QueryCache, paths: &[EntityPath]) -> Vec<Sav
         let results: LatestAtResults = caches.latest_at(
             &query,
             entity_path,
-            Points2D::all_components().iter().copied(), // no generics!
+            Points2D::all_components().iter(), // no generics!
         );
 
         let points = results.component_batch_quiet::<Position2D>().unwrap();

--- a/crates/store/re_query/examples/latest_at.rs
+++ b/crates/store/re_query/examples/latest_at.rs
@@ -30,7 +30,7 @@ fn main() -> anyhow::Result<()> {
     let results: LatestAtResults = caches.latest_at(
         &query,
         &entity_path.into(),
-        MyPoints::all_components().iter().copied(), // no generics!
+        MyPoints::all_components().iter(), // no generics!
     );
 
     // The results can be accessed either through the low-level Chunk APIs, or the higher-level helpers.

--- a/crates/store/re_query/examples/range.rs
+++ b/crates/store/re_query/examples/range.rs
@@ -26,7 +26,7 @@ fn main() -> anyhow::Result<()> {
     let results: RangeResults = caches.range(
         &query,
         &entity_path.into(),
-        MyPoints::all_components().iter().copied(), // no generics!
+        MyPoints::all_components().iter(), // no generics!
     );
 
     // * `get_required` returns an error if the chunk is missing.

--- a/crates/store/re_query/src/cache.rs
+++ b/crates/store/re_query/src/cache.rs
@@ -327,59 +327,63 @@ impl ChunkStoreSubscriber for QueryCache {
                 }
 
                 for (timeline, per_component) in chunk.time_range_per_component() {
-                    for (component_name, time_range) in per_component {
-                        let key = QueryCacheKey::new(
-                            chunk.entity_path().clone(),
-                            timeline,
-                            component_name,
-                        );
+                    for (component_name, per_desc) in per_component {
+                        for (component_desc, time_range) in per_desc {
+                            let key = QueryCacheKey::new(
+                                chunk.entity_path().clone(),
+                                timeline,
+                                component_name,
+                            );
 
-                        // latest-at
-                        {
-                            let mut data_time_min = time_range.min();
-
-                            // If a compaction was triggered, make sure to drop the original chunks too.
-                            if let Some(ChunkCompactionReport {
-                                srcs: compacted_chunks,
-                                new_chunk: _,
-                            }) = compacted
+                            // latest-at
                             {
-                                for chunk in compacted_chunks.values() {
-                                    let data_time_compacted = chunk
-                                        .time_range_per_component()
-                                        .get(&timeline)
-                                        .and_then(|per_component| {
-                                            per_component.get(&component_name)
-                                        })
-                                        .map_or(TimeInt::MAX, |time_range| time_range.min());
+                                let mut data_time_min = time_range.min();
 
-                                    data_time_min =
-                                        TimeInt::min(data_time_min, data_time_compacted);
+                                // If a compaction was triggered, make sure to drop the original chunks too.
+                                if let Some(ChunkCompactionReport {
+                                    srcs: compacted_chunks,
+                                    new_chunk: _,
+                                }) = compacted
+                                {
+                                    for chunk in compacted_chunks.values() {
+                                        let data_time_compacted = chunk
+                                            .time_range_per_component()
+                                            .get(&timeline)
+                                            .and_then(|per_component| {
+                                                per_component.get(&component_name).and_then(
+                                                    |per_desc| per_desc.get(&component_desc),
+                                                )
+                                            })
+                                            .map_or(TimeInt::MAX, |time_range| time_range.min());
+
+                                        data_time_min =
+                                            TimeInt::min(data_time_min, data_time_compacted);
+                                    }
                                 }
+
+                                compacted_events
+                                    .temporal_latest_at
+                                    .entry(key.clone())
+                                    .and_modify(|time| *time = TimeInt::min(*time, data_time_min))
+                                    .or_insert(data_time_min);
                             }
 
-                            compacted_events
-                                .temporal_latest_at
-                                .entry(key.clone())
-                                .and_modify(|time| *time = TimeInt::min(*time, data_time_min))
-                                .or_insert(data_time_min);
-                        }
+                            // range
+                            {
+                                let compacted_events =
+                                    compacted_events.temporal_range.entry(key).or_default();
 
-                        // range
-                        {
-                            let compacted_events =
-                                compacted_events.temporal_range.entry(key).or_default();
-
-                            compacted_events.insert(chunk.id());
-                            // If a compaction was triggered, make sure to drop the original chunks too.
-                            compacted_events.extend(compacted.iter().flat_map(
-                                |ChunkCompactionReport {
-                                     srcs: compacted_chunks,
-                                     new_chunk: _,
-                                 }| {
-                                    compacted_chunks.keys().copied()
-                                },
-                            ));
+                                compacted_events.insert(chunk.id());
+                                // If a compaction was triggered, make sure to drop the original chunks too.
+                                compacted_events.extend(compacted.iter().flat_map(
+                                    |ChunkCompactionReport {
+                                         srcs: compacted_chunks,
+                                         new_chunk: _,
+                                     }| {
+                                        compacted_chunks.keys().copied()
+                                    },
+                                ));
+                            }
                         }
                     }
                 }

--- a/crates/store/re_query/tests/latest_at.rs
+++ b/crates/store/re_query/tests/latest_at.rs
@@ -558,11 +558,7 @@ fn query_and_compare(
     re_log::setup_logging();
 
     for _ in 0..3 {
-        let cached = caches.latest_at(
-            query,
-            entity_path,
-            MyPoints::all_components().iter().copied(),
-        );
+        let cached = caches.latest_at(query, entity_path, MyPoints::all_components().iter());
 
         let cached_points = cached.component_batch::<MyPoint>().unwrap();
         let cached_colors = cached.component_batch::<MyColor>().unwrap_or_default();

--- a/crates/store/re_query/tests/range.rs
+++ b/crates/store/re_query/tests/range.rs
@@ -891,11 +891,7 @@ fn concurrent_multitenant_edge_case() {
     eprintln!("{store}");
 
     {
-        let cached = caches.range(
-            &query,
-            &entity_path,
-            MyPoints::all_components().iter().copied(),
-        );
+        let cached = caches.range(&query, &entity_path, MyPoints::all_components().iter());
 
         let _cached_all_points = cached.get_required(&MyPoint::name()).unwrap();
     }
@@ -969,11 +965,7 @@ fn concurrent_multitenant_edge_case2() {
 
     let query1 = RangeQuery::new(timepoint1[0].0, ResolvedTimeRange::new(123, 223));
     {
-        let cached = caches.range(
-            &query1,
-            &entity_path,
-            MyPoints::all_components().iter().copied(),
-        );
+        let cached = caches.range(&query1, &entity_path, MyPoints::all_components().iter());
 
         let _cached_all_points = cached.get_required(&MyPoint::name()).unwrap();
     }
@@ -982,11 +974,7 @@ fn concurrent_multitenant_edge_case2() {
 
     let query2 = RangeQuery::new(timepoint1[0].0, ResolvedTimeRange::new(423, 523));
     {
-        let cached = caches.range(
-            &query2,
-            &entity_path,
-            MyPoints::all_components().iter().copied(),
-        );
+        let cached = caches.range(&query2, &entity_path, MyPoints::all_components().iter());
 
         let _cached_all_points = cached.get_required(&MyPoint::name()).unwrap();
     }
@@ -1077,11 +1065,7 @@ fn query_and_compare(
     re_log::setup_logging();
 
     for _ in 0..3 {
-        let cached = caches.range(
-            query,
-            entity_path,
-            MyPoints::all_components().iter().copied(),
-        );
+        let cached = caches.range(query, entity_path, MyPoints::all_components().iter());
 
         let all_points_chunks = cached.get_required(&MyPoint::name()).unwrap();
         let all_points_indexed = all_points_chunks

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The annotation context provides additional information on how to display entities.
@@ -75,32 +75,40 @@ pub struct AnnotationContext {
     pub context: crate::components::AnnotationContext,
 }
 
-impl ::re_types_core::SizeBytes for AnnotationContext {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.context.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+            component_name: "rerun.components.AnnotationContext".into(),
+            archetype_field_name: Some("context".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::AnnotationContext>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+            component_name: "AnnotationContextIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.AnnotationContext".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.AnnotationContextIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.AnnotationContext".into(),
-            "rerun.components.AnnotationContextIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+                component_name: "rerun.components.AnnotationContext".into(),
+                archetype_field_name: Some("context".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+                component_name: "AnnotationContextIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -128,26 +136,26 @@ impl ::re_types_core::Archetype for AnnotationContext {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AnnotationContextIndicator = AnnotationContextIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -184,7 +192,16 @@ impl ::re_types_core::AsComponents for AnnotationContext {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.context as &dyn ComponentBatch).into()),
+            (Some(&self.context as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
+                        archetype_field_name: Some(("context").into()),
+                        component_name: ("rerun.components.AnnotationContext").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -201,5 +218,17 @@ impl AnnotationContext {
         Self {
             context: context.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for AnnotationContext {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.context.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::AnnotationContext>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -134,9 +134,9 @@ impl ::re_types_core::Archetype for AnnotationContext {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AnnotationContextIndicator = AnnotationContextIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -187,13 +187,13 @@ impl ::re_types_core::Archetype for AnnotationContext {
 }
 
 impl ::re_types_core::AsComponents for AnnotationContext {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.context as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.AnnotationContext".into()),

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 2D arrows with optional colors, radii, labels, etc.
@@ -87,67 +87,115 @@ pub struct Arrows2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Arrows2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.vectors.heap_size_bytes()
-            + self.origins.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+            component_name: "rerun.components.Vector2D".into(),
+            archetype_field_name: Some("vectors".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Vector2D>>::is_pod()
-            && <Option<Vec<crate::components::Position2D>>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Vector2D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position2D".into(),
-            "rerun.components.Arrows2DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("origins".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "Arrows2DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Vector2D".into(),
-            "rerun.components.Position2D".into(),
-            "rerun.components.Arrows2DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Vector2D".into(),
+                archetype_field_name: Some("vectors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("origins".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "Arrows2DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -175,26 +223,26 @@ impl ::re_types_core::Archetype for Arrows2D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Arrows2DIndicator = Arrows2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -317,28 +365,100 @@ impl ::re_types_core::AsComponents for Arrows2D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.vectors as &dyn ComponentBatch).into()),
-            self.origins
+            (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                        archetype_field_name: Some(("vectors").into()),
+                        component_name: ("rerun.components.Vector2D").into(),
+                    }),
+                }
+            }),
+            (self
+                .origins
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.radii
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("origins").into()),
+                    component_name: ("rerun.components.Position2D").into(),
+                }),
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows2D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -443,5 +563,31 @@ impl Arrows2D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Arrows2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.vectors.heap_size_bytes()
+            + self.origins.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Vector2D>>::is_pod()
+            && <Option<Vec<crate::components::Position2D>>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -221,9 +221,9 @@ impl ::re_types_core::Archetype for Arrows2D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Arrows2DIndicator = Arrows2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -360,13 +360,13 @@ impl ::re_types_core::Archetype for Arrows2D {
 }
 
 impl ::re_types_core::AsComponents for Arrows2D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -379,7 +379,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .origins
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -391,7 +391,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -403,7 +403,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -415,7 +415,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -427,7 +427,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -439,7 +439,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),
@@ -451,7 +451,7 @@ impl ::re_types_core::AsComponents for Arrows2D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows2D".into()),

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 3D arrows with optional colors, radii, labels, etc.
@@ -95,63 +95,105 @@ pub struct Arrows3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Arrows3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.vectors.heap_size_bytes()
-            + self.origins.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+            component_name: "rerun.components.Vector3D".into(),
+            archetype_field_name: Some("vectors".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Vector3D>>::is_pod()
-            && <Option<Vec<crate::components::Position3D>>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Vector3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position3D".into(),
-            "rerun.components.Arrows3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Position3D".into(),
+                archetype_field_name: Some("origins".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "Arrows3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Vector3D".into(),
-            "rerun.components.Position3D".into(),
-            "rerun.components.Arrows3DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Vector3D".into(),
+                archetype_field_name: Some("vectors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Position3D".into(),
+                archetype_field_name: Some("origins".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "Arrows3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -179,26 +221,26 @@ impl ::re_types_core::Archetype for Arrows3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Arrows3DIndicator = Arrows3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -311,25 +353,88 @@ impl ::re_types_core::AsComponents for Arrows3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.vectors as &dyn ComponentBatch).into()),
-            self.origins
+            (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                        archetype_field_name: Some(("vectors").into()),
+                        component_name: ("rerun.components.Vector3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .origins
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.radii
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("origins").into()),
+                    component_name: ("rerun.components.Position3D").into(),
+                }),
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Arrows3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -424,5 +529,29 @@ impl Arrows3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Arrows3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.vectors.heap_size_bytes()
+            + self.origins.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Vector3D>>::is_pod()
+            && <Option<Vec<crate::components::Position3D>>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -219,9 +219,9 @@ impl ::re_types_core::Archetype for Arrows3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Arrows3DIndicator = Arrows3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -348,13 +348,13 @@ impl ::re_types_core::Archetype for Arrows3D {
 }
 
 impl ::re_types_core::AsComponents for Arrows3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.vectors as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -367,7 +367,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .origins
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -379,7 +379,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -391,7 +391,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -403,7 +403,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -415,7 +415,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),
@@ -427,7 +427,7 @@ impl ::re_types_core::AsComponents for Arrows3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Arrows3D".into()),

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -160,9 +160,9 @@ impl ::re_types_core::Archetype for Asset3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Asset3DIndicator = Asset3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -236,13 +236,13 @@ impl ::re_types_core::Archetype for Asset3D {
 }
 
 impl ::re_types_core::AsComponents for Asset3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Asset3D".into()),
@@ -255,7 +255,7 @@ impl ::re_types_core::AsComponents for Asset3D {
                 .media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Asset3D".into()),
@@ -267,7 +267,7 @@ impl ::re_types_core::AsComponents for Asset3D {
                 .albedo_factor
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Asset3D".into()),

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A video binary.
@@ -139,38 +139,52 @@ pub struct AssetVideo {
     pub media_type: Option<crate::components::MediaType>,
 }
 
-impl ::re_types_core::SizeBytes for AssetVideo {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.blob.heap_size_bytes() + self.media_type.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+            component_name: "rerun.components.Blob".into(),
+            archetype_field_name: Some("blob".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::Blob>::is_pod() && <Option<crate::components::MediaType>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Blob".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.MediaType".into(),
-            "rerun.components.AssetVideoIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                component_name: "rerun.components.MediaType".into(),
+                archetype_field_name: Some("media_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                component_name: "AssetVideoIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Blob".into(),
-            "rerun.components.MediaType".into(),
-            "rerun.components.AssetVideoIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                component_name: "rerun.components.Blob".into(),
+                archetype_field_name: Some("blob".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                component_name: "rerun.components.MediaType".into(),
+                archetype_field_name: Some("media_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                component_name: "AssetVideoIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -198,26 +212,26 @@ impl ::re_types_core::Archetype for AssetVideo {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AssetVideoIndicator = AssetVideoIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -263,10 +277,28 @@ impl ::re_types_core::AsComponents for AssetVideo {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.blob as &dyn ComponentBatch).into()),
-            self.media_type
+            (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                        archetype_field_name: Some(("blob").into()),
+                        component_name: ("rerun.components.Blob").into(),
+                    }),
+                }
+            }),
+            (self
+                .media_type
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.AssetVideo".into()),
+                    archetype_field_name: Some(("media_type").into()),
+                    component_name: ("rerun.components.MediaType").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -297,5 +329,17 @@ impl AssetVideo {
     pub fn with_media_type(mut self, media_type: impl Into<crate::components::MediaType>) -> Self {
         self.media_type = Some(media_type.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for AssetVideo {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.blob.heap_size_bytes() + self.media_type.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::Blob>::is_pod() && <Option<crate::components::MediaType>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -210,9 +210,9 @@ impl ::re_types_core::Archetype for AssetVideo {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AssetVideoIndicator = AssetVideoIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -272,13 +272,13 @@ impl ::re_types_core::Archetype for AssetVideo {
 }
 
 impl ::re_types_core::AsComponents for AssetVideo {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.AssetVideo".into()),
@@ -291,7 +291,7 @@ impl ::re_types_core::AsComponents for AssetVideo {
                 .media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.AssetVideo".into()),

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A bar chart.
@@ -55,33 +55,51 @@ pub struct BarChart {
     pub color: Option<crate::components::Color>,
 }
 
-impl ::re_types_core::SizeBytes for BarChart {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.values.heap_size_bytes() + self.color.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            component_name: "rerun.components.TensorData".into(),
+            archetype_field_name: Some("values".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::TensorData>::is_pod() && <Option<crate::components::Color>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            component_name: "BarChartIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.TensorData".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.BarChart".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }]
+    });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.BarChartIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Color".into()]);
-
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.TensorData".into(),
-            "rerun.components.BarChartIndicator".into(),
-            "rerun.components.Color".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.BarChart".into()),
+                component_name: "rerun.components.TensorData".into(),
+                archetype_field_name: Some("values".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.BarChart".into()),
+                component_name: "BarChartIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.BarChart".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
         ]
     });
 
@@ -109,26 +127,26 @@ impl ::re_types_core::Archetype for BarChart {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: BarChartIndicator = BarChartIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -174,10 +192,28 @@ impl ::re_types_core::AsComponents for BarChart {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.values as &dyn ComponentBatch).into()),
-            self.color
+            (Some(&self.values as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.BarChart".into()),
+                        archetype_field_name: Some(("values").into()),
+                        component_name: ("rerun.components.TensorData").into(),
+                    }),
+                }
+            }),
+            (self
+                .color
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.BarChart".into()),
+                    archetype_field_name: Some(("color").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -202,5 +238,17 @@ impl BarChart {
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for BarChart {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.values.heap_size_bytes() + self.color.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::TensorData>::is_pod() && <Option<crate::components::Color>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -125,9 +125,9 @@ impl ::re_types_core::Archetype for BarChart {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: BarChartIndicator = BarChartIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -187,13 +187,13 @@ impl ::re_types_core::Archetype for BarChart {
 }
 
 impl ::re_types_core::AsComponents for BarChart {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.values as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.BarChart".into()),
@@ -206,7 +206,7 @@ impl ::re_types_core::AsComponents for BarChart {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.BarChart".into()),

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 2D boxes with half-extents and optional center, colors etc.
@@ -80,67 +80,115 @@ pub struct Boxes2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Boxes2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.half_sizes.heap_size_bytes()
-            + self.centers.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+            component_name: "rerun.components.HalfSize2D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::HalfSize2D>>::is_pod()
-            && <Option<Vec<crate::components::Position2D>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.HalfSize2D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position2D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Boxes2DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "Boxes2DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.HalfSize2D".into(),
-            "rerun.components.Position2D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Boxes2DIndicator".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.HalfSize2D".into(),
+                archetype_field_name: Some("half_sizes".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "Boxes2DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -168,26 +216,26 @@ impl ::re_types_core::Archetype for Boxes2D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Boxes2DIndicator = Boxes2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -310,28 +358,100 @@ impl ::re_types_core::AsComponents for Boxes2D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.half_sizes as &dyn ComponentBatch).into()),
-            self.centers
+            (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                        archetype_field_name: Some(("half_sizes").into()),
+                        component_name: ("rerun.components.HalfSize2D").into(),
+                    }),
+                }
+            }),
+            (self
+                .centers
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("centers").into()),
+                    component_name: ("rerun.components.Position2D").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.radii
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes2D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -433,5 +553,31 @@ impl Boxes2D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Boxes2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.half_sizes.heap_size_bytes()
+            + self.centers.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::HalfSize2D>>::is_pod()
+            && <Option<Vec<crate::components::Position2D>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -214,9 +214,9 @@ impl ::re_types_core::Archetype for Boxes2D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Boxes2DIndicator = Boxes2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -353,13 +353,13 @@ impl ::re_types_core::Archetype for Boxes2D {
 }
 
 impl ::re_types_core::AsComponents for Boxes2D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -372,7 +372,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .centers
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -384,7 +384,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -396,7 +396,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -408,7 +408,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -420,7 +420,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -432,7 +432,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),
@@ -444,7 +444,7 @@ impl ::re_types_core::AsComponents for Boxes2D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes2D".into()),

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 3D boxes with half-extents and optional center, rotations, colors etc.
@@ -110,75 +110,135 @@ pub struct Boxes3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Boxes3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.half_sizes.heap_size_bytes()
-            + self.centers.heap_size_bytes()
-            + self.rotation_axis_angles.heap_size_bytes()
-            + self.quaternions.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.fill_mode.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+            component_name: "rerun.components.HalfSize3D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::HalfSize3D>>::is_pod()
-            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<crate::components::FillMode>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.HalfSize3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Boxes3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "Boxes3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.FillMode".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.FillMode".into(),
+                archetype_field_name: Some("fill_mode".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 11usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.HalfSize3D".into(),
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Boxes3DIndicator".into(),
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.FillMode".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.HalfSize3D".into(),
+                archetype_field_name: Some("half_sizes".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "Boxes3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.FillMode".into(),
+                archetype_field_name: Some("fill_mode".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -206,26 +266,26 @@ impl ::re_types_core::Archetype for Boxes3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Boxes3DIndicator = Boxes3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -377,34 +437,124 @@ impl ::re_types_core::AsComponents for Boxes3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.half_sizes as &dyn ComponentBatch).into()),
-            self.centers
+            (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                        archetype_field_name: Some(("half_sizes").into()),
+                        component_name: ("rerun.components.HalfSize3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .centers
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.rotation_axis_angles
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("centers").into()),
+                    component_name: ("rerun.components.PoseTranslation3D").into(),
+                }),
+            }),
+            (self
+                .rotation_axis_angles
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.quaternions
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("rotation_axis_angles").into()),
+                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
+                }),
+            }),
+            (self
+                .quaternions
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("quaternions").into()),
+                    component_name: ("rerun.components.PoseRotationQuat").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.radii
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fill_mode
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .fill_mode
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("fill_mode").into()),
+                    component_name: ("rerun.components.FillMode").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Boxes3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -536,5 +686,35 @@ impl Boxes3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Boxes3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.half_sizes.heap_size_bytes()
+            + self.centers.heap_size_bytes()
+            + self.rotation_axis_angles.heap_size_bytes()
+            + self.quaternions.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.fill_mode.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::HalfSize3D>>::is_pod()
+            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<crate::components::FillMode>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -264,9 +264,9 @@ impl ::re_types_core::Archetype for Boxes3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Boxes3DIndicator = Boxes3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -432,13 +432,13 @@ impl ::re_types_core::Archetype for Boxes3D {
 }
 
 impl ::re_types_core::AsComponents for Boxes3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -451,7 +451,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .centers
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -463,7 +463,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .rotation_axis_angles
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -475,7 +475,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .quaternions
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -487,7 +487,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -499,7 +499,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -511,7 +511,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .fill_mode
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -523,7 +523,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -535,7 +535,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),
@@ -547,7 +547,7 @@ impl ::re_types_core::AsComponents for Boxes3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Boxes3D".into()),

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 3D capsules; cylinders with hemispherical caps.
@@ -112,75 +112,127 @@ pub struct Capsules3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Capsules3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.lengths.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.translations.heap_size_bytes()
-            + self.rotation_axis_angles.heap_size_bytes()
-            + self.quaternions.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Length>>::is_pod()
-            && <Vec<crate::components::Radius>>::is_pod()
-            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Length".into(),
-            "rerun.components.Radius".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Length".into(),
+                archetype_field_name: Some("lengths".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Capsules3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("translations".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "Capsules3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 10usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Length".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Capsules3DIndicator".into(),
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Length".into(),
+                archetype_field_name: Some("lengths".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("translations".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "Capsules3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -208,26 +260,26 @@ impl ::re_types_core::Archetype for Capsules3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Capsules3DIndicator = Capsules3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -369,29 +421,110 @@ impl ::re_types_core::AsComponents for Capsules3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.lengths as &dyn ComponentBatch).into()),
-            Some((&self.radii as &dyn ComponentBatch).into()),
-            self.translations
+            (Some(&self.lengths as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                        archetype_field_name: Some(("lengths").into()),
+                        component_name: ("rerun.components.Length").into(),
+                    }),
+                }
+            }),
+            (Some(&self.radii as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                        archetype_field_name: Some(("radii").into()),
+                        component_name: ("rerun.components.Radius").into(),
+                    }),
+                }
+            }),
+            (self
+                .translations
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.rotation_axis_angles
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("translations").into()),
+                    component_name: ("rerun.components.PoseTranslation3D").into(),
+                }),
+            }),
+            (self
+                .rotation_axis_angles
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.quaternions
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("rotation_axis_angles").into()),
+                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
+                }),
+            }),
+            (self
+                .quaternions
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("quaternions").into()),
+                    component_name: ("rerun.components.PoseRotationQuat").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Capsules3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -503,5 +636,33 @@ impl Capsules3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Capsules3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.lengths.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.translations.heap_size_bytes()
+            + self.rotation_axis_angles.heap_size_bytes()
+            + self.quaternions.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Length>>::is_pod()
+            && <Vec<crate::components::Radius>>::is_pod()
+            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -258,9 +258,9 @@ impl ::re_types_core::Archetype for Capsules3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Capsules3DIndicator = Capsules3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -416,13 +416,13 @@ impl ::re_types_core::Archetype for Capsules3D {
 }
 
 impl ::re_types_core::AsComponents for Capsules3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.lengths as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -432,7 +432,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 }
             }),
             (Some(&self.radii as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -445,7 +445,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .translations
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -457,7 +457,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .rotation_axis_angles
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -469,7 +469,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .quaternions
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -481,7 +481,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -493,7 +493,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -505,7 +505,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),
@@ -517,7 +517,7 @@ impl ::re_types_core::AsComponents for Capsules3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Capsules3D".into()),

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A depth image, i.e. as captured by a depth camera.
@@ -114,63 +114,105 @@ pub struct DepthImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
-impl ::re_types_core::SizeBytes for DepthImage {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.buffer.heap_size_bytes()
-            + self.format.heap_size_bytes()
-            + self.meter.heap_size_bytes()
-            + self.colormap.heap_size_bytes()
-            + self.depth_range.heap_size_bytes()
-            + self.point_fill_ratio.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::ImageBuffer>::is_pod()
-            && <crate::components::ImageFormat>::is_pod()
-            && <Option<crate::components::DepthMeter>>::is_pod()
-            && <Option<crate::components::Colormap>>::is_pod()
-            && <Option<crate::components::ValueRange>>::is_pod()
-            && <Option<crate::components::FillRatio>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.DepthImageIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DepthImage".into()),
+            component_name: "DepthImageIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.DepthMeter".into(),
-            "rerun.components.Colormap".into(),
-            "rerun.components.ValueRange".into(),
-            "rerun.components.FillRatio".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.DepthMeter".into(),
+                archetype_field_name: Some("meter".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.Colormap".into(),
+                archetype_field_name: Some("colormap".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ValueRange".into(),
+                archetype_field_name: Some("depth_range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.FillRatio".into(),
+                archetype_field_name: Some("point_fill_ratio".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
-            "rerun.components.DepthImageIndicator".into(),
-            "rerun.components.DepthMeter".into(),
-            "rerun.components.Colormap".into(),
-            "rerun.components.ValueRange".into(),
-            "rerun.components.FillRatio".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "DepthImageIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.DepthMeter".into(),
+                archetype_field_name: Some("meter".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.Colormap".into(),
+                archetype_field_name: Some("colormap".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.ValueRange".into(),
+                archetype_field_name: Some("depth_range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.FillRatio".into(),
+                archetype_field_name: Some("point_fill_ratio".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
@@ -198,26 +240,26 @@ impl ::re_types_core::Archetype for DepthImage {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: DepthImageIndicator = DepthImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -321,23 +363,86 @@ impl ::re_types_core::AsComponents for DepthImage {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.buffer as &dyn ComponentBatch).into()),
-            Some((&self.format as &dyn ComponentBatch).into()),
-            self.meter
+            (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                        archetype_field_name: Some(("buffer").into()),
+                        component_name: ("rerun.components.ImageBuffer").into(),
+                    }),
+                }
+            }),
+            (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                        archetype_field_name: Some(("format").into()),
+                        component_name: ("rerun.components.ImageFormat").into(),
+                    }),
+                }
+            }),
+            (self
+                .meter
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.colormap
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                    archetype_field_name: Some(("meter").into()),
+                    component_name: ("rerun.components.DepthMeter").into(),
+                }),
+            }),
+            (self
+                .colormap
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.depth_range
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                    archetype_field_name: Some(("colormap").into()),
+                    component_name: ("rerun.components.Colormap").into(),
+                }),
+            }),
+            (self
+                .depth_range
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.point_fill_ratio
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                    archetype_field_name: Some(("depth_range").into()),
+                    component_name: ("rerun.components.ValueRange").into(),
+                }),
+            }),
+            (self
+                .point_fill_ratio
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                    archetype_field_name: Some(("point_fill_ratio").into()),
+                    component_name: ("rerun.components.FillRatio").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.DepthImage".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -430,5 +535,29 @@ impl DepthImage {
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for DepthImage {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.buffer.heap_size_bytes()
+            + self.format.heap_size_bytes()
+            + self.meter.heap_size_bytes()
+            + self.colormap.heap_size_bytes()
+            + self.depth_range.heap_size_bytes()
+            + self.point_fill_ratio.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::ImageBuffer>::is_pod()
+            && <crate::components::ImageFormat>::is_pod()
+            && <Option<crate::components::DepthMeter>>::is_pod()
+            && <Option<crate::components::Colormap>>::is_pod()
+            && <Option<crate::components::ValueRange>>::is_pod()
+            && <Option<crate::components::FillRatio>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -238,9 +238,9 @@ impl ::re_types_core::Archetype for DepthImage {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: DepthImageIndicator = DepthImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -358,13 +358,13 @@ impl ::re_types_core::Archetype for DepthImage {
 }
 
 impl ::re_types_core::AsComponents for DepthImage {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -374,7 +374,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -387,7 +387,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .meter
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -399,7 +399,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .colormap
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -411,7 +411,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .depth_range
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -423,7 +423,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .point_fill_ratio
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.DepthImage".into()),
@@ -435,7 +435,7 @@ impl ::re_types_core::AsComponents for DepthImage {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.DepthImage".into()),

--- a/crates/store/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/store/re_types/src/archetypes/disconnected_space.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Spatially disconnect this entity from its parent.
@@ -67,32 +67,40 @@ pub struct DisconnectedSpace {
     pub disconnected_space: crate::components::DisconnectedSpace,
 }
 
-impl ::re_types_core::SizeBytes for DisconnectedSpace {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.disconnected_space.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
+            component_name: "rerun.components.DisconnectedSpace".into(),
+            archetype_field_name: Some("disconnected_space".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::DisconnectedSpace>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
+            component_name: "DisconnectedSpaceIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.DisconnectedSpace".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.DisconnectedSpaceIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.DisconnectedSpace".into(),
-            "rerun.components.DisconnectedSpaceIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
+                component_name: "rerun.components.DisconnectedSpace".into(),
+                archetype_field_name: Some("disconnected_space".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
+                component_name: "DisconnectedSpaceIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -120,26 +128,26 @@ impl ::re_types_core::Archetype for DisconnectedSpace {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: DisconnectedSpaceIndicator = DisconnectedSpaceIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -176,7 +184,16 @@ impl ::re_types_core::AsComponents for DisconnectedSpace {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.disconnected_space as &dyn ComponentBatch).into()),
+            (Some(&self.disconnected_space as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
+                        archetype_field_name: Some(("disconnected_space").into()),
+                        component_name: ("rerun.components.DisconnectedSpace").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -193,5 +210,17 @@ impl DisconnectedSpace {
         Self {
             disconnected_space: disconnected_space.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for DisconnectedSpace {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.disconnected_space.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::DisconnectedSpace>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/store/re_types/src/archetypes/disconnected_space.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -126,9 +126,9 @@ impl ::re_types_core::Archetype for DisconnectedSpace {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: DisconnectedSpaceIndicator = DisconnectedSpaceIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -179,13 +179,13 @@ impl ::re_types_core::Archetype for DisconnectedSpace {
 }
 
 impl ::re_types_core::AsComponents for DisconnectedSpace {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.disconnected_space as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 3D ellipsoids or spheres.
@@ -73,75 +73,135 @@ pub struct Ellipsoids3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Ellipsoids3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.half_sizes.heap_size_bytes()
-            + self.centers.heap_size_bytes()
-            + self.rotation_axis_angles.heap_size_bytes()
-            + self.quaternions.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.line_radii.heap_size_bytes()
-            + self.fill_mode.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+            component_name: "rerun.components.HalfSize3D".into(),
+            archetype_field_name: Some("half_sizes".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::HalfSize3D>>::is_pod()
-            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<crate::components::FillMode>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.HalfSize3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Ellipsoids3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "Ellipsoids3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.FillMode".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("line_radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.FillMode".into(),
+                archetype_field_name: Some("fill_mode".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 11usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.HalfSize3D".into(),
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Ellipsoids3DIndicator".into(),
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.FillMode".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.HalfSize3D".into(),
+                archetype_field_name: Some("half_sizes".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("centers".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "Ellipsoids3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("line_radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.FillMode".into(),
+                archetype_field_name: Some("fill_mode".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -169,26 +229,26 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Ellipsoids3DIndicator = Ellipsoids3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -340,34 +400,124 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.half_sizes as &dyn ComponentBatch).into()),
-            self.centers
+            (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                        archetype_field_name: Some(("half_sizes").into()),
+                        component_name: ("rerun.components.HalfSize3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .centers
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.rotation_axis_angles
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("centers").into()),
+                    component_name: ("rerun.components.PoseTranslation3D").into(),
+                }),
+            }),
+            (self
+                .rotation_axis_angles
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.quaternions
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("rotation_axis_angles").into()),
+                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
+                }),
+            }),
+            (self
+                .quaternions
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("quaternions").into()),
+                    component_name: ("rerun.components.PoseRotationQuat").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.line_radii
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .line_radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fill_mode
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("line_radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .fill_mode
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("fill_mode").into()),
+                    component_name: ("rerun.components.FillMode").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -496,5 +646,35 @@ impl Ellipsoids3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Ellipsoids3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.half_sizes.heap_size_bytes()
+            + self.centers.heap_size_bytes()
+            + self.rotation_axis_angles.heap_size_bytes()
+            + self.quaternions.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.line_radii.heap_size_bytes()
+            + self.fill_mode.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::HalfSize3D>>::is_pod()
+            && <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<crate::components::FillMode>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -227,9 +227,9 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Ellipsoids3DIndicator = Ellipsoids3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -395,13 +395,13 @@ impl ::re_types_core::Archetype for Ellipsoids3D {
 }
 
 impl ::re_types_core::AsComponents for Ellipsoids3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.half_sizes as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -414,7 +414,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .centers
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -426,7 +426,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .rotation_axis_angles
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -438,7 +438,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .quaternions
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -450,7 +450,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -462,7 +462,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .line_radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -474,7 +474,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .fill_mode
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -486,7 +486,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -498,7 +498,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
@@ -510,7 +510,7 @@ impl ::re_types_core::AsComponents for Ellipsoids3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: An image encoded as e.g. a JPEG or PNG.
@@ -66,51 +66,75 @@ pub struct EncodedImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
-impl ::re_types_core::SizeBytes for EncodedImage {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.blob.heap_size_bytes()
-            + self.media_type.heap_size_bytes()
-            + self.opacity.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+            component_name: "rerun.components.Blob".into(),
+            archetype_field_name: Some("blob".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::Blob>::is_pod()
-            && <Option<crate::components::MediaType>>::is_pod()
-            && <Option<crate::components::Opacity>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Blob".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.MediaType".into(),
-            "rerun.components.EncodedImageIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.MediaType".into(),
+                archetype_field_name: Some("media_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "EncodedImageIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Blob".into(),
-            "rerun.components.MediaType".into(),
-            "rerun.components.EncodedImageIndicator".into(),
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.Blob".into(),
+                archetype_field_name: Some("blob".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.MediaType".into(),
+                archetype_field_name: Some("media_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "EncodedImageIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
@@ -138,26 +162,26 @@ impl ::re_types_core::Archetype for EncodedImage {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: EncodedImageIndicator = EncodedImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -226,16 +250,52 @@ impl ::re_types_core::AsComponents for EncodedImage {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.blob as &dyn ComponentBatch).into()),
-            self.media_type
+            (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                        archetype_field_name: Some(("blob").into()),
+                        component_name: ("rerun.components.Blob").into(),
+                    }),
+                }
+            }),
+            (self
+                .media_type
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.opacity
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                    archetype_field_name: Some(("media_type").into()),
+                    component_name: ("rerun.components.MediaType").into(),
+                }),
+            }),
+            (self
+                .opacity
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                    archetype_field_name: Some(("opacity").into()),
+                    component_name: ("rerun.components.Opacity").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.EncodedImage".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -287,5 +347,23 @@ impl EncodedImage {
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for EncodedImage {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.blob.heap_size_bytes()
+            + self.media_type.heap_size_bytes()
+            + self.opacity.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::Blob>::is_pod()
+            && <Option<crate::components::MediaType>>::is_pod()
+            && <Option<crate::components::Opacity>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -160,9 +160,9 @@ impl ::re_types_core::Archetype for EncodedImage {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: EncodedImageIndicator = EncodedImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -245,13 +245,13 @@ impl ::re_types_core::Archetype for EncodedImage {
 }
 
 impl ::re_types_core::AsComponents for EncodedImage {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.blob as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.EncodedImage".into()),
@@ -264,7 +264,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.EncodedImage".into()),
@@ -276,7 +276,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .opacity
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.EncodedImage".into()),
@@ -288,7 +288,7 @@ impl ::re_types_core::AsComponents for EncodedImage {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.EncodedImage".into()),

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -150,9 +150,9 @@ impl ::re_types_core::Archetype for GeoLineStrings {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: GeoLineStringsIndicator = GeoLineStringsIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -230,13 +230,13 @@ impl ::re_types_core::Archetype for GeoLineStrings {
 }
 
 impl ::re_types_core::AsComponents for GeoLineStrings {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.line_strings as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
@@ -249,7 +249,7 @@ impl ::re_types_core::AsComponents for GeoLineStrings {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
@@ -261,7 +261,7 @@ impl ::re_types_core::AsComponents for GeoLineStrings {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Geospatial points with positions expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees), and optional colors and radii.
@@ -65,47 +65,73 @@ pub struct GeoPoints {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for GeoPoints {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.positions.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.LatLon".into(),
+            archetype_field_name: Some("positions".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::LatLon>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.LatLon".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.GeoPointsIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "GeoPointsIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.ClassId".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+            component_name: "rerun.components.ClassId".into(),
+            archetype_field_name: Some("class_ids".into()),
+        }]
+    });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.LatLon".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.GeoPointsIndicator".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.LatLon".into(),
+                archetype_field_name: Some("positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "GeoPointsIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -133,26 +159,26 @@ impl ::re_types_core::Archetype for GeoPoints {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: GeoPointsIndicator = GeoPointsIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -229,16 +255,52 @@ impl ::re_types_core::AsComponents for GeoPoints {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.positions as &dyn ComponentBatch).into()),
-            self.radii
+            (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                        archetype_field_name: Some(("positions").into()),
+                        component_name: ("rerun.components.LatLon").into(),
+                    }),
+                }
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GeoPoints".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -294,5 +356,23 @@ impl GeoPoints {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for GeoPoints {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.positions.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::LatLon>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -157,9 +157,9 @@ impl ::re_types_core::Archetype for GeoPoints {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: GeoPointsIndicator = GeoPointsIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -250,13 +250,13 @@ impl ::re_types_core::Archetype for GeoPoints {
 }
 
 impl ::re_types_core::AsComponents for GeoPoints {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.GeoPoints".into()),
@@ -269,7 +269,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GeoPoints".into()),
@@ -281,7 +281,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GeoPoints".into()),
@@ -293,7 +293,7 @@ impl ::re_types_core::AsComponents for GeoPoints {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GeoPoints".into()),

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A list of edges in a graph.
@@ -34,39 +34,52 @@ pub struct GraphEdges {
     pub graph_type: Option<crate::components::GraphType>,
 }
 
-impl ::re_types_core::SizeBytes for GraphEdges {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.edges.heap_size_bytes() + self.graph_type.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+            component_name: "rerun.components.GraphEdge".into(),
+            archetype_field_name: Some("edges".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::GraphEdge>>::is_pod()
-            && <Option<crate::components::GraphType>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.GraphEdge".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.GraphType".into(),
-            "rerun.components.GraphEdgesIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                component_name: "rerun.components.GraphType".into(),
+                archetype_field_name: Some("graph_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                component_name: "GraphEdgesIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.GraphEdge".into(),
-            "rerun.components.GraphType".into(),
-            "rerun.components.GraphEdgesIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                component_name: "rerun.components.GraphEdge".into(),
+                archetype_field_name: Some("edges".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                component_name: "rerun.components.GraphType".into(),
+                archetype_field_name: Some("graph_type".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                component_name: "GraphEdgesIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -94,26 +107,26 @@ impl ::re_types_core::Archetype for GraphEdges {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: GraphEdgesIndicator = GraphEdgesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -158,10 +171,28 @@ impl ::re_types_core::AsComponents for GraphEdges {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.edges as &dyn ComponentBatch).into()),
-            self.graph_type
+            (Some(&self.edges as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                        archetype_field_name: Some(("edges").into()),
+                        component_name: ("rerun.components.GraphEdge").into(),
+                    }),
+                }
+            }),
+            (self
+                .graph_type
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphEdges".into()),
+                    archetype_field_name: Some(("graph_type").into()),
+                    component_name: ("rerun.components.GraphType").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -188,5 +219,18 @@ impl GraphEdges {
     pub fn with_graph_type(mut self, graph_type: impl Into<crate::components::GraphType>) -> Self {
         self.graph_type = Some(graph_type.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for GraphEdges {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.edges.heap_size_bytes() + self.graph_type.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::GraphEdge>>::is_pod()
+            && <Option<crate::components::GraphType>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -105,9 +105,9 @@ impl ::re_types_core::Archetype for GraphEdges {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: GraphEdgesIndicator = GraphEdgesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -166,13 +166,13 @@ impl ::re_types_core::Archetype for GraphEdges {
 }
 
 impl ::re_types_core::AsComponents for GraphEdges {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.edges as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.GraphEdges".into()),
@@ -185,7 +185,7 @@ impl ::re_types_core::AsComponents for GraphEdges {
                 .graph_type
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphEdges".into()),

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A list of nodes in a graph with optional labels, colors, etc.
@@ -42,55 +42,93 @@ pub struct GraphNodes {
     pub radii: Option<Vec<crate::components::Radius>>,
 }
 
-impl ::re_types_core::SizeBytes for GraphNodes {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.node_ids.heap_size_bytes()
-            + self.positions.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "rerun.components.GraphNode".into(),
+            archetype_field_name: Some("node_ids".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::GraphNode>>::is_pod()
-            && <Option<Vec<crate::components::Position2D>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+            component_name: "GraphNodesIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.GraphNode".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.GraphNodesIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position2D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.Radius".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.GraphNode".into(),
-            "rerun.components.GraphNodesIndicator".into(),
-            "rerun.components.Position2D".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.Radius".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.GraphNode".into(),
+                archetype_field_name: Some("node_ids".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "GraphNodesIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
         ]
     });
 
@@ -118,26 +156,26 @@ impl ::re_types_core::Archetype for GraphNodes {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: GraphNodesIndicator = GraphNodesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -237,22 +275,76 @@ impl ::re_types_core::AsComponents for GraphNodes {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.node_ids as &dyn ComponentBatch).into()),
-            self.positions
+            (Some(&self.node_ids as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                        archetype_field_name: Some(("node_ids").into()),
+                        component_name: ("rerun.components.GraphNode").into(),
+                    }),
+                }
+            }),
+            (self
+                .positions
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                    archetype_field_name: Some(("positions").into()),
+                    component_name: ("rerun.components.Position2D").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.radii
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.GraphNodes".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -326,5 +418,27 @@ impl GraphNodes {
     ) -> Self {
         self.radii = Some(radii.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for GraphNodes {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.node_ids.heap_size_bytes()
+            + self.positions.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::GraphNode>>::is_pod()
+            && <Option<Vec<crate::components::Position2D>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -154,9 +154,9 @@ impl ::re_types_core::Archetype for GraphNodes {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: GraphNodesIndicator = GraphNodesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -270,13 +270,13 @@ impl ::re_types_core::Archetype for GraphNodes {
 }
 
 impl ::re_types_core::AsComponents for GraphNodes {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.node_ids as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.GraphNodes".into()),
@@ -289,7 +289,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .positions
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphNodes".into()),
@@ -301,7 +301,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphNodes".into()),
@@ -313,7 +313,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphNodes".into()),
@@ -325,7 +325,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphNodes".into()),
@@ -337,7 +337,7 @@ impl ::re_types_core::AsComponents for GraphNodes {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.GraphNodes".into()),

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A monochrome or color image.
@@ -145,51 +145,75 @@ pub struct Image {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
-impl ::re_types_core::SizeBytes for Image {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.buffer.heap_size_bytes()
-            + self.format.heap_size_bytes()
-            + self.opacity.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::ImageBuffer>::is_pod()
-            && <crate::components::ImageFormat>::is_pod()
-            && <Option<crate::components::Opacity>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.ImageIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Image".into()),
+            component_name: "ImageIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
-            "rerun.components.ImageIndicator".into(),
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "ImageIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Image".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
@@ -217,26 +241,26 @@ impl ::re_types_core::Archetype for Image {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ImageIndicator = ImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -309,14 +333,50 @@ impl ::re_types_core::AsComponents for Image {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.buffer as &dyn ComponentBatch).into()),
-            Some((&self.format as &dyn ComponentBatch).into()),
-            self.opacity
+            (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Image".into()),
+                        archetype_field_name: Some(("buffer").into()),
+                        component_name: ("rerun.components.ImageBuffer").into(),
+                    }),
+                }
+            }),
+            (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Image".into()),
+                        archetype_field_name: Some(("format").into()),
+                        component_name: ("rerun.components.ImageFormat").into(),
+                    }),
+                }
+            }),
+            (self
+                .opacity
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Image".into()),
+                    archetype_field_name: Some(("opacity").into()),
+                    component_name: ("rerun.components.Opacity").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Image".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -357,5 +417,23 @@ impl Image {
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Image {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.buffer.heap_size_bytes()
+            + self.format.heap_size_bytes()
+            + self.opacity.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::ImageBuffer>::is_pod()
+            && <crate::components::ImageFormat>::is_pod()
+            && <Option<crate::components::Opacity>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -239,9 +239,9 @@ impl ::re_types_core::Archetype for Image {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ImageIndicator = ImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -328,13 +328,13 @@ impl ::re_types_core::Archetype for Image {
 }
 
 impl ::re_types_core::AsComponents for Image {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Image".into()),
@@ -344,7 +344,7 @@ impl ::re_types_core::AsComponents for Image {
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Image".into()),
@@ -357,7 +357,7 @@ impl ::re_types_core::AsComponents for Image {
                 .opacity
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Image".into()),
@@ -369,7 +369,7 @@ impl ::re_types_core::AsComponents for Image {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Image".into()),

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: One or more transforms between the current entity and its parent. Unlike [`archetypes::Transform3D`][crate::archetypes::Transform3D], it is *not* propagated in the transform hierarchy.
@@ -108,52 +108,82 @@ pub struct InstancePoses3D {
     pub mat3x3: Option<Vec<crate::components::PoseTransformMat3x3>>,
 }
 
-impl ::re_types_core::SizeBytes for InstancePoses3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.translations.heap_size_bytes()
-            + self.rotation_axis_angles.heap_size_bytes()
-            + self.quaternions.heap_size_bytes()
-            + self.scales.heap_size_bytes()
-            + self.mat3x3.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
-            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
-            && <Option<Vec<crate::components::PoseScale3D>>>::is_pod()
-            && <Option<Vec<crate::components::PoseTransformMat3x3>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.InstancePoses3DIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+            component_name: "InstancePoses3DIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.PoseScale3D".into(),
-            "rerun.components.PoseTransformMat3x3".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("translations".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseScale3D".into(),
+                archetype_field_name: Some("scales".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseTransformMat3x3".into(),
+                archetype_field_name: Some("mat3x3".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.InstancePoses3DIndicator".into(),
-            "rerun.components.PoseTranslation3D".into(),
-            "rerun.components.PoseRotationAxisAngle".into(),
-            "rerun.components.PoseRotationQuat".into(),
-            "rerun.components.PoseScale3D".into(),
-            "rerun.components.PoseTransformMat3x3".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "InstancePoses3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseTranslation3D".into(),
+                archetype_field_name: Some("translations".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseRotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angles".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseRotationQuat".into(),
+                archetype_field_name: Some("quaternions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseScale3D".into(),
+                archetype_field_name: Some("scales".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                component_name: "rerun.components.PoseTransformMat3x3".into(),
+                archetype_field_name: Some("mat3x3".into()),
+            },
         ]
     });
 
@@ -181,26 +211,26 @@ impl ::re_types_core::Archetype for InstancePoses3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: InstancePoses3DIndicator = InstancePoses3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -294,21 +324,66 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.translations
+            (self
+                .translations
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.rotation_axis_angles
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                    archetype_field_name: Some(("translations").into()),
+                    component_name: ("rerun.components.PoseTranslation3D").into(),
+                }),
+            }),
+            (self
+                .rotation_axis_angles
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.quaternions
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                    archetype_field_name: Some(("rotation_axis_angles").into()),
+                    component_name: ("rerun.components.PoseRotationAxisAngle").into(),
+                }),
+            }),
+            (self
+                .quaternions
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.scales
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                    archetype_field_name: Some(("quaternions").into()),
+                    component_name: ("rerun.components.PoseRotationQuat").into(),
+                }),
+            }),
+            (self
+                .scales
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.mat3x3
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                    archetype_field_name: Some(("scales").into()),
+                    component_name: ("rerun.components.PoseScale3D").into(),
+                }),
+            }),
+            (self
+                .mat3x3
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
+                    archetype_field_name: Some(("mat3x3").into()),
+                    component_name: ("rerun.components.PoseTransformMat3x3").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -382,5 +457,25 @@ impl InstancePoses3D {
     ) -> Self {
         self.mat3x3 = Some(mat3x3.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for InstancePoses3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.translations.heap_size_bytes()
+            + self.rotation_axis_angles.heap_size_bytes()
+            + self.quaternions.heap_size_bytes()
+            + self.scales.heap_size_bytes()
+            + self.mat3x3.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<crate::components::PoseTranslation3D>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationAxisAngle>>>::is_pod()
+            && <Option<Vec<crate::components::PoseRotationQuat>>>::is_pod()
+            && <Option<Vec<crate::components::PoseScale3D>>>::is_pod()
+            && <Option<Vec<crate::components::PoseTransformMat3x3>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -209,9 +209,9 @@ impl ::re_types_core::Archetype for InstancePoses3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: InstancePoses3DIndicator = InstancePoses3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -319,7 +319,7 @@ impl ::re_types_core::Archetype for InstancePoses3D {
 }
 
 impl ::re_types_core::AsComponents for InstancePoses3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -328,7 +328,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .translations
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
@@ -340,7 +340,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .rotation_axis_angles
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
@@ -352,7 +352,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .quaternions
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
@@ -364,7 +364,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .scales
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
@@ -376,7 +376,7 @@ impl ::re_types_core::AsComponents for InstancePoses3D {
                 .mat3x3
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 2D line strips with positions and optional colors, radii, labels, etc.
@@ -114,63 +114,105 @@ pub struct LineStrips2D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for LineStrips2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.strips.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+            component_name: "rerun.components.LineStrip2D".into(),
+            archetype_field_name: Some("strips".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::LineStrip2D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.LineStrip2D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.LineStrips2DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "LineStrips2DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.LineStrip2D".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.LineStrips2DIndicator".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.LineStrip2D".into(),
+                archetype_field_name: Some("strips".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "LineStrips2DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -198,26 +240,26 @@ impl ::re_types_core::Archetype for LineStrips2D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: LineStrips2DIndicator = LineStrips2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -327,25 +369,88 @@ impl ::re_types_core::AsComponents for LineStrips2D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.strips as &dyn ComponentBatch).into()),
-            self.radii
+            (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                        archetype_field_name: Some(("strips").into()),
+                        component_name: ("rerun.components.LineStrip2D").into(),
+                    }),
+                }
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -434,5 +539,29 @@ impl LineStrips2D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for LineStrips2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.strips.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::LineStrip2D>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -238,9 +238,9 @@ impl ::re_types_core::Archetype for LineStrips2D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: LineStrips2DIndicator = LineStrips2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -364,13 +364,13 @@ impl ::re_types_core::Archetype for LineStrips2D {
 }
 
 impl ::re_types_core::AsComponents for LineStrips2D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -383,7 +383,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -395,7 +395,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -407,7 +407,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -419,7 +419,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -431,7 +431,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
@@ -443,7 +443,7 @@ impl ::re_types_core::AsComponents for LineStrips2D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips2D".into()),

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: 3D line strips with positions and optional colors, radii, labels, etc.
@@ -124,59 +124,95 @@ pub struct LineStrips3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for LineStrips3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.strips.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+            component_name: "rerun.components.LineStrip3D".into(),
+            archetype_field_name: Some("strips".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::LineStrip3D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.LineStrip3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.LineStrips3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "LineStrips3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.LineStrip3D".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.LineStrips3DIndicator".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.LineStrip3D".into(),
+                archetype_field_name: Some("strips".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "LineStrips3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -204,26 +240,26 @@ impl ::re_types_core::Archetype for LineStrips3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: LineStrips3DIndicator = LineStrips3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -323,22 +359,76 @@ impl ::re_types_core::AsComponents for LineStrips3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.strips as &dyn ComponentBatch).into()),
-            self.radii
+            (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                        archetype_field_name: Some(("strips").into()),
+                        component_name: ("rerun.components.LineStrip3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -417,5 +507,27 @@ impl LineStrips3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for LineStrips3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.strips.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::LineStrip3D>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -238,9 +238,9 @@ impl ::re_types_core::Archetype for LineStrips3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: LineStrips3DIndicator = LineStrips3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -354,13 +354,13 @@ impl ::re_types_core::Archetype for LineStrips3D {
 }
 
 impl ::re_types_core::AsComponents for LineStrips3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.strips as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
@@ -373,7 +373,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
@@ -385,7 +385,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
@@ -397,7 +397,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
@@ -409,7 +409,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
@@ -421,7 +421,7 @@ impl ::re_types_core::AsComponents for LineStrips3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.LineStrips3D".into()),

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A 3D triangle mesh as specified by its per-mesh and per-vertex properties.
@@ -145,71 +145,125 @@ pub struct Mesh3D {
     pub class_ids: Option<Vec<crate::components::ClassId>>,
 }
 
-impl ::re_types_core::SizeBytes for Mesh3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.vertex_positions.heap_size_bytes()
-            + self.triangle_indices.heap_size_bytes()
-            + self.vertex_normals.heap_size_bytes()
-            + self.vertex_colors.heap_size_bytes()
-            + self.vertex_texcoords.heap_size_bytes()
-            + self.albedo_factor.heap_size_bytes()
-            + self.albedo_texture_buffer.heap_size_bytes()
-            + self.albedo_texture_format.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+            component_name: "rerun.components.Position3D".into(),
+            archetype_field_name: Some("vertex_positions".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Position3D>>::is_pod()
-            && <Option<Vec<crate::components::TriangleIndices>>>::is_pod()
-            && <Option<Vec<crate::components::Vector3D>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Texcoord2D>>>::is_pod()
-            && <Option<crate::components::AlbedoFactor>>::is_pod()
-            && <Option<crate::components::ImageBuffer>>::is_pod()
-            && <Option<crate::components::ImageFormat>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Position3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.TriangleIndices".into(),
-            "rerun.components.Vector3D".into(),
-            "rerun.components.Mesh3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.TriangleIndices".into(),
+                archetype_field_name: Some("triangle_indices".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Vector3D".into(),
+                archetype_field_name: Some("vertex_normals".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "Mesh3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Color".into(),
-            "rerun.components.Texcoord2D".into(),
-            "rerun.components.AlbedoFactor".into(),
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("vertex_colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Texcoord2D".into(),
+                archetype_field_name: Some("vertex_texcoords".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.AlbedoFactor".into(),
+                archetype_field_name: Some("albedo_factor".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("albedo_texture_buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("albedo_texture_format".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 10usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position3D".into(),
-            "rerun.components.TriangleIndices".into(),
-            "rerun.components.Vector3D".into(),
-            "rerun.components.Mesh3DIndicator".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Texcoord2D".into(),
-            "rerun.components.AlbedoFactor".into(),
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
-            "rerun.components.ClassId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Position3D".into(),
+                archetype_field_name: Some("vertex_positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.TriangleIndices".into(),
+                archetype_field_name: Some("triangle_indices".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Vector3D".into(),
+                archetype_field_name: Some("vertex_normals".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "Mesh3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("vertex_colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.Texcoord2D".into(),
+                archetype_field_name: Some("vertex_texcoords".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.AlbedoFactor".into(),
+                archetype_field_name: Some("albedo_factor".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("albedo_texture_buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("albedo_texture_format".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
         ]
     });
 
@@ -237,26 +291,26 @@ impl ::re_types_core::Archetype for Mesh3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Mesh3DIndicator = Mesh3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -394,31 +448,112 @@ impl ::re_types_core::AsComponents for Mesh3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.vertex_positions as &dyn ComponentBatch).into()),
-            self.triangle_indices
+            (Some(&self.vertex_positions as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                        archetype_field_name: Some(("vertex_positions").into()),
+                        component_name: ("rerun.components.Position3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .triangle_indices
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.vertex_normals
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("triangle_indices").into()),
+                    component_name: ("rerun.components.TriangleIndices").into(),
+                }),
+            }),
+            (self
+                .vertex_normals
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.vertex_colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("vertex_normals").into()),
+                    component_name: ("rerun.components.Vector3D").into(),
+                }),
+            }),
+            (self
+                .vertex_colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.vertex_texcoords
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("vertex_colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .vertex_texcoords
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.albedo_factor
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("vertex_texcoords").into()),
+                    component_name: ("rerun.components.Texcoord2D").into(),
+                }),
+            }),
+            (self
+                .albedo_factor
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.albedo_texture_buffer
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("albedo_factor").into()),
+                    component_name: ("rerun.components.AlbedoFactor").into(),
+                }),
+            }),
+            (self
+                .albedo_texture_buffer
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.albedo_texture_format
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("albedo_texture_buffer").into()),
+                    component_name: ("rerun.components.ImageBuffer").into(),
+                }),
+            }),
+            (self
+                .albedo_texture_format
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("albedo_texture_format").into()),
+                    component_name: ("rerun.components.ImageFormat").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Mesh3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -532,5 +667,33 @@ impl Mesh3D {
     ) -> Self {
         self.class_ids = Some(class_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Mesh3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.vertex_positions.heap_size_bytes()
+            + self.triangle_indices.heap_size_bytes()
+            + self.vertex_normals.heap_size_bytes()
+            + self.vertex_colors.heap_size_bytes()
+            + self.vertex_texcoords.heap_size_bytes()
+            + self.albedo_factor.heap_size_bytes()
+            + self.albedo_texture_buffer.heap_size_bytes()
+            + self.albedo_texture_format.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Position3D>>::is_pod()
+            && <Option<Vec<crate::components::TriangleIndices>>>::is_pod()
+            && <Option<Vec<crate::components::Vector3D>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Texcoord2D>>>::is_pod()
+            && <Option<crate::components::AlbedoFactor>>::is_pod()
+            && <Option<crate::components::ImageBuffer>>::is_pod()
+            && <Option<crate::components::ImageFormat>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -289,9 +289,9 @@ impl ::re_types_core::Archetype for Mesh3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Mesh3DIndicator = Mesh3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -443,13 +443,13 @@ impl ::re_types_core::Archetype for Mesh3D {
 }
 
 impl ::re_types_core::AsComponents for Mesh3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.vertex_positions as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -462,7 +462,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .triangle_indices
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -474,7 +474,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .vertex_normals
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -486,7 +486,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .vertex_colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -498,7 +498,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .vertex_texcoords
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -510,7 +510,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .albedo_factor
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -522,7 +522,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .albedo_texture_buffer
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -534,7 +534,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .albedo_texture_format
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),
@@ -546,7 +546,7 @@ impl ::re_types_core::AsComponents for Mesh3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Mesh3D".into()),

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Camera perspective projection (a.k.a. intrinsics).
@@ -136,51 +136,75 @@ pub struct Pinhole {
     pub image_plane_distance: Option<crate::components::ImagePlaneDistance>,
 }
 
-impl ::re_types_core::SizeBytes for Pinhole {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.image_from_camera.heap_size_bytes()
-            + self.resolution.heap_size_bytes()
-            + self.camera_xyz.heap_size_bytes()
-            + self.image_plane_distance.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Pinhole".into()),
+            component_name: "rerun.components.PinholeProjection".into(),
+            archetype_field_name: Some("image_from_camera".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::PinholeProjection>::is_pod()
-            && <Option<crate::components::Resolution>>::is_pod()
-            && <Option<crate::components::ViewCoordinates>>::is_pod()
-            && <Option<crate::components::ImagePlaneDistance>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.PinholeProjection".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Resolution".into(),
-            "rerun.components.PinholeIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.Resolution".into(),
+                archetype_field_name: Some("resolution".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "PinholeIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ViewCoordinates".into(),
-            "rerun.components.ImagePlaneDistance".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.ViewCoordinates".into(),
+                archetype_field_name: Some("camera_xyz".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.ImagePlaneDistance".into(),
+                archetype_field_name: Some("image_plane_distance".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.PinholeProjection".into(),
-            "rerun.components.Resolution".into(),
-            "rerun.components.PinholeIndicator".into(),
-            "rerun.components.ViewCoordinates".into(),
-            "rerun.components.ImagePlaneDistance".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.PinholeProjection".into(),
+                archetype_field_name: Some("image_from_camera".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.Resolution".into(),
+                archetype_field_name: Some("resolution".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "PinholeIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.ViewCoordinates".into(),
+                archetype_field_name: Some("camera_xyz".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                component_name: "rerun.components.ImagePlaneDistance".into(),
+                archetype_field_name: Some("image_plane_distance".into()),
+            },
         ]
     });
 
@@ -208,26 +232,26 @@ impl ::re_types_core::Archetype for Pinhole {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: PinholeIndicator = PinholeIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -298,16 +322,52 @@ impl ::re_types_core::AsComponents for Pinhole {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.image_from_camera as &dyn ComponentBatch).into()),
-            self.resolution
+            (Some(&self.image_from_camera as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                        archetype_field_name: Some(("image_from_camera").into()),
+                        component_name: ("rerun.components.PinholeProjection").into(),
+                    }),
+                }
+            }),
+            (self
+                .resolution
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.camera_xyz
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                    archetype_field_name: Some(("resolution").into()),
+                    component_name: ("rerun.components.Resolution").into(),
+                }),
+            }),
+            (self
+                .camera_xyz
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.image_plane_distance
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                    archetype_field_name: Some(("camera_xyz").into()),
+                    component_name: ("rerun.components.ViewCoordinates").into(),
+                }),
+            }),
+            (self
+                .image_plane_distance
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Pinhole".into()),
+                    archetype_field_name: Some(("image_plane_distance").into()),
+                    component_name: ("rerun.components.ImagePlaneDistance").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -389,5 +449,23 @@ impl Pinhole {
     ) -> Self {
         self.image_plane_distance = Some(image_plane_distance.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Pinhole {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.image_from_camera.heap_size_bytes()
+            + self.resolution.heap_size_bytes()
+            + self.camera_xyz.heap_size_bytes()
+            + self.image_plane_distance.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::PinholeProjection>::is_pod()
+            && <Option<crate::components::Resolution>>::is_pod()
+            && <Option<crate::components::ViewCoordinates>>::is_pod()
+            && <Option<crate::components::ImagePlaneDistance>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -230,9 +230,9 @@ impl ::re_types_core::Archetype for Pinhole {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: PinholeIndicator = PinholeIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -317,13 +317,13 @@ impl ::re_types_core::Archetype for Pinhole {
 }
 
 impl ::re_types_core::AsComponents for Pinhole {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.image_from_camera as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Pinhole".into()),
@@ -336,7 +336,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .resolution
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Pinhole".into()),
@@ -348,7 +348,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .camera_xyz
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Pinhole".into()),
@@ -360,7 +360,7 @@ impl ::re_types_core::AsComponents for Pinhole {
                 .image_plane_distance
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Pinhole".into()),

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A 2D point cloud with positions and optional colors, radii, labels, etc.
@@ -137,67 +137,115 @@ pub struct Points2D {
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
 }
 
-impl ::re_types_core::SizeBytes for Points2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.positions.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-            + self.keypoint_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points2D".into()),
+            component_name: "rerun.components.Position2D".into(),
+            archetype_field_name: Some("positions".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Position2D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::KeypointId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Position2D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Points2DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "Points2DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.KeypointId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.KeypointId".into(),
+                archetype_field_name: Some("keypoint_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position2D".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Points2DIndicator".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.DrawOrder".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.KeypointId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Position2D".into(),
+                archetype_field_name: Some("positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "Points2DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points2D".into()),
+                component_name: "rerun.components.KeypointId".into(),
+                archetype_field_name: Some("keypoint_ids".into()),
+            },
         ]
     });
 
@@ -225,26 +273,26 @@ impl ::re_types_core::Archetype for Points2D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Points2DIndicator = Points2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -367,28 +415,100 @@ impl ::re_types_core::AsComponents for Points2D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.positions as &dyn ComponentBatch).into()),
-            self.radii
+            (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Points2D".into()),
+                        archetype_field_name: Some(("positions").into()),
+                        component_name: ("rerun.components.Position2D").into(),
+                    }),
+                }
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.keypoint_ids
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
+            (self
+                .keypoint_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points2D".into()),
+                    archetype_field_name: Some(("keypoint_ids").into()),
+                    component_name: ("rerun.components.KeypointId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -495,5 +615,31 @@ impl Points2D {
     ) -> Self {
         self.keypoint_ids = Some(keypoint_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Points2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.positions.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+            + self.keypoint_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Position2D>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
+            && <Option<Vec<crate::components::KeypointId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -271,9 +271,9 @@ impl ::re_types_core::Archetype for Points2D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Points2DIndicator = Points2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -410,13 +410,13 @@ impl ::re_types_core::Archetype for Points2D {
 }
 
 impl ::re_types_core::AsComponents for Points2D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -429,7 +429,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -441,7 +441,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -453,7 +453,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -465,7 +465,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -477,7 +477,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -489,7 +489,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),
@@ -501,7 +501,7 @@ impl ::re_types_core::AsComponents for Points2D {
                 .keypoint_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points2D".into()),

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A 3D point cloud with positions and optional colors, radii, labels, etc.
@@ -130,63 +130,105 @@ pub struct Points3D {
     pub keypoint_ids: Option<Vec<crate::components::KeypointId>>,
 }
 
-impl ::re_types_core::SizeBytes for Points3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.positions.heap_size_bytes()
-            + self.radii.heap_size_bytes()
-            + self.colors.heap_size_bytes()
-            + self.labels.heap_size_bytes()
-            + self.show_labels.heap_size_bytes()
-            + self.class_ids.heap_size_bytes()
-            + self.keypoint_ids.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Points3D".into()),
+            component_name: "rerun.components.Position3D".into(),
+            archetype_field_name: Some("positions".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::components::Position3D>>::is_pod()
-            && <Option<Vec<crate::components::Radius>>>::is_pod()
-            && <Option<Vec<crate::components::Color>>>::is_pod()
-            && <Option<Vec<crate::components::Text>>>::is_pod()
-            && <Option<crate::components::ShowLabels>>::is_pod()
-            && <Option<Vec<crate::components::ClassId>>>::is_pod()
-            && <Option<Vec<crate::components::KeypointId>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Position3D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Points3DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "Points3DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.KeypointId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.KeypointId".into(),
+                archetype_field_name: Some("keypoint_ids".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Position3D".into(),
-            "rerun.components.Radius".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.Points3DIndicator".into(),
-            "rerun.components.Text".into(),
-            "rerun.components.ShowLabels".into(),
-            "rerun.components.ClassId".into(),
-            "rerun.components.KeypointId".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Position3D".into(),
+                archetype_field_name: Some("positions".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Radius".into(),
+                archetype_field_name: Some("radii".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("colors".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "Points3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.ShowLabels".into(),
+                archetype_field_name: Some("show_labels".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.ClassId".into(),
+                archetype_field_name: Some("class_ids".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                component_name: "rerun.components.KeypointId".into(),
+                archetype_field_name: Some("keypoint_ids".into()),
+            },
         ]
     });
 
@@ -214,26 +256,26 @@ impl ::re_types_core::Archetype for Points3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Points3DIndicator = Points3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -346,25 +388,88 @@ impl ::re_types_core::AsComponents for Points3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.positions as &dyn ComponentBatch).into()),
-            self.radii
+            (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Points3D".into()),
+                        archetype_field_name: Some(("positions").into()),
+                        component_name: ("rerun.components.Position3D").into(),
+                    }),
+                }
+            }),
+            (self
+                .radii
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.colors
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("radii").into()),
+                    component_name: ("rerun.components.Radius").into(),
+                }),
+            }),
+            (self
+                .colors
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("colors").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .labels
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.show_labels
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("labels").into()),
+                    component_name: ("rerun.components.Text").into(),
+                }),
+            }),
+            (self
+                .show_labels
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.class_ids
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("show_labels").into()),
+                    component_name: ("rerun.components.ShowLabels").into(),
+                }),
+            }),
+            (self
+                .class_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.keypoint_ids
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("class_ids").into()),
+                    component_name: ("rerun.components.ClassId").into(),
+                }),
+            }),
+            (self
+                .keypoint_ids
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.Points3D".into()),
+                    archetype_field_name: Some(("keypoint_ids").into()),
+                    component_name: ("rerun.components.KeypointId").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -461,5 +566,29 @@ impl Points3D {
     ) -> Self {
         self.keypoint_ids = Some(keypoint_ids.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Points3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.positions.heap_size_bytes()
+            + self.radii.heap_size_bytes()
+            + self.colors.heap_size_bytes()
+            + self.labels.heap_size_bytes()
+            + self.show_labels.heap_size_bytes()
+            + self.class_ids.heap_size_bytes()
+            + self.keypoint_ids.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::components::Position3D>>::is_pod()
+            && <Option<Vec<crate::components::Radius>>>::is_pod()
+            && <Option<Vec<crate::components::Color>>>::is_pod()
+            && <Option<Vec<crate::components::Text>>>::is_pod()
+            && <Option<crate::components::ShowLabels>>::is_pod()
+            && <Option<Vec<crate::components::ClassId>>>::is_pod()
+            && <Option<Vec<crate::components::KeypointId>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -254,9 +254,9 @@ impl ::re_types_core::Archetype for Points3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Points3DIndicator = Points3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -383,13 +383,13 @@ impl ::re_types_core::Archetype for Points3D {
 }
 
 impl ::re_types_core::AsComponents for Points3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.positions as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -402,7 +402,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .radii
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -414,7 +414,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .colors
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -426,7 +426,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .labels
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -438,7 +438,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .show_labels
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -450,7 +450,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .class_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),
@@ -462,7 +462,7 @@ impl ::re_types_core::AsComponents for Points3D {
                 .keypoint_ids
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Points3D".into()),

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A double-precision scalar, e.g. for use for time-series plots.
@@ -59,32 +59,40 @@ pub struct Scalar {
     pub scalar: crate::components::Scalar,
 }
 
-impl ::re_types_core::SizeBytes for Scalar {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.scalar.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Scalar".into()),
+            component_name: "rerun.components.Scalar".into(),
+            archetype_field_name: Some("scalar".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::Scalar>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Scalar".into()),
+            component_name: "ScalarIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Scalar".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.ScalarIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Scalar".into(),
-            "rerun.components.ScalarIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Scalar".into()),
+                component_name: "rerun.components.Scalar".into(),
+                archetype_field_name: Some("scalar".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Scalar".into()),
+                component_name: "ScalarIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -112,26 +120,26 @@ impl ::re_types_core::Archetype for Scalar {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ScalarIndicator = ScalarIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -168,7 +176,16 @@ impl ::re_types_core::AsComponents for Scalar {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.scalar as &dyn ComponentBatch).into()),
+            (Some(&self.scalar as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Scalar".into()),
+                        archetype_field_name: Some(("scalar").into()),
+                        component_name: ("rerun.components.Scalar").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -185,5 +202,17 @@ impl Scalar {
         Self {
             scalar: scalar.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for Scalar {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.scalar.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::Scalar>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -118,9 +118,9 @@ impl ::re_types_core::Archetype for Scalar {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ScalarIndicator = ScalarIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -171,13 +171,13 @@ impl ::re_types_core::Archetype for Scalar {
 }
 
 impl ::re_types_core::AsComponents for Scalar {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.scalar as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Scalar".into()),

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: An image made up of integer [`components::ClassId`][crate::components::ClassId]s.
@@ -83,51 +83,75 @@ pub struct SegmentationImage {
     pub draw_order: Option<crate::components::DrawOrder>,
 }
 
-impl ::re_types_core::SizeBytes for SegmentationImage {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.buffer.heap_size_bytes()
-            + self.format.heap_size_bytes()
-            + self.opacity.heap_size_bytes()
-            + self.draw_order.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::ImageBuffer>::is_pod()
-            && <crate::components::ImageFormat>::is_pod()
-            && <Option<crate::components::Opacity>>::is_pod()
-            && <Option<crate::components::DrawOrder>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.SegmentationImageIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+            component_name: "SegmentationImageIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ImageBuffer".into(),
-            "rerun.components.ImageFormat".into(),
-            "rerun.components.SegmentationImageIndicator".into(),
-            "rerun.components.Opacity".into(),
-            "rerun.components.DrawOrder".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.ImageBuffer".into(),
+                archetype_field_name: Some("buffer".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.ImageFormat".into(),
+                archetype_field_name: Some("format".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "SegmentationImageIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.Opacity".into(),
+                archetype_field_name: Some("opacity".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                component_name: "rerun.components.DrawOrder".into(),
+                archetype_field_name: Some("draw_order".into()),
+            },
         ]
     });
 
@@ -155,26 +179,26 @@ impl ::re_types_core::Archetype for SegmentationImage {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: SegmentationImageIndicator = SegmentationImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -247,14 +271,50 @@ impl ::re_types_core::AsComponents for SegmentationImage {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.buffer as &dyn ComponentBatch).into()),
-            Some((&self.format as &dyn ComponentBatch).into()),
-            self.opacity
+            (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                        archetype_field_name: Some(("buffer").into()),
+                        component_name: ("rerun.components.ImageBuffer").into(),
+                    }),
+                }
+            }),
+            (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                        archetype_field_name: Some(("format").into()),
+                        component_name: ("rerun.components.ImageFormat").into(),
+                    }),
+                }
+            }),
+            (self
+                .opacity
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.draw_order
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                    archetype_field_name: Some(("opacity").into()),
+                    component_name: ("rerun.components.Opacity").into(),
+                }),
+            }),
+            (self
+                .draw_order
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
+                    archetype_field_name: Some(("draw_order").into()),
+                    component_name: ("rerun.components.DrawOrder").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -295,5 +355,23 @@ impl SegmentationImage {
     pub fn with_draw_order(mut self, draw_order: impl Into<crate::components::DrawOrder>) -> Self {
         self.draw_order = Some(draw_order.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for SegmentationImage {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.buffer.heap_size_bytes()
+            + self.format.heap_size_bytes()
+            + self.opacity.heap_size_bytes()
+            + self.draw_order.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::ImageBuffer>::is_pod()
+            && <crate::components::ImageFormat>::is_pod()
+            && <Option<crate::components::Opacity>>::is_pod()
+            && <Option<crate::components::DrawOrder>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -177,9 +177,9 @@ impl ::re_types_core::Archetype for SegmentationImage {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: SegmentationImageIndicator = SegmentationImageIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -266,13 +266,13 @@ impl ::re_types_core::Archetype for SegmentationImage {
 }
 
 impl ::re_types_core::AsComponents for SegmentationImage {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.buffer as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
@@ -282,7 +282,7 @@ impl ::re_types_core::AsComponents for SegmentationImage {
                 }
             }),
             (Some(&self.format as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
@@ -295,7 +295,7 @@ impl ::re_types_core::AsComponents for SegmentationImage {
                 .opacity
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
@@ -307,7 +307,7 @@ impl ::re_types_core::AsComponents for SegmentationImage {
                 .draw_order
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SegmentationImage".into()),

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Define the style properties for a line series in a chart.
@@ -90,48 +90,72 @@ pub struct SeriesLine {
     pub aggregation_policy: Option<crate::components::AggregationPolicy>,
 }
 
-impl ::re_types_core::SizeBytes for SeriesLine {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.color.heap_size_bytes()
-            + self.width.heap_size_bytes()
-            + self.name.heap_size_bytes()
-            + self.aggregation_policy.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::Color>>::is_pod()
-            && <Option<crate::components::StrokeWidth>>::is_pod()
-            && <Option<crate::components::Name>>::is_pod()
-            && <Option<crate::components::AggregationPolicy>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.SeriesLineIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+            component_name: "SeriesLineIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Color".into(),
-            "rerun.components.StrokeWidth".into(),
-            "rerun.components.Name".into(),
-            "rerun.components.AggregationPolicy".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.StrokeWidth".into(),
+                archetype_field_name: Some("width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.AggregationPolicy".into(),
+                archetype_field_name: Some("aggregation_policy".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.SeriesLineIndicator".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.StrokeWidth".into(),
-            "rerun.components.Name".into(),
-            "rerun.components.AggregationPolicy".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "SeriesLineIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.StrokeWidth".into(),
+                archetype_field_name: Some("width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                component_name: "rerun.components.AggregationPolicy".into(),
+                archetype_field_name: Some("aggregation_policy".into()),
+            },
         ]
     });
 
@@ -159,26 +183,26 @@ impl ::re_types_core::Archetype for SeriesLine {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: SeriesLineIndicator = SeriesLineIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -244,18 +268,52 @@ impl ::re_types_core::AsComponents for SeriesLine {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.color
+            (self
+                .color
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.width
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                    archetype_field_name: Some(("color").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .width
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.name
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                    archetype_field_name: Some(("width").into()),
+                    component_name: ("rerun.components.StrokeWidth").into(),
+                }),
+            }),
+            (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                        archetype_field_name: Some(("name").into()),
+                        component_name: ("rerun.components.Name").into(),
+                    }),
+                }
+            }),
+            (self
+                .aggregation_policy
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.aggregation_policy
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesLine".into()),
+                    archetype_field_name: Some(("aggregation_policy").into()),
+                    component_name: ("rerun.components.AggregationPolicy").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -312,5 +370,23 @@ impl SeriesLine {
     ) -> Self {
         self.aggregation_policy = Some(aggregation_policy.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for SeriesLine {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.color.heap_size_bytes()
+            + self.width.heap_size_bytes()
+            + self.name.heap_size_bytes()
+            + self.aggregation_policy.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::Color>>::is_pod()
+            && <Option<crate::components::StrokeWidth>>::is_pod()
+            && <Option<crate::components::Name>>::is_pod()
+            && <Option<crate::components::AggregationPolicy>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -181,9 +181,9 @@ impl ::re_types_core::Archetype for SeriesLine {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: SeriesLineIndicator = SeriesLineIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -263,7 +263,7 @@ impl ::re_types_core::Archetype for SeriesLine {
 }
 
 impl ::re_types_core::AsComponents for SeriesLine {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -272,7 +272,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesLine".into()),
@@ -284,7 +284,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .width
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesLine".into()),
@@ -293,7 +293,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 }),
             }),
             (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.SeriesLine".into()),
@@ -306,7 +306,7 @@ impl ::re_types_core::AsComponents for SeriesLine {
                 .aggregation_policy
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesLine".into()),

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Define the style properties for a point series in a chart.
@@ -88,48 +88,72 @@ pub struct SeriesPoint {
     pub marker_size: Option<crate::components::MarkerSize>,
 }
 
-impl ::re_types_core::SizeBytes for SeriesPoint {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.color.heap_size_bytes()
-            + self.marker.heap_size_bytes()
-            + self.name.heap_size_bytes()
-            + self.marker_size.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::Color>>::is_pod()
-            && <Option<crate::components::MarkerShape>>::is_pod()
-            && <Option<crate::components::Name>>::is_pod()
-            && <Option<crate::components::MarkerSize>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.SeriesPointIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+            component_name: "SeriesPointIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Color".into(),
-            "rerun.components.MarkerShape".into(),
-            "rerun.components.Name".into(),
-            "rerun.components.MarkerSize".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.MarkerShape".into(),
+                archetype_field_name: Some("marker".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.MarkerSize".into(),
+                archetype_field_name: Some("marker_size".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.SeriesPointIndicator".into(),
-            "rerun.components.Color".into(),
-            "rerun.components.MarkerShape".into(),
-            "rerun.components.Name".into(),
-            "rerun.components.MarkerSize".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "SeriesPointIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.MarkerShape".into(),
+                archetype_field_name: Some("marker".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                component_name: "rerun.components.MarkerSize".into(),
+                archetype_field_name: Some("marker_size".into()),
+            },
         ]
     });
 
@@ -157,26 +181,26 @@ impl ::re_types_core::Archetype for SeriesPoint {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: SeriesPointIndicator = SeriesPointIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -241,18 +265,52 @@ impl ::re_types_core::AsComponents for SeriesPoint {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.color
+            (self
+                .color
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.marker
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                    archetype_field_name: Some(("color").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
+            (self
+                .marker
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.name
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                    archetype_field_name: Some(("marker").into()),
+                    component_name: ("rerun.components.MarkerShape").into(),
+                }),
+            }),
+            (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                        archetype_field_name: Some(("name").into()),
+                        component_name: ("rerun.components.Name").into(),
+                    }),
+                }
+            }),
+            (self
+                .marker_size
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.marker_size
-                .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
+                    archetype_field_name: Some(("marker_size").into()),
+                    component_name: ("rerun.components.MarkerSize").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -305,5 +363,23 @@ impl SeriesPoint {
     ) -> Self {
         self.marker_size = Some(marker_size.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for SeriesPoint {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.color.heap_size_bytes()
+            + self.marker.heap_size_bytes()
+            + self.name.heap_size_bytes()
+            + self.marker_size.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::Color>>::is_pod()
+            && <Option<crate::components::MarkerShape>>::is_pod()
+            && <Option<crate::components::Name>>::is_pod()
+            && <Option<crate::components::MarkerSize>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -179,9 +179,9 @@ impl ::re_types_core::Archetype for SeriesPoint {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: SeriesPointIndicator = SeriesPointIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -260,7 +260,7 @@ impl ::re_types_core::Archetype for SeriesPoint {
 }
 
 impl ::re_types_core::AsComponents for SeriesPoint {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -269,7 +269,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
@@ -281,7 +281,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .marker
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
@@ -290,7 +290,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 }),
             }),
             (self.name.as_ref().map(|comp| (comp as &dyn ComponentBatch))).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
@@ -303,7 +303,7 @@ impl ::re_types_core::AsComponents for SeriesPoint {
                 .marker_size
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.SeriesPoint".into()),

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -137,9 +137,9 @@ impl ::re_types_core::Archetype for Tensor {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TensorIndicator = TensorIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -199,13 +199,13 @@ impl ::re_types_core::Archetype for Tensor {
 }
 
 impl ::re_types_core::AsComponents for Tensor {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.data as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Tensor".into()),
@@ -218,7 +218,7 @@ impl ::re_types_core::AsComponents for Tensor {
                 .value_range
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.Tensor".into()),

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A text element intended to be displayed in its own text box.
@@ -102,33 +102,51 @@ pub struct TextDocument {
     pub media_type: Option<crate::components::MediaType>,
 }
 
-impl ::re_types_core::SizeBytes for TextDocument {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.text.heap_size_bytes() + self.media_type.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            component_name: "rerun.components.Text".into(),
+            archetype_field_name: Some("text".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::Text>::is_pod() && <Option<crate::components::MediaType>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            component_name: "TextDocumentIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Text".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.TextDocument".into()),
+            component_name: "rerun.components.MediaType".into(),
+            archetype_field_name: Some("media_type".into()),
+        }]
+    });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.TextDocumentIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.MediaType".into()]);
-
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Text".into(),
-            "rerun.components.TextDocumentIndicator".into(),
-            "rerun.components.MediaType".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.TextDocument".into()),
+                component_name: "rerun.components.Text".into(),
+                archetype_field_name: Some("text".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.TextDocument".into()),
+                component_name: "TextDocumentIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.TextDocument".into()),
+                component_name: "rerun.components.MediaType".into(),
+                archetype_field_name: Some("media_type".into()),
+            },
         ]
     });
 
@@ -156,26 +174,26 @@ impl ::re_types_core::Archetype for TextDocument {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: TextDocumentIndicator = TextDocumentIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -221,10 +239,28 @@ impl ::re_types_core::AsComponents for TextDocument {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.text as &dyn ComponentBatch).into()),
-            self.media_type
+            (Some(&self.text as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.TextDocument".into()),
+                        archetype_field_name: Some(("text").into()),
+                        component_name: ("rerun.components.Text").into(),
+                    }),
+                }
+            }),
+            (self
+                .media_type
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.archetypes.TextDocument".into()),
+                    archetype_field_name: Some(("media_type").into()),
+                    component_name: ("rerun.components.MediaType").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -255,5 +291,17 @@ impl TextDocument {
     pub fn with_media_type(mut self, media_type: impl Into<crate::components::MediaType>) -> Self {
         self.media_type = Some(media_type.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for TextDocument {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.text.heap_size_bytes() + self.media_type.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::Text>::is_pod() && <Option<crate::components::MediaType>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -172,9 +172,9 @@ impl ::re_types_core::Archetype for TextDocument {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TextDocumentIndicator = TextDocumentIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -234,13 +234,13 @@ impl ::re_types_core::Archetype for TextDocument {
 }
 
 impl ::re_types_core::AsComponents for TextDocument {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.text as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.TextDocument".into()),
@@ -253,7 +253,7 @@ impl ::re_types_core::AsComponents for TextDocument {
                 .media_type
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.TextDocument".into()),

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -154,9 +154,9 @@ impl ::re_types_core::Archetype for TextLog {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TextLogIndicator = TextLogIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -225,13 +225,13 @@ impl ::re_types_core::Archetype for TextLog {
 }
 
 impl ::re_types_core::AsComponents for TextLog {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.text as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.TextLog".into()),
@@ -244,7 +244,7 @@ impl ::re_types_core::AsComponents for TextLog {
                 .level
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.TextLog".into()),
@@ -256,7 +256,7 @@ impl ::re_types_core::AsComponents for TextLog {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.TextLog".into()),

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: A transform between two 3D spaces, i.e. a pose.
@@ -193,60 +193,102 @@ pub struct Transform3D {
     pub axis_length: Option<crate::components::AxisLength>,
 }
 
-impl ::re_types_core::SizeBytes for Transform3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.translation.heap_size_bytes()
-            + self.rotation_axis_angle.heap_size_bytes()
-            + self.quaternion.heap_size_bytes()
-            + self.scale.heap_size_bytes()
-            + self.mat3x3.heap_size_bytes()
-            + self.relation.heap_size_bytes()
-            + self.axis_length.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::Translation3D>>::is_pod()
-            && <Option<crate::components::RotationAxisAngle>>::is_pod()
-            && <Option<crate::components::RotationQuat>>::is_pod()
-            && <Option<crate::components::Scale3D>>::is_pod()
-            && <Option<crate::components::TransformMat3x3>>::is_pod()
-            && <Option<crate::components::TransformRelation>>::is_pod()
-            && <Option<crate::components::AxisLength>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Transform3DIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.Transform3D".into()),
+            component_name: "Transform3DIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Translation3D".into(),
-            "rerun.components.RotationAxisAngle".into(),
-            "rerun.components.RotationQuat".into(),
-            "rerun.components.Scale3D".into(),
-            "rerun.components.TransformMat3x3".into(),
-            "rerun.components.TransformRelation".into(),
-            "rerun.components.AxisLength".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.Translation3D".into(),
+                archetype_field_name: Some("translation".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.RotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angle".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.RotationQuat".into(),
+                archetype_field_name: Some("quaternion".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.Scale3D".into(),
+                archetype_field_name: Some("scale".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.TransformMat3x3".into(),
+                archetype_field_name: Some("mat3x3".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.TransformRelation".into(),
+                archetype_field_name: Some("relation".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.AxisLength".into(),
+                archetype_field_name: Some("axis_length".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 8usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Transform3DIndicator".into(),
-            "rerun.components.Translation3D".into(),
-            "rerun.components.RotationAxisAngle".into(),
-            "rerun.components.RotationQuat".into(),
-            "rerun.components.Scale3D".into(),
-            "rerun.components.TransformMat3x3".into(),
-            "rerun.components.TransformRelation".into(),
-            "rerun.components.AxisLength".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "Transform3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.Translation3D".into(),
+                archetype_field_name: Some("translation".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.RotationAxisAngle".into(),
+                archetype_field_name: Some("rotation_axis_angle".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.RotationQuat".into(),
+                archetype_field_name: Some("quaternion".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.Scale3D".into(),
+                archetype_field_name: Some("scale".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.TransformMat3x3".into(),
+                archetype_field_name: Some("mat3x3".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.TransformRelation".into(),
+                archetype_field_name: Some("relation".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                component_name: "rerun.components.AxisLength".into(),
+                archetype_field_name: Some("axis_length".into()),
+            },
         ]
     });
 
@@ -274,26 +316,26 @@ impl ::re_types_core::Archetype for Transform3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: Transform3DIndicator = Transform3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -391,13 +433,76 @@ impl ::re_types_core::AsComponents for Transform3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.translation as &dyn ComponentBatch).into()),
-            Some((&self.rotation_axis_angle as &dyn ComponentBatch).into()),
-            Some((&self.quaternion as &dyn ComponentBatch).into()),
-            Some((&self.scale as &dyn ComponentBatch).into()),
-            Some((&self.mat3x3 as &dyn ComponentBatch).into()),
-            Some((&self.relation as &dyn ComponentBatch).into()),
-            Some((&self.axis_length as &dyn ComponentBatch).into()),
+            (Some(&self.translation as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("translation").into()),
+                        component_name: ("rerun.components.Translation3D").into(),
+                    }),
+                }
+            }),
+            (Some(&self.rotation_axis_angle as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("rotation_axis_angle").into()),
+                        component_name: ("rerun.components.RotationAxisAngle").into(),
+                    }),
+                }
+            }),
+            (Some(&self.quaternion as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("quaternion").into()),
+                        component_name: ("rerun.components.RotationQuat").into(),
+                    }),
+                }
+            }),
+            (Some(&self.scale as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("scale").into()),
+                        component_name: ("rerun.components.Scale3D").into(),
+                    }),
+                }
+            }),
+            (Some(&self.mat3x3 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("mat3x3").into()),
+                        component_name: ("rerun.components.TransformMat3x3").into(),
+                    }),
+                }
+            }),
+            (Some(&self.relation as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("relation").into()),
+                        component_name: ("rerun.components.TransformRelation").into(),
+                    }),
+                }
+            }),
+            (Some(&self.axis_length as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.Transform3D".into()),
+                        archetype_field_name: Some(("axis_length").into()),
+                        component_name: ("rerun.components.AxisLength").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -487,5 +592,29 @@ impl Transform3D {
     ) -> Self {
         self.axis_length = Some(axis_length.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Transform3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.translation.heap_size_bytes()
+            + self.rotation_axis_angle.heap_size_bytes()
+            + self.quaternion.heap_size_bytes()
+            + self.scale.heap_size_bytes()
+            + self.mat3x3.heap_size_bytes()
+            + self.relation.heap_size_bytes()
+            + self.axis_length.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::Translation3D>>::is_pod()
+            && <Option<crate::components::RotationAxisAngle>>::is_pod()
+            && <Option<crate::components::RotationQuat>>::is_pod()
+            && <Option<crate::components::Scale3D>>::is_pod()
+            && <Option<crate::components::TransformMat3x3>>::is_pod()
+            && <Option<crate::components::TransformRelation>>::is_pod()
+            && <Option<crate::components::AxisLength>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -314,9 +314,9 @@ impl ::re_types_core::Archetype for Transform3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: Transform3DIndicator = Transform3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -428,13 +428,13 @@ impl ::re_types_core::Archetype for Transform3D {
 }
 
 impl ::re_types_core::AsComponents for Transform3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.translation as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -444,7 +444,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.rotation_axis_angle as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -454,7 +454,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.quaternion as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -464,7 +464,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.scale as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -474,7 +474,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.mat3x3 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -484,7 +484,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.relation as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),
@@ -494,7 +494,7 @@ impl ::re_types_core::AsComponents for Transform3D {
                 }
             }),
             (Some(&self.axis_length as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Transform3D".into()),

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -217,9 +217,9 @@ impl ::re_types_core::Archetype for VideoFrameReference {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: VideoFrameReferenceIndicator = VideoFrameReferenceIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -283,13 +283,13 @@ impl ::re_types_core::Archetype for VideoFrameReference {
 }
 
 impl ::re_types_core::AsComponents for VideoFrameReference {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.timestamp as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
@@ -302,7 +302,7 @@ impl ::re_types_core::AsComponents for VideoFrameReference {
                 .video_reference
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: How we interpret the coordinate system of an entity/space.
@@ -66,32 +66,40 @@ pub struct ViewCoordinates {
     pub xyz: crate::components::ViewCoordinates,
 }
 
-impl ::re_types_core::SizeBytes for ViewCoordinates {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.xyz.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+            component_name: "rerun.components.ViewCoordinates".into(),
+            archetype_field_name: Some("xyz".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::components::ViewCoordinates>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+            component_name: "ViewCoordinatesIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.ViewCoordinates".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.ViewCoordinatesIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.ViewCoordinates".into(),
-            "rerun.components.ViewCoordinatesIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+                component_name: "rerun.components.ViewCoordinates".into(),
+                archetype_field_name: Some("xyz".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+                component_name: "ViewCoordinatesIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -119,26 +127,26 @@ impl ::re_types_core::Archetype for ViewCoordinates {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ViewCoordinatesIndicator = ViewCoordinatesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -175,7 +183,16 @@ impl ::re_types_core::AsComponents for ViewCoordinates {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.xyz as &dyn ComponentBatch).into()),
+            (Some(&self.xyz as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
+                        archetype_field_name: Some(("xyz").into()),
+                        component_name: ("rerun.components.ViewCoordinates").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -190,5 +207,17 @@ impl ViewCoordinates {
     #[inline]
     pub fn new(xyz: impl Into<crate::components::ViewCoordinates>) -> Self {
         Self { xyz: xyz.into() }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewCoordinates {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.xyz.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::components::ViewCoordinates>::is_pod()
     }
 }

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -125,9 +125,9 @@ impl ::re_types_core::Archetype for ViewCoordinates {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ViewCoordinatesIndicator = ViewCoordinatesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -178,13 +178,13 @@ impl ::re_types_core::Archetype for ViewCoordinates {
 }
 
 impl ::re_types_core::AsComponents for ViewCoordinates {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.xyz as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration for the background of a view.
@@ -28,34 +28,51 @@ pub struct Background {
     pub color: Option<crate::components::Color>,
 }
 
-impl ::re_types_core::SizeBytes for Background {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.kind.heap_size_bytes() + self.color.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            component_name: "rerun.blueprint.components.BackgroundKind".into(),
+            archetype_field_name: Some("kind".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::BackgroundKind>::is_pod()
-            && <Option<crate::components::Color>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            component_name: "BackgroundIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.BackgroundKind".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+            component_name: "rerun.components.Color".into(),
+            archetype_field_name: Some("color".into()),
+        }]
+    });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.BackgroundIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.components.Color".into()]);
-
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.BackgroundKind".into(),
-            "rerun.blueprint.components.BackgroundIndicator".into(),
-            "rerun.components.Color".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+                component_name: "rerun.blueprint.components.BackgroundKind".into(),
+                archetype_field_name: Some("kind".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+                component_name: "BackgroundIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
         ]
     });
 
@@ -83,26 +100,26 @@ impl ::re_types_core::Archetype for Background {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: BackgroundIndicator = BackgroundIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -148,10 +165,28 @@ impl ::re_types_core::AsComponents for Background {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.kind as &dyn ComponentBatch).into()),
-            self.color
+            (Some(&self.kind as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+                        archetype_field_name: Some(("kind").into()),
+                        component_name: ("rerun.blueprint.components.BackgroundKind").into(),
+                    }),
+                }
+            }),
+            (self
+                .color
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
+                    archetype_field_name: Some(("color").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -176,5 +211,18 @@ impl Background {
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for Background {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.kind.heap_size_bytes() + self.color.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::BackgroundKind>::is_pod()
+            && <Option<crate::components::Color>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -98,9 +98,9 @@ impl ::re_types_core::Archetype for Background {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: BackgroundIndicator = BackgroundIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -160,13 +160,13 @@ impl ::re_types_core::Archetype for Background {
 }
 
 impl ::re_types_core::AsComponents for Background {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.kind as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
@@ -179,7 +179,7 @@ impl ::re_types_core::AsComponents for Background {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.Background".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The query for the dataframe view.
@@ -41,52 +41,82 @@ pub struct DataframeQuery {
     pub select: Option<crate::blueprint::components::SelectedColumns>,
 }
 
-impl ::re_types_core::SizeBytes for DataframeQuery {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.timeline.heap_size_bytes()
-            + self.filter_by_range.heap_size_bytes()
-            + self.filter_is_not_null.heap_size_bytes()
-            + self.apply_latest_at.heap_size_bytes()
-            + self.select.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::blueprint::components::TimelineName>>::is_pod()
-            && <Option<crate::blueprint::components::FilterByRange>>::is_pod()
-            && <Option<crate::blueprint::components::FilterIsNotNull>>::is_pod()
-            && <Option<crate::blueprint::components::ApplyLatestAt>>::is_pod()
-            && <Option<crate::blueprint::components::SelectedColumns>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.DataframeQueryIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+            component_name: "DataframeQueryIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.TimelineName".into(),
-            "rerun.blueprint.components.FilterByRange".into(),
-            "rerun.blueprint.components.FilterIsNotNull".into(),
-            "rerun.blueprint.components.ApplyLatestAt".into(),
-            "rerun.blueprint.components.SelectedColumns".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.TimelineName".into(),
+                archetype_field_name: Some("timeline".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.FilterByRange".into(),
+                archetype_field_name: Some("filter_by_range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.FilterIsNotNull".into(),
+                archetype_field_name: Some("filter_is_not_null".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.ApplyLatestAt".into(),
+                archetype_field_name: Some("apply_latest_at".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.SelectedColumns".into(),
+                archetype_field_name: Some("select".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.DataframeQueryIndicator".into(),
-            "rerun.blueprint.components.TimelineName".into(),
-            "rerun.blueprint.components.FilterByRange".into(),
-            "rerun.blueprint.components.FilterIsNotNull".into(),
-            "rerun.blueprint.components.ApplyLatestAt".into(),
-            "rerun.blueprint.components.SelectedColumns".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "DataframeQueryIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.TimelineName".into(),
+                archetype_field_name: Some("timeline".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.FilterByRange".into(),
+                archetype_field_name: Some("filter_by_range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.FilterIsNotNull".into(),
+                archetype_field_name: Some("filter_is_not_null".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.ApplyLatestAt".into(),
+                archetype_field_name: Some("apply_latest_at".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                component_name: "rerun.blueprint.components.SelectedColumns".into(),
+                archetype_field_name: Some("select".into()),
+            },
         ]
     });
 
@@ -114,26 +144,26 @@ impl ::re_types_core::Archetype for DataframeQuery {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: DataframeQueryIndicator = DataframeQueryIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -213,21 +243,66 @@ impl ::re_types_core::AsComponents for DataframeQuery {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.timeline
+            (self
+                .timeline
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.filter_by_range
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                    archetype_field_name: Some(("timeline").into()),
+                    component_name: ("rerun.blueprint.components.TimelineName").into(),
+                }),
+            }),
+            (self
+                .filter_by_range
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.filter_is_not_null
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                    archetype_field_name: Some(("filter_by_range").into()),
+                    component_name: ("rerun.blueprint.components.FilterByRange").into(),
+                }),
+            }),
+            (self
+                .filter_is_not_null
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.apply_latest_at
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                    archetype_field_name: Some(("filter_is_not_null").into()),
+                    component_name: ("rerun.blueprint.components.FilterIsNotNull").into(),
+                }),
+            }),
+            (self
+                .apply_latest_at
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.select
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                    archetype_field_name: Some(("apply_latest_at").into()),
+                    component_name: ("rerun.blueprint.components.ApplyLatestAt").into(),
+                }),
+            }),
+            (self
+                .select
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
+                    archetype_field_name: Some(("select").into()),
+                    component_name: ("rerun.blueprint.components.SelectedColumns").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -302,5 +377,25 @@ impl DataframeQuery {
     ) -> Self {
         self.select = Some(select.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for DataframeQuery {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.timeline.heap_size_bytes()
+            + self.filter_by_range.heap_size_bytes()
+            + self.filter_is_not_null.heap_size_bytes()
+            + self.apply_latest_at.heap_size_bytes()
+            + self.select.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::blueprint::components::TimelineName>>::is_pod()
+            && <Option<crate::blueprint::components::FilterByRange>>::is_pod()
+            && <Option<crate::blueprint::components::FilterIsNotNull>>::is_pod()
+            && <Option<crate::blueprint::components::ApplyLatestAt>>::is_pod()
+            && <Option<crate::blueprint::components::SelectedColumns>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -142,9 +142,9 @@ impl ::re_types_core::Archetype for DataframeQuery {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: DataframeQueryIndicator = DataframeQueryIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -238,7 +238,7 @@ impl ::re_types_core::Archetype for DataframeQuery {
 }
 
 impl ::re_types_core::AsComponents for DataframeQuery {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -247,7 +247,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .timeline
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
@@ -259,7 +259,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .filter_by_range
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
@@ -271,7 +271,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .filter_is_not_null
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
@@ -283,7 +283,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .apply_latest_at
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
@@ -295,7 +295,7 @@ impl ::re_types_core::AsComponents for DataframeQuery {
                 .select
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration for the 3D line grid.
@@ -49,52 +49,82 @@ pub struct LineGrid3D {
     pub color: Option<crate::components::Color>,
 }
 
-impl ::re_types_core::SizeBytes for LineGrid3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.visible.heap_size_bytes()
-            + self.spacing.heap_size_bytes()
-            + self.plane.heap_size_bytes()
-            + self.stroke_width.heap_size_bytes()
-            + self.color.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::blueprint::components::Visible>>::is_pod()
-            && <Option<crate::blueprint::components::GridSpacing>>::is_pod()
-            && <Option<crate::components::Plane3D>>::is_pod()
-            && <Option<crate::components::StrokeWidth>>::is_pod()
-            && <Option<crate::components::Color>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.LineGrid3DIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+            component_name: "LineGrid3DIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.Visible".into(),
-            "rerun.blueprint.components.GridSpacing".into(),
-            "rerun.components.Plane3D".into(),
-            "rerun.components.StrokeWidth".into(),
-            "rerun.components.Color".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.blueprint.components.GridSpacing".into(),
+                archetype_field_name: Some("spacing".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.Plane3D".into(),
+                archetype_field_name: Some("plane".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.StrokeWidth".into(),
+                archetype_field_name: Some("stroke_width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.LineGrid3DIndicator".into(),
-            "rerun.blueprint.components.Visible".into(),
-            "rerun.blueprint.components.GridSpacing".into(),
-            "rerun.components.Plane3D".into(),
-            "rerun.components.StrokeWidth".into(),
-            "rerun.components.Color".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "LineGrid3DIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.blueprint.components.GridSpacing".into(),
+                archetype_field_name: Some("spacing".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.Plane3D".into(),
+                archetype_field_name: Some("plane".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.StrokeWidth".into(),
+                archetype_field_name: Some("stroke_width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                component_name: "rerun.components.Color".into(),
+                archetype_field_name: Some("color".into()),
+            },
         ]
     });
 
@@ -122,26 +152,26 @@ impl ::re_types_core::Archetype for LineGrid3D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: LineGrid3DIndicator = LineGrid3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -218,21 +248,66 @@ impl ::re_types_core::AsComponents for LineGrid3D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.visible
+            (self
+                .visible
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.spacing
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                    archetype_field_name: Some(("visible").into()),
+                    component_name: ("rerun.blueprint.components.Visible").into(),
+                }),
+            }),
+            (self
+                .spacing
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.plane
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                    archetype_field_name: Some(("spacing").into()),
+                    component_name: ("rerun.blueprint.components.GridSpacing").into(),
+                }),
+            }),
+            (self
+                .plane
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.stroke_width
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                    archetype_field_name: Some(("plane").into()),
+                    component_name: ("rerun.components.Plane3D").into(),
+                }),
+            }),
+            (self
+                .stroke_width
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.color
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                    archetype_field_name: Some(("stroke_width").into()),
+                    component_name: ("rerun.components.StrokeWidth").into(),
+                }),
+            }),
+            (self
+                .color
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
+                    archetype_field_name: Some(("color").into()),
+                    component_name: ("rerun.components.Color").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -309,5 +384,25 @@ impl LineGrid3D {
     pub fn with_color(mut self, color: impl Into<crate::components::Color>) -> Self {
         self.color = Some(color.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for LineGrid3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.visible.heap_size_bytes()
+            + self.spacing.heap_size_bytes()
+            + self.plane.heap_size_bytes()
+            + self.stroke_width.heap_size_bytes()
+            + self.color.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::blueprint::components::Visible>>::is_pod()
+            && <Option<crate::blueprint::components::GridSpacing>>::is_pod()
+            && <Option<crate::components::Plane3D>>::is_pod()
+            && <Option<crate::components::StrokeWidth>>::is_pod()
+            && <Option<crate::components::Color>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -150,9 +150,9 @@ impl ::re_types_core::Archetype for LineGrid3D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: LineGrid3DIndicator = LineGrid3DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -243,7 +243,7 @@ impl ::re_types_core::Archetype for LineGrid3D {
 }
 
 impl ::re_types_core::AsComponents for LineGrid3D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -252,7 +252,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .visible
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
@@ -264,7 +264,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .spacing
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
@@ -276,7 +276,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .plane
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
@@ -288,7 +288,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .stroke_width
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
@@ -300,7 +300,7 @@ impl ::re_types_core::AsComponents for LineGrid3D {
                 .color
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration for the background map of the map view.
@@ -27,32 +27,40 @@ pub struct MapBackground {
     pub provider: crate::blueprint::components::MapProvider,
 }
 
-impl ::re_types_core::SizeBytes for MapBackground {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.provider.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::MapProvider>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.MapBackgroundIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+            component_name: "MapBackgroundIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.MapProvider".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+            component_name: "rerun.blueprint.components.MapProvider".into(),
+            archetype_field_name: Some("provider".into()),
+        }]
+    });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.MapBackgroundIndicator".into(),
-            "rerun.blueprint.components.MapProvider".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+                component_name: "MapBackgroundIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+                component_name: "rerun.blueprint.components.MapProvider".into(),
+                archetype_field_name: Some("provider".into()),
+            },
         ]
     });
 
@@ -80,26 +88,26 @@ impl ::re_types_core::Archetype for MapBackground {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: MapBackgroundIndicator = MapBackgroundIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -136,7 +144,16 @@ impl ::re_types_core::AsComponents for MapBackground {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.provider as &dyn ComponentBatch).into()),
+            (Some(&self.provider as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
+                        archetype_field_name: Some(("provider").into()),
+                        component_name: ("rerun.blueprint.components.MapProvider").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -153,5 +170,17 @@ impl MapBackground {
         Self {
             provider: provider.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for MapBackground {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.provider.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::MapProvider>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -86,9 +86,9 @@ impl ::re_types_core::Archetype for MapBackground {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: MapBackgroundIndicator = MapBackgroundIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -139,13 +139,13 @@ impl ::re_types_core::Archetype for MapBackground {
 }
 
 impl ::re_types_core::AsComponents for MapBackground {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.provider as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration of the map view zoom level.
@@ -27,32 +27,40 @@ pub struct MapZoom {
     pub zoom: crate::blueprint::components::ZoomLevel,
 }
 
-impl ::re_types_core::SizeBytes for MapZoom {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.zoom.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::ZoomLevel>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.MapZoomIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+            component_name: "MapZoomIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ZoomLevel".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+            component_name: "rerun.blueprint.components.ZoomLevel".into(),
+            archetype_field_name: Some("zoom".into()),
+        }]
+    });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.MapZoomIndicator".into(),
-            "rerun.blueprint.components.ZoomLevel".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+                component_name: "MapZoomIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+                component_name: "rerun.blueprint.components.ZoomLevel".into(),
+                archetype_field_name: Some("zoom".into()),
+            },
         ]
     });
 
@@ -80,26 +88,26 @@ impl ::re_types_core::Archetype for MapZoom {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: MapZoomIndicator = MapZoomIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -136,7 +144,16 @@ impl ::re_types_core::AsComponents for MapZoom {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.zoom as &dyn ComponentBatch).into()),
+            (Some(&self.zoom as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
+                        archetype_field_name: Some(("zoom").into()),
+                        component_name: ("rerun.blueprint.components.ZoomLevel").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -151,5 +168,17 @@ impl MapZoom {
     #[inline]
     pub fn new(zoom: impl Into<crate::blueprint::components::ZoomLevel>) -> Self {
         Self { zoom: zoom.into() }
+    }
+}
+
+impl ::re_types_core::SizeBytes for MapZoom {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.zoom.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::ZoomLevel>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -86,9 +86,9 @@ impl ::re_types_core::Archetype for MapZoom {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: MapZoomIndicator = MapZoomIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -139,13 +139,13 @@ impl ::re_types_core::Archetype for MapZoom {
 }
 
 impl ::re_types_core::AsComponents for MapZoom {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.zoom as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration for the legend of a plot.
@@ -32,39 +32,52 @@ pub struct PlotLegend {
     pub visible: Option<crate::blueprint::components::Visible>,
 }
 
-impl ::re_types_core::SizeBytes for PlotLegend {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.corner.heap_size_bytes() + self.visible.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::blueprint::components::Corner2D>>::is_pod()
-            && <Option<crate::blueprint::components::Visible>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.PlotLegendIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+            component_name: "PlotLegendIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.Corner2D".into(),
-            "rerun.blueprint.components.Visible".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                component_name: "rerun.blueprint.components.Corner2D".into(),
+                archetype_field_name: Some("corner".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.PlotLegendIndicator".into(),
-            "rerun.blueprint.components.Corner2D".into(),
-            "rerun.blueprint.components.Visible".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                component_name: "PlotLegendIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                component_name: "rerun.blueprint.components.Corner2D".into(),
+                archetype_field_name: Some("corner".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
         ]
     });
 
@@ -92,26 +105,26 @@ impl ::re_types_core::Archetype for PlotLegend {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: PlotLegendIndicator = PlotLegendIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -155,12 +168,30 @@ impl ::re_types_core::AsComponents for PlotLegend {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.corner
+            (self
+                .corner
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.visible
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                    archetype_field_name: Some(("corner").into()),
+                    component_name: ("rerun.blueprint.components.Corner2D").into(),
+                }),
+            }),
+            (self
+                .visible
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
+                    archetype_field_name: Some(("visible").into()),
+                    component_name: ("rerun.blueprint.components.Visible").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -202,5 +233,18 @@ impl PlotLegend {
     ) -> Self {
         self.visible = Some(visible.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for PlotLegend {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.corner.heap_size_bytes() + self.visible.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::blueprint::components::Corner2D>>::is_pod()
+            && <Option<crate::blueprint::components::Visible>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -103,9 +103,9 @@ impl ::re_types_core::Archetype for PlotLegend {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: PlotLegendIndicator = PlotLegendIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -163,7 +163,7 @@ impl ::re_types_core::Archetype for PlotLegend {
 }
 
 impl ::re_types_core::AsComponents for PlotLegend {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -172,7 +172,7 @@ impl ::re_types_core::AsComponents for PlotLegend {
                 .corner
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
@@ -184,7 +184,7 @@ impl ::re_types_core::AsComponents for PlotLegend {
                 .visible
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configuration for the scalar axis of a plot.
@@ -30,39 +30,52 @@ pub struct ScalarAxis {
     pub zoom_lock: Option<crate::blueprint::components::LockRangeDuringZoom>,
 }
 
-impl ::re_types_core::SizeBytes for ScalarAxis {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.range.heap_size_bytes() + self.zoom_lock.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::Range1D>>::is_pod()
-            && <Option<crate::blueprint::components::LockRangeDuringZoom>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ScalarAxisIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+            component_name: "ScalarAxisIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Range1D".into(),
-            "rerun.blueprint.components.LockRangeDuringZoom".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                component_name: "rerun.components.Range1D".into(),
+                archetype_field_name: Some("range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                component_name: "rerun.blueprint.components.LockRangeDuringZoom".into(),
+                archetype_field_name: Some("zoom_lock".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.ScalarAxisIndicator".into(),
-            "rerun.components.Range1D".into(),
-            "rerun.blueprint.components.LockRangeDuringZoom".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                component_name: "ScalarAxisIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                component_name: "rerun.components.Range1D".into(),
+                archetype_field_name: Some("range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                component_name: "rerun.blueprint.components.LockRangeDuringZoom".into(),
+                archetype_field_name: Some("zoom_lock".into()),
+            },
         ]
     });
 
@@ -90,26 +103,26 @@ impl ::re_types_core::Archetype for ScalarAxis {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ScalarAxisIndicator = ScalarAxisIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -153,12 +166,30 @@ impl ::re_types_core::AsComponents for ScalarAxis {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.range
+            (self
+                .range
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.zoom_lock
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                    archetype_field_name: Some(("range").into()),
+                    component_name: ("rerun.components.Range1D").into(),
+                }),
+            }),
+            (self
+                .zoom_lock
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
+                    archetype_field_name: Some(("zoom_lock").into()),
+                    component_name: ("rerun.blueprint.components.LockRangeDuringZoom").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -195,5 +226,18 @@ impl ScalarAxis {
     ) -> Self {
         self.zoom_lock = Some(zoom_lock.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for ScalarAxis {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.range.heap_size_bytes() + self.zoom_lock.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::Range1D>>::is_pod()
+            && <Option<crate::blueprint::components::LockRangeDuringZoom>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -101,9 +101,9 @@ impl ::re_types_core::Archetype for ScalarAxis {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ScalarAxisIndicator = ScalarAxisIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -161,7 +161,7 @@ impl ::re_types_core::Archetype for ScalarAxis {
 }
 
 impl ::re_types_core::AsComponents for ScalarAxis {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -170,7 +170,7 @@ impl ::re_types_core::AsComponents for ScalarAxis {
                 .range
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
@@ -182,7 +182,7 @@ impl ::re_types_core::AsComponents for ScalarAxis {
                 .zoom_lock
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The description of a single view.
@@ -42,49 +42,73 @@ pub struct SpaceViewBlueprint {
     pub visible: Option<crate::blueprint::components::Visible>,
 }
 
-impl ::re_types_core::SizeBytes for SpaceViewBlueprint {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.class_identifier.heap_size_bytes()
-            + self.display_name.heap_size_bytes()
-            + self.space_origin.heap_size_bytes()
-            + self.visible.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+            component_name: "rerun.blueprint.components.SpaceViewClass".into(),
+            archetype_field_name: Some("class_identifier".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::SpaceViewClass>::is_pod()
-            && <Option<crate::components::Name>>::is_pod()
-            && <Option<crate::blueprint::components::SpaceViewOrigin>>::is_pod()
-            && <Option<crate::blueprint::components::Visible>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+            component_name: "SpaceViewBlueprintIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.SpaceViewClass".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(
-        || ["rerun.blueprint.components.SpaceViewBlueprintIndicator".into()],
-    );
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Name".into(),
-            "rerun.blueprint.components.SpaceViewOrigin".into(),
-            "rerun.blueprint.components.Visible".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("display_name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.blueprint.components.SpaceViewOrigin".into(),
+                archetype_field_name: Some("space_origin".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.SpaceViewClass".into(),
-            "rerun.blueprint.components.SpaceViewBlueprintIndicator".into(),
-            "rerun.components.Name".into(),
-            "rerun.blueprint.components.SpaceViewOrigin".into(),
-            "rerun.blueprint.components.Visible".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.blueprint.components.SpaceViewClass".into(),
+                archetype_field_name: Some("class_identifier".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "SpaceViewBlueprintIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("display_name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.blueprint.components.SpaceViewOrigin".into(),
+                archetype_field_name: Some("space_origin".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
         ]
     });
 
@@ -113,26 +137,26 @@ impl ::re_types_core::Archetype for SpaceViewBlueprint {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: SpaceViewBlueprintIndicator = SpaceViewBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -203,16 +227,54 @@ impl ::re_types_core::AsComponents for SpaceViewBlueprint {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.class_identifier as &dyn ComponentBatch).into()),
-            self.display_name
+            (Some(&self.class_identifier as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some(
+                            "rerun.blueprint.archetypes.SpaceViewBlueprint".into(),
+                        ),
+                        archetype_field_name: Some(("class_identifier").into()),
+                        component_name: ("rerun.blueprint.components.SpaceViewClass").into(),
+                    }),
+                }
+            }),
+            (self
+                .display_name
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.space_origin
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                    archetype_field_name: Some(("display_name").into()),
+                    component_name: ("rerun.components.Name").into(),
+                }),
+            }),
+            (self
+                .space_origin
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.visible
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                    archetype_field_name: Some(("space_origin").into()),
+                    component_name: ("rerun.blueprint.components.SpaceViewOrigin").into(),
+                }),
+            }),
+            (self
+                .visible
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
+                    archetype_field_name: Some(("visible").into()),
+                    component_name: ("rerun.blueprint.components.Visible").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -267,5 +329,23 @@ impl SpaceViewBlueprint {
     ) -> Self {
         self.visible = Some(visible.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for SpaceViewBlueprint {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.class_identifier.heap_size_bytes()
+            + self.display_name.heap_size_bytes()
+            + self.space_origin.heap_size_bytes()
+            + self.visible.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::SpaceViewClass>::is_pod()
+            && <Option<crate::components::Name>>::is_pod()
+            && <Option<crate::blueprint::components::SpaceViewOrigin>>::is_pod()
+            && <Option<crate::blueprint::components::Visible>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -135,9 +135,9 @@ impl ::re_types_core::Archetype for SpaceViewBlueprint {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: SpaceViewBlueprintIndicator = SpaceViewBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -222,13 +222,13 @@ impl ::re_types_core::Archetype for SpaceViewBlueprint {
 }
 
 impl ::re_types_core::AsComponents for SpaceViewBlueprint {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.class_identifier as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some(
@@ -243,7 +243,7 @@ impl ::re_types_core::AsComponents for SpaceViewBlueprint {
                 .display_name
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
@@ -255,7 +255,7 @@ impl ::re_types_core::AsComponents for SpaceViewBlueprint {
                 .space_origin
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
@@ -267,7 +267,7 @@ impl ::re_types_core::AsComponents for SpaceViewBlueprint {
                 .visible
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The contents of a `SpaceView`.
@@ -64,32 +64,40 @@ pub struct SpaceViewContents {
     pub query: Vec<crate::blueprint::components::QueryExpression>,
 }
 
-impl ::re_types_core::SizeBytes for SpaceViewContents {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.query.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::blueprint::components::QueryExpression>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.SpaceViewContentsIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
+            component_name: "SpaceViewContentsIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.QueryExpression".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
+            component_name: "rerun.blueprint.components.QueryExpression".into(),
+            archetype_field_name: Some("query".into()),
+        }]
+    });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.SpaceViewContentsIndicator".into(),
-            "rerun.blueprint.components.QueryExpression".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
+                component_name: "SpaceViewContentsIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
+                component_name: "rerun.blueprint.components.QueryExpression".into(),
+                archetype_field_name: Some("query".into()),
+            },
         ]
     });
 
@@ -117,26 +125,26 @@ impl ::re_types_core::Archetype for SpaceViewContents {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: SpaceViewContentsIndicator = SpaceViewContentsIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -172,7 +180,16 @@ impl ::re_types_core::AsComponents for SpaceViewContents {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.query as &dyn ComponentBatch).into()),
+            (Some(&self.query as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
+                        archetype_field_name: Some(("query").into()),
+                        component_name: ("rerun.blueprint.components.QueryExpression").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -191,5 +208,17 @@ impl SpaceViewContents {
         Self {
             query: query.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for SpaceViewContents {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.query.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::blueprint::components::QueryExpression>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -123,9 +123,9 @@ impl ::re_types_core::Archetype for SpaceViewContents {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: SpaceViewContentsIndicator = SpaceViewContentsIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -175,13 +175,13 @@ impl ::re_types_core::Archetype for SpaceViewContents {
 }
 
 impl ::re_types_core::AsComponents for SpaceViewContents {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.query as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configures how tensor scalars are mapped to color.
@@ -39,46 +39,62 @@ pub struct TensorScalarMapping {
     pub gamma: Option<crate::components::GammaCorrection>,
 }
 
-impl ::re_types_core::SizeBytes for TensorScalarMapping {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.mag_filter.heap_size_bytes()
-            + self.colormap.heap_size_bytes()
-            + self.gamma.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::MagnificationFilter>>::is_pod()
-            && <Option<crate::components::Colormap>>::is_pod()
-            && <Option<crate::components::GammaCorrection>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
-        ["rerun.blueprint.components.TensorScalarMappingIndicator".into()]
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+            component_name: "TensorScalarMappingIndicator".into(),
+            archetype_field_name: None,
+        }]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 3usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.MagnificationFilter".into(),
-            "rerun.components.Colormap".into(),
-            "rerun.components.GammaCorrection".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.MagnificationFilter".into(),
+                archetype_field_name: Some("mag_filter".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.Colormap".into(),
+                archetype_field_name: Some("colormap".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.GammaCorrection".into(),
+                archetype_field_name: Some("gamma".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
-            "rerun.components.MagnificationFilter".into(),
-            "rerun.components.Colormap".into(),
-            "rerun.components.GammaCorrection".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "TensorScalarMappingIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.MagnificationFilter".into(),
+                archetype_field_name: Some("mag_filter".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.Colormap".into(),
+                archetype_field_name: Some("colormap".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                component_name: "rerun.components.GammaCorrection".into(),
+                archetype_field_name: Some("gamma".into()),
+            },
         ]
     });
 
@@ -107,26 +123,26 @@ impl ::re_types_core::Archetype for TensorScalarMapping {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: TensorScalarMappingIndicator = TensorScalarMappingIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -182,15 +198,42 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.mag_filter
+            (self
+                .mag_filter
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.colormap
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                    archetype_field_name: Some(("mag_filter").into()),
+                    component_name: ("rerun.components.MagnificationFilter").into(),
+                }),
+            }),
+            (self
+                .colormap
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.gamma
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                    archetype_field_name: Some(("colormap").into()),
+                    component_name: ("rerun.components.Colormap").into(),
+                }),
+            }),
+            (self
+                .gamma
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
+                    archetype_field_name: Some(("gamma").into()),
+                    component_name: ("rerun.components.GammaCorrection").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -241,5 +284,21 @@ impl TensorScalarMapping {
     pub fn with_gamma(mut self, gamma: impl Into<crate::components::GammaCorrection>) -> Self {
         self.gamma = Some(gamma.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorScalarMapping {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.mag_filter.heap_size_bytes()
+            + self.colormap.heap_size_bytes()
+            + self.gamma.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::MagnificationFilter>>::is_pod()
+            && <Option<crate::components::Colormap>>::is_pod()
+            && <Option<crate::components::GammaCorrection>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -121,9 +121,9 @@ impl ::re_types_core::Archetype for TensorScalarMapping {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TensorScalarMappingIndicator = TensorScalarMappingIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -193,7 +193,7 @@ impl ::re_types_core::Archetype for TensorScalarMapping {
 }
 
 impl ::re_types_core::AsComponents for TensorScalarMapping {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -202,7 +202,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .mag_filter
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
@@ -214,7 +214,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .colormap
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
@@ -226,7 +226,7 @@ impl ::re_types_core::AsComponents for TensorScalarMapping {
                 .gamma
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -136,9 +136,9 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TensorSliceSelectionIndicator = TensorSliceSelectionIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -231,7 +231,7 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
 }
 
 impl ::re_types_core::AsComponents for TensorSliceSelection {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -240,7 +240,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .width
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
@@ -252,7 +252,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .height
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
@@ -264,7 +264,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .indices
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
@@ -276,7 +276,7 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
                 .slider
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Specifies a 2D slice of a tensor.
@@ -44,50 +44,72 @@ pub struct TensorSliceSelection {
     pub slider: Option<Vec<crate::blueprint::components::TensorDimensionIndexSlider>>,
 }
 
-impl ::re_types_core::SizeBytes for TensorSliceSelection {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.width.heap_size_bytes()
-            + self.height.heap_size_bytes()
-            + self.indices.heap_size_bytes()
-            + self.slider.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::components::TensorWidthDimension>>::is_pod()
-            && <Option<crate::components::TensorHeightDimension>>::is_pod()
-            && <Option<Vec<crate::components::TensorDimensionIndexSelection>>>::is_pod()
-            && <Option<Vec<crate::blueprint::components::TensorDimensionIndexSlider>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
     once_cell::sync::Lazy::new(|| {
-        ["rerun.blueprint.components.TensorSliceSelectionIndicator".into()]
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+            component_name: "TensorSliceSelectionIndicator".into(),
+            archetype_field_name: None,
+        }]
     });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 4usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.TensorWidthDimension".into(),
-            "rerun.components.TensorHeightDimension".into(),
-            "rerun.components.TensorDimensionIndexSelection".into(),
-            "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorWidthDimension".into(),
+                archetype_field_name: Some("width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorHeightDimension".into(),
+                archetype_field_name: Some("height".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorDimensionIndexSelection".into(),
+                archetype_field_name: Some("indices".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
+                archetype_field_name: Some("slider".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
-            "rerun.components.TensorWidthDimension".into(),
-            "rerun.components.TensorHeightDimension".into(),
-            "rerun.components.TensorDimensionIndexSelection".into(),
-            "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "TensorSliceSelectionIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorWidthDimension".into(),
+                archetype_field_name: Some("width".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorHeightDimension".into(),
+                archetype_field_name: Some("height".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.components.TensorDimensionIndexSelection".into(),
+                archetype_field_name: Some("indices".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                component_name: "rerun.blueprint.components.TensorDimensionIndexSlider".into(),
+                archetype_field_name: Some("slider".into()),
+            },
         ]
     });
 
@@ -116,26 +138,26 @@ impl ::re_types_core::Archetype for TensorSliceSelection {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: TensorSliceSelectionIndicator = TensorSliceSelectionIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -214,18 +236,55 @@ impl ::re_types_core::AsComponents for TensorSliceSelection {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.width
+            (self
+                .width
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.height
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                    archetype_field_name: Some(("width").into()),
+                    component_name: ("rerun.components.TensorWidthDimension").into(),
+                }),
+            }),
+            (self
+                .height
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.indices
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                    archetype_field_name: Some(("height").into()),
+                    component_name: ("rerun.components.TensorHeightDimension").into(),
+                }),
+            }),
+            (self
+                .indices
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.slider
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                    archetype_field_name: Some(("indices").into()),
+                    component_name: ("rerun.components.TensorDimensionIndexSelection").into(),
+                }),
+            }),
+            (self
+                .slider
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
+                    archetype_field_name: Some(("slider").into()),
+                    component_name: ("rerun.blueprint.components.TensorDimensionIndexSlider")
+                        .into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -294,5 +353,23 @@ impl TensorSliceSelection {
     ) -> Self {
         self.slider = Some(slider.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorSliceSelection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.width.heap_size_bytes()
+            + self.height.heap_size_bytes()
+            + self.indices.heap_size_bytes()
+            + self.slider.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::components::TensorWidthDimension>>::is_pod()
+            && <Option<crate::components::TensorHeightDimension>>::is_pod()
+            && <Option<Vec<crate::components::TensorDimensionIndexSelection>>>::is_pod()
+            && <Option<Vec<crate::blueprint::components::TensorDimensionIndexSlider>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configures how a selected tensor slice is shown on screen.
@@ -25,32 +25,40 @@ pub struct TensorViewFit {
     pub scaling: Option<crate::blueprint::components::ViewFit>,
 }
 
-impl ::re_types_core::SizeBytes for TensorViewFit {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.scaling.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::blueprint::components::ViewFit>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.TensorViewFitIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+            component_name: "TensorViewFitIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ViewFit".into()]);
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+            component_name: "rerun.blueprint.components.ViewFit".into(),
+            archetype_field_name: Some("scaling".into()),
+        }]
+    });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.TensorViewFitIndicator".into(),
-            "rerun.blueprint.components.ViewFit".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+                component_name: "TensorViewFitIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+                component_name: "rerun.blueprint.components.ViewFit".into(),
+                archetype_field_name: Some("scaling".into()),
+            },
         ]
     });
 
@@ -78,26 +86,26 @@ impl ::re_types_core::Archetype for TensorViewFit {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: TensorViewFitIndicator = TensorViewFitIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -131,9 +139,18 @@ impl ::re_types_core::AsComponents for TensorViewFit {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.scaling
+            (self
+                .scaling
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
+                    archetype_field_name: Some(("scaling").into()),
+                    component_name: ("rerun.blueprint.components.ViewFit").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -158,5 +175,17 @@ impl TensorViewFit {
     ) -> Self {
         self.scaling = Some(scaling.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorViewFit {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.scaling.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::blueprint::components::ViewFit>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -84,9 +84,9 @@ impl ::re_types_core::Archetype for TensorViewFit {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: TensorViewFitIndicator = TensorViewFitIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -134,7 +134,7 @@ impl ::re_types_core::Archetype for TensorViewFit {
 }
 
 impl ::re_types_core::AsComponents for TensorViewFit {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -143,7 +143,7 @@ impl ::re_types_core::AsComponents for TensorViewFit {
                 .scaling
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Configures what range of each timeline is shown on a view.
@@ -35,32 +35,40 @@ pub struct VisibleTimeRanges {
     pub ranges: Vec<crate::blueprint::components::VisibleTimeRange>,
 }
 
-impl ::re_types_core::SizeBytes for VisibleTimeRanges {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.ranges.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+            component_name: "rerun.blueprint.components.VisibleTimeRange".into(),
+            archetype_field_name: Some("ranges".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::blueprint::components::VisibleTimeRange>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+            component_name: "VisibleTimeRangesIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.VisibleTimeRange".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.VisibleTimeRangesIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.VisibleTimeRange".into(),
-            "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+                component_name: "rerun.blueprint.components.VisibleTimeRange".into(),
+                archetype_field_name: Some("ranges".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+                component_name: "VisibleTimeRangesIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -88,26 +96,26 @@ impl ::re_types_core::Archetype for VisibleTimeRanges {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: VisibleTimeRangesIndicator = VisibleTimeRangesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -143,7 +151,16 @@ impl ::re_types_core::AsComponents for VisibleTimeRanges {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.ranges as &dyn ComponentBatch).into()),
+            (Some(&self.ranges as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
+                        archetype_field_name: Some(("ranges").into()),
+                        component_name: ("rerun.blueprint.components.VisibleTimeRange").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -162,5 +179,17 @@ impl VisibleTimeRanges {
         Self {
             ranges: ranges.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for VisibleTimeRanges {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.ranges.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::blueprint::components::VisibleTimeRange>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -94,9 +94,9 @@ impl ::re_types_core::Archetype for VisibleTimeRanges {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: VisibleTimeRangesIndicator = VisibleTimeRangesIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -146,13 +146,13 @@ impl ::re_types_core::Archetype for VisibleTimeRanges {
 }
 
 impl ::re_types_core::AsComponents for VisibleTimeRanges {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.ranges as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: Controls the visual bounds of a 2D view.
@@ -33,32 +33,40 @@ pub struct VisualBounds2D {
     pub range: crate::blueprint::components::VisualBounds2D,
 }
 
-impl ::re_types_core::SizeBytes for VisualBounds2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.range.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+            component_name: "rerun.blueprint.components.VisualBounds2D".into(),
+            archetype_field_name: Some("range".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::VisualBounds2D>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+            component_name: "VisualBounds2DIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.VisualBounds2D".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.VisualBounds2DIndicator".into()]);
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 2usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.VisualBounds2D".into(),
-            "rerun.blueprint.components.VisualBounds2DIndicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+                component_name: "rerun.blueprint.components.VisualBounds2D".into(),
+                archetype_field_name: Some("range".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+                component_name: "VisualBounds2DIndicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -86,26 +94,26 @@ impl ::re_types_core::Archetype for VisualBounds2D {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: VisualBounds2DIndicator = VisualBounds2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -142,7 +150,16 @@ impl ::re_types_core::AsComponents for VisualBounds2D {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.range as &dyn ComponentBatch).into()),
+            (Some(&self.range as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
+                        archetype_field_name: Some(("range").into()),
+                        component_name: ("rerun.blueprint.components.VisualBounds2D").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -159,5 +176,17 @@ impl VisualBounds2D {
         Self {
             range: range.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for VisualBounds2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.range.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::VisualBounds2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -92,9 +92,9 @@ impl ::re_types_core::Archetype for VisualBounds2D {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: VisualBounds2DIndicator = VisualBounds2DIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -145,13 +145,13 @@ impl ::re_types_core::Archetype for VisualBounds2D {
 }
 
 impl ::re_types_core::AsComponents for VisualBounds2D {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.range as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),

--- a/crates/store/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/store/re_types/src/blueprint/components/active_tab.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The active tab in a tabbed container.
@@ -27,44 +27,10 @@ pub struct ActiveTab(
     pub crate::datatypes::EntityPath,
 );
 
-impl ::re_types_core::SizeBytes for ActiveTab {
+impl ::re_types_core::Component for ActiveTab {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::EntityPath>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::EntityPath>> From<T> for ActiveTab {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::EntityPath> for ActiveTab {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ActiveTab {
-    type Target = crate::datatypes::EntityPath;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ActiveTab {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ActiveTab")
     }
 }
 
@@ -101,9 +67,43 @@ impl ::re_types_core::Loggable for ActiveTab {
     }
 }
 
-impl ::re_types_core::Component for ActiveTab {
+impl<T: Into<crate::datatypes::EntityPath>> From<T> for ActiveTab {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::EntityPath> for ActiveTab {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ActiveTab".into()
+    fn borrow(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ActiveTab {
+    type Target = crate::datatypes::EntityPath;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ActiveTab {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ActiveTab {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::EntityPath>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/active_tab.rs
+++ b/crates/store/re_types/src/blueprint/components/active_tab.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
+++ b/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether empty cells in a dataframe should be filled with a latest-at query.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ApplyLatestAt(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for ApplyLatestAt {
+impl ::re_types_core::Component for ApplyLatestAt {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for ApplyLatestAt {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for ApplyLatestAt {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ApplyLatestAt {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ApplyLatestAt {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ApplyLatestAt")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for ApplyLatestAt {
     }
 }
 
-impl ::re_types_core::Component for ApplyLatestAt {
+impl<T: Into<crate::datatypes::Bool>> From<T> for ApplyLatestAt {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for ApplyLatestAt {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ApplyLatestAt".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ApplyLatestAt {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ApplyLatestAt {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ApplyLatestAt {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
+++ b/crates/store/re_types/src/blueprint/components/apply_latest_at.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The type of the background in a view.
@@ -38,45 +38,10 @@ pub enum BackgroundKind {
     SolidColor = 3,
 }
 
-impl ::re_types_core::reflection::Enum for BackgroundKind {
+impl ::re_types_core::Component for BackgroundKind {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::GradientDark, Self::GradientBright, Self::SolidColor]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::GradientDark => {
-                "A dark gradient.\n\nIn 3D views it changes depending on the direction of the view."
-            }
-            Self::GradientBright => {
-                "A bright gradient.\n\nIn 3D views it changes depending on the direction of the view."
-            }
-            Self::SolidColor => "Simple uniform color.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for BackgroundKind {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for BackgroundKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::GradientDark => write!(f, "GradientDark"),
-            Self::GradientBright => write!(f, "GradientBright"),
-            Self::SolidColor => write!(f, "SolidColor"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.BackgroundKind")
     }
 }
 
@@ -167,9 +132,44 @@ impl ::re_types_core::Loggable for BackgroundKind {
     }
 }
 
-impl ::re_types_core::Component for BackgroundKind {
+impl std::fmt::Display for BackgroundKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::GradientDark => write!(f, "GradientDark"),
+            Self::GradientBright => write!(f, "GradientBright"),
+            Self::SolidColor => write!(f, "SolidColor"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for BackgroundKind {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.BackgroundKind".into()
+    fn variants() -> &'static [Self] {
+        &[Self::GradientDark, Self::GradientBright, Self::SolidColor]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::GradientDark => {
+                "A dark gradient.\n\nIn 3D views it changes depending on the direction of the view."
+            }
+            Self::GradientBright => {
+                "A bright gradient.\n\nIn 3D views it changes depending on the direction of the view."
+            }
+            Self::SolidColor => "Simple uniform color.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for BackgroundKind {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/blueprint/components/background_kind.rs
+++ b/crates/store/re_types/src/blueprint/components/background_kind.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/column_share.rs
+++ b/crates/store/re_types/src/blueprint/components/column_share.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The layout share of a column in the container.
@@ -25,44 +25,10 @@ pub struct ColumnShare(
     pub crate::datatypes::Float32,
 );
 
-impl ::re_types_core::SizeBytes for ColumnShare {
+impl ::re_types_core::Component for ColumnShare {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for ColumnShare {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for ColumnShare {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ColumnShare {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ColumnShare {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ColumnShare")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for ColumnShare {
     }
 }
 
-impl ::re_types_core::Component for ColumnShare {
+impl<T: Into<crate::datatypes::Float32>> From<T> for ColumnShare {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for ColumnShare {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ColumnShare".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ColumnShare {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ColumnShare {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ColumnShare {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/column_share.rs
+++ b/crates/store/re_types/src/blueprint/components/column_share.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Describe a component column to be selected in the dataframe view.
@@ -23,48 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ComponentColumnSelector(pub crate::blueprint::datatypes::ComponentColumnSelector);
 
-impl ::re_types_core::SizeBytes for ComponentColumnSelector {
+impl ::re_types_core::Component for ComponentColumnSelector {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::ComponentColumnSelector>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::ComponentColumnSelector>> From<T>
-    for ComponentColumnSelector
-{
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::ComponentColumnSelector>
-    for ComponentColumnSelector
-{
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::ComponentColumnSelector {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ComponentColumnSelector {
-    type Target = crate::blueprint::datatypes::ComponentColumnSelector;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::ComponentColumnSelector {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ComponentColumnSelector {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::ComponentColumnSelector {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ComponentColumnSelector")
     }
 }
 
@@ -103,9 +65,47 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
     }
 }
 
-impl ::re_types_core::Component for ComponentColumnSelector {
+impl<T: Into<crate::blueprint::datatypes::ComponentColumnSelector>> From<T>
+    for ComponentColumnSelector
+{
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::ComponentColumnSelector>
+    for ComponentColumnSelector
+{
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ComponentColumnSelector".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::ComponentColumnSelector {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ComponentColumnSelector {
+    type Target = crate::blueprint::datatypes::ComponentColumnSelector;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::ComponentColumnSelector {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ComponentColumnSelector {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::ComponentColumnSelector {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ComponentColumnSelector {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::ComponentColumnSelector>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/components/component_column_selector.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/corner2d.rs
+++ b/crates/store/re_types/src/blueprint/components/corner2d.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: One of four 2D corners, typically used to align objects.
@@ -37,48 +37,10 @@ pub enum Corner2D {
     RightBottom = 4,
 }
 
-impl ::re_types_core::reflection::Enum for Corner2D {
+impl ::re_types_core::Component for Corner2D {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::LeftTop,
-            Self::RightTop,
-            Self::LeftBottom,
-            Self::RightBottom,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::LeftTop => "Left top corner.",
-            Self::RightTop => "Right top corner.",
-            Self::LeftBottom => "Left bottom corner.",
-            Self::RightBottom => "Right bottom corner.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for Corner2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for Corner2D {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::LeftTop => write!(f, "LeftTop"),
-            Self::RightTop => write!(f, "RightTop"),
-            Self::LeftBottom => write!(f, "LeftBottom"),
-            Self::RightBottom => write!(f, "RightBottom"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.Corner2D")
     }
 }
 
@@ -170,9 +132,47 @@ impl ::re_types_core::Loggable for Corner2D {
     }
 }
 
-impl ::re_types_core::Component for Corner2D {
+impl std::fmt::Display for Corner2D {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LeftTop => write!(f, "LeftTop"),
+            Self::RightTop => write!(f, "RightTop"),
+            Self::LeftBottom => write!(f, "LeftBottom"),
+            Self::RightBottom => write!(f, "RightBottom"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for Corner2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.Corner2D".into()
+    fn variants() -> &'static [Self] {
+        &[
+            Self::LeftTop,
+            Self::RightTop,
+            Self::LeftBottom,
+            Self::RightBottom,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::LeftTop => "Left top corner.",
+            Self::RightTop => "Right top corner.",
+            Self::LeftBottom => "Left bottom corner.",
+            Self::RightBottom => "Right bottom corner.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for Corner2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/blueprint/components/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_by_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Configuration for a filter-by-range feature of the dataframe view.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct FilterByRange(pub crate::blueprint::datatypes::FilterByRange);
 
-impl ::re_types_core::SizeBytes for FilterByRange {
+impl ::re_types_core::Component for FilterByRange {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::FilterByRange>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::FilterByRange>> From<T> for FilterByRange {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::FilterByRange> for FilterByRange {
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::FilterByRange {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for FilterByRange {
-    type Target = crate::blueprint::datatypes::FilterByRange;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::FilterByRange {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for FilterByRange {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::FilterByRange {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.FilterByRange")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for FilterByRange {
     }
 }
 
-impl ::re_types_core::Component for FilterByRange {
+impl<T: Into<crate::blueprint::datatypes::FilterByRange>> From<T> for FilterByRange {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::FilterByRange> for FilterByRange {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.FilterByRange".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::FilterByRange {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for FilterByRange {
+    type Target = crate::blueprint::datatypes::FilterByRange;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::FilterByRange {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FilterByRange {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::FilterByRange {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for FilterByRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::FilterByRange>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_by_range.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Configuration for the filter is not null feature of the dataframe view.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct FilterIsNotNull(pub crate::blueprint::datatypes::FilterIsNotNull);
 
-impl ::re_types_core::SizeBytes for FilterIsNotNull {
+impl ::re_types_core::Component for FilterIsNotNull {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::FilterIsNotNull>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::FilterIsNotNull>> From<T> for FilterIsNotNull {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::FilterIsNotNull> for FilterIsNotNull {
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::FilterIsNotNull {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for FilterIsNotNull {
-    type Target = crate::blueprint::datatypes::FilterIsNotNull;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::FilterIsNotNull {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for FilterIsNotNull {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::FilterIsNotNull {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.FilterIsNotNull")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for FilterIsNotNull {
     }
 }
 
-impl ::re_types_core::Component for FilterIsNotNull {
+impl<T: Into<crate::blueprint::datatypes::FilterIsNotNull>> From<T> for FilterIsNotNull {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::FilterIsNotNull> for FilterIsNotNull {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.FilterIsNotNull".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::FilterIsNotNull {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for FilterIsNotNull {
+    type Target = crate::blueprint::datatypes::FilterIsNotNull;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::FilterIsNotNull {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FilterIsNotNull {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::FilterIsNotNull {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for FilterIsNotNull {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::FilterIsNotNull>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/components/filter_is_not_null.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/grid_spacing.rs
+++ b/crates/store/re_types/src/blueprint/components/grid_spacing.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Space between grid lines of one line to the next in scene units.
@@ -25,44 +25,10 @@ pub struct GridSpacing(
     pub crate::datatypes::Float32,
 );
 
-impl ::re_types_core::SizeBytes for GridSpacing {
+impl ::re_types_core::Component for GridSpacing {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for GridSpacing {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for GridSpacing {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for GridSpacing {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for GridSpacing {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.GridSpacing")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for GridSpacing {
     }
 }
 
-impl ::re_types_core::Component for GridSpacing {
+impl<T: Into<crate::datatypes::Float32>> From<T> for GridSpacing {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for GridSpacing {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.GridSpacing".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for GridSpacing {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GridSpacing {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for GridSpacing {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/grid_spacing.rs
+++ b/crates/store/re_types/src/blueprint/components/grid_spacing.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/included_content.rs
+++ b/crates/store/re_types/src/blueprint/components/included_content.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: All the contents in the container.
@@ -28,44 +28,10 @@ pub struct IncludedContent(
     pub crate::datatypes::EntityPath,
 );
 
-impl ::re_types_core::SizeBytes for IncludedContent {
+impl ::re_types_core::Component for IncludedContent {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::EntityPath>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::EntityPath>> From<T> for IncludedContent {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::EntityPath> for IncludedContent {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for IncludedContent {
-    type Target = crate::datatypes::EntityPath;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for IncludedContent {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.IncludedContent")
     }
 }
 
@@ -102,9 +68,43 @@ impl ::re_types_core::Loggable for IncludedContent {
     }
 }
 
-impl ::re_types_core::Component for IncludedContent {
+impl<T: Into<crate::datatypes::EntityPath>> From<T> for IncludedContent {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::EntityPath> for IncludedContent {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.IncludedContent".into()
+    fn borrow(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for IncludedContent {
+    type Target = crate::datatypes::EntityPath;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for IncludedContent {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for IncludedContent {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::EntityPath>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/included_content.rs
+++ b/crates/store/re_types/src/blueprint/components/included_content.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/interactive.rs
+++ b/crates/store/re_types/src/blueprint/components/interactive.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the entity can be interacted with.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Interactive(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for Interactive {
+impl ::re_types_core::Component for Interactive {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for Interactive {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for Interactive {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Interactive {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Interactive {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.Interactive")
     }
 }
 
@@ -99,9 +65,43 @@ impl ::re_types_core::Loggable for Interactive {
     }
 }
 
-impl ::re_types_core::Component for Interactive {
+impl<T: Into<crate::datatypes::Bool>> From<T> for Interactive {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for Interactive {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.Interactive".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Interactive {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Interactive {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Interactive {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/interactive.rs
+++ b/crates/store/re_types/src/blueprint/components/interactive.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Indicate whether the range should be locked when zooming in on the data.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct LockRangeDuringZoom(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for LockRangeDuringZoom {
+impl ::re_types_core::Component for LockRangeDuringZoom {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for LockRangeDuringZoom {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for LockRangeDuringZoom {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for LockRangeDuringZoom {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for LockRangeDuringZoom {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.LockRangeDuringZoom")
     }
 }
 
@@ -99,9 +65,43 @@ impl ::re_types_core::Loggable for LockRangeDuringZoom {
     }
 }
 
-impl ::re_types_core::Component for LockRangeDuringZoom {
+impl<T: Into<crate::datatypes::Bool>> From<T> for LockRangeDuringZoom {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for LockRangeDuringZoom {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.LockRangeDuringZoom".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for LockRangeDuringZoom {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for LockRangeDuringZoom {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for LockRangeDuringZoom {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
+++ b/crates/store/re_types/src/blueprint/components/lock_range_during_zoom.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Name of the map provider to be used in Map views.
@@ -37,48 +37,10 @@ pub enum MapProvider {
     MapboxSatellite = 4,
 }
 
-impl ::re_types_core::reflection::Enum for MapProvider {
+impl ::re_types_core::Component for MapProvider {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::OpenStreetMap,
-            Self::MapboxStreets,
-            Self::MapboxDark,
-            Self::MapboxSatellite,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::OpenStreetMap => "`OpenStreetMap` is the default map provider.",
-            Self::MapboxStreets => "Mapbox Streets is a minimalistic map designed by Mapbox.",
-            Self::MapboxDark => "Mapbox Dark is a dark-themed map designed by Mapbox.",
-            Self::MapboxSatellite => "Mapbox Satellite is a satellite map designed by Mapbox.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for MapProvider {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for MapProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::OpenStreetMap => write!(f, "OpenStreetMap"),
-            Self::MapboxStreets => write!(f, "MapboxStreets"),
-            Self::MapboxDark => write!(f, "MapboxDark"),
-            Self::MapboxSatellite => write!(f, "MapboxSatellite"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.MapProvider")
     }
 }
 
@@ -170,9 +132,47 @@ impl ::re_types_core::Loggable for MapProvider {
     }
 }
 
-impl ::re_types_core::Component for MapProvider {
+impl std::fmt::Display for MapProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OpenStreetMap => write!(f, "OpenStreetMap"),
+            Self::MapboxStreets => write!(f, "MapboxStreets"),
+            Self::MapboxDark => write!(f, "MapboxDark"),
+            Self::MapboxSatellite => write!(f, "MapboxSatellite"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for MapProvider {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.MapProvider".into()
+    fn variants() -> &'static [Self] {
+        &[
+            Self::OpenStreetMap,
+            Self::MapboxStreets,
+            Self::MapboxDark,
+            Self::MapboxSatellite,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::OpenStreetMap => "`OpenStreetMap` is the default map provider.",
+            Self::MapboxStreets => "Mapbox Streets is a minimalistic map designed by Mapbox.",
+            Self::MapboxDark => "Mapbox Dark is a dark-themed map designed by Mapbox.",
+            Self::MapboxSatellite => "Mapbox Satellite is a satellite map designed by Mapbox.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for MapProvider {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/blueprint/components/map_provider.rs
+++ b/crates/store/re_types/src/blueprint/components/map_provider.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Tri-state for panel controls.
@@ -34,41 +34,10 @@ pub enum PanelState {
     Expanded = 3,
 }
 
-impl ::re_types_core::reflection::Enum for PanelState {
+impl ::re_types_core::Component for PanelState {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::Hidden, Self::Collapsed, Self::Expanded]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Hidden => "Completely hidden.",
-            Self::Collapsed => "Visible, but as small as possible on its shorter axis.",
-            Self::Expanded => "Fully expanded.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for PanelState {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for PanelState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Hidden => write!(f, "Hidden"),
-            Self::Collapsed => write!(f, "Collapsed"),
-            Self::Expanded => write!(f, "Expanded"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.PanelState")
     }
 }
 
@@ -159,9 +128,40 @@ impl ::re_types_core::Loggable for PanelState {
     }
 }
 
-impl ::re_types_core::Component for PanelState {
+impl std::fmt::Display for PanelState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hidden => write!(f, "Hidden"),
+            Self::Collapsed => write!(f, "Collapsed"),
+            Self::Expanded => write!(f, "Expanded"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for PanelState {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.PanelState".into()
+    fn variants() -> &'static [Self] {
+        &[Self::Hidden, Self::Collapsed, Self::Expanded]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Hidden => "Completely hidden.",
+            Self::Collapsed => "Visible, but as small as possible on its shorter axis.",
+            Self::Expanded => "Fully expanded.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for PanelState {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/blueprint/components/panel_state.rs
+++ b/crates/store/re_types/src/blueprint/components/panel_state.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/store/re_types/src/blueprint/components/query_expression.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: An individual query expression used to filter a set of [`datatypes::EntityPath`][crate::datatypes::EntityPath]s.
@@ -32,44 +32,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct QueryExpression(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for QueryExpression {
+impl ::re_types_core::Component for QueryExpression {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for QueryExpression {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for QueryExpression {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for QueryExpression {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for QueryExpression {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.QueryExpression")
     }
 }
 
@@ -106,9 +72,43 @@ impl ::re_types_core::Loggable for QueryExpression {
     }
 }
 
-impl ::re_types_core::Component for QueryExpression {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for QueryExpression {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for QueryExpression {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.QueryExpression".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for QueryExpression {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for QueryExpression {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for QueryExpression {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/query_expression.rs
+++ b/crates/store/re_types/src/blueprint/components/query_expression.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/row_share.rs
+++ b/crates/store/re_types/src/blueprint/components/row_share.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The layout share of a row in the container.
@@ -25,44 +25,10 @@ pub struct RowShare(
     pub crate::datatypes::Float32,
 );
 
-impl ::re_types_core::SizeBytes for RowShare {
+impl ::re_types_core::Component for RowShare {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for RowShare {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for RowShare {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for RowShare {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for RowShare {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.RowShare")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for RowShare {
     }
 }
 
-impl ::re_types_core::Component for RowShare {
+impl<T: Into<crate::datatypes::Float32>> From<T> for RowShare {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for RowShare {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.RowShare".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RowShare {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RowShare {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for RowShare {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/row_share.rs
+++ b/crates/store/re_types/src/blueprint/components/row_share.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/components/selected_columns.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Describe a component column to be selected in the dataframe view.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct SelectedColumns(pub crate::blueprint::datatypes::SelectedColumns);
 
-impl ::re_types_core::SizeBytes for SelectedColumns {
+impl ::re_types_core::Component for SelectedColumns {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::SelectedColumns>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::SelectedColumns>> From<T> for SelectedColumns {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::SelectedColumns> for SelectedColumns {
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::SelectedColumns {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for SelectedColumns {
-    type Target = crate::blueprint::datatypes::SelectedColumns;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::SelectedColumns {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for SelectedColumns {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::SelectedColumns {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.SelectedColumns")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for SelectedColumns {
     }
 }
 
-impl ::re_types_core::Component for SelectedColumns {
+impl<T: Into<crate::blueprint::datatypes::SelectedColumns>> From<T> for SelectedColumns {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::SelectedColumns> for SelectedColumns {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.SelectedColumns".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::SelectedColumns {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for SelectedColumns {
+    type Target = crate::blueprint::datatypes::SelectedColumns;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::SelectedColumns {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SelectedColumns {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::SelectedColumns {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for SelectedColumns {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::SelectedColumns>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/components/selected_columns.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_class.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The class identifier of view, e.g. `"2D"`, `"TextLog"`, ….
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct SpaceViewClass(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for SpaceViewClass {
+impl ::re_types_core::Component for SpaceViewClass {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for SpaceViewClass {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for SpaceViewClass {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for SpaceViewClass {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for SpaceViewClass {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.SpaceViewClass")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for SpaceViewClass {
     }
 }
 
-impl ::re_types_core::Component for SpaceViewClass {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for SpaceViewClass {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for SpaceViewClass {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.SpaceViewClass".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for SpaceViewClass {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SpaceViewClass {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for SpaceViewClass {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/space_view_class.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_class.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_origin.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The origin of a `SpaceView`.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct SpaceViewOrigin(pub crate::datatypes::EntityPath);
 
-impl ::re_types_core::SizeBytes for SpaceViewOrigin {
+impl ::re_types_core::Component for SpaceViewOrigin {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::EntityPath>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::EntityPath>> From<T> for SpaceViewOrigin {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::EntityPath> for SpaceViewOrigin {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for SpaceViewOrigin {
-    type Target = crate::datatypes::EntityPath;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for SpaceViewOrigin {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.SpaceViewOrigin")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for SpaceViewOrigin {
     }
 }
 
-impl ::re_types_core::Component for SpaceViewOrigin {
+impl<T: Into<crate::datatypes::EntityPath>> From<T> for SpaceViewOrigin {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::EntityPath> for SpaceViewOrigin {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.SpaceViewOrigin".into()
+    fn borrow(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for SpaceViewOrigin {
+    type Target = crate::datatypes::EntityPath;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SpaceViewOrigin {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for SpaceViewOrigin {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::EntityPath>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/space_view_origin.rs
+++ b/crates/store/re_types/src/blueprint/components/space_view_origin.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Show a slider for the index of some dimension of a slider.
@@ -23,48 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TensorDimensionIndexSlider(pub crate::blueprint::datatypes::TensorDimensionIndexSlider);
 
-impl ::re_types_core::SizeBytes for TensorDimensionIndexSlider {
+impl ::re_types_core::Component for TensorDimensionIndexSlider {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::TensorDimensionIndexSlider>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::TensorDimensionIndexSlider>> From<T>
-    for TensorDimensionIndexSlider
-{
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::TensorDimensionIndexSlider>
-    for TensorDimensionIndexSlider
-{
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::TensorDimensionIndexSlider {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TensorDimensionIndexSlider {
-    type Target = crate::blueprint::datatypes::TensorDimensionIndexSlider;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::TensorDimensionIndexSlider {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TensorDimensionIndexSlider {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::TensorDimensionIndexSlider {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.TensorDimensionIndexSlider")
     }
 }
 
@@ -103,9 +65,47 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
     }
 }
 
-impl ::re_types_core::Component for TensorDimensionIndexSlider {
+impl<T: Into<crate::blueprint::datatypes::TensorDimensionIndexSlider>> From<T>
+    for TensorDimensionIndexSlider
+{
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::TensorDimensionIndexSlider>
+    for TensorDimensionIndexSlider
+{
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.TensorDimensionIndexSlider".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::TensorDimensionIndexSlider {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TensorDimensionIndexSlider {
+    type Target = crate::blueprint::datatypes::TensorDimensionIndexSlider;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::TensorDimensionIndexSlider {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TensorDimensionIndexSlider {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::TensorDimensionIndexSlider {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimensionIndexSlider {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::TensorDimensionIndexSlider>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/components/tensor_dimension_index_slider.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/timeline_name.rs
+++ b/crates/store/re_types/src/blueprint/components/timeline_name.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A timeline identified by its name.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TimelineName(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for TimelineName {
+impl ::re_types_core::Component for TimelineName {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for TimelineName {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for TimelineName {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TimelineName {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TimelineName {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.TimelineName")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for TimelineName {
     }
 }
 
-impl ::re_types_core::Component for TimelineName {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for TimelineName {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for TimelineName {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.TimelineName".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TimelineName {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TimelineName {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TimelineName {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/timeline_name.rs
+++ b/crates/store/re_types/src/blueprint/components/timeline_name.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Determines whether an image or texture should be scaled to fit the viewport.
@@ -34,47 +34,10 @@ pub enum ViewFit {
     FillKeepAspectRatio = 3,
 }
 
-impl ::re_types_core::reflection::Enum for ViewFit {
+impl ::re_types_core::Component for ViewFit {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::Original, Self::Fill, Self::FillKeepAspectRatio]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Original => {
-                "No scaling, pixel size will match the image's width/height dimensions in pixels."
-            }
-            Self::Fill => {
-                "Scale the image for the largest possible fit in the view's container."
-            }
-            Self::FillKeepAspectRatio => {
-                "Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for ViewFit {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for ViewFit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Original => write!(f, "Original"),
-            Self::Fill => write!(f, "Fill"),
-            Self::FillKeepAspectRatio => write!(f, "FillKeepAspectRatio"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ViewFit")
     }
 }
 
@@ -165,9 +128,46 @@ impl ::re_types_core::Loggable for ViewFit {
     }
 }
 
-impl ::re_types_core::Component for ViewFit {
+impl std::fmt::Display for ViewFit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Original => write!(f, "Original"),
+            Self::Fill => write!(f, "Fill"),
+            Self::FillKeepAspectRatio => write!(f, "FillKeepAspectRatio"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for ViewFit {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ViewFit".into()
+    fn variants() -> &'static [Self] {
+        &[Self::Original, Self::Fill, Self::FillKeepAspectRatio]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Original => {
+                "No scaling, pixel size will match the image's width/height dimensions in pixels."
+            }
+            Self::Fill => {
+                "Scale the image for the largest possible fit in the view's container."
+            }
+            Self::FillKeepAspectRatio => {
+                "Scale the image for the largest possible fit in the view's container, but keep the original aspect ratio."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewFit {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/blueprint/components/view_fit.rs
+++ b/crates/store/re_types/src/blueprint/components/view_fit.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Hash of a viewer recommendation.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ViewerRecommendationHash(pub crate::datatypes::UInt64);
 
-impl ::re_types_core::SizeBytes for ViewerRecommendationHash {
+impl ::re_types_core::Component for ViewerRecommendationHash {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::UInt64>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::UInt64>> From<T> for ViewerRecommendationHash {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::UInt64> for ViewerRecommendationHash {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::UInt64 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ViewerRecommendationHash {
-    type Target = crate::datatypes::UInt64;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::UInt64 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ViewerRecommendationHash {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::UInt64 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ViewerRecommendationHash")
     }
 }
 
@@ -107,9 +73,43 @@ impl ::re_types_core::Loggable for ViewerRecommendationHash {
     }
 }
 
-impl ::re_types_core::Component for ViewerRecommendationHash {
+impl<T: Into<crate::datatypes::UInt64>> From<T> for ViewerRecommendationHash {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::UInt64> for ViewerRecommendationHash {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ViewerRecommendationHash".into()
+    fn borrow(&self) -> &crate::datatypes::UInt64 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ViewerRecommendationHash {
+    type Target = crate::datatypes::UInt64;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::UInt64 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ViewerRecommendationHash {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::UInt64 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewerRecommendationHash {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::UInt64>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
+++ b/crates/store/re_types/src/blueprint/components/viewer_recommendation_hash.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/visible.rs
+++ b/crates/store/re_types/src/blueprint/components/visible.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the container, view, entity or instance is currently visible.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Visible(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for Visible {
+impl ::re_types_core::Component for Visible {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for Visible {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for Visible {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Visible {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Visible {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.Visible")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for Visible {
     }
 }
 
-impl ::re_types_core::Component for Visible {
+impl<T: Into<crate::datatypes::Bool>> From<T> for Visible {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for Visible {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.Visible".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Visible {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Visible {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Visible {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visible.rs
+++ b/crates/store/re_types/src/blueprint/components/visible.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/store/re_types/src/blueprint/components/visible_time_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The range of values on a given timeline that will be included in a view's query.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct VisibleTimeRange(pub crate::datatypes::VisibleTimeRange);
 
-impl ::re_types_core::SizeBytes for VisibleTimeRange {
+impl ::re_types_core::Component for VisibleTimeRange {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::VisibleTimeRange>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::VisibleTimeRange>> From<T> for VisibleTimeRange {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::VisibleTimeRange> for VisibleTimeRange {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::VisibleTimeRange {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for VisibleTimeRange {
-    type Target = crate::datatypes::VisibleTimeRange;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::VisibleTimeRange {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for VisibleTimeRange {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::VisibleTimeRange {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.VisibleTimeRange")
     }
 }
 
@@ -99,9 +65,43 @@ impl ::re_types_core::Loggable for VisibleTimeRange {
     }
 }
 
-impl ::re_types_core::Component for VisibleTimeRange {
+impl<T: Into<crate::datatypes::VisibleTimeRange>> From<T> for VisibleTimeRange {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::VisibleTimeRange> for VisibleTimeRange {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.VisibleTimeRange".into()
+    fn borrow(&self) -> &crate::datatypes::VisibleTimeRange {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for VisibleTimeRange {
+    type Target = crate::datatypes::VisibleTimeRange;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::VisibleTimeRange {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for VisibleTimeRange {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::VisibleTimeRange {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for VisibleTimeRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::VisibleTimeRange>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visible_time_range.rs
+++ b/crates/store/re_types/src/blueprint/components/visible_time_range.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Visual bounds in 2D space used for `Spatial2DView`.
@@ -26,44 +26,10 @@ pub struct VisualBounds2D(
     pub crate::datatypes::Range2D,
 );
 
-impl ::re_types_core::SizeBytes for VisualBounds2D {
+impl ::re_types_core::Component for VisualBounds2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Range2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Range2D>> From<T> for VisualBounds2D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Range2D> for VisualBounds2D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Range2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for VisualBounds2D {
-    type Target = crate::datatypes::Range2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Range2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for VisualBounds2D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Range2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.VisualBounds2D")
     }
 }
 
@@ -100,9 +66,43 @@ impl ::re_types_core::Loggable for VisualBounds2D {
     }
 }
 
-impl ::re_types_core::Component for VisualBounds2D {
+impl<T: Into<crate::datatypes::Range2D>> From<T> for VisualBounds2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Range2D> for VisualBounds2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.VisualBounds2D".into()
+    fn borrow(&self) -> &crate::datatypes::Range2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for VisualBounds2D {
+    type Target = crate::datatypes::Range2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Range2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for VisualBounds2D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Range2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for VisualBounds2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Range2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/components/visual_bounds2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/zoom_level.rs
+++ b/crates/store/re_types/src/blueprint/components/zoom_level.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/components/zoom_level.rs
+++ b/crates/store/re_types/src/blueprint/components/zoom_level.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A zoom level determines how much of the world is visible on a map.
@@ -25,44 +25,10 @@ pub struct ZoomLevel(
     pub crate::datatypes::Float64,
 );
 
-impl ::re_types_core::SizeBytes for ZoomLevel {
+impl ::re_types_core::Component for ZoomLevel {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float64>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float64>> From<T> for ZoomLevel {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float64> for ZoomLevel {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float64 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ZoomLevel {
-    type Target = crate::datatypes::Float64;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float64 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ZoomLevel {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float64 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ZoomLevel")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for ZoomLevel {
     }
 }
 
-impl ::re_types_core::Component for ZoomLevel {
+impl<T: Into<crate::datatypes::Float64>> From<T> for ZoomLevel {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float64> for ZoomLevel {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ZoomLevel".into()
+    fn borrow(&self) -> &crate::datatypes::Float64 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ZoomLevel {
+    type Target = crate::datatypes::Float64;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float64 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ZoomLevel {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float64 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ZoomLevel {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float64>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Describe a component column to be selected in the dataframe view.
@@ -26,18 +26,6 @@ pub struct ComponentColumnSelector {
 
     /// The name of the component.
     pub component: crate::datatypes::Utf8,
-}
-
-impl ::re_types_core::SizeBytes for ComponentColumnSelector {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.entity_path.heap_size_bytes() + self.component.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::EntityPath>::is_pod() && <crate::datatypes::Utf8>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ComponentColumnSelector);
@@ -345,5 +333,17 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
                 .with_context("rerun.blueprint.datatypes.ComponentColumnSelector")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for ComponentColumnSelector {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.entity_path.heap_size_bytes() + self.component.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::EntityPath>::is_pod() && <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Configuration for the filter-by-range feature of the dataframe view.
@@ -26,18 +26,6 @@ pub struct FilterByRange {
 
     /// End of the time range (inclusive).
     pub end: crate::datatypes::TimeInt,
-}
-
-impl ::re_types_core::SizeBytes for FilterByRange {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.start.heap_size_bytes() + self.end.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TimeInt>::is_pod() && <crate::datatypes::TimeInt>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(FilterByRange);
@@ -239,5 +227,17 @@ impl ::re_types_core::Loggable for FilterByRange {
                 .with_context("rerun.blueprint.datatypes.FilterByRange")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for FilterByRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.start.heap_size_bytes() + self.end.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TimeInt>::is_pod() && <crate::datatypes::TimeInt>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_by_range.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Configuration for the filter is not null feature of the dataframe view.
@@ -26,19 +26,6 @@ pub struct FilterIsNotNull {
 
     /// The column used when the filter by event feature is used.
     pub column: crate::blueprint::datatypes::ComponentColumnSelector,
-}
-
-impl ::re_types_core::SizeBytes for FilterIsNotNull {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.active.heap_size_bytes() + self.column.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-            && <crate::blueprint::datatypes::ComponentColumnSelector>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(FilterIsNotNull);
@@ -230,5 +217,18 @@ impl ::re_types_core::Loggable for FilterIsNotNull {
                 .with_context("rerun.blueprint.datatypes.FilterIsNotNull")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for FilterIsNotNull {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.active.heap_size_bytes() + self.column.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
+            && <crate::blueprint::datatypes::ComponentColumnSelector>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/filter_is_not_null.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: List of selected columns in a dataframe.
@@ -26,19 +26,6 @@ pub struct SelectedColumns {
 
     /// The component columns to include
     pub component_columns: Vec<crate::blueprint::datatypes::ComponentColumnSelector>,
-}
-
-impl ::re_types_core::SizeBytes for SelectedColumns {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.time_columns.heap_size_bytes() + self.component_columns.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::Utf8>>::is_pod()
-            && <Vec<crate::blueprint::datatypes::ComponentColumnSelector>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(SelectedColumns);
@@ -467,5 +454,18 @@ impl ::re_types_core::Loggable for SelectedColumns {
                 .with_context("rerun.blueprint.datatypes.SelectedColumns")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for SelectedColumns {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.time_columns.heap_size_bytes() + self.component_columns.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::Utf8>>::is_pod()
+            && <Vec<crate::blueprint::datatypes::ComponentColumnSelector>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Defines a slider for the index of some dimension.
@@ -23,32 +23,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub struct TensorDimensionIndexSlider {
     /// The dimension number.
     pub dimension: u32,
-}
-
-impl ::re_types_core::SizeBytes for TensorDimensionIndexSlider {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.dimension.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod()
-    }
-}
-
-impl From<u32> for TensorDimensionIndexSlider {
-    #[inline]
-    fn from(dimension: u32) -> Self {
-        Self { dimension }
-    }
-}
-
-impl From<TensorDimensionIndexSlider> for u32 {
-    #[inline]
-    fn from(value: TensorDimensionIndexSlider) -> Self {
-        value.dimension
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSlider);
@@ -195,5 +169,31 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSlider {
                 .with_context("rerun.blueprint.datatypes.TensorDimensionIndexSlider")?
             }
         })
+    }
+}
+
+impl From<u32> for TensorDimensionIndexSlider {
+    #[inline]
+    fn from(dimension: u32) -> Self {
+        Self { dimension }
+    }
+}
+
+impl From<TensorDimensionIndexSlider> for u32 {
+    #[inline]
+    fn from(value: TensorDimensionIndexSlider) -> Self {
+        value.dimension
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimensionIndexSlider {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.dimension.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/tensor_dimension_index_slider.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/bar_chart_view.rs
+++ b/crates/store/re_types/src/blueprint/views/bar_chart_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A bar chart view.
@@ -25,15 +25,10 @@ pub struct BarChartView {
     pub plot_legend: crate::blueprint::archetypes::PlotLegend,
 }
 
-impl ::re_types_core::SizeBytes for BarChartView {
+impl ::re_types_core::View for BarChartView {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.plot_legend.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::archetypes::PlotLegend>::is_pod()
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "BarChart".into()
     }
 }
 
@@ -68,9 +63,14 @@ impl std::ops::DerefMut for BarChartView {
     }
 }
 
-impl ::re_types_core::View for BarChartView {
+impl ::re_types_core::SizeBytes for BarChartView {
     #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "BarChart".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.plot_legend.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::archetypes::PlotLegend>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/bar_chart_view.rs
+++ b/crates/store/re_types/src/blueprint/views/bar_chart_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/dataframe_view.rs
+++ b/crates/store/re_types/src/blueprint/views/dataframe_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A view to display any data in a tabular form.
@@ -27,15 +27,10 @@ pub struct DataframeView {
     pub query: crate::blueprint::archetypes::DataframeQuery,
 }
 
-impl ::re_types_core::SizeBytes for DataframeView {
+impl ::re_types_core::View for DataframeView {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.query.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::archetypes::DataframeQuery>::is_pod()
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "Dataframe".into()
     }
 }
 
@@ -68,9 +63,14 @@ impl std::ops::DerefMut for DataframeView {
     }
 }
 
-impl ::re_types_core::View for DataframeView {
+impl ::re_types_core::SizeBytes for DataframeView {
     #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "Dataframe".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.query.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::archetypes::DataframeQuery>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/dataframe_view.rs
+++ b/crates/store/re_types/src/blueprint/views/dataframe_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/graph_view.rs
+++ b/crates/store/re_types/src/blueprint/views/graph_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A graph view to display time-variying, directed or undirected graph visualization.
@@ -27,15 +27,10 @@ pub struct GraphView {
     pub visual_bounds: crate::blueprint::archetypes::VisualBounds2D,
 }
 
-impl ::re_types_core::SizeBytes for GraphView {
+impl ::re_types_core::View for GraphView {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.visual_bounds.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::archetypes::VisualBounds2D>::is_pod()
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "Graph".into()
     }
 }
 
@@ -70,9 +65,14 @@ impl std::ops::DerefMut for GraphView {
     }
 }
 
-impl ::re_types_core::View for GraphView {
+impl ::re_types_core::SizeBytes for GraphView {
     #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "Graph".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.visual_bounds.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::archetypes::VisualBounds2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/graph_view.rs
+++ b/crates/store/re_types/src/blueprint/views/graph_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/map_view.rs
+++ b/crates/store/re_types/src/blueprint/views/map_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A 2D map view to display geospatial primitives.
@@ -28,6 +28,13 @@ pub struct MapView {
     pub background: crate::blueprint::archetypes::MapBackground,
 }
 
+impl ::re_types_core::View for MapView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "Map".into()
+    }
+}
+
 impl ::re_types_core::SizeBytes for MapView {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
@@ -38,12 +45,5 @@ impl ::re_types_core::SizeBytes for MapView {
     fn is_pod() -> bool {
         <crate::blueprint::archetypes::MapZoom>::is_pod()
             && <crate::blueprint::archetypes::MapBackground>::is_pod()
-    }
-}
-
-impl ::re_types_core::View for MapView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "Map".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/map_view.rs
+++ b/crates/store/re_types/src/blueprint/views/map_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/spatial2d_view.rs
+++ b/crates/store/re_types/src/blueprint/views/spatial2d_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: For viewing spatial 2D data.
@@ -37,6 +37,13 @@ pub struct Spatial2DView {
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 
+impl ::re_types_core::View for Spatial2DView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "2D".into()
+    }
+}
+
 impl ::re_types_core::SizeBytes for Spatial2DView {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
@@ -50,12 +57,5 @@ impl ::re_types_core::SizeBytes for Spatial2DView {
         <crate::blueprint::archetypes::Background>::is_pod()
             && <crate::blueprint::archetypes::VisualBounds2D>::is_pod()
             && <crate::blueprint::archetypes::VisibleTimeRanges>::is_pod()
-    }
-}
-
-impl ::re_types_core::View for Spatial2DView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "2D".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/spatial2d_view.rs
+++ b/crates/store/re_types/src/blueprint/views/spatial2d_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/spatial3d_view.rs
+++ b/crates/store/re_types/src/blueprint/views/spatial3d_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: For viewing spatial 3D data.
@@ -34,6 +34,13 @@ pub struct Spatial3DView {
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 
+impl ::re_types_core::View for Spatial3DView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "3D".into()
+    }
+}
+
 impl ::re_types_core::SizeBytes for Spatial3DView {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
@@ -47,12 +54,5 @@ impl ::re_types_core::SizeBytes for Spatial3DView {
         <crate::blueprint::archetypes::Background>::is_pod()
             && <crate::blueprint::archetypes::LineGrid3D>::is_pod()
             && <crate::blueprint::archetypes::VisibleTimeRanges>::is_pod()
-    }
-}
-
-impl ::re_types_core::View for Spatial3DView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "3D".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/spatial3d_view.rs
+++ b/crates/store/re_types/src/blueprint/views/spatial3d_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/tensor_view.rs
+++ b/crates/store/re_types/src/blueprint/views/tensor_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A view on a tensor of any dimensionality.
@@ -31,6 +31,13 @@ pub struct TensorView {
     pub view_fit: crate::blueprint::archetypes::TensorViewFit,
 }
 
+impl ::re_types_core::View for TensorView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "Tensor".into()
+    }
+}
+
 impl ::re_types_core::SizeBytes for TensorView {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
@@ -44,12 +51,5 @@ impl ::re_types_core::SizeBytes for TensorView {
         <crate::blueprint::archetypes::TensorSliceSelection>::is_pod()
             && <crate::blueprint::archetypes::TensorScalarMapping>::is_pod()
             && <crate::blueprint::archetypes::TensorViewFit>::is_pod()
-    }
-}
-
-impl ::re_types_core::View for TensorView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "Tensor".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/tensor_view.rs
+++ b/crates/store/re_types/src/blueprint/views/tensor_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/text_document_view.rs
+++ b/crates/store/re_types/src/blueprint/views/text_document_view.rs
@@ -13,14 +13,21 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A view of a single text document, for use with [`archetypes::TextDocument`][crate::archetypes::TextDocument].
 #[derive(Clone, Debug)]
 pub struct TextDocumentView {}
+
+impl ::re_types_core::View for TextDocumentView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "TextDocument".into()
+    }
+}
 
 impl ::re_types_core::SizeBytes for TextDocumentView {
     #[inline]
@@ -31,12 +38,5 @@ impl ::re_types_core::SizeBytes for TextDocumentView {
     #[inline]
     fn is_pod() -> bool {
         true
-    }
-}
-
-impl ::re_types_core::View for TextDocumentView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "TextDocument".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/text_document_view.rs
+++ b/crates/store/re_types/src/blueprint/views/text_document_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/text_log_view.rs
+++ b/crates/store/re_types/src/blueprint/views/text_log_view.rs
@@ -13,14 +13,21 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A view of a text log, for use with [`archetypes::TextLog`][crate::archetypes::TextLog].
 #[derive(Clone, Debug)]
 pub struct TextLogView {}
+
+impl ::re_types_core::View for TextLogView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "TextLog".into()
+    }
+}
 
 impl ::re_types_core::SizeBytes for TextLogView {
     #[inline]
@@ -31,12 +38,5 @@ impl ::re_types_core::SizeBytes for TextLogView {
     #[inline]
     fn is_pod() -> bool {
         true
-    }
-}
-
-impl ::re_types_core::View for TextLogView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "TextLog".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/text_log_view.rs
+++ b/crates/store/re_types/src/blueprint/views/text_log_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/blueprint/views/time_series_view.rs
+++ b/crates/store/re_types/src/blueprint/views/time_series_view.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **View**: A time series view for scalars over time, for use with [`archetypes::Scalar`][crate::archetypes::Scalar].
@@ -34,6 +34,13 @@ pub struct TimeSeriesView {
     pub time_ranges: crate::blueprint::archetypes::VisibleTimeRanges,
 }
 
+impl ::re_types_core::View for TimeSeriesView {
+    #[inline]
+    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
+        "TimeSeries".into()
+    }
+}
+
 impl ::re_types_core::SizeBytes for TimeSeriesView {
     #[inline]
     fn heap_size_bytes(&self) -> u64 {
@@ -47,12 +54,5 @@ impl ::re_types_core::SizeBytes for TimeSeriesView {
         <crate::blueprint::archetypes::ScalarAxis>::is_pod()
             && <crate::blueprint::archetypes::PlotLegend>::is_pod()
             && <crate::blueprint::archetypes::VisibleTimeRanges>::is_pod()
-    }
-}
-
-impl ::re_types_core::View for TimeSeriesView {
-    #[inline]
-    fn identifier() -> ::re_types_core::SpaceViewClassIdentifier {
-        "TimeSeries".into()
     }
 }

--- a/crates/store/re_types/src/blueprint/views/time_series_view.rs
+++ b/crates/store/re_types/src/blueprint/views/time_series_view.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Policy for aggregation of multiple scalar plot values.
@@ -49,58 +49,10 @@ pub enum AggregationPolicy {
     MinMaxAverage = 6,
 }
 
-impl ::re_types_core::reflection::Enum for AggregationPolicy {
+impl ::re_types_core::Component for AggregationPolicy {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::Off,
-            Self::Average,
-            Self::Max,
-            Self::Min,
-            Self::MinMax,
-            Self::MinMaxAverage,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Off => "No aggregation.",
-            Self::Average => "Average all points in the range together.",
-            Self::Max => "Keep only the maximum values in the range.",
-            Self::Min => "Keep only the minimum values in the range.",
-            Self::MinMax => {
-                "Keep both the minimum and maximum values in the range.\n\nThis will yield two aggregated points instead of one, effectively creating a vertical line."
-            }
-            Self::MinMaxAverage => {
-                "Find both the minimum and maximum values in the range, then use the average of those."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for AggregationPolicy {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for AggregationPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Off => write!(f, "Off"),
-            Self::Average => write!(f, "Average"),
-            Self::Max => write!(f, "Max"),
-            Self::Min => write!(f, "Min"),
-            Self::MinMax => write!(f, "MinMax"),
-            Self::MinMaxAverage => write!(f, "MinMaxAverage"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.AggregationPolicy")
     }
 }
 
@@ -194,9 +146,57 @@ impl ::re_types_core::Loggable for AggregationPolicy {
     }
 }
 
-impl ::re_types_core::Component for AggregationPolicy {
+impl std::fmt::Display for AggregationPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Off => write!(f, "Off"),
+            Self::Average => write!(f, "Average"),
+            Self::Max => write!(f, "Max"),
+            Self::Min => write!(f, "Min"),
+            Self::MinMax => write!(f, "MinMax"),
+            Self::MinMaxAverage => write!(f, "MinMaxAverage"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for AggregationPolicy {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.AggregationPolicy".into()
+    fn variants() -> &'static [Self] {
+        &[
+            Self::Off,
+            Self::Average,
+            Self::Max,
+            Self::Min,
+            Self::MinMax,
+            Self::MinMaxAverage,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Off => "No aggregation.",
+            Self::Average => "Average all points in the range together.",
+            Self::Max => "Keep only the maximum values in the range.",
+            Self::Min => "Keep only the minimum values in the range.",
+            Self::MinMax => {
+                "Keep both the minimum and maximum values in the range.\n\nThis will yield two aggregated points instead of one, effectively creating a vertical line."
+            }
+            Self::MinMaxAverage => {
+                "Find both the minimum and maximum values in the range, then use the average of those."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for AggregationPolicy {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/aggregation_policy.rs
+++ b/crates/store/re_types/src/components/aggregation_policy.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/albedo_factor.rs
+++ b/crates/store/re_types/src/components/albedo_factor.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A color multiplier, usually applied to a whole entity, e.g. a mesh.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct AlbedoFactor(pub crate::datatypes::Rgba32);
 
-impl ::re_types_core::SizeBytes for AlbedoFactor {
+impl ::re_types_core::Component for AlbedoFactor {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Rgba32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Rgba32>> From<T> for AlbedoFactor {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Rgba32> for AlbedoFactor {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Rgba32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AlbedoFactor {
-    type Target = crate::datatypes::Rgba32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Rgba32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AlbedoFactor {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Rgba32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.AlbedoFactor")
     }
 }
 
@@ -107,9 +73,43 @@ impl ::re_types_core::Loggable for AlbedoFactor {
     }
 }
 
-impl ::re_types_core::Component for AlbedoFactor {
+impl<T: Into<crate::datatypes::Rgba32>> From<T> for AlbedoFactor {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Rgba32> for AlbedoFactor {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.AlbedoFactor".into()
+    fn borrow(&self) -> &crate::datatypes::Rgba32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AlbedoFactor {
+    type Target = crate::datatypes::Rgba32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Rgba32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AlbedoFactor {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Rgba32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AlbedoFactor {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Rgba32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/albedo_factor.rs
+++ b/crates/store/re_types/src/components/albedo_factor.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The annotation context provides additional information on how to display entities.
@@ -31,23 +31,10 @@ pub struct AnnotationContext(
     pub Vec<crate::datatypes::ClassDescriptionMapElem>,
 );
 
-impl ::re_types_core::SizeBytes for AnnotationContext {
+impl ::re_types_core::Component for AnnotationContext {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::ClassDescriptionMapElem>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::datatypes::ClassDescriptionMapElem>, T: IntoIterator<Item = I>> From<T>
-    for AnnotationContext
-{
-    fn from(v: T) -> Self {
-        Self(v.into_iter().map(|v| v.into()).collect())
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.AnnotationContext")
     }
 }
 
@@ -189,9 +176,22 @@ impl ::re_types_core::Loggable for AnnotationContext {
     }
 }
 
-impl ::re_types_core::Component for AnnotationContext {
+impl<I: Into<crate::datatypes::ClassDescriptionMapElem>, T: IntoIterator<Item = I>> From<T>
+    for AnnotationContext
+{
+    fn from(v: T) -> Self {
+        Self(v.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl ::re_types_core::SizeBytes for AnnotationContext {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.AnnotationContext".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::ClassDescriptionMapElem>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/axis_length.rs
+++ b/crates/store/re_types/src/components/axis_length.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The length of an axis in local units of the space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct AxisLength(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for AxisLength {
+impl ::re_types_core::Component for AxisLength {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for AxisLength {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for AxisLength {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AxisLength {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AxisLength {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.AxisLength")
     }
 }
 
@@ -106,9 +72,43 @@ impl ::re_types_core::Loggable for AxisLength {
     }
 }
 
-impl ::re_types_core::Component for AxisLength {
+impl<T: Into<crate::datatypes::Float32>> From<T> for AxisLength {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for AxisLength {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.AxisLength".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AxisLength {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AxisLength {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AxisLength {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/axis_length.rs
+++ b/crates/store/re_types/src/components/axis_length.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/blob.rs
+++ b/crates/store/re_types/src/components/blob.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A binary blob of data.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Blob(pub crate::datatypes::Blob);
 
-impl ::re_types_core::SizeBytes for Blob {
+impl ::re_types_core::Component for Blob {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Blob>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Blob>> From<T> for Blob {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Blob> for Blob {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Blob {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Blob {
-    type Target = crate::datatypes::Blob;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Blob {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Blob {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Blob {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Blob")
     }
 }
 
@@ -99,9 +65,43 @@ impl ::re_types_core::Loggable for Blob {
     }
 }
 
-impl ::re_types_core::Component for Blob {
+impl<T: Into<crate::datatypes::Blob>> From<T> for Blob {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Blob> for Blob {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Blob".into()
+    fn borrow(&self) -> &crate::datatypes::Blob {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Blob {
+    type Target = crate::datatypes::Blob;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Blob {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Blob {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Blob {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Blob {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Blob>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/blob.rs
+++ b/crates/store/re_types/src/components/blob.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/class_id.rs
+++ b/crates/store/re_types/src/components/class_id.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 16-bit ID representing a type of semantic class.
@@ -28,44 +28,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ClassId(pub crate::datatypes::ClassId);
 
-impl ::re_types_core::SizeBytes for ClassId {
+impl ::re_types_core::Component for ClassId {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::ClassId>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::ClassId>> From<T> for ClassId {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::ClassId> for ClassId {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::ClassId {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ClassId {
-    type Target = crate::datatypes::ClassId;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::ClassId {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ClassId {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::ClassId {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ClassId")
     }
 }
 
@@ -110,9 +76,43 @@ impl ::re_types_core::Loggable for ClassId {
     }
 }
 
-impl ::re_types_core::Component for ClassId {
+impl<T: Into<crate::datatypes::ClassId>> From<T> for ClassId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::ClassId> for ClassId {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ClassId".into()
+    fn borrow(&self) -> &crate::datatypes::ClassId {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ClassId {
+    type Target = crate::datatypes::ClassId;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::ClassId {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ClassId {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::ClassId {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ClassId {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::ClassId>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/class_id.rs
+++ b/crates/store/re_types/src/components/class_id.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/color.rs
+++ b/crates/store/re_types/src/components/color.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Color(pub crate::datatypes::Rgba32);
 
-impl ::re_types_core::SizeBytes for Color {
+impl ::re_types_core::Component for Color {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Rgba32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Rgba32>> From<T> for Color {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Rgba32> for Color {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Rgba32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Color {
-    type Target = crate::datatypes::Rgba32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Rgba32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Color {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Rgba32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Color")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for Color {
     }
 }
 
-impl ::re_types_core::Component for Color {
+impl<T: Into<crate::datatypes::Rgba32>> From<T> for Color {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Rgba32> for Color {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Color".into()
+    fn borrow(&self) -> &crate::datatypes::Rgba32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Color {
+    type Target = crate::datatypes::Rgba32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Rgba32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Color {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Rgba32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Color {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Rgba32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/color.rs
+++ b/crates/store/re_types/src/components/color.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/colormap.rs
+++ b/crates/store/re_types/src/components/colormap.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Colormap for mapping scalar values within a given range to a color.
@@ -73,71 +73,10 @@ pub enum Colormap {
     CyanToYellow = 7,
 }
 
-impl ::re_types_core::reflection::Enum for Colormap {
+impl ::re_types_core::Component for Colormap {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::Grayscale,
-            Self::Inferno,
-            Self::Magma,
-            Self::Plasma,
-            Self::Turbo,
-            Self::Viridis,
-            Self::CyanToYellow,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Grayscale => {
-                "A simple black to white gradient.\n\nThis is a sRGB gray gradient which is perceptually uniform."
-            }
-            Self::Inferno => {
-                "The Inferno colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from black to red to bright yellow."
-            }
-            Self::Magma => {
-                "The Magma colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from black to purple to white."
-            }
-            Self::Plasma => {
-                "The Plasma colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from dark blue to purple to yellow."
-            }
-            Self::Turbo => {
-                "Google's Turbo colormap map.\n\nThis is a perceptually non-uniform rainbow colormap addressing many issues of\nmore traditional rainbow colormaps like Jet.\nIt is more perceptually uniform without sharp transitions and is more colorblind-friendly.\nDetails: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>"
-            }
-            Self::Viridis => {
-                "The Viridis colormap from Matplotlib\n\nThis is a perceptually uniform colormap which is robust to color blindness.\nIt interpolates from dark purple to green to yellow."
-            }
-            Self::CyanToYellow => {
-                "Rasmusgo's Cyan to Yellow colormap\n\nThis is a perceptually uniform colormap which is robust to color blindness.\nIt is especially suited for visualizing signed values.\nIt interpolates from cyan to blue to dark gray to brass to yellow."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for Colormap {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for Colormap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Grayscale => write!(f, "Grayscale"),
-            Self::Inferno => write!(f, "Inferno"),
-            Self::Magma => write!(f, "Magma"),
-            Self::Plasma => write!(f, "Plasma"),
-            Self::Turbo => write!(f, "Turbo"),
-            Self::Viridis => write!(f, "Viridis"),
-            Self::CyanToYellow => write!(f, "CyanToYellow"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Colormap")
     }
 }
 
@@ -232,9 +171,70 @@ impl ::re_types_core::Loggable for Colormap {
     }
 }
 
-impl ::re_types_core::Component for Colormap {
+impl std::fmt::Display for Colormap {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Grayscale => write!(f, "Grayscale"),
+            Self::Inferno => write!(f, "Inferno"),
+            Self::Magma => write!(f, "Magma"),
+            Self::Plasma => write!(f, "Plasma"),
+            Self::Turbo => write!(f, "Turbo"),
+            Self::Viridis => write!(f, "Viridis"),
+            Self::CyanToYellow => write!(f, "CyanToYellow"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for Colormap {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Colormap".into()
+    fn variants() -> &'static [Self] {
+        &[
+            Self::Grayscale,
+            Self::Inferno,
+            Self::Magma,
+            Self::Plasma,
+            Self::Turbo,
+            Self::Viridis,
+            Self::CyanToYellow,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Grayscale => {
+                "A simple black to white gradient.\n\nThis is a sRGB gray gradient which is perceptually uniform."
+            }
+            Self::Inferno => {
+                "The Inferno colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from black to red to bright yellow."
+            }
+            Self::Magma => {
+                "The Magma colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from black to purple to white."
+            }
+            Self::Plasma => {
+                "The Plasma colormap from Matplotlib.\n\nThis is a perceptually uniform colormap.\nIt interpolates from dark blue to purple to yellow."
+            }
+            Self::Turbo => {
+                "Google's Turbo colormap map.\n\nThis is a perceptually non-uniform rainbow colormap addressing many issues of\nmore traditional rainbow colormaps like Jet.\nIt is more perceptually uniform without sharp transitions and is more colorblind-friendly.\nDetails: <https://research.google/blog/turbo-an-improved-rainbow-colormap-for-visualization/>"
+            }
+            Self::Viridis => {
+                "The Viridis colormap from Matplotlib\n\nThis is a perceptually uniform colormap which is robust to color blindness.\nIt interpolates from dark purple to green to yellow."
+            }
+            Self::CyanToYellow => {
+                "Rasmusgo's Cyan to Yellow colormap\n\nThis is a perceptually uniform colormap which is robust to color blindness.\nIt is especially suited for visualizing signed values.\nIt interpolates from cyan to blue to dark gray to brass to yellow."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for Colormap {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/depth_meter.rs
+++ b/crates/store/re_types/src/components/depth_meter.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The world->depth map scaling factor.
@@ -30,44 +30,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct DepthMeter(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for DepthMeter {
+impl ::re_types_core::Component for DepthMeter {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for DepthMeter {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for DepthMeter {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for DepthMeter {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for DepthMeter {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.DepthMeter")
     }
 }
 
@@ -112,9 +78,43 @@ impl ::re_types_core::Loggable for DepthMeter {
     }
 }
 
-impl ::re_types_core::Component for DepthMeter {
+impl<T: Into<crate::datatypes::Float32>> From<T> for DepthMeter {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for DepthMeter {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.DepthMeter".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for DepthMeter {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for DepthMeter {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for DepthMeter {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/depth_meter.rs
+++ b/crates/store/re_types/src/components/depth_meter.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/disconnected_space.rs
+++ b/crates/store/re_types/src/components/disconnected_space.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Spatially disconnect this entity from its parent.
@@ -34,44 +34,10 @@ pub struct DisconnectedSpace(
     pub crate::datatypes::Bool,
 );
 
-impl ::re_types_core::SizeBytes for DisconnectedSpace {
+impl ::re_types_core::Component for DisconnectedSpace {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for DisconnectedSpace {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for DisconnectedSpace {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for DisconnectedSpace {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for DisconnectedSpace {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.DisconnectedSpace")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for DisconnectedSpace {
     }
 }
 
-impl ::re_types_core::Component for DisconnectedSpace {
+impl<T: Into<crate::datatypes::Bool>> From<T> for DisconnectedSpace {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for DisconnectedSpace {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.DisconnectedSpace".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for DisconnectedSpace {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for DisconnectedSpace {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for DisconnectedSpace {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/disconnected_space.rs
+++ b/crates/store/re_types/src/components/disconnected_space.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/draw_order.rs
+++ b/crates/store/re_types/src/components/draw_order.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Draw order of 2D elements. Higher values are drawn on top of lower values.
@@ -28,44 +28,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct DrawOrder(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for DrawOrder {
+impl ::re_types_core::Component for DrawOrder {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for DrawOrder {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for DrawOrder {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for DrawOrder {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for DrawOrder {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.DrawOrder")
     }
 }
 
@@ -111,9 +77,43 @@ impl ::re_types_core::Loggable for DrawOrder {
     }
 }
 
-impl ::re_types_core::Component for DrawOrder {
+impl<T: Into<crate::datatypes::Float32>> From<T> for DrawOrder {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for DrawOrder {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.DrawOrder".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for DrawOrder {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for DrawOrder {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for DrawOrder {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/draw_order.rs
+++ b/crates/store/re_types/src/components/draw_order.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/entity_path.rs
+++ b/crates/store/re_types/src/components/entity_path.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A path to an entity, usually to reference some data that is part of the target entity.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct EntityPath(pub crate::datatypes::EntityPath);
 
-impl ::re_types_core::SizeBytes for EntityPath {
+impl ::re_types_core::Component for EntityPath {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::EntityPath>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::EntityPath>> From<T> for EntityPath {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::EntityPath> for EntityPath {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for EntityPath {
-    type Target = crate::datatypes::EntityPath;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::EntityPath {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for EntityPath {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.EntityPath")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for EntityPath {
     }
 }
 
-impl ::re_types_core::Component for EntityPath {
+impl<T: Into<crate::datatypes::EntityPath>> From<T> for EntityPath {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::EntityPath> for EntityPath {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.EntityPath".into()
+    fn borrow(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for EntityPath {
+    type Target = crate::datatypes::EntityPath;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::EntityPath {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for EntityPath {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::EntityPath {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for EntityPath {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::EntityPath>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/entity_path.rs
+++ b/crates/store/re_types/src/components/entity_path.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: How a geometric shape is drawn and colored.
@@ -46,47 +46,10 @@ pub enum FillMode {
     Solid = 3,
 }
 
-impl ::re_types_core::reflection::Enum for FillMode {
+impl ::re_types_core::Component for FillMode {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::MajorWireframe, Self::DenseWireframe, Self::Solid]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::MajorWireframe => {
-                "Lines are drawn around the parts of the shape which directly correspond to the logged data.\n\nExamples of what this means:\n\n* An [`archetypes::Ellipsoids3D`][crate::archetypes::Ellipsoids3D] will draw three axis-aligned ellipses that are cross-sections\n  of each ellipsoid, each of which displays two out of three of the sizes of the ellipsoid.\n* For [`archetypes::Boxes3D`][crate::archetypes::Boxes3D], it is the edges of the box, identical to `DenseWireframe`."
-            }
-            Self::DenseWireframe => {
-                "Many lines are drawn to represent the surface of the shape in a see-through fashion.\n\nExamples of what this means:\n\n* An [`archetypes::Ellipsoids3D`][crate::archetypes::Ellipsoids3D] will draw a wireframe triangle mesh that approximates each\n  ellipsoid.\n* For [`archetypes::Boxes3D`][crate::archetypes::Boxes3D], it is the edges of the box, identical to `MajorWireframe`."
-            }
-            Self::Solid => {
-                "The surface of the shape is filled in with a solid color. No lines are drawn."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for FillMode {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for FillMode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::MajorWireframe => write!(f, "MajorWireframe"),
-            Self::DenseWireframe => write!(f, "DenseWireframe"),
-            Self::Solid => write!(f, "Solid"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.FillMode")
     }
 }
 
@@ -177,9 +140,46 @@ impl ::re_types_core::Loggable for FillMode {
     }
 }
 
-impl ::re_types_core::Component for FillMode {
+impl std::fmt::Display for FillMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MajorWireframe => write!(f, "MajorWireframe"),
+            Self::DenseWireframe => write!(f, "DenseWireframe"),
+            Self::Solid => write!(f, "Solid"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for FillMode {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.FillMode".into()
+    fn variants() -> &'static [Self] {
+        &[Self::MajorWireframe, Self::DenseWireframe, Self::Solid]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::MajorWireframe => {
+                "Lines are drawn around the parts of the shape which directly correspond to the logged data.\n\nExamples of what this means:\n\n* An [`archetypes::Ellipsoids3D`][crate::archetypes::Ellipsoids3D] will draw three axis-aligned ellipses that are cross-sections\n  of each ellipsoid, each of which displays two out of three of the sizes of the ellipsoid.\n* For [`archetypes::Boxes3D`][crate::archetypes::Boxes3D], it is the edges of the box, identical to `DenseWireframe`."
+            }
+            Self::DenseWireframe => {
+                "Many lines are drawn to represent the surface of the shape in a see-through fashion.\n\nExamples of what this means:\n\n* An [`archetypes::Ellipsoids3D`][crate::archetypes::Ellipsoids3D] will draw a wireframe triangle mesh that approximates each\n  ellipsoid.\n* For [`archetypes::Boxes3D`][crate::archetypes::Boxes3D], it is the edges of the box, identical to `MajorWireframe`."
+            }
+            Self::Solid => {
+                "The surface of the shape is filled in with a solid color. No lines are drawn."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for FillMode {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/fill_mode.rs
+++ b/crates/store/re_types/src/components/fill_mode.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/fill_ratio.rs
+++ b/crates/store/re_types/src/components/fill_ratio.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: How much a primitive fills out the available space.
@@ -28,44 +28,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct FillRatio(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for FillRatio {
+impl ::re_types_core::Component for FillRatio {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for FillRatio {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for FillRatio {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for FillRatio {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for FillRatio {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.FillRatio")
     }
 }
 
@@ -110,9 +76,43 @@ impl ::re_types_core::Loggable for FillRatio {
     }
 }
 
-impl ::re_types_core::Component for FillRatio {
+impl<T: Into<crate::datatypes::Float32>> From<T> for FillRatio {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for FillRatio {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.FillRatio".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for FillRatio {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for FillRatio {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for FillRatio {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/fill_ratio.rs
+++ b/crates/store/re_types/src/components/fill_ratio.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/gamma_correction.rs
+++ b/crates/store/re_types/src/components/gamma_correction.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A gamma correction value to be used with a scalar value or color.
@@ -29,44 +29,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct GammaCorrection(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for GammaCorrection {
+impl ::re_types_core::Component for GammaCorrection {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for GammaCorrection {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for GammaCorrection {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for GammaCorrection {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for GammaCorrection {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.GammaCorrection")
     }
 }
 
@@ -111,9 +77,43 @@ impl ::re_types_core::Loggable for GammaCorrection {
     }
 }
 
-impl ::re_types_core::Component for GammaCorrection {
+impl<T: Into<crate::datatypes::Float32>> From<T> for GammaCorrection {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for GammaCorrection {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.GammaCorrection".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for GammaCorrection {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GammaCorrection {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for GammaCorrection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/gamma_correction.rs
+++ b/crates/store/re_types/src/components/gamma_correction.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/geo_line_string.rs
+++ b/crates/store/re_types/src/components/geo_line_string.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A geospatial line string expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).
@@ -23,21 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct GeoLineString(pub Vec<crate::datatypes::DVec2D>);
 
-impl ::re_types_core::SizeBytes for GeoLineString {
+impl ::re_types_core::Component for GeoLineString {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::DVec2D>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::datatypes::DVec2D>, T: IntoIterator<Item = I>> From<T> for GeoLineString {
-    fn from(v: T) -> Self {
-        Self(v.into_iter().map(|v| v.into()).collect())
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.GeoLineString")
     }
 }
 
@@ -261,9 +250,20 @@ impl ::re_types_core::Loggable for GeoLineString {
     }
 }
 
-impl ::re_types_core::Component for GeoLineString {
+impl<I: Into<crate::datatypes::DVec2D>, T: IntoIterator<Item = I>> From<T> for GeoLineString {
+    fn from(v: T) -> Self {
+        Self(v.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl ::re_types_core::SizeBytes for GeoLineString {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.GeoLineString".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::DVec2D>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/geo_line_string.rs
+++ b/crates/store/re_types/src/components/geo_line_string.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/graph_edge.rs
+++ b/crates/store/re_types/src/components/graph_edge.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: An edge in a graph connecting two nodes.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct GraphEdge(pub crate::datatypes::Utf8Pair);
 
-impl ::re_types_core::SizeBytes for GraphEdge {
+impl ::re_types_core::Component for GraphEdge {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8Pair>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8Pair>> From<T> for GraphEdge {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8Pair> for GraphEdge {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8Pair {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for GraphEdge {
-    type Target = crate::datatypes::Utf8Pair;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8Pair {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for GraphEdge {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8Pair {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.GraphEdge")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for GraphEdge {
     }
 }
 
-impl ::re_types_core::Component for GraphEdge {
+impl<T: Into<crate::datatypes::Utf8Pair>> From<T> for GraphEdge {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8Pair> for GraphEdge {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.GraphEdge".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8Pair {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for GraphEdge {
+    type Target = crate::datatypes::Utf8Pair;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8Pair {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GraphEdge {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8Pair {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for GraphEdge {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8Pair>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/graph_edge.rs
+++ b/crates/store/re_types/src/components/graph_edge.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/graph_node.rs
+++ b/crates/store/re_types/src/components/graph_node.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A string-based ID representing a node in a graph.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct GraphNode(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for GraphNode {
+impl ::re_types_core::Component for GraphNode {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for GraphNode {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for GraphNode {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for GraphNode {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for GraphNode {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.GraphNode")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for GraphNode {
     }
 }
 
-impl ::re_types_core::Component for GraphNode {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for GraphNode {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for GraphNode {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.GraphNode".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for GraphNode {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GraphNode {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for GraphNode {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/graph_node.rs
+++ b/crates/store/re_types/src/components/graph_node.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/graph_type.rs
+++ b/crates/store/re_types/src/components/graph_type.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/graph_type.rs
+++ b/crates/store/re_types/src/components/graph_type.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Specifies if a graph has directed or undirected edges.
@@ -31,39 +31,10 @@ pub enum GraphType {
     Directed = 2,
 }
 
-impl ::re_types_core::reflection::Enum for GraphType {
+impl ::re_types_core::Component for GraphType {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::Undirected, Self::Directed]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Undirected => "The graph has undirected edges.",
-            Self::Directed => "The graph has directed edges.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for GraphType {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for GraphType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Undirected => write!(f, "Undirected"),
-            Self::Directed => write!(f, "Directed"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.GraphType")
     }
 }
 
@@ -153,9 +124,38 @@ impl ::re_types_core::Loggable for GraphType {
     }
 }
 
-impl ::re_types_core::Component for GraphType {
+impl std::fmt::Display for GraphType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Undirected => write!(f, "Undirected"),
+            Self::Directed => write!(f, "Directed"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for GraphType {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.GraphType".into()
+    fn variants() -> &'static [Self] {
+        &[Self::Undirected, Self::Directed]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Undirected => "The graph has undirected edges.",
+            Self::Directed => "The graph has directed edges.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for GraphType {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/half_size2d.rs
+++ b/crates/store/re_types/src/components/half_size2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Half-size (radius) of a 2D box.
@@ -28,44 +28,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct HalfSize2D(pub crate::datatypes::Vec2D);
 
-impl ::re_types_core::SizeBytes for HalfSize2D {
+impl ::re_types_core::Component for HalfSize2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec2D>> From<T> for HalfSize2D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec2D> for HalfSize2D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for HalfSize2D {
-    type Target = crate::datatypes::Vec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for HalfSize2D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.HalfSize2D")
     }
 }
 
@@ -110,9 +76,43 @@ impl ::re_types_core::Loggable for HalfSize2D {
     }
 }
 
-impl ::re_types_core::Component for HalfSize2D {
+impl<T: Into<crate::datatypes::Vec2D>> From<T> for HalfSize2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec2D> for HalfSize2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.HalfSize2D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for HalfSize2D {
+    type Target = crate::datatypes::Vec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for HalfSize2D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for HalfSize2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/half_size2d.rs
+++ b/crates/store/re_types/src/components/half_size2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/half_size3d.rs
+++ b/crates/store/re_types/src/components/half_size3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Half-size (radius) of a 3D box.
@@ -28,44 +28,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct HalfSize3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for HalfSize3D {
+impl ::re_types_core::Component for HalfSize3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for HalfSize3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for HalfSize3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for HalfSize3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for HalfSize3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.HalfSize3D")
     }
 }
 
@@ -110,9 +76,43 @@ impl ::re_types_core::Loggable for HalfSize3D {
     }
 }
 
-impl ::re_types_core::Component for HalfSize3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for HalfSize3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for HalfSize3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.HalfSize3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for HalfSize3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for HalfSize3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for HalfSize3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/half_size3d.rs
+++ b/crates/store/re_types/src/components/half_size3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/image_buffer.rs
+++ b/crates/store/re_types/src/components/image_buffer.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A buffer that is known to store image data.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ImageBuffer(pub crate::datatypes::Blob);
 
-impl ::re_types_core::SizeBytes for ImageBuffer {
+impl ::re_types_core::Component for ImageBuffer {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Blob>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Blob>> From<T> for ImageBuffer {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Blob> for ImageBuffer {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Blob {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ImageBuffer {
-    type Target = crate::datatypes::Blob;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Blob {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ImageBuffer {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Blob {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ImageBuffer")
     }
 }
 
@@ -99,9 +65,43 @@ impl ::re_types_core::Loggable for ImageBuffer {
     }
 }
 
-impl ::re_types_core::Component for ImageBuffer {
+impl<T: Into<crate::datatypes::Blob>> From<T> for ImageBuffer {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Blob> for ImageBuffer {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ImageBuffer".into()
+    fn borrow(&self) -> &crate::datatypes::Blob {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ImageBuffer {
+    type Target = crate::datatypes::Blob;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Blob {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ImageBuffer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Blob {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ImageBuffer {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Blob>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/image_buffer.rs
+++ b/crates/store/re_types/src/components/image_buffer.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/image_format.rs
+++ b/crates/store/re_types/src/components/image_format.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The metadata describing the contents of a [`components::ImageBuffer`][crate::components::ImageBuffer].
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ImageFormat(pub crate::datatypes::ImageFormat);
 
-impl ::re_types_core::SizeBytes for ImageFormat {
+impl ::re_types_core::Component for ImageFormat {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::ImageFormat>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::ImageFormat>> From<T> for ImageFormat {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::ImageFormat> for ImageFormat {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::ImageFormat {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ImageFormat {
-    type Target = crate::datatypes::ImageFormat;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::ImageFormat {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ImageFormat {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::ImageFormat {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ImageFormat")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for ImageFormat {
     }
 }
 
-impl ::re_types_core::Component for ImageFormat {
+impl<T: Into<crate::datatypes::ImageFormat>> From<T> for ImageFormat {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::ImageFormat> for ImageFormat {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ImageFormat".into()
+    fn borrow(&self) -> &crate::datatypes::ImageFormat {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ImageFormat {
+    type Target = crate::datatypes::ImageFormat;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::ImageFormat {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ImageFormat {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::ImageFormat {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ImageFormat {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::ImageFormat>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/image_format.rs
+++ b/crates/store/re_types/src/components/image_format.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/image_plane_distance.rs
+++ b/crates/store/re_types/src/components/image_plane_distance.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The distance from the camera origin to the image plane when the projection is shown in a 3D viewer.
@@ -24,44 +24,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct ImagePlaneDistance(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for ImagePlaneDistance {
+impl ::re_types_core::Component for ImagePlaneDistance {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for ImagePlaneDistance {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for ImagePlaneDistance {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ImagePlaneDistance {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ImagePlaneDistance {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ImagePlaneDistance")
     }
 }
 
@@ -107,9 +73,43 @@ impl ::re_types_core::Loggable for ImagePlaneDistance {
     }
 }
 
-impl ::re_types_core::Component for ImagePlaneDistance {
+impl<T: Into<crate::datatypes::Float32>> From<T> for ImagePlaneDistance {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for ImagePlaneDistance {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ImagePlaneDistance".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ImagePlaneDistance {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ImagePlaneDistance {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ImagePlaneDistance {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/image_plane_distance.rs
+++ b/crates/store/re_types/src/components/image_plane_distance.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/keypoint_id.rs
+++ b/crates/store/re_types/src/components/keypoint_id.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 16-bit ID representing a type of semantic keypoint within a class.
@@ -40,44 +40,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct KeypointId(pub crate::datatypes::KeypointId);
 
-impl ::re_types_core::SizeBytes for KeypointId {
+impl ::re_types_core::Component for KeypointId {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::KeypointId>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::KeypointId>> From<T> for KeypointId {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::KeypointId> for KeypointId {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::KeypointId {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for KeypointId {
-    type Target = crate::datatypes::KeypointId;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::KeypointId {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for KeypointId {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::KeypointId {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.KeypointId")
     }
 }
 
@@ -122,9 +88,43 @@ impl ::re_types_core::Loggable for KeypointId {
     }
 }
 
-impl ::re_types_core::Component for KeypointId {
+impl<T: Into<crate::datatypes::KeypointId>> From<T> for KeypointId {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::KeypointId> for KeypointId {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.KeypointId".into()
+    fn borrow(&self) -> &crate::datatypes::KeypointId {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for KeypointId {
+    type Target = crate::datatypes::KeypointId;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::KeypointId {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for KeypointId {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::KeypointId {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for KeypointId {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::KeypointId>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/keypoint_id.rs
+++ b/crates/store/re_types/src/components/keypoint_id.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/lat_lon.rs
+++ b/crates/store/re_types/src/components/lat_lon.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A geospatial position expressed in [EPSG:4326](https://epsg.io/4326) latitude and longitude (North/East-positive degrees).
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct LatLon(pub crate::datatypes::DVec2D);
 
-impl ::re_types_core::SizeBytes for LatLon {
+impl ::re_types_core::Component for LatLon {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::DVec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::DVec2D>> From<T> for LatLon {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::DVec2D> for LatLon {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::DVec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for LatLon {
-    type Target = crate::datatypes::DVec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::DVec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for LatLon {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::DVec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.LatLon")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for LatLon {
     }
 }
 
-impl ::re_types_core::Component for LatLon {
+impl<T: Into<crate::datatypes::DVec2D>> From<T> for LatLon {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::DVec2D> for LatLon {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.LatLon".into()
+    fn borrow(&self) -> &crate::datatypes::DVec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for LatLon {
+    type Target = crate::datatypes::DVec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::DVec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for LatLon {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::DVec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for LatLon {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::DVec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/lat_lon.rs
+++ b/crates/store/re_types/src/components/lat_lon.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/length.rs
+++ b/crates/store/re_types/src/components/length.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Length, or one-dimensional size.
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Length(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for Length {
+impl ::re_types_core::Component for Length {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for Length {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for Length {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Length {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Length {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Length")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for Length {
     }
 }
 
-impl ::re_types_core::Component for Length {
+impl<T: Into<crate::datatypes::Float32>> From<T> for Length {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for Length {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Length".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Length {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Length {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Length {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/length.rs
+++ b/crates/store/re_types/src/components/length.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A line strip in 2D space.
@@ -33,21 +33,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LineStrip2D(pub Vec<crate::datatypes::Vec2D>);
 
-impl ::re_types_core::SizeBytes for LineStrip2D {
+impl ::re_types_core::Component for LineStrip2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::Vec2D>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::datatypes::Vec2D>, T: IntoIterator<Item = I>> From<T> for LineStrip2D {
-    fn from(v: T) -> Self {
-        Self(v.into_iter().map(|v| v.into()).collect())
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.LineStrip2D")
     }
 }
 
@@ -270,9 +259,20 @@ impl ::re_types_core::Loggable for LineStrip2D {
     }
 }
 
-impl ::re_types_core::Component for LineStrip2D {
+impl<I: Into<crate::datatypes::Vec2D>, T: IntoIterator<Item = I>> From<T> for LineStrip2D {
+    fn from(v: T) -> Self {
+        Self(v.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl ::re_types_core::SizeBytes for LineStrip2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.LineStrip2D".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::Vec2D>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A line strip in 3D space.
@@ -33,21 +33,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LineStrip3D(pub Vec<crate::datatypes::Vec3D>);
 
-impl ::re_types_core::SizeBytes for LineStrip3D {
+impl ::re_types_core::Component for LineStrip3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::Vec3D>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::datatypes::Vec3D>, T: IntoIterator<Item = I>> From<T> for LineStrip3D {
-    fn from(v: T) -> Self {
-        Self(v.into_iter().map(|v| v.into()).collect())
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.LineStrip3D")
     }
 }
 
@@ -270,9 +259,20 @@ impl ::re_types_core::Loggable for LineStrip3D {
     }
 }
 
-impl ::re_types_core::Component for LineStrip3D {
+impl<I: Into<crate::datatypes::Vec3D>, T: IntoIterator<Item = I>> From<T> for LineStrip3D {
+    fn from(v: T) -> Self {
+        Self(v.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl ::re_types_core::SizeBytes for LineStrip3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.LineStrip3D".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::Vec3D>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Filter used when magnifying an image/texture such that a single pixel/texel is displayed as multiple pixels on screen.
@@ -36,43 +36,10 @@ pub enum MagnificationFilter {
     Linear = 2,
 }
 
-impl ::re_types_core::reflection::Enum for MagnificationFilter {
+impl ::re_types_core::Component for MagnificationFilter {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::Nearest, Self::Linear]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Nearest => {
-                "Show the nearest pixel value.\n\nThis will give a blocky appearance when zooming in.\nUsed as default when rendering 2D images."
-            }
-            Self::Linear => {
-                "Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.\n\nUsed as default for mesh rendering."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for MagnificationFilter {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for MagnificationFilter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Nearest => write!(f, "Nearest"),
-            Self::Linear => write!(f, "Linear"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.MagnificationFilter")
     }
 }
 
@@ -162,9 +129,42 @@ impl ::re_types_core::Loggable for MagnificationFilter {
     }
 }
 
-impl ::re_types_core::Component for MagnificationFilter {
+impl std::fmt::Display for MagnificationFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Nearest => write!(f, "Nearest"),
+            Self::Linear => write!(f, "Linear"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for MagnificationFilter {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.MagnificationFilter".into()
+    fn variants() -> &'static [Self] {
+        &[Self::Nearest, Self::Linear]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Nearest => {
+                "Show the nearest pixel value.\n\nThis will give a blocky appearance when zooming in.\nUsed as default when rendering 2D images."
+            }
+            Self::Linear => {
+                "Linearly interpolate the nearest neighbors, creating a smoother look when zooming in.\n\nUsed as default for mesh rendering."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for MagnificationFilter {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/magnification_filter.rs
+++ b/crates/store/re_types/src/components/magnification_filter.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The visual appearance of a point in e.g. a 2D plot.
@@ -55,66 +55,10 @@ pub enum MarkerShape {
     Asterisk = 10,
 }
 
-impl ::re_types_core::reflection::Enum for MarkerShape {
+impl ::re_types_core::Component for MarkerShape {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::Circle,
-            Self::Diamond,
-            Self::Square,
-            Self::Cross,
-            Self::Plus,
-            Self::Up,
-            Self::Down,
-            Self::Left,
-            Self::Right,
-            Self::Asterisk,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Circle => "`⏺`",
-            Self::Diamond => "`◆`",
-            Self::Square => "`◼\u{fe0f}`",
-            Self::Cross => "`x`",
-            Self::Plus => "`+`",
-            Self::Up => "`▲`",
-            Self::Down => "`▼`",
-            Self::Left => "`◀`",
-            Self::Right => "`▶`",
-            Self::Asterisk => "`*`",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for MarkerShape {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for MarkerShape {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Circle => write!(f, "Circle"),
-            Self::Diamond => write!(f, "Diamond"),
-            Self::Square => write!(f, "Square"),
-            Self::Cross => write!(f, "Cross"),
-            Self::Plus => write!(f, "Plus"),
-            Self::Up => write!(f, "Up"),
-            Self::Down => write!(f, "Down"),
-            Self::Left => write!(f, "Left"),
-            Self::Right => write!(f, "Right"),
-            Self::Asterisk => write!(f, "Asterisk"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.MarkerShape")
     }
 }
 
@@ -212,9 +156,65 @@ impl ::re_types_core::Loggable for MarkerShape {
     }
 }
 
-impl ::re_types_core::Component for MarkerShape {
+impl std::fmt::Display for MarkerShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Circle => write!(f, "Circle"),
+            Self::Diamond => write!(f, "Diamond"),
+            Self::Square => write!(f, "Square"),
+            Self::Cross => write!(f, "Cross"),
+            Self::Plus => write!(f, "Plus"),
+            Self::Up => write!(f, "Up"),
+            Self::Down => write!(f, "Down"),
+            Self::Left => write!(f, "Left"),
+            Self::Right => write!(f, "Right"),
+            Self::Asterisk => write!(f, "Asterisk"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for MarkerShape {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.MarkerShape".into()
+    fn variants() -> &'static [Self] {
+        &[
+            Self::Circle,
+            Self::Diamond,
+            Self::Square,
+            Self::Cross,
+            Self::Plus,
+            Self::Up,
+            Self::Down,
+            Self::Left,
+            Self::Right,
+            Self::Asterisk,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Circle => "`⏺`",
+            Self::Diamond => "`◆`",
+            Self::Square => "`◼\u{fe0f}`",
+            Self::Cross => "`x`",
+            Self::Plus => "`+`",
+            Self::Up => "`▲`",
+            Self::Down => "`▼`",
+            Self::Left => "`◀`",
+            Self::Right => "`▶`",
+            Self::Asterisk => "`*`",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for MarkerShape {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/marker_shape.rs
+++ b/crates/store/re_types/src/components/marker_shape.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/marker_size.rs
+++ b/crates/store/re_types/src/components/marker_size.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Radius of a marker of a point in e.g. a 2D plot, measured in UI points.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct MarkerSize(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for MarkerSize {
+impl ::re_types_core::Component for MarkerSize {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for MarkerSize {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for MarkerSize {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for MarkerSize {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for MarkerSize {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.MarkerSize")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for MarkerSize {
     }
 }
 
-impl ::re_types_core::Component for MarkerSize {
+impl<T: Into<crate::datatypes::Float32>> From<T> for MarkerSize {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for MarkerSize {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.MarkerSize".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for MarkerSize {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for MarkerSize {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for MarkerSize {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/marker_size.rs
+++ b/crates/store/re_types/src/components/marker_size.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/media_type.rs
+++ b/crates/store/re_types/src/components/media_type.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A standardized media type (RFC2046, formerly known as MIME types), encoded as a string.
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct MediaType(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for MediaType {
+impl ::re_types_core::Component for MediaType {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for MediaType {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for MediaType {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for MediaType {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for MediaType {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.MediaType")
     }
 }
 
@@ -100,9 +66,43 @@ impl ::re_types_core::Loggable for MediaType {
     }
 }
 
-impl ::re_types_core::Component for MediaType {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for MediaType {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for MediaType {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.MediaType".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for MediaType {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for MediaType {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for MediaType {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/media_type.rs
+++ b/crates/store/re_types/src/components/media_type.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/name.rs
+++ b/crates/store/re_types/src/components/name.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A display name, typically for an entity or a item like a plot series.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Name(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for Name {
+impl ::re_types_core::Component for Name {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for Name {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for Name {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Name {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Name {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Name")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for Name {
     }
 }
 
-impl ::re_types_core::Component for Name {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for Name {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for Name {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Name".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Name {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Name {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Name {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/name.rs
+++ b/crates/store/re_types/src/components/name.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/opacity.rs
+++ b/crates/store/re_types/src/components/opacity.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Degree of transparency ranging from 0.0 (fully transparent) to 1.0 (fully opaque).
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Opacity(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for Opacity {
+impl ::re_types_core::Component for Opacity {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for Opacity {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for Opacity {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Opacity {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Opacity {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Opacity")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for Opacity {
     }
 }
 
-impl ::re_types_core::Component for Opacity {
+impl<T: Into<crate::datatypes::Float32>> From<T> for Opacity {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for Opacity {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Opacity".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Opacity {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Opacity {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Opacity {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/opacity.rs
+++ b/crates/store/re_types/src/components/opacity.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pinhole_projection.rs
+++ b/crates/store/re_types/src/components/pinhole_projection.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Camera projection, from image coordinates to view coordinates.
@@ -32,44 +32,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd)]
 pub struct PinholeProjection(pub crate::datatypes::Mat3x3);
 
-impl ::re_types_core::SizeBytes for PinholeProjection {
+impl ::re_types_core::Component for PinholeProjection {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Mat3x3>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Mat3x3>> From<T> for PinholeProjection {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Mat3x3> for PinholeProjection {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PinholeProjection {
-    type Target = crate::datatypes::Mat3x3;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PinholeProjection {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PinholeProjection")
     }
 }
 
@@ -114,9 +80,43 @@ impl ::re_types_core::Loggable for PinholeProjection {
     }
 }
 
-impl ::re_types_core::Component for PinholeProjection {
+impl<T: Into<crate::datatypes::Mat3x3>> From<T> for PinholeProjection {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Mat3x3> for PinholeProjection {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PinholeProjection".into()
+    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PinholeProjection {
+    type Target = crate::datatypes::Mat3x3;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PinholeProjection {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PinholeProjection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Mat3x3>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pinhole_projection.rs
+++ b/crates/store/re_types/src/components/pinhole_projection.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/plane3d.rs
+++ b/crates/store/re_types/src/components/plane3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: An infinite 3D plane represented by a unit normal vector and a distance.
@@ -31,44 +31,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Plane3D(pub crate::datatypes::Plane3D);
 
-impl ::re_types_core::SizeBytes for Plane3D {
+impl ::re_types_core::Component for Plane3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Plane3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Plane3D>> From<T> for Plane3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Plane3D> for Plane3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Plane3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Plane3D {
-    type Target = crate::datatypes::Plane3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Plane3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Plane3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Plane3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Plane3D")
     }
 }
 
@@ -113,9 +79,43 @@ impl ::re_types_core::Loggable for Plane3D {
     }
 }
 
-impl ::re_types_core::Component for Plane3D {
+impl<T: Into<crate::datatypes::Plane3D>> From<T> for Plane3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Plane3D> for Plane3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Plane3D".into()
+    fn borrow(&self) -> &crate::datatypes::Plane3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Plane3D {
+    type Target = crate::datatypes::Plane3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Plane3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Plane3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Plane3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Plane3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Plane3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/plane3d.rs
+++ b/crates/store/re_types/src/components/plane3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: 3D rotation represented by a rotation around a given axis that doesn't propagate in the transform hierarchy.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct PoseRotationAxisAngle(pub crate::datatypes::RotationAxisAngle);
 
-impl ::re_types_core::SizeBytes for PoseRotationAxisAngle {
+impl ::re_types_core::Component for PoseRotationAxisAngle {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::RotationAxisAngle>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::RotationAxisAngle>> From<T> for PoseRotationAxisAngle {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::RotationAxisAngle> for PoseRotationAxisAngle {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::RotationAxisAngle {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PoseRotationAxisAngle {
-    type Target = crate::datatypes::RotationAxisAngle;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::RotationAxisAngle {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PoseRotationAxisAngle {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::RotationAxisAngle {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PoseRotationAxisAngle")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for PoseRotationAxisAngle {
     }
 }
 
-impl ::re_types_core::Component for PoseRotationAxisAngle {
+impl<T: Into<crate::datatypes::RotationAxisAngle>> From<T> for PoseRotationAxisAngle {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::RotationAxisAngle> for PoseRotationAxisAngle {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PoseRotationAxisAngle".into()
+    fn borrow(&self) -> &crate::datatypes::RotationAxisAngle {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PoseRotationAxisAngle {
+    type Target = crate::datatypes::RotationAxisAngle;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::RotationAxisAngle {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PoseRotationAxisAngle {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::RotationAxisAngle {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PoseRotationAxisAngle {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::RotationAxisAngle>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/pose_rotation_axis_angle.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pose_rotation_quat.rs
+++ b/crates/store/re_types/src/components/pose_rotation_quat.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3D rotation expressed as a quaternion that doesn't propagate in the transform hierarchy.
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct PoseRotationQuat(pub crate::datatypes::Quaternion);
 
-impl ::re_types_core::SizeBytes for PoseRotationQuat {
+impl ::re_types_core::Component for PoseRotationQuat {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Quaternion>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Quaternion>> From<T> for PoseRotationQuat {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Quaternion> for PoseRotationQuat {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Quaternion {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PoseRotationQuat {
-    type Target = crate::datatypes::Quaternion;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Quaternion {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PoseRotationQuat {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Quaternion {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PoseRotationQuat")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for PoseRotationQuat {
     }
 }
 
-impl ::re_types_core::Component for PoseRotationQuat {
+impl<T: Into<crate::datatypes::Quaternion>> From<T> for PoseRotationQuat {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Quaternion> for PoseRotationQuat {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PoseRotationQuat".into()
+    fn borrow(&self) -> &crate::datatypes::Quaternion {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PoseRotationQuat {
+    type Target = crate::datatypes::Quaternion;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Quaternion {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PoseRotationQuat {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Quaternion {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PoseRotationQuat {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Quaternion>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pose_rotation_quat.rs
+++ b/crates/store/re_types/src/components/pose_rotation_quat.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pose_scale3d.rs
+++ b/crates/store/re_types/src/components/pose_scale3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3D scale factor that doesn't propagate in the transform hierarchy.
@@ -27,44 +27,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct PoseScale3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for PoseScale3D {
+impl ::re_types_core::Component for PoseScale3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for PoseScale3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for PoseScale3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PoseScale3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PoseScale3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PoseScale3D")
     }
 }
 
@@ -109,9 +75,43 @@ impl ::re_types_core::Loggable for PoseScale3D {
     }
 }
 
-impl ::re_types_core::Component for PoseScale3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for PoseScale3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for PoseScale3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PoseScale3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PoseScale3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PoseScale3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PoseScale3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pose_scale3d.rs
+++ b/crates/store/re_types/src/components/pose_scale3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pose_transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/pose_transform_mat3x3.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3x3 transformation matrix Matrix that doesn't propagate in the transform hierarchy.
@@ -35,44 +35,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct PoseTransformMat3x3(pub crate::datatypes::Mat3x3);
 
-impl ::re_types_core::SizeBytes for PoseTransformMat3x3 {
+impl ::re_types_core::Component for PoseTransformMat3x3 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Mat3x3>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Mat3x3>> From<T> for PoseTransformMat3x3 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Mat3x3> for PoseTransformMat3x3 {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PoseTransformMat3x3 {
-    type Target = crate::datatypes::Mat3x3;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PoseTransformMat3x3 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PoseTransformMat3x3")
     }
 }
 
@@ -117,9 +83,43 @@ impl ::re_types_core::Loggable for PoseTransformMat3x3 {
     }
 }
 
-impl ::re_types_core::Component for PoseTransformMat3x3 {
+impl<T: Into<crate::datatypes::Mat3x3>> From<T> for PoseTransformMat3x3 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Mat3x3> for PoseTransformMat3x3 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PoseTransformMat3x3".into()
+    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PoseTransformMat3x3 {
+    type Target = crate::datatypes::Mat3x3;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PoseTransformMat3x3 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PoseTransformMat3x3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Mat3x3>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pose_transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/pose_transform_mat3x3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/pose_translation3d.rs
+++ b/crates/store/re_types/src/components/pose_translation3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A translation vector in 3D space that doesn't propagate in the transform hierarchy.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct PoseTranslation3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for PoseTranslation3D {
+impl ::re_types_core::Component for PoseTranslation3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for PoseTranslation3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for PoseTranslation3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for PoseTranslation3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for PoseTranslation3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.PoseTranslation3D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for PoseTranslation3D {
     }
 }
 
-impl ::re_types_core::Component for PoseTranslation3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for PoseTranslation3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for PoseTranslation3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.PoseTranslation3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PoseTranslation3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PoseTranslation3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PoseTranslation3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/pose_translation3d.rs
+++ b/crates/store/re_types/src/components/pose_translation3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/position2d.rs
+++ b/crates/store/re_types/src/components/position2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A position in 2D space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Position2D(pub crate::datatypes::Vec2D);
 
-impl ::re_types_core::SizeBytes for Position2D {
+impl ::re_types_core::Component for Position2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec2D>> From<T> for Position2D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec2D> for Position2D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Position2D {
-    type Target = crate::datatypes::Vec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Position2D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Position2D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Position2D {
     }
 }
 
-impl ::re_types_core::Component for Position2D {
+impl<T: Into<crate::datatypes::Vec2D>> From<T> for Position2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec2D> for Position2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Position2D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Position2D {
+    type Target = crate::datatypes::Vec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Position2D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Position2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/position2d.rs
+++ b/crates/store/re_types/src/components/position2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/position3d.rs
+++ b/crates/store/re_types/src/components/position3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A position in 3D space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Position3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for Position3D {
+impl ::re_types_core::Component for Position3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for Position3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for Position3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Position3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Position3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Position3D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Position3D {
     }
 }
 
-impl ::re_types_core::Component for Position3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for Position3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for Position3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Position3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Position3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Position3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Position3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/position3d.rs
+++ b/crates/store/re_types/src/components/position3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/radius.rs
+++ b/crates/store/re_types/src/components/radius.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The radius of something, e.g. a point.
@@ -30,44 +30,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Radius(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for Radius {
+impl ::re_types_core::Component for Radius {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for Radius {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for Radius {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Radius {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Radius {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Radius")
     }
 }
 
@@ -112,9 +78,43 @@ impl ::re_types_core::Loggable for Radius {
     }
 }
 
-impl ::re_types_core::Component for Radius {
+impl<T: Into<crate::datatypes::Float32>> From<T> for Radius {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for Radius {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Radius".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Radius {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Radius {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Radius {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/radius.rs
+++ b/crates/store/re_types/src/components/radius.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/range1d.rs
+++ b/crates/store/re_types/src/components/range1d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 1D range, specifying a lower and upper bound.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Range1D(pub crate::datatypes::Range1D);
 
-impl ::re_types_core::SizeBytes for Range1D {
+impl ::re_types_core::Component for Range1D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Range1D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Range1D>> From<T> for Range1D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Range1D> for Range1D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Range1D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Range1D {
-    type Target = crate::datatypes::Range1D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Range1D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Range1D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Range1D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Range1D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Range1D {
     }
 }
 
-impl ::re_types_core::Component for Range1D {
+impl<T: Into<crate::datatypes::Range1D>> From<T> for Range1D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Range1D> for Range1D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Range1D".into()
+    fn borrow(&self) -> &crate::datatypes::Range1D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Range1D {
+    type Target = crate::datatypes::Range1D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Range1D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Range1D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Range1D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Range1D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Range1D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/range1d.rs
+++ b/crates/store/re_types/src/components/range1d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/recording_uri.rs
+++ b/crates/store/re_types/src/components/recording_uri.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/recording_uri.rs
+++ b/crates/store/re_types/src/components/recording_uri.rs
@@ -13,53 +13,19 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A recording URI (Uniform Resource Identifier).
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RecordingUri(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for RecordingUri {
+impl ::re_types_core::Component for RecordingUri {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for RecordingUri {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for RecordingUri {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for RecordingUri {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for RecordingUri {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.RecordingUri")
     }
 }
 
@@ -96,9 +62,43 @@ impl ::re_types_core::Loggable for RecordingUri {
     }
 }
 
-impl ::re_types_core::Component for RecordingUri {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for RecordingUri {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for RecordingUri {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.RecordingUri".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RecordingUri {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RecordingUri {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for RecordingUri {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/resolution.rs
+++ b/crates/store/re_types/src/components/resolution.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Pixel resolution width & height, e.g. of a camera sensor.
@@ -24,44 +24,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Copy, PartialEq)]
 pub struct Resolution(pub crate::datatypes::Vec2D);
 
-impl ::re_types_core::SizeBytes for Resolution {
+impl ::re_types_core::Component for Resolution {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec2D>> From<T> for Resolution {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec2D> for Resolution {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Resolution {
-    type Target = crate::datatypes::Vec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Resolution {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Resolution")
     }
 }
 
@@ -106,9 +72,43 @@ impl ::re_types_core::Loggable for Resolution {
     }
 }
 
-impl ::re_types_core::Component for Resolution {
+impl<T: Into<crate::datatypes::Vec2D>> From<T> for Resolution {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec2D> for Resolution {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Resolution".into()
+    fn borrow(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Resolution {
+    type Target = crate::datatypes::Vec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Resolution {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Resolution {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/resolution.rs
+++ b/crates/store/re_types/src/components/resolution.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/rotation_axis_angle.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: 3D rotation represented by a rotation around a given axis.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct RotationAxisAngle(pub crate::datatypes::RotationAxisAngle);
 
-impl ::re_types_core::SizeBytes for RotationAxisAngle {
+impl ::re_types_core::Component for RotationAxisAngle {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::RotationAxisAngle>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::RotationAxisAngle>> From<T> for RotationAxisAngle {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::RotationAxisAngle> for RotationAxisAngle {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::RotationAxisAngle {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for RotationAxisAngle {
-    type Target = crate::datatypes::RotationAxisAngle;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::RotationAxisAngle {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for RotationAxisAngle {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::RotationAxisAngle {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.RotationAxisAngle")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
     }
 }
 
-impl ::re_types_core::Component for RotationAxisAngle {
+impl<T: Into<crate::datatypes::RotationAxisAngle>> From<T> for RotationAxisAngle {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::RotationAxisAngle> for RotationAxisAngle {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.RotationAxisAngle".into()
+    fn borrow(&self) -> &crate::datatypes::RotationAxisAngle {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RotationAxisAngle {
+    type Target = crate::datatypes::RotationAxisAngle;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::RotationAxisAngle {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RotationAxisAngle {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::RotationAxisAngle {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for RotationAxisAngle {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::RotationAxisAngle>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/components/rotation_axis_angle.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/rotation_quat.rs
+++ b/crates/store/re_types/src/components/rotation_quat.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3D rotation expressed as a quaternion.
@@ -26,44 +26,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct RotationQuat(pub crate::datatypes::Quaternion);
 
-impl ::re_types_core::SizeBytes for RotationQuat {
+impl ::re_types_core::Component for RotationQuat {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Quaternion>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Quaternion>> From<T> for RotationQuat {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Quaternion> for RotationQuat {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Quaternion {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for RotationQuat {
-    type Target = crate::datatypes::Quaternion;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Quaternion {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for RotationQuat {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Quaternion {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.RotationQuat")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for RotationQuat {
     }
 }
 
-impl ::re_types_core::Component for RotationQuat {
+impl<T: Into<crate::datatypes::Quaternion>> From<T> for RotationQuat {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Quaternion> for RotationQuat {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.RotationQuat".into()
+    fn borrow(&self) -> &crate::datatypes::Quaternion {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RotationQuat {
+    type Target = crate::datatypes::Quaternion;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Quaternion {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RotationQuat {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Quaternion {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for RotationQuat {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Quaternion>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/rotation_quat.rs
+++ b/crates/store/re_types/src/components/rotation_quat.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/scalar.rs
+++ b/crates/store/re_types/src/components/scalar.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A scalar value, encoded as a 64-bit floating point.
@@ -25,44 +25,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Scalar(pub crate::datatypes::Float64);
 
-impl ::re_types_core::SizeBytes for Scalar {
+impl ::re_types_core::Component for Scalar {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float64>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float64>> From<T> for Scalar {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float64> for Scalar {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float64 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Scalar {
-    type Target = crate::datatypes::Float64;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float64 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Scalar {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float64 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Scalar")
     }
 }
 
@@ -107,9 +73,43 @@ impl ::re_types_core::Loggable for Scalar {
     }
 }
 
-impl ::re_types_core::Component for Scalar {
+impl<T: Into<crate::datatypes::Float64>> From<T> for Scalar {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float64> for Scalar {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Scalar".into()
+    fn borrow(&self) -> &crate::datatypes::Float64 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Scalar {
+    type Target = crate::datatypes::Float64;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float64 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Scalar {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float64 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Scalar {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float64>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/scalar.rs
+++ b/crates/store/re_types/src/components/scalar.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/scale3d.rs
+++ b/crates/store/re_types/src/components/scale3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3D scale factor.
@@ -27,44 +27,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Scale3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for Scale3D {
+impl ::re_types_core::Component for Scale3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for Scale3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for Scale3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Scale3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Scale3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Scale3D")
     }
 }
 
@@ -109,9 +75,43 @@ impl ::re_types_core::Loggable for Scale3D {
     }
 }
 
-impl ::re_types_core::Component for Scale3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for Scale3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for Scale3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Scale3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Scale3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Scale3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Scale3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/scale3d.rs
+++ b/crates/store/re_types/src/components/scale3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/show_labels.rs
+++ b/crates/store/re_types/src/components/show_labels.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the entity's [`components::Text`][crate::components::Text] label is shown.
@@ -29,44 +29,10 @@ pub struct ShowLabels(
     pub crate::datatypes::Bool,
 );
 
-impl ::re_types_core::SizeBytes for ShowLabels {
+impl ::re_types_core::Component for ShowLabels {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for ShowLabels {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for ShowLabels {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ShowLabels {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ShowLabels {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ShowLabels")
     }
 }
 
@@ -103,9 +69,43 @@ impl ::re_types_core::Loggable for ShowLabels {
     }
 }
 
-impl ::re_types_core::Component for ShowLabels {
+impl<T: Into<crate::datatypes::Bool>> From<T> for ShowLabels {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for ShowLabels {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ShowLabels".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ShowLabels {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ShowLabels {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ShowLabels {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/show_labels.rs
+++ b/crates/store/re_types/src/components/show_labels.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/stroke_width.rs
+++ b/crates/store/re_types/src/components/stroke_width.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The width of a stroke specified in UI points.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct StrokeWidth(pub crate::datatypes::Float32);
 
-impl ::re_types_core::SizeBytes for StrokeWidth {
+impl ::re_types_core::Component for StrokeWidth {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Float32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Float32>> From<T> for StrokeWidth {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Float32> for StrokeWidth {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for StrokeWidth {
-    type Target = crate::datatypes::Float32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Float32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for StrokeWidth {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.StrokeWidth")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for StrokeWidth {
     }
 }
 
-impl ::re_types_core::Component for StrokeWidth {
+impl<T: Into<crate::datatypes::Float32>> From<T> for StrokeWidth {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Float32> for StrokeWidth {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.StrokeWidth".into()
+    fn borrow(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for StrokeWidth {
+    type Target = crate::datatypes::Float32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Float32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for StrokeWidth {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Float32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for StrokeWidth {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Float32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/stroke_width.rs
+++ b/crates/store/re_types/src/components/stroke_width.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/tensor_data.rs
+++ b/crates/store/re_types/src/components/tensor_data.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: An N-dimensional array of numbers.
@@ -30,44 +30,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TensorData(pub crate::datatypes::TensorData);
 
-impl ::re_types_core::SizeBytes for TensorData {
+impl ::re_types_core::Component for TensorData {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TensorData>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::TensorData>> From<T> for TensorData {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::TensorData> for TensorData {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::TensorData {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TensorData {
-    type Target = crate::datatypes::TensorData;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::TensorData {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TensorData {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorData {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TensorData")
     }
 }
 
@@ -104,9 +70,43 @@ impl ::re_types_core::Loggable for TensorData {
     }
 }
 
-impl ::re_types_core::Component for TensorData {
+impl<T: Into<crate::datatypes::TensorData>> From<T> for TensorData {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::TensorData> for TensorData {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TensorData".into()
+    fn borrow(&self) -> &crate::datatypes::TensorData {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TensorData {
+    type Target = crate::datatypes::TensorData;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::TensorData {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TensorData {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorData {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorData {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TensorData>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/tensor_data.rs
+++ b/crates/store/re_types/src/components/tensor_data.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Specifies a concrete index on a tensor dimension.
@@ -23,48 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TensorDimensionIndexSelection(pub crate::datatypes::TensorDimensionIndexSelection);
 
-impl ::re_types_core::SizeBytes for TensorDimensionIndexSelection {
+impl ::re_types_core::Component for TensorDimensionIndexSelection {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TensorDimensionIndexSelection>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::TensorDimensionIndexSelection>> From<T>
-    for TensorDimensionIndexSelection
-{
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::TensorDimensionIndexSelection>
-    for TensorDimensionIndexSelection
-{
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::TensorDimensionIndexSelection {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TensorDimensionIndexSelection {
-    type Target = crate::datatypes::TensorDimensionIndexSelection;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::TensorDimensionIndexSelection {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TensorDimensionIndexSelection {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionIndexSelection {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TensorDimensionIndexSelection")
     }
 }
 
@@ -103,9 +65,47 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
     }
 }
 
-impl ::re_types_core::Component for TensorDimensionIndexSelection {
+impl<T: Into<crate::datatypes::TensorDimensionIndexSelection>> From<T>
+    for TensorDimensionIndexSelection
+{
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::TensorDimensionIndexSelection>
+    for TensorDimensionIndexSelection
+{
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TensorDimensionIndexSelection".into()
+    fn borrow(&self) -> &crate::datatypes::TensorDimensionIndexSelection {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TensorDimensionIndexSelection {
+    type Target = crate::datatypes::TensorDimensionIndexSelection;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::TensorDimensionIndexSelection {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TensorDimensionIndexSelection {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionIndexSelection {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimensionIndexSelection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TensorDimensionIndexSelection>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/components/tensor_dimension_index_selection.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_height_dimension.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Specifies which dimension to use for height.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TensorHeightDimension(pub crate::datatypes::TensorDimensionSelection);
 
-impl ::re_types_core::SizeBytes for TensorHeightDimension {
+impl ::re_types_core::Component for TensorHeightDimension {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TensorDimensionSelection>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::TensorDimensionSelection>> From<T> for TensorHeightDimension {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::TensorDimensionSelection> for TensorHeightDimension {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::TensorDimensionSelection {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TensorHeightDimension {
-    type Target = crate::datatypes::TensorDimensionSelection;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::TensorDimensionSelection {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TensorHeightDimension {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionSelection {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TensorHeightDimension")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for TensorHeightDimension {
     }
 }
 
-impl ::re_types_core::Component for TensorHeightDimension {
+impl<T: Into<crate::datatypes::TensorDimensionSelection>> From<T> for TensorHeightDimension {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::TensorDimensionSelection> for TensorHeightDimension {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TensorHeightDimension".into()
+    fn borrow(&self) -> &crate::datatypes::TensorDimensionSelection {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TensorHeightDimension {
+    type Target = crate::datatypes::TensorDimensionSelection;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::TensorDimensionSelection {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TensorHeightDimension {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionSelection {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorHeightDimension {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TensorDimensionSelection>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/tensor_height_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_height_dimension.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_width_dimension.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Specifies which dimension to use for width.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TensorWidthDimension(pub crate::datatypes::TensorDimensionSelection);
 
-impl ::re_types_core::SizeBytes for TensorWidthDimension {
+impl ::re_types_core::Component for TensorWidthDimension {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TensorDimensionSelection>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::TensorDimensionSelection>> From<T> for TensorWidthDimension {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::TensorDimensionSelection> for TensorWidthDimension {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::TensorDimensionSelection {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TensorWidthDimension {
-    type Target = crate::datatypes::TensorDimensionSelection;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::TensorDimensionSelection {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TensorWidthDimension {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionSelection {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TensorWidthDimension")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for TensorWidthDimension {
     }
 }
 
-impl ::re_types_core::Component for TensorWidthDimension {
+impl<T: Into<crate::datatypes::TensorDimensionSelection>> From<T> for TensorWidthDimension {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::TensorDimensionSelection> for TensorWidthDimension {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TensorWidthDimension".into()
+    fn borrow(&self) -> &crate::datatypes::TensorDimensionSelection {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TensorWidthDimension {
+    type Target = crate::datatypes::TensorDimensionSelection;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::TensorDimensionSelection {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TensorWidthDimension {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::TensorDimensionSelection {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorWidthDimension {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TensorDimensionSelection>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/tensor_width_dimension.rs
+++ b/crates/store/re_types/src/components/tensor_width_dimension.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/texcoord2d.rs
+++ b/crates/store/re_types/src/components/texcoord2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 2D texture UV coordinate.
@@ -38,44 +38,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Texcoord2D(pub crate::datatypes::Vec2D);
 
-impl ::re_types_core::SizeBytes for Texcoord2D {
+impl ::re_types_core::Component for Texcoord2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec2D>> From<T> for Texcoord2D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec2D> for Texcoord2D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Texcoord2D {
-    type Target = crate::datatypes::Vec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Texcoord2D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Texcoord2D")
     }
 }
 
@@ -120,9 +86,43 @@ impl ::re_types_core::Loggable for Texcoord2D {
     }
 }
 
-impl ::re_types_core::Component for Texcoord2D {
+impl<T: Into<crate::datatypes::Vec2D>> From<T> for Texcoord2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec2D> for Texcoord2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Texcoord2D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Texcoord2D {
+    type Target = crate::datatypes::Vec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Texcoord2D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Texcoord2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/texcoord2d.rs
+++ b/crates/store/re_types/src/components/texcoord2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/text.rs
+++ b/crates/store/re_types/src/components/text.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A string of text, e.g. for labels and text documents.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Text(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for Text {
+impl ::re_types_core::Component for Text {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for Text {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for Text {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Text {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Text {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Text")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for Text {
     }
 }
 
-impl ::re_types_core::Component for Text {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for Text {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for Text {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Text".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Text {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Text {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Text {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/text.rs
+++ b/crates/store/re_types/src/components/text.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/text_log_level.rs
+++ b/crates/store/re_types/src/components/text_log_level.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The severity level of a text log message.
@@ -31,44 +31,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TextLogLevel(pub crate::datatypes::Utf8);
 
-impl ::re_types_core::SizeBytes for TextLogLevel {
+impl ::re_types_core::Component for TextLogLevel {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Utf8>> From<T> for TextLogLevel {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Utf8> for TextLogLevel {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TextLogLevel {
-    type Target = crate::datatypes::Utf8;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Utf8 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TextLogLevel {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TextLogLevel")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for TextLogLevel {
     }
 }
 
-impl ::re_types_core::Component for TextLogLevel {
+impl<T: Into<crate::datatypes::Utf8>> From<T> for TextLogLevel {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Utf8> for TextLogLevel {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TextLogLevel".into()
+    fn borrow(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TextLogLevel {
+    type Target = crate::datatypes::Utf8;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Utf8 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TextLogLevel {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Utf8 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TextLogLevel {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/text_log_level.rs
+++ b/crates/store/re_types/src/components/text_log_level.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/transform_mat3x3.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A 3x3 transformation matrix Matrix.
@@ -35,44 +35,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TransformMat3x3(pub crate::datatypes::Mat3x3);
 
-impl ::re_types_core::SizeBytes for TransformMat3x3 {
+impl ::re_types_core::Component for TransformMat3x3 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Mat3x3>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Mat3x3>> From<T> for TransformMat3x3 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Mat3x3> for TransformMat3x3 {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TransformMat3x3 {
-    type Target = crate::datatypes::Mat3x3;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Mat3x3 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TransformMat3x3 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TransformMat3x3")
     }
 }
 
@@ -117,9 +83,43 @@ impl ::re_types_core::Loggable for TransformMat3x3 {
     }
 }
 
-impl ::re_types_core::Component for TransformMat3x3 {
+impl<T: Into<crate::datatypes::Mat3x3>> From<T> for TransformMat3x3 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Mat3x3> for TransformMat3x3 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TransformMat3x3".into()
+    fn borrow(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TransformMat3x3 {
+    type Target = crate::datatypes::Mat3x3;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Mat3x3 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TransformMat3x3 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Mat3x3 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TransformMat3x3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Mat3x3>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/transform_mat3x3.rs
+++ b/crates/store/re_types/src/components/transform_mat3x3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Specifies relation a spatial transform describes.
@@ -39,43 +39,10 @@ pub enum TransformRelation {
     ChildFromParent = 2,
 }
 
-impl ::re_types_core::reflection::Enum for TransformRelation {
+impl ::re_types_core::Component for TransformRelation {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::ParentFromChild, Self::ChildFromParent]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::ParentFromChild => {
-                "The transform describes how to transform into the parent entity's space.\n\nE.g. a translation of (0, 1, 0) with this [`components::TransformRelation`][crate::components::TransformRelation] logged at `parent/child` means\nthat from the point of view of `parent`, `parent/child` is translated 1 unit along `parent`'s Y axis.\nFrom perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis."
-            }
-            Self::ChildFromParent => {
-                "The transform describes how to transform into the child entity's space.\n\nE.g. a translation of (0, 1, 0) with this [`components::TransformRelation`][crate::components::TransformRelation] logged at `parent/child` means\nthat from the point of view of `parent`, `parent/child` is translated -1 unit along `parent`'s Y axis.\nFrom perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for TransformRelation {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for TransformRelation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ParentFromChild => write!(f, "ParentFromChild"),
-            Self::ChildFromParent => write!(f, "ChildFromParent"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TransformRelation")
     }
 }
 
@@ -165,9 +132,42 @@ impl ::re_types_core::Loggable for TransformRelation {
     }
 }
 
-impl ::re_types_core::Component for TransformRelation {
+impl std::fmt::Display for TransformRelation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ParentFromChild => write!(f, "ParentFromChild"),
+            Self::ChildFromParent => write!(f, "ChildFromParent"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for TransformRelation {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TransformRelation".into()
+    fn variants() -> &'static [Self] {
+        &[Self::ParentFromChild, Self::ChildFromParent]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::ParentFromChild => {
+                "The transform describes how to transform into the parent entity's space.\n\nE.g. a translation of (0, 1, 0) with this [`components::TransformRelation`][crate::components::TransformRelation] logged at `parent/child` means\nthat from the point of view of `parent`, `parent/child` is translated 1 unit along `parent`'s Y axis.\nFrom perspective of `parent/child`, the `parent` entity is translated -1 unit along `parent/child`'s Y axis."
+            }
+            Self::ChildFromParent => {
+                "The transform describes how to transform into the child entity's space.\n\nE.g. a translation of (0, 1, 0) with this [`components::TransformRelation`][crate::components::TransformRelation] logged at `parent/child` means\nthat from the point of view of `parent`, `parent/child` is translated -1 unit along `parent`'s Y axis.\nFrom perspective of `parent/child`, the `parent` entity is translated 1 unit along `parent/child`'s Y axis."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for TransformRelation {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/components/transform_relation.rs
+++ b/crates/store/re_types/src/components/transform_relation.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/translation3d.rs
+++ b/crates/store/re_types/src/components/translation3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A translation vector in 3D space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Translation3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for Translation3D {
+impl ::re_types_core::Component for Translation3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for Translation3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for Translation3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Translation3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Translation3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Translation3D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Translation3D {
     }
 }
 
-impl ::re_types_core::Component for Translation3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for Translation3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for Translation3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Translation3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Translation3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Translation3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Translation3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/translation3d.rs
+++ b/crates/store/re_types/src/components/translation3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/triangle_indices.rs
+++ b/crates/store/re_types/src/components/triangle_indices.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The three indices of a triangle in a triangle mesh.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct TriangleIndices(pub crate::datatypes::UVec3D);
 
-impl ::re_types_core::SizeBytes for TriangleIndices {
+impl ::re_types_core::Component for TriangleIndices {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::UVec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::UVec3D>> From<T> for TriangleIndices {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::UVec3D> for TriangleIndices {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::UVec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for TriangleIndices {
-    type Target = crate::datatypes::UVec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::UVec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for TriangleIndices {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::UVec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.TriangleIndices")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for TriangleIndices {
     }
 }
 
-impl ::re_types_core::Component for TriangleIndices {
+impl<T: Into<crate::datatypes::UVec3D>> From<T> for TriangleIndices {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::UVec3D> for TriangleIndices {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.TriangleIndices".into()
+    fn borrow(&self) -> &crate::datatypes::UVec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for TriangleIndices {
+    type Target = crate::datatypes::UVec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::UVec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TriangleIndices {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::UVec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for TriangleIndices {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::UVec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/triangle_indices.rs
+++ b/crates/store/re_types/src/components/triangle_indices.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/value_range.rs
+++ b/crates/store/re_types/src/components/value_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Range of expected or valid values, specifying a lower and upper bound.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct ValueRange(pub crate::datatypes::Range1D);
 
-impl ::re_types_core::SizeBytes for ValueRange {
+impl ::re_types_core::Component for ValueRange {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Range1D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Range1D>> From<T> for ValueRange {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Range1D> for ValueRange {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Range1D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ValueRange {
-    type Target = crate::datatypes::Range1D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Range1D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ValueRange {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Range1D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ValueRange")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for ValueRange {
     }
 }
 
-impl ::re_types_core::Component for ValueRange {
+impl<T: Into<crate::datatypes::Range1D>> From<T> for ValueRange {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Range1D> for ValueRange {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ValueRange".into()
+    fn borrow(&self) -> &crate::datatypes::Range1D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ValueRange {
+    type Target = crate::datatypes::Range1D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Range1D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ValueRange {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Range1D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ValueRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Range1D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/value_range.rs
+++ b/crates/store/re_types/src/components/value_range.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/vector2d.rs
+++ b/crates/store/re_types/src/components/vector2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A vector in 2D space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Vector2D(pub crate::datatypes::Vec2D);
 
-impl ::re_types_core::SizeBytes for Vector2D {
+impl ::re_types_core::Component for Vector2D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec2D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec2D>> From<T> for Vector2D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec2D> for Vector2D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Vector2D {
-    type Target = crate::datatypes::Vec2D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec2D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Vector2D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Vector2D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Vector2D {
     }
 }
 
-impl ::re_types_core::Component for Vector2D {
+impl<T: Into<crate::datatypes::Vec2D>> From<T> for Vector2D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec2D> for Vector2D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Vector2D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Vector2D {
+    type Target = crate::datatypes::Vec2D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec2D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Vector2D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec2D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Vector2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec2D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/vector2d.rs
+++ b/crates/store/re_types/src/components/vector2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/vector3d.rs
+++ b/crates/store/re_types/src/components/vector3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: A vector in 3D space.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct Vector3D(pub crate::datatypes::Vec3D);
 
-impl ::re_types_core::SizeBytes for Vector3D {
+impl ::re_types_core::Component for Vector3D {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Vec3D>> From<T> for Vector3D {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Vec3D> for Vector3D {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for Vector3D {
-    type Target = crate::datatypes::Vec3D;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Vec3D {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for Vector3D {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.Vector3D")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for Vector3D {
     }
 }
 
-impl ::re_types_core::Component for Vector3D {
+impl<T: Into<crate::datatypes::Vec3D>> From<T> for Vector3D {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Vec3D> for Vector3D {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.Vector3D".into()
+    fn borrow(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Vector3D {
+    type Target = crate::datatypes::Vec3D;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Vec3D {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for Vector3D {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Vec3D {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Vector3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/vector3d.rs
+++ b/crates/store/re_types/src/components/vector3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/video_timestamp.rs
+++ b/crates/store/re_types/src/components/video_timestamp.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Timestamp inside a [`archetypes::AssetVideo`][crate::archetypes::AssetVideo].
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct VideoTimestamp(pub crate::datatypes::VideoTimestamp);
 
-impl ::re_types_core::SizeBytes for VideoTimestamp {
+impl ::re_types_core::Component for VideoTimestamp {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::VideoTimestamp>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::VideoTimestamp>> From<T> for VideoTimestamp {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::VideoTimestamp> for VideoTimestamp {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::VideoTimestamp {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for VideoTimestamp {
-    type Target = crate::datatypes::VideoTimestamp;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::VideoTimestamp {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for VideoTimestamp {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::VideoTimestamp {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.VideoTimestamp")
     }
 }
 
@@ -106,9 +72,43 @@ impl ::re_types_core::Loggable for VideoTimestamp {
     }
 }
 
-impl ::re_types_core::Component for VideoTimestamp {
+impl<T: Into<crate::datatypes::VideoTimestamp>> From<T> for VideoTimestamp {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::VideoTimestamp> for VideoTimestamp {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.VideoTimestamp".into()
+    fn borrow(&self) -> &crate::datatypes::VideoTimestamp {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for VideoTimestamp {
+    type Target = crate::datatypes::VideoTimestamp;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::VideoTimestamp {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for VideoTimestamp {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::VideoTimestamp {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for VideoTimestamp {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::VideoTimestamp>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/video_timestamp.rs
+++ b/crates/store/re_types/src/components/video_timestamp.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/components/view_coordinates.rs
+++ b/crates/store/re_types/src/components/view_coordinates.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: How we interpret the coordinate system of an entity/space.
@@ -43,44 +43,10 @@ pub struct ViewCoordinates(
     pub crate::datatypes::ViewCoordinates,
 );
 
-impl ::re_types_core::SizeBytes for ViewCoordinates {
+impl ::re_types_core::Component for ViewCoordinates {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::ViewCoordinates>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::ViewCoordinates>> From<T> for ViewCoordinates {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::ViewCoordinates> for ViewCoordinates {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::ViewCoordinates {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ViewCoordinates {
-    type Target = crate::datatypes::ViewCoordinates;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::ViewCoordinates {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ViewCoordinates {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::ViewCoordinates {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ViewCoordinates")
     }
 }
 
@@ -125,9 +91,43 @@ impl ::re_types_core::Loggable for ViewCoordinates {
     }
 }
 
-impl ::re_types_core::Component for ViewCoordinates {
+impl<T: Into<crate::datatypes::ViewCoordinates>> From<T> for ViewCoordinates {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::ViewCoordinates> for ViewCoordinates {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ViewCoordinates".into()
+    fn borrow(&self) -> &crate::datatypes::ViewCoordinates {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ViewCoordinates {
+    type Target = crate::datatypes::ViewCoordinates;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::ViewCoordinates {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ViewCoordinates {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::ViewCoordinates {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewCoordinates {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::ViewCoordinates>::is_pod()
     }
 }

--- a/crates/store/re_types/src/components/view_coordinates.rs
+++ b/crates/store/re_types/src/components/view_coordinates.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/angle.rs
+++ b/crates/store/re_types/src/datatypes/angle.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Angle in radians.
@@ -24,32 +24,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub struct Angle {
     /// Angle in radians. One turn is equal to 2π (or τ) radians.
     pub radians: f32,
-}
-
-impl ::re_types_core::SizeBytes for Angle {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.radians.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <f32>::is_pod()
-    }
-}
-
-impl From<f32> for Angle {
-    #[inline]
-    fn from(radians: f32) -> Self {
-        Self { radians }
-    }
-}
-
-impl From<Angle> for f32 {
-    #[inline]
-    fn from(value: Angle) -> Self {
-        value.radians
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(Angle);
@@ -164,5 +138,31 @@ impl ::re_types_core::Loggable for Angle {
                     .collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<f32> for Angle {
+    #[inline]
+    fn from(radians: f32) -> Self {
+        Self { radians }
+    }
+}
+
+impl From<Angle> for f32 {
+    #[inline]
+    fn from(value: Angle) -> Self {
+        value.radians
+    }
+}
+
+impl ::re_types_core::SizeBytes for Angle {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.radians.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <f32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/angle.rs
+++ b/crates/store/re_types/src/datatypes/angle.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/annotation_info.rs
+++ b/crates/store/re_types/src/datatypes/annotation_info.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Annotation info annotating a class id or key-point id.
@@ -32,20 +32,6 @@ pub struct AnnotationInfo {
 
     /// The color that will be applied to the annotated entity.
     pub color: Option<crate::datatypes::Rgba32>,
-}
-
-impl ::re_types_core::SizeBytes for AnnotationInfo {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.id.heap_size_bytes() + self.label.heap_size_bytes() + self.color.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u16>::is_pod()
-            && <Option<crate::datatypes::Utf8>>::is_pod()
-            && <Option<crate::datatypes::Rgba32>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AnnotationInfo);
@@ -325,5 +311,19 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                 .with_context("rerun.datatypes.AnnotationInfo")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AnnotationInfo {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.id.heap_size_bytes() + self.label.heap_size_bytes() + self.color.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u16>::is_pod()
+            && <Option<crate::datatypes::Utf8>>::is_pod()
+            && <Option<crate::datatypes::Rgba32>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/annotation_info.rs
+++ b/crates/store/re_types/src/datatypes/annotation_info.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A binary blob of data.
@@ -24,32 +24,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Blob(pub ::re_types_core::ArrowBuffer<u8>);
-
-impl ::re_types_core::SizeBytes for Blob {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <::re_types_core::ArrowBuffer<u8>>::is_pod()
-    }
-}
-
-impl From<::re_types_core::ArrowBuffer<u8>> for Blob {
-    #[inline]
-    fn from(data: ::re_types_core::ArrowBuffer<u8>) -> Self {
-        Self(data)
-    }
-}
-
-impl From<Blob> for ::re_types_core::ArrowBuffer<u8> {
-    #[inline]
-    fn from(value: Blob) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Blob);
 
@@ -192,5 +166,31 @@ impl ::re_types_core::Loggable for Blob {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.datatypes.Blob#data")
         .with_context("rerun.datatypes.Blob")?)
+    }
+}
+
+impl From<::re_types_core::ArrowBuffer<u8>> for Blob {
+    #[inline]
+    fn from(data: ::re_types_core::ArrowBuffer<u8>) -> Self {
+        Self(data)
+    }
+}
+
+impl From<Blob> for ::re_types_core::ArrowBuffer<u8> {
+    #[inline]
+    fn from(value: Blob) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Blob {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <::re_types_core::ArrowBuffer<u8>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/channel_datatype.rs
+++ b/crates/store/re_types/src/datatypes/channel_datatype.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: The innermost datatype of an image.
@@ -58,72 +58,6 @@ pub enum ChannelDatatype {
 
     /// 64-bit IEEE-754 floating point, also known as `double`.
     F64 = 35,
-}
-
-impl ::re_types_core::reflection::Enum for ChannelDatatype {
-    #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::U8,
-            Self::I8,
-            Self::U16,
-            Self::I16,
-            Self::U32,
-            Self::I32,
-            Self::U64,
-            Self::I64,
-            Self::F16,
-            Self::F32,
-            Self::F64,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::U8 => "8-bit unsigned integer.",
-            Self::I8 => "8-bit signed integer.",
-            Self::U16 => "16-bit unsigned integer.",
-            Self::I16 => "16-bit signed integer.",
-            Self::U32 => "32-bit unsigned integer.",
-            Self::I32 => "32-bit signed integer.",
-            Self::U64 => "64-bit unsigned integer.",
-            Self::I64 => "64-bit signed integer.",
-            Self::F16 => "16-bit IEEE-754 floating point, also known as `half`.",
-            Self::F32 => "32-bit IEEE-754 floating point, also known as `float` or `single`.",
-            Self::F64 => "64-bit IEEE-754 floating point, also known as `double`.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for ChannelDatatype {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for ChannelDatatype {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::U8 => write!(f, "U8"),
-            Self::I8 => write!(f, "I8"),
-            Self::U16 => write!(f, "U16"),
-            Self::I16 => write!(f, "I16"),
-            Self::U32 => write!(f, "U32"),
-            Self::I32 => write!(f, "I32"),
-            Self::U64 => write!(f, "U64"),
-            Self::I64 => write!(f, "I64"),
-            Self::F16 => write!(f, "F16"),
-            Self::F32 => write!(f, "F32"),
-            Self::F64 => write!(f, "F64"),
-        }
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ChannelDatatype);
@@ -218,5 +152,71 @@ impl ::re_types_core::Loggable for ChannelDatatype {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.datatypes.ChannelDatatype")?)
+    }
+}
+
+impl std::fmt::Display for ChannelDatatype {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::U8 => write!(f, "U8"),
+            Self::I8 => write!(f, "I8"),
+            Self::U16 => write!(f, "U16"),
+            Self::I16 => write!(f, "I16"),
+            Self::U32 => write!(f, "U32"),
+            Self::I32 => write!(f, "I32"),
+            Self::U64 => write!(f, "U64"),
+            Self::I64 => write!(f, "I64"),
+            Self::F16 => write!(f, "F16"),
+            Self::F32 => write!(f, "F32"),
+            Self::F64 => write!(f, "F64"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for ChannelDatatype {
+    #[inline]
+    fn variants() -> &'static [Self] {
+        &[
+            Self::U8,
+            Self::I8,
+            Self::U16,
+            Self::I16,
+            Self::U32,
+            Self::I32,
+            Self::U64,
+            Self::I64,
+            Self::F16,
+            Self::F32,
+            Self::F64,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::U8 => "8-bit unsigned integer.",
+            Self::I8 => "8-bit signed integer.",
+            Self::U16 => "16-bit unsigned integer.",
+            Self::I16 => "16-bit signed integer.",
+            Self::U32 => "32-bit unsigned integer.",
+            Self::I32 => "32-bit signed integer.",
+            Self::U64 => "64-bit unsigned integer.",
+            Self::I64 => "64-bit signed integer.",
+            Self::F16 => "16-bit IEEE-754 floating point, also known as `half`.",
+            Self::F32 => "32-bit IEEE-754 floating point, also known as `float` or `single`.",
+            Self::F64 => "64-bit IEEE-754 floating point, also known as `double`.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ChannelDatatype {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/datatypes/channel_datatype.rs
+++ b/crates/store/re_types/src/datatypes/channel_datatype.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/class_description.rs
+++ b/crates/store/re_types/src/datatypes/class_description.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: The description of a semantic Class.
@@ -42,22 +42,6 @@ pub struct ClassDescription {
 
     /// The connections between keypoints.
     pub keypoint_connections: Vec<crate::datatypes::KeypointPair>,
-}
-
-impl ::re_types_core::SizeBytes for ClassDescription {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.info.heap_size_bytes()
-            + self.keypoint_annotations.heap_size_bytes()
-            + self.keypoint_connections.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::AnnotationInfo>::is_pod()
-            && <Vec<crate::datatypes::AnnotationInfo>>::is_pod()
-            && <Vec<crate::datatypes::KeypointPair>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ClassDescription);
@@ -473,5 +457,21 @@ impl ::re_types_core::Loggable for ClassDescription {
                 .with_context("rerun.datatypes.ClassDescription")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for ClassDescription {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.info.heap_size_bytes()
+            + self.keypoint_annotations.heap_size_bytes()
+            + self.keypoint_connections.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::AnnotationInfo>::is_pod()
+            && <Vec<crate::datatypes::AnnotationInfo>>::is_pod()
+            && <Vec<crate::datatypes::KeypointPair>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/class_description.rs
+++ b/crates/store/re_types/src/datatypes/class_description.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/store/re_types/src/datatypes/class_description_map_elem.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A helper type for mapping [`datatypes::ClassId`][crate::datatypes::ClassId]s to class descriptions.
@@ -28,18 +28,6 @@ pub struct ClassDescriptionMapElem {
 
     /// The value: class name, color, etc.
     pub class_description: crate::datatypes::ClassDescription,
-}
-
-impl ::re_types_core::SizeBytes for ClassDescriptionMapElem {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.class_id.heap_size_bytes() + self.class_description.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::ClassId>::is_pod() && <crate::datatypes::ClassDescription>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ClassDescriptionMapElem);
@@ -239,5 +227,17 @@ impl ::re_types_core::Loggable for ClassDescriptionMapElem {
                 .with_context("rerun.datatypes.ClassDescriptionMapElem")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for ClassDescriptionMapElem {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.class_id.heap_size_bytes() + self.class_description.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::ClassId>::is_pod() && <crate::datatypes::ClassDescription>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/class_description_map_elem.rs
+++ b/crates/store/re_types/src/datatypes/class_description_map_elem.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/class_id.rs
+++ b/crates/store/re_types/src/datatypes/class_id.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 16-bit ID representing a type of semantic class.
@@ -37,32 +37,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct ClassId(pub u16);
-
-impl ::re_types_core::SizeBytes for ClassId {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u16>::is_pod()
-    }
-}
-
-impl From<u16> for ClassId {
-    #[inline]
-    fn from(id: u16) -> Self {
-        Self(id)
-    }
-}
-
-impl From<ClassId> for u16 {
-    #[inline]
-    fn from(value: ClassId) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(ClassId);
 
@@ -172,5 +146,31 @@ impl ::re_types_core::Loggable for ClassId {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u16> for ClassId {
+    #[inline]
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
+impl From<ClassId> for u16 {
+    #[inline]
+    fn from(value: ClassId) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ClassId {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u16>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/class_id.rs
+++ b/crates/store/re_types/src/datatypes/class_id.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/color_model.rs
+++ b/crates/store/re_types/src/datatypes/color_model.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Specified what color components are present in an [`archetypes::Image`][crate::archetypes::Image].
@@ -44,48 +44,6 @@ pub enum ColorModel {
     /// Blue, Green, Red, Alpha
     #[allow(clippy::upper_case_acronyms)]
     BGRA = 5,
-}
-
-impl ::re_types_core::reflection::Enum for ColorModel {
-    #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::L, Self::RGB, Self::RGBA, Self::BGR, Self::BGRA]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::L => "Grayscale luminance intencity/brightness/value, sometimes called `Y`",
-            Self::RGB => "Red, Green, Blue",
-            Self::RGBA => "Red, Green, Blue, Alpha",
-            Self::BGR => "Blue, Green, Red",
-            Self::BGRA => "Blue, Green, Red, Alpha",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for ColorModel {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for ColorModel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::L => write!(f, "L"),
-            Self::RGB => write!(f, "RGB"),
-            Self::RGBA => write!(f, "RGBA"),
-            Self::BGR => write!(f, "BGR"),
-            Self::BGRA => write!(f, "BGRA"),
-        }
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ColorModel);
@@ -174,5 +132,47 @@ impl ::re_types_core::Loggable for ColorModel {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.datatypes.ColorModel")?)
+    }
+}
+
+impl std::fmt::Display for ColorModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::L => write!(f, "L"),
+            Self::RGB => write!(f, "RGB"),
+            Self::RGBA => write!(f, "RGBA"),
+            Self::BGR => write!(f, "BGR"),
+            Self::BGRA => write!(f, "BGRA"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for ColorModel {
+    #[inline]
+    fn variants() -> &'static [Self] {
+        &[Self::L, Self::RGB, Self::RGBA, Self::BGR, Self::BGRA]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::L => "Grayscale luminance intencity/brightness/value, sometimes called `Y`",
+            Self::RGB => "Red, Green, Blue",
+            Self::RGBA => "Red, Green, Blue, Alpha",
+            Self::BGR => "Blue, Green, Red",
+            Self::BGRA => "Blue, Green, Red, Alpha",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ColorModel {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/datatypes/color_model.rs
+++ b/crates/store/re_types/src/datatypes/color_model.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/dvec2d.rs
+++ b/crates/store/re_types/src/datatypes/dvec2d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A double-precision vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct DVec2D(pub [f64; 2usize]);
-
-impl ::re_types_core::SizeBytes for DVec2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f64; 2usize]>::is_pod()
-    }
-}
-
-impl From<[f64; 2usize]> for DVec2D {
-    #[inline]
-    fn from(xy: [f64; 2usize]) -> Self {
-        Self(xy)
-    }
-}
-
-impl From<DVec2D> for [f64; 2usize] {
-    #[inline]
-    fn from(value: DVec2D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(DVec2D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for DVec2D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f64; 2usize]> for DVec2D {
+    #[inline]
+    fn from(xy: [f64; 2usize]) -> Self {
+        Self(xy)
+    }
+}
+
+impl From<DVec2D> for [f64; 2usize] {
+    #[inline]
+    fn from(value: DVec2D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for DVec2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f64; 2usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/dvec2d.rs
+++ b/crates/store/re_types/src/datatypes/dvec2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/image_format.rs
+++ b/crates/store/re_types/src/datatypes/image_format.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: The metadata describing the contents of a [`components::ImageBuffer`][crate::components::ImageBuffer].
@@ -41,26 +41,6 @@ pub struct ImageFormat {
     ///
     /// Also requires a [`datatypes::ColorModel`][crate::datatypes::ColorModel] to fully specify the pixel format.
     pub channel_datatype: Option<crate::datatypes::ChannelDatatype>,
-}
-
-impl ::re_types_core::SizeBytes for ImageFormat {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.width.heap_size_bytes()
-            + self.height.heap_size_bytes()
-            + self.pixel_format.heap_size_bytes()
-            + self.color_model.heap_size_bytes()
-            + self.channel_datatype.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod()
-            && <u32>::is_pod()
-            && <Option<crate::datatypes::PixelFormat>>::is_pod()
-            && <Option<crate::datatypes::ColorModel>>::is_pod()
-            && <Option<crate::datatypes::ChannelDatatype>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ImageFormat);
@@ -387,5 +367,25 @@ impl ::re_types_core::Loggable for ImageFormat {
                 .with_context("rerun.datatypes.ImageFormat")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for ImageFormat {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.width.heap_size_bytes()
+            + self.height.heap_size_bytes()
+            + self.pixel_format.heap_size_bytes()
+            + self.color_model.heap_size_bytes()
+            + self.channel_datatype.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod()
+            && <u32>::is_pod()
+            && <Option<crate::datatypes::PixelFormat>>::is_pod()
+            && <Option<crate::datatypes::ColorModel>>::is_pod()
+            && <Option<crate::datatypes::ChannelDatatype>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/image_format.rs
+++ b/crates/store/re_types/src/datatypes/image_format.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_id.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 16-bit ID representing a type of semantic keypoint within a class.
@@ -39,32 +39,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 #[cfg_attr(feature = "serde", derive(::serde::Serialize, ::serde::Deserialize))]
 pub struct KeypointId(pub u16);
-
-impl ::re_types_core::SizeBytes for KeypointId {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u16>::is_pod()
-    }
-}
-
-impl From<u16> for KeypointId {
-    #[inline]
-    fn from(id: u16) -> Self {
-        Self(id)
-    }
-}
-
-impl From<KeypointId> for u16 {
-    #[inline]
-    fn from(value: KeypointId) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(KeypointId);
 
@@ -174,5 +148,31 @@ impl ::re_types_core::Loggable for KeypointId {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u16> for KeypointId {
+    #[inline]
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
+impl From<KeypointId> for u16 {
+    #[inline]
+    fn from(value: KeypointId) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for KeypointId {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u16>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/keypoint_id.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_id.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_pair.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A connection between two [`datatypes::KeypointId`][crate::datatypes::KeypointId]s.
@@ -26,18 +26,6 @@ pub struct KeypointPair {
 
     /// The second point of the pair.
     pub keypoint1: crate::datatypes::KeypointId,
-}
-
-impl ::re_types_core::SizeBytes for KeypointPair {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.keypoint0.heap_size_bytes() + self.keypoint1.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::KeypointId>::is_pod() && <crate::datatypes::KeypointId>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(KeypointPair);
@@ -248,5 +236,17 @@ impl ::re_types_core::Loggable for KeypointPair {
                 .with_context("rerun.datatypes.KeypointPair")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for KeypointPair {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.keypoint0.heap_size_bytes() + self.keypoint1.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::KeypointId>::is_pod() && <crate::datatypes::KeypointId>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/keypoint_pair.rs
+++ b/crates/store/re_types/src/datatypes/keypoint_pair.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/mat3x3.rs
+++ b/crates/store/re_types/src/datatypes/mat3x3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/mat3x3.rs
+++ b/crates/store/re_types/src/datatypes/mat3x3.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 3x3 Matrix.
@@ -34,32 +34,6 @@ pub struct Mat3x3(
     /// Flat list of matrix coefficients in column-major order.
     pub [f32; 9usize],
 );
-
-impl ::re_types_core::SizeBytes for Mat3x3 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 9usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 9usize]> for Mat3x3 {
-    #[inline]
-    fn from(flat_columns: [f32; 9usize]) -> Self {
-        Self(flat_columns)
-    }
-}
-
-impl From<Mat3x3> for [f32; 9usize] {
-    #[inline]
-    fn from(value: Mat3x3) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Mat3x3);
 
@@ -257,5 +231,31 @@ impl ::re_types_core::Loggable for Mat3x3 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 9usize]> for Mat3x3 {
+    #[inline]
+    fn from(flat_columns: [f32; 9usize]) -> Self {
+        Self(flat_columns)
+    }
+}
+
+impl From<Mat3x3> for [f32; 9usize] {
+    #[inline]
+    fn from(value: Mat3x3) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Mat3x3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 9usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/mat4x4.rs
+++ b/crates/store/re_types/src/datatypes/mat4x4.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/mat4x4.rs
+++ b/crates/store/re_types/src/datatypes/mat4x4.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 4x4 Matrix.
@@ -34,32 +34,6 @@ pub struct Mat4x4(
     /// Flat list of matrix coefficients in column-major order.
     pub [f32; 16usize],
 );
-
-impl ::re_types_core::SizeBytes for Mat4x4 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 16usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 16usize]> for Mat4x4 {
-    #[inline]
-    fn from(flat_columns: [f32; 16usize]) -> Self {
-        Self(flat_columns)
-    }
-}
-
-impl From<Mat4x4> for [f32; 16usize] {
-    #[inline]
-    fn from(value: Mat4x4) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Mat4x4);
 
@@ -257,5 +231,31 @@ impl ::re_types_core::Loggable for Mat4x4 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 16usize]> for Mat4x4 {
+    #[inline]
+    fn from(flat_columns: [f32; 16usize]) -> Self {
+        Self(flat_columns)
+    }
+}
+
+impl From<Mat4x4> for [f32; 16usize] {
+    #[inline]
+    fn from(value: Mat4x4) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Mat4x4 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 16usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/pixel_format.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/pixel_format.rs
+++ b/crates/store/re_types/src/datatypes/pixel_format.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Specifieds a particular format of an [`archetypes::Image`][crate::archetypes::Image].
@@ -125,89 +125,6 @@ pub enum PixelFormat {
     Y_U_V16_FullRange = 50,
 }
 
-impl ::re_types_core::reflection::Enum for PixelFormat {
-    #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::Y_U_V12_LimitedRange,
-            Self::NV12,
-            Self::YUY2,
-            Self::Y8_FullRange,
-            Self::Y_U_V24_LimitedRange,
-            Self::Y_U_V24_FullRange,
-            Self::Y8_LimitedRange,
-            Self::Y_U_V12_FullRange,
-            Self::Y_U_V16_LimitedRange,
-            Self::Y_U_V16_FullRange,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Y_U_V12_LimitedRange => {
-                "`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe resolution of the Y plane."
-            }
-            Self::NV12 => {
-                "`NV12` (aka `Y_UV12`) is a YUV 4:2:0 chroma downsampled form at with 12 bits per pixel and 8 bits per channel.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane,\nfollowed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc."
-            }
-            Self::YUY2 => {
-                "`YUY2` (aka `YUYV`, `YUYV16` or `NV21`), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nThe order of the channels is Y0, U0, Y1, V0, all in the same plane."
-            }
-            Self::Y8_FullRange => {
-                "Monochrome Y plane only, essentially a YUV 4:0:0 planar format.\n\nAlso known as just \"gray\". This is virtually identical to a 8bit luminance/grayscale (see [`datatypes::ColorModel`][crate::datatypes::ColorModel]).\n\nThis uses entire range YUV, i.e. Y is expected to be within [0, 255].\n(as opposed to \"limited range\" YUV as used e.g. in NV12)."
-            }
-            Self::Y_U_V24_LimitedRange => {
-                "`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes."
-            }
-            Self::Y_U_V24_FullRange => {
-                "`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes."
-            }
-            Self::Y8_LimitedRange => {
-                "Monochrome Y plane only, essentially a YUV 4:0:0 planar format.\n\nAlso known as just \"gray\".\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235].\nIf not for this range limitation/remapping, this is almost identical to 8bit luminace/grayscale (see [`datatypes::ColorModel`][crate::datatypes::ColorModel])."
-            }
-            Self::Y_U_V12_FullRange => {
-                "`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe resolution of the Y plane."
-            }
-            Self::Y_U_V16_LimitedRange => {
-                "`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe horizontal resolution of the Y plane."
-            }
-            Self::Y_U_V16_FullRange => {
-                "`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe horizontal resolution of the Y plane."
-            }
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for PixelFormat {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for PixelFormat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Y_U_V12_LimitedRange => write!(f, "Y_U_V12_LimitedRange"),
-            Self::NV12 => write!(f, "NV12"),
-            Self::YUY2 => write!(f, "YUY2"),
-            Self::Y8_FullRange => write!(f, "Y8_FullRange"),
-            Self::Y_U_V24_LimitedRange => write!(f, "Y_U_V24_LimitedRange"),
-            Self::Y_U_V24_FullRange => write!(f, "Y_U_V24_FullRange"),
-            Self::Y8_LimitedRange => write!(f, "Y8_LimitedRange"),
-            Self::Y_U_V12_FullRange => write!(f, "Y_U_V12_FullRange"),
-            Self::Y_U_V16_LimitedRange => write!(f, "Y_U_V16_LimitedRange"),
-            Self::Y_U_V16_FullRange => write!(f, "Y_U_V16_FullRange"),
-        }
-    }
-}
-
 ::re_types_core::macros::impl_into_cow!(PixelFormat);
 
 impl ::re_types_core::Loggable for PixelFormat {
@@ -299,5 +216,88 @@ impl ::re_types_core::Loggable for PixelFormat {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.datatypes.PixelFormat")?)
+    }
+}
+
+impl std::fmt::Display for PixelFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Y_U_V12_LimitedRange => write!(f, "Y_U_V12_LimitedRange"),
+            Self::NV12 => write!(f, "NV12"),
+            Self::YUY2 => write!(f, "YUY2"),
+            Self::Y8_FullRange => write!(f, "Y8_FullRange"),
+            Self::Y_U_V24_LimitedRange => write!(f, "Y_U_V24_LimitedRange"),
+            Self::Y_U_V24_FullRange => write!(f, "Y_U_V24_FullRange"),
+            Self::Y8_LimitedRange => write!(f, "Y8_LimitedRange"),
+            Self::Y_U_V12_FullRange => write!(f, "Y_U_V12_FullRange"),
+            Self::Y_U_V16_LimitedRange => write!(f, "Y_U_V16_LimitedRange"),
+            Self::Y_U_V16_FullRange => write!(f, "Y_U_V16_FullRange"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for PixelFormat {
+    #[inline]
+    fn variants() -> &'static [Self] {
+        &[
+            Self::Y_U_V12_LimitedRange,
+            Self::NV12,
+            Self::YUY2,
+            Self::Y8_FullRange,
+            Self::Y_U_V24_LimitedRange,
+            Self::Y_U_V24_FullRange,
+            Self::Y8_LimitedRange,
+            Self::Y_U_V12_FullRange,
+            Self::Y_U_V16_LimitedRange,
+            Self::Y_U_V16_FullRange,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Y_U_V12_LimitedRange => {
+                "`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe resolution of the Y plane."
+            }
+            Self::NV12 => {
+                "`NV12` (aka `Y_UV12`) is a YUV 4:2:0 chroma downsampled form at with 12 bits per pixel and 8 bits per channel.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane,\nfollowed by a plane with interleaved lines ordered as U0, V0, U1, V1, etc."
+            }
+            Self::YUY2 => {
+                "`YUY2` (aka `YUYV`, `YUYV16` or `NV21`), is a YUV 4:2:2 chroma downsampled format with 16 bits per pixel and 8 bits per channel.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nThe order of the channels is Y0, U0, Y1, V0, all in the same plane."
+            }
+            Self::Y8_FullRange => {
+                "Monochrome Y plane only, essentially a YUV 4:0:0 planar format.\n\nAlso known as just \"gray\". This is virtually identical to a 8bit luminance/grayscale (see [`datatypes::ColorModel`][crate::datatypes::ColorModel]).\n\nThis uses entire range YUV, i.e. Y is expected to be within [0, 255].\n(as opposed to \"limited range\" YUV as used e.g. in NV12)."
+            }
+            Self::Y_U_V24_LimitedRange => {
+                "`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes."
+            }
+            Self::Y_U_V24_FullRange => {
+                "`Y_U_V24` is a YUV 4:4:4 fully planar YUV format without chroma downsampling, also known as `I444`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes."
+            }
+            Self::Y8_LimitedRange => {
+                "Monochrome Y plane only, essentially a YUV 4:0:0 planar format.\n\nAlso known as just \"gray\".\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235].\nIf not for this range limitation/remapping, this is almost identical to 8bit luminace/grayscale (see [`datatypes::ColorModel`][crate::datatypes::ColorModel])."
+            }
+            Self::Y_U_V12_FullRange => {
+                "`Y_U_V12` is a YUV 4:2:0 fully planar YUV format without chroma downsampling, also known as `I420`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe resolution of the Y plane."
+            }
+            Self::Y_U_V16_LimitedRange => {
+                "`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.\n\nThis uses limited range YUV, i.e. Y is expected to be within [16, 235] and U/V within [16, 240].\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe horizontal resolution of the Y plane."
+            }
+            Self::Y_U_V16_FullRange => {
+                "`Y_U_V16` is a YUV 4:2:2 fully planar YUV format without chroma downsampling, also known as `I422`.\n\nThis uses full range YUV with all components ranging from 0 to 255\n(as opposed to \"limited range\" YUV as used e.g. in NV12).\n\nFirst comes entire image in Y in one plane, followed by the U and V planes, which each only have half\nthe horizontal resolution of the Y plane."
+            }
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for PixelFormat {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/datatypes/plane3d.rs
+++ b/crates/store/re_types/src/datatypes/plane3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/plane3d.rs
+++ b/crates/store/re_types/src/datatypes/plane3d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: An infinite 3D plane represented by a unit normal vector and a distance.
@@ -30,32 +30,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Plane3D(pub [f32; 4usize]);
-
-impl ::re_types_core::SizeBytes for Plane3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 4usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 4usize]> for Plane3D {
-    #[inline]
-    fn from(xyzd: [f32; 4usize]) -> Self {
-        Self(xyzd)
-    }
-}
-
-impl From<Plane3D> for [f32; 4usize] {
-    #[inline]
-    fn from(value: Plane3D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Plane3D);
 
@@ -253,5 +227,31 @@ impl ::re_types_core::Loggable for Plane3D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 4usize]> for Plane3D {
+    #[inline]
+    fn from(xyzd: [f32; 4usize]) -> Self {
+        Self(xyzd)
+    }
+}
+
+impl From<Plane3D> for [f32; 4usize] {
+    #[inline]
+    fn from(value: Plane3D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Plane3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 4usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/quaternion.rs
+++ b/crates/store/re_types/src/datatypes/quaternion.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A Quaternion represented by 4 real numbers.
@@ -25,32 +25,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[derive(Clone, Debug, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Quaternion(pub [f32; 4usize]);
-
-impl ::re_types_core::SizeBytes for Quaternion {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 4usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 4usize]> for Quaternion {
-    #[inline]
-    fn from(xyzw: [f32; 4usize]) -> Self {
-        Self(xyzw)
-    }
-}
-
-impl From<Quaternion> for [f32; 4usize] {
-    #[inline]
-    fn from(value: Quaternion) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Quaternion);
 
@@ -248,5 +222,31 @@ impl ::re_types_core::Loggable for Quaternion {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 4usize]> for Quaternion {
+    #[inline]
+    fn from(xyzw: [f32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<Quaternion> for [f32; 4usize] {
+    #[inline]
+    fn from(value: Quaternion) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Quaternion {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 4usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/quaternion.rs
+++ b/crates/store/re_types/src/datatypes/quaternion.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/range1d.rs
+++ b/crates/store/re_types/src/datatypes/range1d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/range1d.rs
+++ b/crates/store/re_types/src/datatypes/range1d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 1D range, specifying a lower and upper bound.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Range1D(pub [f64; 2usize]);
-
-impl ::re_types_core::SizeBytes for Range1D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f64; 2usize]>::is_pod()
-    }
-}
-
-impl From<[f64; 2usize]> for Range1D {
-    #[inline]
-    fn from(range: [f64; 2usize]) -> Self {
-        Self(range)
-    }
-}
-
-impl From<Range1D> for [f64; 2usize] {
-    #[inline]
-    fn from(value: Range1D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Range1D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for Range1D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f64; 2usize]> for Range1D {
+    #[inline]
+    fn from(range: [f64; 2usize]) -> Self {
+        Self(range)
+    }
+}
+
+impl From<Range1D> for [f64; 2usize] {
+    #[inline]
+    fn from(value: Range1D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Range1D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f64; 2usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/range2d.rs
+++ b/crates/store/re_types/src/datatypes/range2d.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: An Axis-Aligned Bounding Box in 2D space, implemented as the minimum and maximum corners.
@@ -27,18 +27,6 @@ pub struct Range2D {
 
     /// The range of the Y-axis (usually top and bottom bounds).
     pub y_range: crate::datatypes::Range1D,
-}
-
-impl ::re_types_core::SizeBytes for Range2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.x_range.heap_size_bytes() + self.y_range.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Range1D>::is_pod() && <crate::datatypes::Range1D>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(Range2D);
@@ -403,5 +391,17 @@ impl ::re_types_core::Loggable for Range2D {
                 .with_context("rerun.datatypes.Range2D")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for Range2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.x_range.heap_size_bytes() + self.y_range.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Range1D>::is_pod() && <crate::datatypes::Range1D>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/range2d.rs
+++ b/crates/store/re_types/src/datatypes/range2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/rgba32.rs
+++ b/crates/store/re_types/src/datatypes/rgba32.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
@@ -27,32 +27,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 )]
 #[repr(transparent)]
 pub struct Rgba32(pub u32);
-
-impl ::re_types_core::SizeBytes for Rgba32 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod()
-    }
-}
-
-impl From<u32> for Rgba32 {
-    #[inline]
-    fn from(rgba: u32) -> Self {
-        Self(rgba)
-    }
-}
-
-impl From<Rgba32> for u32 {
-    #[inline]
-    fn from(value: Rgba32) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Rgba32);
 
@@ -162,5 +136,31 @@ impl ::re_types_core::Loggable for Rgba32 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u32> for Rgba32 {
+    #[inline]
+    fn from(rgba: u32) -> Self {
+        Self(rgba)
+    }
+}
+
+impl From<Rgba32> for u32 {
+    #[inline]
+    fn from(value: Rgba32) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Rgba32 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/rgba32.rs
+++ b/crates/store/re_types/src/datatypes/rgba32.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: 3D rotation represented by a rotation around a given axis.
@@ -30,18 +30,6 @@ pub struct RotationAxisAngle {
 
     /// How much to rotate around the axis.
     pub angle: crate::datatypes::Angle,
-}
-
-impl ::re_types_core::SizeBytes for RotationAxisAngle {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.axis.heap_size_bytes() + self.angle.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Vec3D>::is_pod() && <crate::datatypes::Angle>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(RotationAxisAngle);
@@ -316,5 +304,17 @@ impl ::re_types_core::Loggable for RotationAxisAngle {
                 .with_context("rerun.datatypes.RotationAxisAngle")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for RotationAxisAngle {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.axis.heap_size_bytes() + self.angle.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Vec3D>::is_pod() && <crate::datatypes::Angle>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
+++ b/crates/store/re_types/src/datatypes/rotation_axis_angle.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: The underlying storage for [`archetypes::Tensor`][crate::archetypes::Tensor].
@@ -55,41 +55,6 @@ pub enum TensorBuffer {
 
     /// 64bit IEEE-754 floating point, also known as `double`.
     F64(::re_types_core::ArrowBuffer<f64>),
-}
-
-impl ::re_types_core::SizeBytes for TensorBuffer {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        #![allow(clippy::match_same_arms)]
-        match self {
-            Self::U8(v) => v.heap_size_bytes(),
-            Self::U16(v) => v.heap_size_bytes(),
-            Self::U32(v) => v.heap_size_bytes(),
-            Self::U64(v) => v.heap_size_bytes(),
-            Self::I8(v) => v.heap_size_bytes(),
-            Self::I16(v) => v.heap_size_bytes(),
-            Self::I32(v) => v.heap_size_bytes(),
-            Self::I64(v) => v.heap_size_bytes(),
-            Self::F16(v) => v.heap_size_bytes(),
-            Self::F32(v) => v.heap_size_bytes(),
-            Self::F64(v) => v.heap_size_bytes(),
-        }
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <::re_types_core::ArrowBuffer<u8>>::is_pod()
-            && <::re_types_core::ArrowBuffer<u16>>::is_pod()
-            && <::re_types_core::ArrowBuffer<u32>>::is_pod()
-            && <::re_types_core::ArrowBuffer<u64>>::is_pod()
-            && <::re_types_core::ArrowBuffer<i8>>::is_pod()
-            && <::re_types_core::ArrowBuffer<i16>>::is_pod()
-            && <::re_types_core::ArrowBuffer<i32>>::is_pod()
-            && <::re_types_core::ArrowBuffer<i64>>::is_pod()
-            && <::re_types_core::ArrowBuffer<half::f16>>::is_pod()
-            && <::re_types_core::ArrowBuffer<f32>>::is_pod()
-            && <::re_types_core::ArrowBuffer<f64>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorBuffer);
@@ -1762,5 +1727,40 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .with_context("rerun.datatypes.TensorBuffer")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorBuffer {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        #![allow(clippy::match_same_arms)]
+        match self {
+            Self::U8(v) => v.heap_size_bytes(),
+            Self::U16(v) => v.heap_size_bytes(),
+            Self::U32(v) => v.heap_size_bytes(),
+            Self::U64(v) => v.heap_size_bytes(),
+            Self::I8(v) => v.heap_size_bytes(),
+            Self::I16(v) => v.heap_size_bytes(),
+            Self::I32(v) => v.heap_size_bytes(),
+            Self::I64(v) => v.heap_size_bytes(),
+            Self::F16(v) => v.heap_size_bytes(),
+            Self::F32(v) => v.heap_size_bytes(),
+            Self::F64(v) => v.heap_size_bytes(),
+        }
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <::re_types_core::ArrowBuffer<u8>>::is_pod()
+            && <::re_types_core::ArrowBuffer<u16>>::is_pod()
+            && <::re_types_core::ArrowBuffer<u32>>::is_pod()
+            && <::re_types_core::ArrowBuffer<u64>>::is_pod()
+            && <::re_types_core::ArrowBuffer<i8>>::is_pod()
+            && <::re_types_core::ArrowBuffer<i16>>::is_pod()
+            && <::re_types_core::ArrowBuffer<i32>>::is_pod()
+            && <::re_types_core::ArrowBuffer<i64>>::is_pod()
+            && <::re_types_core::ArrowBuffer<half::f16>>::is_pod()
+            && <::re_types_core::ArrowBuffer<f32>>::is_pod()
+            && <::re_types_core::ArrowBuffer<f64>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/tensor_data.rs
+++ b/crates/store/re_types/src/datatypes/tensor_data.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/tensor_data.rs
+++ b/crates/store/re_types/src/datatypes/tensor_data.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: An N-dimensional array of numbers.
@@ -33,19 +33,6 @@ pub struct TensorData {
 
     /// The content/data.
     pub buffer: crate::datatypes::TensorBuffer,
-}
-
-impl ::re_types_core::SizeBytes for TensorData {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.shape.heap_size_bytes() + self.buffer.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::datatypes::TensorDimension>>::is_pod()
-            && <crate::datatypes::TensorBuffer>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorData);
@@ -310,5 +297,18 @@ impl ::re_types_core::Loggable for TensorData {
                 .with_context("rerun.datatypes.TensorData")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorData {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.shape.heap_size_bytes() + self.buffer.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::datatypes::TensorDimension>>::is_pod()
+            && <crate::datatypes::TensorBuffer>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A single dimension within a multi-dimensional tensor.
@@ -26,18 +26,6 @@ pub struct TensorDimension {
 
     /// The name of this dimension, e.g. "width", "height", "channel", "batch', ….
     pub name: Option<::re_types_core::ArrowString>,
-}
-
-impl ::re_types_core::SizeBytes for TensorDimension {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.size.heap_size_bytes() + self.name.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u64>::is_pod() && <Option<::re_types_core::ArrowString>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorDimension);
@@ -263,5 +251,17 @@ impl ::re_types_core::Loggable for TensorDimension {
                 .with_context("rerun.datatypes.TensorDimension")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimension {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.size.heap_size_bytes() + self.name.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u64>::is_pod() && <Option<::re_types_core::ArrowString>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Indexing a specific tensor dimension.
@@ -28,18 +28,6 @@ pub struct TensorDimensionIndexSelection {
 
     /// The index along the dimension to use.
     pub index: u64,
-}
-
-impl ::re_types_core::SizeBytes for TensorDimensionIndexSelection {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.dimension.heap_size_bytes() + self.index.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod() && <u64>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorDimensionIndexSelection);
@@ -236,5 +224,17 @@ impl ::re_types_core::Loggable for TensorDimensionIndexSelection {
                 .with_context("rerun.datatypes.TensorDimensionIndexSelection")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimensionIndexSelection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.dimension.heap_size_bytes() + self.index.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod() && <u64>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_index_selection.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Selection of a single tensor dimension.
@@ -26,18 +26,6 @@ pub struct TensorDimensionSelection {
 
     /// Invert the direction of the dimension.
     pub invert: bool,
-}
-
-impl ::re_types_core::SizeBytes for TensorDimensionSelection {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.dimension.heap_size_bytes() + self.invert.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod() && <bool>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(TensorDimensionSelection);
@@ -231,5 +219,17 @@ impl ::re_types_core::Loggable for TensorDimensionSelection {
                 .with_context("rerun.datatypes.TensorDimensionSelection")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for TensorDimensionSelection {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.dimension.heap_size_bytes() + self.invert.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod() && <bool>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension_selection.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/utf8pair.rs
+++ b/crates/store/re_types/src/datatypes/utf8pair.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Stores a tuple of UTF-8 strings.
@@ -26,18 +26,6 @@ pub struct Utf8Pair {
 
     /// The second string.
     pub second: crate::datatypes::Utf8,
-}
-
-impl ::re_types_core::SizeBytes for Utf8Pair {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.first.heap_size_bytes() + self.second.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod() && <crate::datatypes::Utf8>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(Utf8Pair);
@@ -312,5 +300,17 @@ impl ::re_types_core::Loggable for Utf8Pair {
                 .with_context("rerun.datatypes.Utf8Pair")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for Utf8Pair {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.first.heap_size_bytes() + self.second.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod() && <crate::datatypes::Utf8>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/utf8pair.rs
+++ b/crates/store/re_types/src/datatypes/utf8pair.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/uuid.rs
+++ b/crates/store/re_types/src/datatypes/uuid.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 16-byte UUID.
@@ -24,32 +24,6 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 pub struct Uuid {
     /// The raw bytes representing the UUID.
     pub bytes: [u8; 16usize],
-}
-
-impl ::re_types_core::SizeBytes for Uuid {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.bytes.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u8; 16usize]>::is_pod()
-    }
-}
-
-impl From<[u8; 16usize]> for Uuid {
-    #[inline]
-    fn from(bytes: [u8; 16usize]) -> Self {
-        Self { bytes }
-    }
-}
-
-impl From<Uuid> for [u8; 16usize] {
-    #[inline]
-    fn from(value: Uuid) -> Self {
-        value.bytes
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(Uuid);
@@ -252,5 +226,31 @@ impl ::re_types_core::Loggable for Uuid {
                     .collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[u8; 16usize]> for Uuid {
+    #[inline]
+    fn from(bytes: [u8; 16usize]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl From<Uuid> for [u8; 16usize] {
+    #[inline]
+    fn from(value: Uuid) -> Self {
+        value.bytes
+    }
+}
+
+impl ::re_types_core::SizeBytes for Uuid {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.bytes.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u8; 16usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/uuid.rs
+++ b/crates/store/re_types/src/datatypes/uuid.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/uvec2d.rs
+++ b/crates/store/re_types/src/datatypes/uvec2d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A uint32 vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec2D(pub [u32; 2usize]);
-
-impl ::re_types_core::SizeBytes for UVec2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u32; 2usize]>::is_pod()
-    }
-}
-
-impl From<[u32; 2usize]> for UVec2D {
-    #[inline]
-    fn from(xy: [u32; 2usize]) -> Self {
-        Self(xy)
-    }
-}
-
-impl From<UVec2D> for [u32; 2usize] {
-    #[inline]
-    fn from(value: UVec2D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(UVec2D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for UVec2D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[u32; 2usize]> for UVec2D {
+    #[inline]
+    fn from(xy: [u32; 2usize]) -> Self {
+        Self(xy)
+    }
+}
+
+impl From<UVec2D> for [u32; 2usize] {
+    #[inline]
+    fn from(value: UVec2D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for UVec2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u32; 2usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/uvec2d.rs
+++ b/crates/store/re_types/src/datatypes/uvec2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/uvec3d.rs
+++ b/crates/store/re_types/src/datatypes/uvec3d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A uint32 vector in 3D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec3D(pub [u32; 3usize]);
-
-impl ::re_types_core::SizeBytes for UVec3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u32; 3usize]>::is_pod()
-    }
-}
-
-impl From<[u32; 3usize]> for UVec3D {
-    #[inline]
-    fn from(xyz: [u32; 3usize]) -> Self {
-        Self(xyz)
-    }
-}
-
-impl From<UVec3D> for [u32; 3usize] {
-    #[inline]
-    fn from(value: UVec3D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(UVec3D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for UVec3D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[u32; 3usize]> for UVec3D {
+    #[inline]
+    fn from(xyz: [u32; 3usize]) -> Self {
+        Self(xyz)
+    }
+}
+
+impl From<UVec3D> for [u32; 3usize] {
+    #[inline]
+    fn from(value: UVec3D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for UVec3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u32; 3usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/uvec3d.rs
+++ b/crates/store/re_types/src/datatypes/uvec3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/uvec4d.rs
+++ b/crates/store/re_types/src/datatypes/uvec4d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A uint vector in 4D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, Hash, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct UVec4D(pub [u32; 4usize]);
-
-impl ::re_types_core::SizeBytes for UVec4D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u32; 4usize]>::is_pod()
-    }
-}
-
-impl From<[u32; 4usize]> for UVec4D {
-    #[inline]
-    fn from(xyzw: [u32; 4usize]) -> Self {
-        Self(xyzw)
-    }
-}
-
-impl From<UVec4D> for [u32; 4usize] {
-    #[inline]
-    fn from(value: UVec4D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(UVec4D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for UVec4D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[u32; 4usize]> for UVec4D {
+    #[inline]
+    fn from(xyzw: [u32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<UVec4D> for [u32; 4usize] {
+    #[inline]
+    fn from(value: UVec4D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for UVec4D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u32; 4usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/uvec4d.rs
+++ b/crates/store/re_types/src/datatypes/uvec4d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/vec2d.rs
+++ b/crates/store/re_types/src/datatypes/vec2d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/vec2d.rs
+++ b/crates/store/re_types/src/datatypes/vec2d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A vector in 2D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec2D(pub [f32; 2usize]);
-
-impl ::re_types_core::SizeBytes for Vec2D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 2usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 2usize]> for Vec2D {
-    #[inline]
-    fn from(xy: [f32; 2usize]) -> Self {
-        Self(xy)
-    }
-}
-
-impl From<Vec2D> for [f32; 2usize] {
-    #[inline]
-    fn from(value: Vec2D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Vec2D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for Vec2D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 2usize]> for Vec2D {
+    #[inline]
+    fn from(xy: [f32; 2usize]) -> Self {
+        Self(xy)
+    }
+}
+
+impl From<Vec2D> for [f32; 2usize] {
+    #[inline]
+    fn from(value: Vec2D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Vec2D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 2usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/vec3d.rs
+++ b/crates/store/re_types/src/datatypes/vec3d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/vec3d.rs
+++ b/crates/store/re_types/src/datatypes/vec3d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A vector in 3D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec3D(pub [f32; 3usize]);
-
-impl ::re_types_core::SizeBytes for Vec3D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 3usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 3usize]> for Vec3D {
-    #[inline]
-    fn from(xyz: [f32; 3usize]) -> Self {
-        Self(xyz)
-    }
-}
-
-impl From<Vec3D> for [f32; 3usize] {
-    #[inline]
-    fn from(value: Vec3D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Vec3D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for Vec3D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 3usize]> for Vec3D {
+    #[inline]
+    fn from(xyz: [f32; 3usize]) -> Self {
+        Self(xyz)
+    }
+}
+
+impl From<Vec3D> for [f32; 3usize] {
+    #[inline]
+    fn from(value: Vec3D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Vec3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 3usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/vec4d.rs
+++ b/crates/store/re_types/src/datatypes/vec4d.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/vec4d.rs
+++ b/crates/store/re_types/src/datatypes/vec4d.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A vector in 4D space.
 #[derive(Clone, Debug, Default, Copy, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
 pub struct Vec4D(pub [f32; 4usize]);
-
-impl ::re_types_core::SizeBytes for Vec4D {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[f32; 4usize]>::is_pod()
-    }
-}
-
-impl From<[f32; 4usize]> for Vec4D {
-    #[inline]
-    fn from(xyzw: [f32; 4usize]) -> Self {
-        Self(xyzw)
-    }
-}
-
-impl From<Vec4D> for [f32; 4usize] {
-    #[inline]
-    fn from(value: Vec4D) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Vec4D);
 
@@ -245,5 +219,31 @@ impl ::re_types_core::Loggable for Vec4D {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[f32; 4usize]> for Vec4D {
+    #[inline]
+    fn from(xyzw: [f32; 4usize]) -> Self {
+        Self(xyzw)
+    }
+}
+
+impl From<Vec4D> for [f32; 4usize] {
+    #[inline]
+    fn from(value: Vec4D) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Vec4D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[f32; 4usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/video_timestamp.rs
+++ b/crates/store/re_types/src/datatypes/video_timestamp.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Presentation timestamp within a [`archetypes::AssetVideo`][crate::archetypes::AssetVideo].
@@ -27,32 +27,6 @@ pub struct VideoTimestamp(
     /// Presentation timestamp value in nanoseconds.
     pub i64,
 );
-
-impl ::re_types_core::SizeBytes for VideoTimestamp {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <i64>::is_pod()
-    }
-}
-
-impl From<i64> for VideoTimestamp {
-    #[inline]
-    fn from(timestamp_ns: i64) -> Self {
-        Self(timestamp_ns)
-    }
-}
-
-impl From<VideoTimestamp> for i64 {
-    #[inline]
-    fn from(value: VideoTimestamp) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(VideoTimestamp);
 
@@ -162,5 +136,31 @@ impl ::re_types_core::Loggable for VideoTimestamp {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<i64> for VideoTimestamp {
+    #[inline]
+    fn from(timestamp_ns: i64) -> Self {
+        Self(timestamp_ns)
+    }
+}
+
+impl From<VideoTimestamp> for i64 {
+    #[inline]
+    fn from(value: VideoTimestamp) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for VideoTimestamp {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <i64>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/video_timestamp.rs
+++ b/crates/store/re_types/src/datatypes/video_timestamp.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/datatypes/view_coordinates.rs
+++ b/crates/store/re_types/src/datatypes/view_coordinates.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: How we interpret the coordinate system of an entity/space.
@@ -42,32 +42,6 @@ pub struct ViewCoordinates(
     /// The directions of the [x, y, z] axes.
     pub [u8; 3usize],
 );
-
-impl ::re_types_core::SizeBytes for ViewCoordinates {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u8; 3usize]>::is_pod()
-    }
-}
-
-impl From<[u8; 3usize]> for ViewCoordinates {
-    #[inline]
-    fn from(coordinates: [u8; 3usize]) -> Self {
-        Self(coordinates)
-    }
-}
-
-impl From<ViewCoordinates> for [u8; 3usize] {
-    #[inline]
-    fn from(value: ViewCoordinates) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(ViewCoordinates);
 
@@ -265,5 +239,31 @@ impl ::re_types_core::Loggable for ViewCoordinates {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<[u8; 3usize]> for ViewCoordinates {
+    #[inline]
+    fn from(coordinates: [u8; 3usize]) -> Self {
+        Self(coordinates)
+    }
+}
+
+impl From<ViewCoordinates> for [u8; 3usize] {
+    #[inline]
+    fn from(value: ViewCoordinates) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewCoordinates {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u8; 3usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/datatypes/view_coordinates.rs
+++ b/crates/store/re_types/src/datatypes/view_coordinates.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -44,120 +44,252 @@ pub struct AffixFuzzer1 {
     pub fuzz1022: crate::testing::components::AffixFuzzer22,
 }
 
-impl ::re_types_core::SizeBytes for AffixFuzzer1 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.fuzz1001.heap_size_bytes()
-            + self.fuzz1002.heap_size_bytes()
-            + self.fuzz1003.heap_size_bytes()
-            + self.fuzz1004.heap_size_bytes()
-            + self.fuzz1005.heap_size_bytes()
-            + self.fuzz1006.heap_size_bytes()
-            + self.fuzz1007.heap_size_bytes()
-            + self.fuzz1008.heap_size_bytes()
-            + self.fuzz1009.heap_size_bytes()
-            + self.fuzz1010.heap_size_bytes()
-            + self.fuzz1011.heap_size_bytes()
-            + self.fuzz1012.heap_size_bytes()
-            + self.fuzz1013.heap_size_bytes()
-            + self.fuzz1014.heap_size_bytes()
-            + self.fuzz1015.heap_size_bytes()
-            + self.fuzz1016.heap_size_bytes()
-            + self.fuzz1017.heap_size_bytes()
-            + self.fuzz1018.heap_size_bytes()
-            + self.fuzz1019.heap_size_bytes()
-            + self.fuzz1020.heap_size_bytes()
-            + self.fuzz1021.heap_size_bytes()
-            + self.fuzz1022.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::components::AffixFuzzer1>::is_pod()
-            && <crate::testing::components::AffixFuzzer2>::is_pod()
-            && <crate::testing::components::AffixFuzzer3>::is_pod()
-            && <crate::testing::components::AffixFuzzer4>::is_pod()
-            && <crate::testing::components::AffixFuzzer5>::is_pod()
-            && <crate::testing::components::AffixFuzzer6>::is_pod()
-            && <crate::testing::components::AffixFuzzer7>::is_pod()
-            && <crate::testing::components::AffixFuzzer8>::is_pod()
-            && <crate::testing::components::AffixFuzzer9>::is_pod()
-            && <crate::testing::components::AffixFuzzer10>::is_pod()
-            && <crate::testing::components::AffixFuzzer11>::is_pod()
-            && <crate::testing::components::AffixFuzzer12>::is_pod()
-            && <crate::testing::components::AffixFuzzer13>::is_pod()
-            && <crate::testing::components::AffixFuzzer14>::is_pod()
-            && <crate::testing::components::AffixFuzzer15>::is_pod()
-            && <crate::testing::components::AffixFuzzer16>::is_pod()
-            && <crate::testing::components::AffixFuzzer17>::is_pod()
-            && <crate::testing::components::AffixFuzzer18>::is_pod()
-            && <crate::testing::components::AffixFuzzer19>::is_pod()
-            && <crate::testing::components::AffixFuzzer20>::is_pod()
-            && <crate::testing::components::AffixFuzzer21>::is_pod()
-            && <crate::testing::components::AffixFuzzer22>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 22usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 22usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer19".into(),
-            "rerun.testing.components.AffixFuzzer20".into(),
-            "rerun.testing.components.AffixFuzzer21".into(),
-            "rerun.testing.components.AffixFuzzer22".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz1001".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz1002".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz1003".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz1004".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz1005".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz1006".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz1007".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz1008".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz1009".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz1010".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz1011".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz1012".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz1013".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz1014".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz1015".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz1016".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz1017".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz1018".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer19".into(),
+                archetype_field_name: Some("fuzz1019".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer20".into(),
+                archetype_field_name: Some("fuzz1020".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer21".into(),
+                archetype_field_name: Some("fuzz1021".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer22".into(),
+                archetype_field_name: Some("fuzz1022".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer1Indicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+            component_name: "AffixFuzzer1Indicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 23usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 23usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer19".into(),
-            "rerun.testing.components.AffixFuzzer20".into(),
-            "rerun.testing.components.AffixFuzzer21".into(),
-            "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer1Indicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz1001".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz1002".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz1003".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz1004".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz1005".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz1006".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz1007".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz1008".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz1009".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz1010".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz1011".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz1012".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz1013".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz1014".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz1015".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz1016".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz1017".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz1018".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer19".into(),
+                archetype_field_name: Some("fuzz1019".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer20".into(),
+                archetype_field_name: Some("fuzz1020".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer21".into(),
+                archetype_field_name: Some("fuzz1021".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "rerun.testing.components.AffixFuzzer22".into(),
+                archetype_field_name: Some("fuzz1022".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                component_name: "AffixFuzzer1Indicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -185,26 +317,26 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AffixFuzzer1Indicator = AffixFuzzer1Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -537,28 +669,226 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.fuzz1001 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1002 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1003 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1004 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1005 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1006 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1007 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1008 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1009 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1010 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1011 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1012 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1013 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1014 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1015 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1016 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1017 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1018 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1019 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1020 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1021 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1022 as &dyn ComponentBatch).into()),
+            (Some(&self.fuzz1001 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1001").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer1").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1002 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1002").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer2").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1003 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1003").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer3").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1004 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1004").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer4").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1005 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1005").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer5").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1006 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1006").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer6").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1007 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1007").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer7").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1008 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1008").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer8").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1009 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1009").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer9").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1010 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1010").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer10").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1011 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1011").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer11").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1012 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1012").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer12").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1013 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1013").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer13").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1014 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1014").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer14").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1015 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1015").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer15").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1016 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1016").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer16").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1017 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1017").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer17").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1018 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1018").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer18").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1019 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1019").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer19").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1020 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1020").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer20").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1021 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1021").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer21").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1022 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
+                        archetype_field_name: Some(("fuzz1022").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer22").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -619,5 +949,59 @@ impl AffixFuzzer1 {
             fuzz1021: fuzz1021.into(),
             fuzz1022: fuzz1022.into(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer1 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.fuzz1001.heap_size_bytes()
+            + self.fuzz1002.heap_size_bytes()
+            + self.fuzz1003.heap_size_bytes()
+            + self.fuzz1004.heap_size_bytes()
+            + self.fuzz1005.heap_size_bytes()
+            + self.fuzz1006.heap_size_bytes()
+            + self.fuzz1007.heap_size_bytes()
+            + self.fuzz1008.heap_size_bytes()
+            + self.fuzz1009.heap_size_bytes()
+            + self.fuzz1010.heap_size_bytes()
+            + self.fuzz1011.heap_size_bytes()
+            + self.fuzz1012.heap_size_bytes()
+            + self.fuzz1013.heap_size_bytes()
+            + self.fuzz1014.heap_size_bytes()
+            + self.fuzz1015.heap_size_bytes()
+            + self.fuzz1016.heap_size_bytes()
+            + self.fuzz1017.heap_size_bytes()
+            + self.fuzz1018.heap_size_bytes()
+            + self.fuzz1019.heap_size_bytes()
+            + self.fuzz1020.heap_size_bytes()
+            + self.fuzz1021.heap_size_bytes()
+            + self.fuzz1022.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::components::AffixFuzzer1>::is_pod()
+            && <crate::testing::components::AffixFuzzer2>::is_pod()
+            && <crate::testing::components::AffixFuzzer3>::is_pod()
+            && <crate::testing::components::AffixFuzzer4>::is_pod()
+            && <crate::testing::components::AffixFuzzer5>::is_pod()
+            && <crate::testing::components::AffixFuzzer6>::is_pod()
+            && <crate::testing::components::AffixFuzzer7>::is_pod()
+            && <crate::testing::components::AffixFuzzer8>::is_pod()
+            && <crate::testing::components::AffixFuzzer9>::is_pod()
+            && <crate::testing::components::AffixFuzzer10>::is_pod()
+            && <crate::testing::components::AffixFuzzer11>::is_pod()
+            && <crate::testing::components::AffixFuzzer12>::is_pod()
+            && <crate::testing::components::AffixFuzzer13>::is_pod()
+            && <crate::testing::components::AffixFuzzer14>::is_pod()
+            && <crate::testing::components::AffixFuzzer15>::is_pod()
+            && <crate::testing::components::AffixFuzzer16>::is_pod()
+            && <crate::testing::components::AffixFuzzer17>::is_pod()
+            && <crate::testing::components::AffixFuzzer18>::is_pod()
+            && <crate::testing::components::AffixFuzzer19>::is_pod()
+            && <crate::testing::components::AffixFuzzer20>::is_pod()
+            && <crate::testing::components::AffixFuzzer21>::is_pod()
+            && <crate::testing::components::AffixFuzzer22>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -315,9 +315,9 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AffixFuzzer1Indicator = AffixFuzzer1Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -664,13 +664,13 @@ impl ::re_types_core::Archetype for AffixFuzzer1 {
 }
 
 impl ::re_types_core::AsComponents for AffixFuzzer1 {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.fuzz1001 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -680,7 +680,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1002 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -690,7 +690,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1003 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -700,7 +700,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1004 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -710,7 +710,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1005 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -720,7 +720,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1006 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -730,7 +730,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1007 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -740,7 +740,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1008 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -750,7 +750,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1009 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -760,7 +760,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1010 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -770,7 +770,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1011 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -780,7 +780,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1012 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -790,7 +790,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1013 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -800,7 +800,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1014 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -810,7 +810,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1015 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -820,7 +820,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1016 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -830,7 +830,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1017 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -840,7 +840,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1018 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -850,7 +850,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1019 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -860,7 +860,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1020 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -870,7 +870,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1021 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
@@ -880,7 +880,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer1 {
                 }
             }),
             (Some(&self.fuzz1022 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -41,108 +41,222 @@ pub struct AffixFuzzer2 {
     pub fuzz1122: Vec<crate::testing::components::AffixFuzzer22>,
 }
 
-impl ::re_types_core::SizeBytes for AffixFuzzer2 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.fuzz1101.heap_size_bytes()
-            + self.fuzz1102.heap_size_bytes()
-            + self.fuzz1103.heap_size_bytes()
-            + self.fuzz1104.heap_size_bytes()
-            + self.fuzz1105.heap_size_bytes()
-            + self.fuzz1106.heap_size_bytes()
-            + self.fuzz1107.heap_size_bytes()
-            + self.fuzz1108.heap_size_bytes()
-            + self.fuzz1109.heap_size_bytes()
-            + self.fuzz1110.heap_size_bytes()
-            + self.fuzz1111.heap_size_bytes()
-            + self.fuzz1112.heap_size_bytes()
-            + self.fuzz1113.heap_size_bytes()
-            + self.fuzz1114.heap_size_bytes()
-            + self.fuzz1115.heap_size_bytes()
-            + self.fuzz1116.heap_size_bytes()
-            + self.fuzz1117.heap_size_bytes()
-            + self.fuzz1118.heap_size_bytes()
-            + self.fuzz1122.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::testing::components::AffixFuzzer1>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer2>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer3>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer4>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer5>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer6>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer7>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer8>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer9>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer10>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer11>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer12>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer13>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer14>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer15>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer16>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer17>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer18>>::is_pod()
-            && <Vec<crate::testing::components::AffixFuzzer22>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer22".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz1101".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz1102".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz1103".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz1104".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz1105".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz1106".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz1107".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz1108".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz1109".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz1110".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz1111".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz1112".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz1113".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz1114".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz1115".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz1116".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz1117".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz1118".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer22".into(),
+                archetype_field_name: Some("fuzz1122".into()),
+            },
         ]
     });
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer2Indicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+            component_name: "AffixFuzzer2Indicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 20usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 20usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
-            "rerun.testing.components.AffixFuzzer22".into(),
-            "rerun.testing.components.AffixFuzzer2Indicator".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz1101".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz1102".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz1103".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz1104".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz1105".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz1106".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz1107".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz1108".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz1109".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz1110".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz1111".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz1112".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz1113".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz1114".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz1115".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz1116".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz1117".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz1118".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "rerun.testing.components.AffixFuzzer22".into(),
+                archetype_field_name: Some("fuzz1122".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                component_name: "AffixFuzzer2Indicator".into(),
+                archetype_field_name: None,
+            },
         ]
     });
 
@@ -170,26 +284,26 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AffixFuzzer2Indicator = AffixFuzzer2Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -461,25 +575,196 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.fuzz1101 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1102 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1103 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1104 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1105 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1106 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1107 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1108 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1109 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1110 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1111 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1112 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1113 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1114 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1115 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1116 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1117 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1118 as &dyn ComponentBatch).into()),
-            Some((&self.fuzz1122 as &dyn ComponentBatch).into()),
+            (Some(&self.fuzz1101 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1101").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer1").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1102 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1102").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer2").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1103 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1103").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer3").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1104 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1104").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer4").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1105 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1105").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer5").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1106 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1106").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer6").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1107 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1107").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer7").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1108 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1108").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer8").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1109 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1109").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer9").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1110 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1110").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer10").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1111 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1111").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer11").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1112 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1112").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer12").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1113 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1113").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer13").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1114 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1114").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer14").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1115 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1115").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer15").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1116 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1116").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer16").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1117 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1117").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer17").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1118 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1118").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer18").into(),
+                    }),
+                }
+            }),
+            (Some(&self.fuzz1122 as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
+                        archetype_field_name: Some(("fuzz1122").into()),
+                        component_name: ("rerun.testing.components.AffixFuzzer22").into(),
+                    }),
+                }
+            }),
         ]
         .into_iter()
         .flatten()
@@ -534,5 +819,53 @@ impl AffixFuzzer2 {
             fuzz1118: fuzz1118.into_iter().map(Into::into).collect(),
             fuzz1122: fuzz1122.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer2 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.fuzz1101.heap_size_bytes()
+            + self.fuzz1102.heap_size_bytes()
+            + self.fuzz1103.heap_size_bytes()
+            + self.fuzz1104.heap_size_bytes()
+            + self.fuzz1105.heap_size_bytes()
+            + self.fuzz1106.heap_size_bytes()
+            + self.fuzz1107.heap_size_bytes()
+            + self.fuzz1108.heap_size_bytes()
+            + self.fuzz1109.heap_size_bytes()
+            + self.fuzz1110.heap_size_bytes()
+            + self.fuzz1111.heap_size_bytes()
+            + self.fuzz1112.heap_size_bytes()
+            + self.fuzz1113.heap_size_bytes()
+            + self.fuzz1114.heap_size_bytes()
+            + self.fuzz1115.heap_size_bytes()
+            + self.fuzz1116.heap_size_bytes()
+            + self.fuzz1117.heap_size_bytes()
+            + self.fuzz1118.heap_size_bytes()
+            + self.fuzz1122.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::testing::components::AffixFuzzer1>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer2>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer3>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer4>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer5>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer6>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer7>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer8>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer9>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer10>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer11>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer12>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer13>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer14>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer15>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer16>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer17>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer18>>::is_pod()
+            && <Vec<crate::testing::components::AffixFuzzer22>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -282,9 +282,9 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AffixFuzzer2Indicator = AffixFuzzer2Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -570,13 +570,13 @@ impl ::re_types_core::Archetype for AffixFuzzer2 {
 }
 
 impl ::re_types_core::AsComponents for AffixFuzzer2 {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.fuzz1101 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -586,7 +586,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1102 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -596,7 +596,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1103 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -606,7 +606,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1104 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -616,7 +616,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1105 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -626,7 +626,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1106 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -636,7 +636,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1107 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -646,7 +646,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1108 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -656,7 +656,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1109 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -666,7 +666,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1110 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -676,7 +676,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1111 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -686,7 +686,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1112 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -696,7 +696,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1113 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -706,7 +706,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1114 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -716,7 +716,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1115 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -726,7 +726,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1116 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -736,7 +736,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1117 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -746,7 +746,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1118 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
@@ -756,7 +756,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer2 {
                 }
             }),
             (Some(&self.fuzz1122 as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -40,104 +40,212 @@ pub struct AffixFuzzer3 {
     pub fuzz2018: Option<crate::testing::components::AffixFuzzer18>,
 }
 
-impl ::re_types_core::SizeBytes for AffixFuzzer3 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.fuzz2001.heap_size_bytes()
-            + self.fuzz2002.heap_size_bytes()
-            + self.fuzz2003.heap_size_bytes()
-            + self.fuzz2004.heap_size_bytes()
-            + self.fuzz2005.heap_size_bytes()
-            + self.fuzz2006.heap_size_bytes()
-            + self.fuzz2007.heap_size_bytes()
-            + self.fuzz2008.heap_size_bytes()
-            + self.fuzz2009.heap_size_bytes()
-            + self.fuzz2010.heap_size_bytes()
-            + self.fuzz2011.heap_size_bytes()
-            + self.fuzz2012.heap_size_bytes()
-            + self.fuzz2013.heap_size_bytes()
-            + self.fuzz2014.heap_size_bytes()
-            + self.fuzz2015.heap_size_bytes()
-            + self.fuzz2016.heap_size_bytes()
-            + self.fuzz2017.heap_size_bytes()
-            + self.fuzz2018.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::components::AffixFuzzer1>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer2>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer3>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer4>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer5>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer6>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer7>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer8>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer9>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer10>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer11>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer12>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer13>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer14>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer15>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer16>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer17>>::is_pod()
-            && <Option<crate::testing::components::AffixFuzzer18>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer3Indicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+            component_name: "AffixFuzzer3Indicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz2001".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz2002".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz2003".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz2004".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz2005".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz2006".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz2007".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz2008".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz2009".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz2010".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz2011".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz2012".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz2013".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz2014".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz2015".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz2016".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz2017".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz2018".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer3Indicator".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "AffixFuzzer3Indicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz2001".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz2002".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz2003".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz2004".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz2005".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz2006".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz2007".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz2008".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz2009".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz2010".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz2011".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz2012".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz2013".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz2014".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz2015".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz2016".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz2017".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz2018".into()),
+            },
         ]
     });
 
@@ -165,26 +273,26 @@ impl ::re_types_core::Archetype for AffixFuzzer3 {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AffixFuzzer3Indicator = AffixFuzzer3Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -407,60 +515,222 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.fuzz2001
+            (self
+                .fuzz2001
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2002
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2001").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer1").into(),
+                }),
+            }),
+            (self
+                .fuzz2002
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2003
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2002").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer2").into(),
+                }),
+            }),
+            (self
+                .fuzz2003
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2004
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2003").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer3").into(),
+                }),
+            }),
+            (self
+                .fuzz2004
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2005
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2004").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer4").into(),
+                }),
+            }),
+            (self
+                .fuzz2005
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2006
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2005").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer5").into(),
+                }),
+            }),
+            (self
+                .fuzz2006
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2007
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2006").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer6").into(),
+                }),
+            }),
+            (self
+                .fuzz2007
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2008
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2007").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer7").into(),
+                }),
+            }),
+            (self
+                .fuzz2008
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2009
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2008").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer8").into(),
+                }),
+            }),
+            (self
+                .fuzz2009
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2010
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2009").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer9").into(),
+                }),
+            }),
+            (self
+                .fuzz2010
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2011
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2010").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer10").into(),
+                }),
+            }),
+            (self
+                .fuzz2011
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2012
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2011").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer11").into(),
+                }),
+            }),
+            (self
+                .fuzz2012
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2013
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2012").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer12").into(),
+                }),
+            }),
+            (self
+                .fuzz2013
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2014
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2013").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer13").into(),
+                }),
+            }),
+            (self
+                .fuzz2014
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2015
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2014").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer14").into(),
+                }),
+            }),
+            (self
+                .fuzz2015
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2016
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2015").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer15").into(),
+                }),
+            }),
+            (self
+                .fuzz2016
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2017
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2016").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer16").into(),
+                }),
+            }),
+            (self
+                .fuzz2017
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.fuzz2018
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2017").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer17").into(),
+                }),
+            }),
+            (self
+                .fuzz2018
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
+                    archetype_field_name: Some(("fuzz2018").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer18").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -656,5 +926,51 @@ impl AffixFuzzer3 {
     ) -> Self {
         self.fuzz2018 = Some(fuzz2018.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.fuzz2001.heap_size_bytes()
+            + self.fuzz2002.heap_size_bytes()
+            + self.fuzz2003.heap_size_bytes()
+            + self.fuzz2004.heap_size_bytes()
+            + self.fuzz2005.heap_size_bytes()
+            + self.fuzz2006.heap_size_bytes()
+            + self.fuzz2007.heap_size_bytes()
+            + self.fuzz2008.heap_size_bytes()
+            + self.fuzz2009.heap_size_bytes()
+            + self.fuzz2010.heap_size_bytes()
+            + self.fuzz2011.heap_size_bytes()
+            + self.fuzz2012.heap_size_bytes()
+            + self.fuzz2013.heap_size_bytes()
+            + self.fuzz2014.heap_size_bytes()
+            + self.fuzz2015.heap_size_bytes()
+            + self.fuzz2016.heap_size_bytes()
+            + self.fuzz2017.heap_size_bytes()
+            + self.fuzz2018.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::components::AffixFuzzer1>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer2>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer3>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer4>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer5>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer6>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer7>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer8>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer9>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer10>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer11>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer12>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer13>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer14>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer15>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer16>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer17>>::is_pod()
+            && <Option<crate::testing::components::AffixFuzzer18>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -271,9 +271,9 @@ impl ::re_types_core::Archetype for AffixFuzzer3 {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AffixFuzzer3Indicator = AffixFuzzer3Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -510,7 +510,7 @@ impl ::re_types_core::Archetype for AffixFuzzer3 {
 }
 
 impl ::re_types_core::AsComponents for AffixFuzzer3 {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -519,7 +519,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2001
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -531,7 +531,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2002
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -543,7 +543,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2003
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -555,7 +555,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2004
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -567,7 +567,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2005
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -579,7 +579,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2006
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -591,7 +591,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2007
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -603,7 +603,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2008
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -615,7 +615,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2009
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -627,7 +627,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2010
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -639,7 +639,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2011
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -651,7 +651,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2012
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -663,7 +663,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2013
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -675,7 +675,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2014
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -687,7 +687,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2015
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -699,7 +699,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2016
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -711,7 +711,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2017
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
@@ -723,7 +723,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer3 {
                 .fuzz2018
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -40,104 +40,212 @@ pub struct AffixFuzzer4 {
     pub fuzz2118: Option<Vec<crate::testing::components::AffixFuzzer18>>,
 }
 
-impl ::re_types_core::SizeBytes for AffixFuzzer4 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.fuzz2101.heap_size_bytes()
-            + self.fuzz2102.heap_size_bytes()
-            + self.fuzz2103.heap_size_bytes()
-            + self.fuzz2104.heap_size_bytes()
-            + self.fuzz2105.heap_size_bytes()
-            + self.fuzz2106.heap_size_bytes()
-            + self.fuzz2107.heap_size_bytes()
-            + self.fuzz2108.heap_size_bytes()
-            + self.fuzz2109.heap_size_bytes()
-            + self.fuzz2110.heap_size_bytes()
-            + self.fuzz2111.heap_size_bytes()
-            + self.fuzz2112.heap_size_bytes()
-            + self.fuzz2113.heap_size_bytes()
-            + self.fuzz2114.heap_size_bytes()
-            + self.fuzz2115.heap_size_bytes()
-            + self.fuzz2116.heap_size_bytes()
-            + self.fuzz2117.heap_size_bytes()
-            + self.fuzz2118.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<crate::testing::components::AffixFuzzer1>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer2>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer3>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer4>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer5>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer6>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer7>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer8>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer9>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer10>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer11>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer12>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer13>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer14>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer15>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer16>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer17>>>::is_pod()
-            && <Option<Vec<crate::testing::components::AffixFuzzer18>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.testing.components.AffixFuzzer4Indicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+            component_name: "AffixFuzzer4Indicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 18usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 18usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz2101".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz2102".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz2103".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz2104".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz2105".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz2106".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz2107".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz2108".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz2109".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz2110".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz2111".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz2112".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz2113".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz2114".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz2115".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz2116".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz2117".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz2118".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 19usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.testing.components.AffixFuzzer4Indicator".into(),
-            "rerun.testing.components.AffixFuzzer1".into(),
-            "rerun.testing.components.AffixFuzzer2".into(),
-            "rerun.testing.components.AffixFuzzer3".into(),
-            "rerun.testing.components.AffixFuzzer4".into(),
-            "rerun.testing.components.AffixFuzzer5".into(),
-            "rerun.testing.components.AffixFuzzer6".into(),
-            "rerun.testing.components.AffixFuzzer7".into(),
-            "rerun.testing.components.AffixFuzzer8".into(),
-            "rerun.testing.components.AffixFuzzer9".into(),
-            "rerun.testing.components.AffixFuzzer10".into(),
-            "rerun.testing.components.AffixFuzzer11".into(),
-            "rerun.testing.components.AffixFuzzer12".into(),
-            "rerun.testing.components.AffixFuzzer13".into(),
-            "rerun.testing.components.AffixFuzzer14".into(),
-            "rerun.testing.components.AffixFuzzer15".into(),
-            "rerun.testing.components.AffixFuzzer16".into(),
-            "rerun.testing.components.AffixFuzzer17".into(),
-            "rerun.testing.components.AffixFuzzer18".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "AffixFuzzer4Indicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer1".into(),
+                archetype_field_name: Some("fuzz2101".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer2".into(),
+                archetype_field_name: Some("fuzz2102".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer3".into(),
+                archetype_field_name: Some("fuzz2103".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer4".into(),
+                archetype_field_name: Some("fuzz2104".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer5".into(),
+                archetype_field_name: Some("fuzz2105".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer6".into(),
+                archetype_field_name: Some("fuzz2106".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer7".into(),
+                archetype_field_name: Some("fuzz2107".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer8".into(),
+                archetype_field_name: Some("fuzz2108".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer9".into(),
+                archetype_field_name: Some("fuzz2109".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer10".into(),
+                archetype_field_name: Some("fuzz2110".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer11".into(),
+                archetype_field_name: Some("fuzz2111".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer12".into(),
+                archetype_field_name: Some("fuzz2112".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer13".into(),
+                archetype_field_name: Some("fuzz2113".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer14".into(),
+                archetype_field_name: Some("fuzz2114".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer15".into(),
+                archetype_field_name: Some("fuzz2115".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer16".into(),
+                archetype_field_name: Some("fuzz2116".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer17".into(),
+                archetype_field_name: Some("fuzz2117".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                component_name: "rerun.testing.components.AffixFuzzer18".into(),
+                archetype_field_name: Some("fuzz2118".into()),
+            },
         ]
     });
 
@@ -165,26 +273,26 @@ impl ::re_types_core::Archetype for AffixFuzzer4 {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: AffixFuzzer4Indicator = AffixFuzzer4Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -461,60 +569,222 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.fuzz2101
+            (self
+                .fuzz2101
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2102
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2101").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer1").into(),
+                }),
+            }),
+            (self
+                .fuzz2102
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2103
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2102").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer2").into(),
+                }),
+            }),
+            (self
+                .fuzz2103
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2104
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2103").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer3").into(),
+                }),
+            }),
+            (self
+                .fuzz2104
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2105
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2104").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer4").into(),
+                }),
+            }),
+            (self
+                .fuzz2105
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2106
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2105").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer5").into(),
+                }),
+            }),
+            (self
+                .fuzz2106
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2107
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2106").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer6").into(),
+                }),
+            }),
+            (self
+                .fuzz2107
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2108
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2107").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer7").into(),
+                }),
+            }),
+            (self
+                .fuzz2108
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2109
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2108").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer8").into(),
+                }),
+            }),
+            (self
+                .fuzz2109
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2110
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2109").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer9").into(),
+                }),
+            }),
+            (self
+                .fuzz2110
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2111
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2110").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer10").into(),
+                }),
+            }),
+            (self
+                .fuzz2111
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2112
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2111").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer11").into(),
+                }),
+            }),
+            (self
+                .fuzz2112
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2113
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2112").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer12").into(),
+                }),
+            }),
+            (self
+                .fuzz2113
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2114
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2113").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer13").into(),
+                }),
+            }),
+            (self
+                .fuzz2114
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2115
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2114").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer14").into(),
+                }),
+            }),
+            (self
+                .fuzz2115
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2116
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2115").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer15").into(),
+                }),
+            }),
+            (self
+                .fuzz2116
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2117
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2116").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer16").into(),
+                }),
+            }),
+            (self
+                .fuzz2117
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.fuzz2118
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2117").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer17").into(),
+                }),
+            }),
+            (self
+                .fuzz2118
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
+                    archetype_field_name: Some(("fuzz2118").into()),
+                    component_name: ("rerun.testing.components.AffixFuzzer18").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -710,5 +980,51 @@ impl AffixFuzzer4 {
     ) -> Self {
         self.fuzz2118 = Some(fuzz2118.into_iter().map(Into::into).collect());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer4 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.fuzz2101.heap_size_bytes()
+            + self.fuzz2102.heap_size_bytes()
+            + self.fuzz2103.heap_size_bytes()
+            + self.fuzz2104.heap_size_bytes()
+            + self.fuzz2105.heap_size_bytes()
+            + self.fuzz2106.heap_size_bytes()
+            + self.fuzz2107.heap_size_bytes()
+            + self.fuzz2108.heap_size_bytes()
+            + self.fuzz2109.heap_size_bytes()
+            + self.fuzz2110.heap_size_bytes()
+            + self.fuzz2111.heap_size_bytes()
+            + self.fuzz2112.heap_size_bytes()
+            + self.fuzz2113.heap_size_bytes()
+            + self.fuzz2114.heap_size_bytes()
+            + self.fuzz2115.heap_size_bytes()
+            + self.fuzz2116.heap_size_bytes()
+            + self.fuzz2117.heap_size_bytes()
+            + self.fuzz2118.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<crate::testing::components::AffixFuzzer1>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer2>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer3>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer4>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer5>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer6>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer7>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer8>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer9>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer10>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer11>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer12>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer13>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer14>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer15>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer16>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer17>>>::is_pod()
+            && <Option<Vec<crate::testing::components::AffixFuzzer18>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -271,9 +271,9 @@ impl ::re_types_core::Archetype for AffixFuzzer4 {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: AffixFuzzer4Indicator = AffixFuzzer4Indicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -564,7 +564,7 @@ impl ::re_types_core::Archetype for AffixFuzzer4 {
 }
 
 impl ::re_types_core::AsComponents for AffixFuzzer4 {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -573,7 +573,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2101
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -585,7 +585,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2102
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -597,7 +597,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2103
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -609,7 +609,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2104
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -621,7 +621,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2105
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -633,7 +633,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2106
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -645,7 +645,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2107
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -657,7 +657,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2108
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -669,7 +669,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2109
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -681,7 +681,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2110
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -693,7 +693,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2111
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -705,7 +705,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2112
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -717,7 +717,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2113
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -729,7 +729,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2114
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -741,7 +741,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2115
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -753,7 +753,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2116
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -765,7 +765,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2117
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
@@ -777,7 +777,7 @@ impl ::re_types_core::AsComponents for AffixFuzzer4 {
                 .fuzz2118
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer1(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer1 {
+impl ::re_types_core::Component for AffixFuzzer1 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer1 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer1 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer1 {
-    type Target = crate::testing::datatypes::AffixFuzzer1;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer1 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer1")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer1 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer1 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer1 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer1".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer1 {
+    type Target = crate::testing::datatypes::AffixFuzzer1;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer1 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer1 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer1.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer10(pub Option<::re_types_core::ArrowString>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer10 {
+impl ::re_types_core::Component for AffixFuzzer10 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<::re_types_core::ArrowString>>::is_pod()
-    }
-}
-
-impl From<Option<::re_types_core::ArrowString>> for AffixFuzzer10 {
-    #[inline]
-    fn from(single_string_optional: Option<::re_types_core::ArrowString>) -> Self {
-        Self(single_string_optional)
-    }
-}
-
-impl From<AffixFuzzer10> for Option<::re_types_core::ArrowString> {
-    #[inline]
-    fn from(value: AffixFuzzer10) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer10 {
-    type Target = Option<::re_types_core::ArrowString>;
-
-    #[inline]
-    fn deref(&self) -> &Option<::re_types_core::ArrowString> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer10 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<::re_types_core::ArrowString> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer10")
     }
 }
 
@@ -176,9 +141,44 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer10 {
+impl From<Option<::re_types_core::ArrowString>> for AffixFuzzer10 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer10".into()
+    fn from(single_string_optional: Option<::re_types_core::ArrowString>) -> Self {
+        Self(single_string_optional)
+    }
+}
+
+impl From<AffixFuzzer10> for Option<::re_types_core::ArrowString> {
+    #[inline]
+    fn from(value: AffixFuzzer10) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer10 {
+    type Target = Option<::re_types_core::ArrowString>;
+
+    #[inline]
+    fn deref(&self) -> &Option<::re_types_core::ArrowString> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer10 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<::re_types_core::ArrowString> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer10 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<::re_types_core::ArrowString>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer11(pub Option<::re_types_core::ArrowBuffer<f32>>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer11 {
+impl ::re_types_core::Component for AffixFuzzer11 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<::re_types_core::ArrowBuffer<f32>>>::is_pod()
-    }
-}
-
-impl From<Option<::re_types_core::ArrowBuffer<f32>>> for AffixFuzzer11 {
-    #[inline]
-    fn from(many_floats_optional: Option<::re_types_core::ArrowBuffer<f32>>) -> Self {
-        Self(many_floats_optional)
-    }
-}
-
-impl From<AffixFuzzer11> for Option<::re_types_core::ArrowBuffer<f32>> {
-    #[inline]
-    fn from(value: AffixFuzzer11) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer11 {
-    type Target = Option<::re_types_core::ArrowBuffer<f32>>;
-
-    #[inline]
-    fn deref(&self) -> &Option<::re_types_core::ArrowBuffer<f32>> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer11 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<::re_types_core::ArrowBuffer<f32>> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer11")
     }
 }
 
@@ -209,9 +174,44 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer11 {
+impl From<Option<::re_types_core::ArrowBuffer<f32>>> for AffixFuzzer11 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer11".into()
+    fn from(many_floats_optional: Option<::re_types_core::ArrowBuffer<f32>>) -> Self {
+        Self(many_floats_optional)
+    }
+}
+
+impl From<AffixFuzzer11> for Option<::re_types_core::ArrowBuffer<f32>> {
+    #[inline]
+    fn from(value: AffixFuzzer11) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer11 {
+    type Target = Option<::re_types_core::ArrowBuffer<f32>>;
+
+    #[inline]
+    fn deref(&self) -> &Option<::re_types_core::ArrowBuffer<f32>> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer11 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<::re_types_core::ArrowBuffer<f32>> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer11 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<::re_types_core::ArrowBuffer<f32>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer12(pub Vec<::re_types_core::ArrowString>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer12 {
+impl ::re_types_core::Component for AffixFuzzer12 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<::re_types_core::ArrowString>>::is_pod()
-    }
-}
-
-impl From<Vec<::re_types_core::ArrowString>> for AffixFuzzer12 {
-    #[inline]
-    fn from(many_strings_required: Vec<::re_types_core::ArrowString>) -> Self {
-        Self(many_strings_required)
-    }
-}
-
-impl From<AffixFuzzer12> for Vec<::re_types_core::ArrowString> {
-    #[inline]
-    fn from(value: AffixFuzzer12) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer12 {
-    type Target = Vec<::re_types_core::ArrowString>;
-
-    #[inline]
-    fn deref(&self) -> &Vec<::re_types_core::ArrowString> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer12 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Vec<::re_types_core::ArrowString> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer12")
     }
 }
 
@@ -248,9 +213,44 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer12 {
+impl From<Vec<::re_types_core::ArrowString>> for AffixFuzzer12 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer12".into()
+    fn from(many_strings_required: Vec<::re_types_core::ArrowString>) -> Self {
+        Self(many_strings_required)
+    }
+}
+
+impl From<AffixFuzzer12> for Vec<::re_types_core::ArrowString> {
+    #[inline]
+    fn from(value: AffixFuzzer12) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer12 {
+    type Target = Vec<::re_types_core::ArrowString>;
+
+    #[inline]
+    fn deref(&self) -> &Vec<::re_types_core::ArrowString> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer12 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Vec<::re_types_core::ArrowString> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer12 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<::re_types_core::ArrowString>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer13(pub Option<Vec<::re_types_core::ArrowString>>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer13 {
+impl ::re_types_core::Component for AffixFuzzer13 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<::re_types_core::ArrowString>>>::is_pod()
-    }
-}
-
-impl From<Option<Vec<::re_types_core::ArrowString>>> for AffixFuzzer13 {
-    #[inline]
-    fn from(many_strings_optional: Option<Vec<::re_types_core::ArrowString>>) -> Self {
-        Self(many_strings_optional)
-    }
-}
-
-impl From<AffixFuzzer13> for Option<Vec<::re_types_core::ArrowString>> {
-    #[inline]
-    fn from(value: AffixFuzzer13) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer13 {
-    type Target = Option<Vec<::re_types_core::ArrowString>>;
-
-    #[inline]
-    fn deref(&self) -> &Option<Vec<::re_types_core::ArrowString>> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer13 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<Vec<::re_types_core::ArrowString>> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer13")
     }
 }
 
@@ -248,9 +213,44 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer13 {
+impl From<Option<Vec<::re_types_core::ArrowString>>> for AffixFuzzer13 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer13".into()
+    fn from(many_strings_optional: Option<Vec<::re_types_core::ArrowString>>) -> Self {
+        Self(many_strings_optional)
+    }
+}
+
+impl From<AffixFuzzer13> for Option<Vec<::re_types_core::ArrowString>> {
+    #[inline]
+    fn from(value: AffixFuzzer13) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer13 {
+    type Target = Option<Vec<::re_types_core::ArrowString>>;
+
+    #[inline]
+    fn deref(&self) -> &Option<Vec<::re_types_core::ArrowString>> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer13 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<Vec<::re_types_core::ArrowString>> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer13 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<::re_types_core::ArrowString>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer14(pub crate::testing::datatypes::AffixFuzzer3);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer14 {
+impl ::re_types_core::Component for AffixFuzzer14 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer3>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer3>> From<T> for AffixFuzzer14 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer3> for AffixFuzzer14 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer3 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer14 {
-    type Target = crate::testing::datatypes::AffixFuzzer3;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer3 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer14 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer3 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer14")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer14 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer14 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer3>> From<T> for AffixFuzzer14 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer3> for AffixFuzzer14 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer14".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer3 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer14 {
+    type Target = crate::testing::datatypes::AffixFuzzer3;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer3 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer14 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer3 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer14 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer3>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer14.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer15(pub Option<crate::testing::datatypes::AffixFuzzer3>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer15 {
+impl ::re_types_core::Component for AffixFuzzer15 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer3>>> From<T> for AffixFuzzer15 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer3>> for AffixFuzzer15 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer3> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer15 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer3>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer3> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer15 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer3> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer15")
     }
 }
 
@@ -157,9 +123,43 @@ impl ::re_types_core::Loggable for AffixFuzzer15 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer15 {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer3>>> From<T> for AffixFuzzer15 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer3>> for AffixFuzzer15 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer15".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer3> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer15 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer3>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer3> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer15 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer3> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer15 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer15.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -13,31 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer16(pub Vec<crate::testing::datatypes::AffixFuzzer3>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer16 {
+impl ::re_types_core::Component for AffixFuzzer16 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>> From<T>
-    for AffixFuzzer16
-{
-    fn from(v: T) -> Self {
-        Self(v.into_iter().map(|v| v.into()).collect())
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer16")
     }
 }
 
@@ -181,9 +168,22 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer16 {
+impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>> From<T>
+    for AffixFuzzer16
+{
+    fn from(v: T) -> Self {
+        Self(v.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer16 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer16".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -13,31 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer17(pub Option<Vec<crate::testing::datatypes::AffixFuzzer3>>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer17 {
+impl ::re_types_core::Component for AffixFuzzer17 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<crate::testing::datatypes::AffixFuzzer3>>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>> From<Option<T>>
-    for AffixFuzzer17
-{
-    fn from(v: Option<T>) -> Self {
-        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer17")
     }
 }
 
@@ -181,9 +168,22 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer17 {
+impl<I: Into<crate::testing::datatypes::AffixFuzzer3>, T: IntoIterator<Item = I>> From<Option<T>>
+    for AffixFuzzer17
+{
+    fn from(v: Option<T>) -> Self {
+        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer17 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer17".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<crate::testing::datatypes::AffixFuzzer3>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -13,31 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer18(pub Option<Vec<crate::testing::datatypes::AffixFuzzer4>>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer18 {
+impl ::re_types_core::Component for AffixFuzzer18 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<crate::testing::datatypes::AffixFuzzer4>>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::testing::datatypes::AffixFuzzer4>, T: IntoIterator<Item = I>> From<Option<T>>
-    for AffixFuzzer18
-{
-    fn from(v: Option<T>) -> Self {
-        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer18")
     }
 }
 
@@ -181,9 +168,22 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer18 {
+impl<I: Into<crate::testing::datatypes::AffixFuzzer4>, T: IntoIterator<Item = I>> From<Option<T>>
+    for AffixFuzzer18
+{
+    fn from(v: Option<T>) -> Self {
+        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer18 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer18".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<crate::testing::datatypes::AffixFuzzer4>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer19(pub crate::testing::datatypes::AffixFuzzer5);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer19 {
+impl ::re_types_core::Component for AffixFuzzer19 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer5>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer5>> From<T> for AffixFuzzer19 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer5> for AffixFuzzer19 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer5 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer19 {
-    type Target = crate::testing::datatypes::AffixFuzzer5;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer5 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer19 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer5 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer19")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer19 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer19 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer5>> From<T> for AffixFuzzer19 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer5> for AffixFuzzer19 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer19".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer5 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer19 {
+    type Target = crate::testing::datatypes::AffixFuzzer5;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer5 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer19 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer5 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer19 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer5>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer19.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer2(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer2 {
+impl ::re_types_core::Component for AffixFuzzer2 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer2 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer2 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer2 {
-    type Target = crate::testing::datatypes::AffixFuzzer1;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer2 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer2")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer2 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer2 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer2 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer2".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer2 {
+    type Target = crate::testing::datatypes::AffixFuzzer1;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer2 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer2 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer2.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AffixFuzzer20(pub crate::testing::datatypes::AffixFuzzer20);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer20 {
+impl ::re_types_core::Component for AffixFuzzer20 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer20>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer20>> From<T> for AffixFuzzer20 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer20> for AffixFuzzer20 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer20 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer20 {
-    type Target = crate::testing::datatypes::AffixFuzzer20;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer20 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer20 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer20 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer20")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer20 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer20>> From<T> for AffixFuzzer20 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer20> for AffixFuzzer20 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer20".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer20 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer20 {
+    type Target = crate::testing::datatypes::AffixFuzzer20;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer20 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer20 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer20 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer20 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer20>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer20.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer21(pub crate::testing::datatypes::AffixFuzzer21);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer21 {
+impl ::re_types_core::Component for AffixFuzzer21 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer21>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer21>> From<T> for AffixFuzzer21 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer21> for AffixFuzzer21 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer21 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer21 {
-    type Target = crate::testing::datatypes::AffixFuzzer21;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer21 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer21 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer21 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer21")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer21 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer21>> From<T> for AffixFuzzer21 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer21> for AffixFuzzer21 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer21".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer21 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer21 {
+    type Target = crate::testing::datatypes::AffixFuzzer21;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer21 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer21 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer21 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer21 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer21>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer21.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer22(pub Option<crate::testing::datatypes::AffixFuzzer22>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer22 {
+impl ::re_types_core::Component for AffixFuzzer22 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer22>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer22>>> From<T> for AffixFuzzer22 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer22>> for AffixFuzzer22 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer22> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer22 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer22>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer22> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer22 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer22> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer22")
     }
 }
 
@@ -137,9 +103,43 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer22 {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer22>>> From<T> for AffixFuzzer22 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer22>> for AffixFuzzer22 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer22".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer22> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer22 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer22>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer22> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer22 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer22> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer22 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer22>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer22.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer23(pub Option<crate::testing::datatypes::MultiEnum>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer23 {
+impl ::re_types_core::Component for AffixFuzzer23 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::MultiEnum>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::MultiEnum>>> From<T> for AffixFuzzer23 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::MultiEnum>> for AffixFuzzer23 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::MultiEnum> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer23 {
-    type Target = Option<crate::testing::datatypes::MultiEnum>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::MultiEnum> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer23 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::MultiEnum> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer23")
     }
 }
 
@@ -141,9 +107,43 @@ impl ::re_types_core::Loggable for AffixFuzzer23 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer23 {
+impl<T: Into<Option<crate::testing::datatypes::MultiEnum>>> From<T> for AffixFuzzer23 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::MultiEnum>> for AffixFuzzer23 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer23".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::MultiEnum> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer23 {
+    type Target = Option<crate::testing::datatypes::MultiEnum>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::MultiEnum> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer23 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::MultiEnum> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer23 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::MultiEnum>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer23.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer3(pub crate::testing::datatypes::AffixFuzzer1);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer3 {
+impl ::re_types_core::Component for AffixFuzzer3 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
-    }
-}
-
-impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer3 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer3 {
-    #[inline]
-    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer3 {
-    type Target = crate::testing::datatypes::AffixFuzzer1;
-
-    #[inline]
-    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer3 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer3")
     }
 }
 
@@ -95,9 +61,43 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer3 {
+impl<T: Into<crate::testing::datatypes::AffixFuzzer1>> From<T> for AffixFuzzer3 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::testing::datatypes::AffixFuzzer1> for AffixFuzzer3 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer3".into()
+    fn borrow(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer3 {
+    type Target = crate::testing::datatypes::AffixFuzzer1;
+
+    #[inline]
+    fn deref(&self) -> &crate::testing::datatypes::AffixFuzzer1 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer3 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::testing::datatypes::AffixFuzzer1 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer1>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer4(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer4 {
+impl ::re_types_core::Component for AffixFuzzer4 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer4 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer4 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer4 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer4 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer4")
     }
 }
 
@@ -168,9 +134,43 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer4 {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer4 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer4 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer4".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer4 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer4 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer4 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer4.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer5(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer5 {
+impl ::re_types_core::Component for AffixFuzzer5 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer5 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer5 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer5 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer5 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer5")
     }
 }
 
@@ -168,9 +134,43 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer5 {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer5 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer5 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer5".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer5 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer5 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer5 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer5.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
@@ -13,52 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer6(pub Option<crate::testing::datatypes::AffixFuzzer1>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer6 {
+impl ::re_types_core::Component for AffixFuzzer6 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer6 {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer6 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer6 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer6 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer6")
     }
 }
 
@@ -168,9 +134,43 @@ impl ::re_types_core::Loggable for AffixFuzzer6 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer6 {
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer1>>> From<T> for AffixFuzzer6 {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer1>> for AffixFuzzer6 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer6".into()
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer6 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer1>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer1> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer6 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer1> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer6 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer6.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -13,31 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer7(pub Option<Vec<crate::testing::datatypes::AffixFuzzer1>>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer7 {
+impl ::re_types_core::Component for AffixFuzzer7 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<Vec<crate::testing::datatypes::AffixFuzzer1>>>::is_pod()
-    }
-}
-
-impl<I: Into<crate::testing::datatypes::AffixFuzzer1>, T: IntoIterator<Item = I>> From<Option<T>>
-    for AffixFuzzer7
-{
-    fn from(v: Option<T>) -> Self {
-        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer7")
     }
 }
 
@@ -179,9 +166,22 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer7 {
+impl<I: Into<crate::testing::datatypes::AffixFuzzer1>, T: IntoIterator<Item = I>> From<Option<T>>
+    for AffixFuzzer7
+{
+    fn from(v: Option<T>) -> Self {
+        Self(v.map(|v| v.into_iter().map(|v| v.into()).collect()))
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer7 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer7".into()
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<Vec<crate::testing::datatypes::AffixFuzzer1>>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer8(pub Option<f32>);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer8 {
+impl ::re_types_core::Component for AffixFuzzer8 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<f32>>::is_pod()
-    }
-}
-
-impl From<Option<f32>> for AffixFuzzer8 {
-    #[inline]
-    fn from(single_float_optional: Option<f32>) -> Self {
-        Self(single_float_optional)
-    }
-}
-
-impl From<AffixFuzzer8> for Option<f32> {
-    #[inline]
-    fn from(value: AffixFuzzer8) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer8 {
-    type Target = Option<f32>;
-
-    #[inline]
-    fn deref(&self) -> &Option<f32> {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer8 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<f32> {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer8")
     }
 }
 
@@ -142,9 +107,44 @@ impl ::re_types_core::Loggable for AffixFuzzer8 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer8 {
+impl From<Option<f32>> for AffixFuzzer8 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer8".into()
+    fn from(single_float_optional: Option<f32>) -> Self {
+        Self(single_float_optional)
+    }
+}
+
+impl From<AffixFuzzer8> for Option<f32> {
+    #[inline]
+    fn from(value: AffixFuzzer8) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer8 {
+    type Target = Option<f32>;
+
+    #[inline]
+    fn deref(&self) -> &Option<f32> {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer8 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<f32> {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer8 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<f32>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer8.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -13,53 +13,18 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer9(pub ::re_types_core::ArrowString);
 
-impl ::re_types_core::SizeBytes for AffixFuzzer9 {
+impl ::re_types_core::Component for AffixFuzzer9 {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <::re_types_core::ArrowString>::is_pod()
-    }
-}
-
-impl From<::re_types_core::ArrowString> for AffixFuzzer9 {
-    #[inline]
-    fn from(single_string_required: ::re_types_core::ArrowString) -> Self {
-        Self(single_string_required)
-    }
-}
-
-impl From<AffixFuzzer9> for ::re_types_core::ArrowString {
-    #[inline]
-    fn from(value: AffixFuzzer9) -> Self {
-        value.0
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer9 {
-    type Target = ::re_types_core::ArrowString;
-
-    #[inline]
-    fn deref(&self) -> &::re_types_core::ArrowString {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer9 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut ::re_types_core::ArrowString {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.testing.components.AffixFuzzer9")
     }
 }
 
@@ -176,9 +141,44 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
     }
 }
 
-impl ::re_types_core::Component for AffixFuzzer9 {
+impl From<::re_types_core::ArrowString> for AffixFuzzer9 {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.testing.components.AffixFuzzer9".into()
+    fn from(single_string_required: ::re_types_core::ArrowString) -> Self {
+        Self(single_string_required)
+    }
+}
+
+impl From<AffixFuzzer9> for ::re_types_core::ArrowString {
+    #[inline]
+    fn from(value: AffixFuzzer9) -> Self {
+        value.0
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer9 {
+    type Target = ::re_types_core::ArrowString;
+
+    #[inline]
+    fn deref(&self) -> &::re_types_core::ArrowString {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer9 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut ::re_types_core::ArrowString {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer9 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <::re_types_core::ArrowString>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -29,34 +29,6 @@ pub struct AffixFuzzer1 {
     pub flattened_scalar: f32,
     pub almost_flattened_scalar: crate::testing::datatypes::FlattenedScalar,
     pub from_parent: Option<bool>,
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer1 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.single_float_optional.heap_size_bytes()
-            + self.single_string_required.heap_size_bytes()
-            + self.single_string_optional.heap_size_bytes()
-            + self.many_floats_optional.heap_size_bytes()
-            + self.many_strings_required.heap_size_bytes()
-            + self.many_strings_optional.heap_size_bytes()
-            + self.flattened_scalar.heap_size_bytes()
-            + self.almost_flattened_scalar.heap_size_bytes()
-            + self.from_parent.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<f32>>::is_pod()
-            && <::re_types_core::ArrowString>::is_pod()
-            && <Option<::re_types_core::ArrowString>>::is_pod()
-            && <Option<::re_types_core::ArrowBuffer<f32>>>::is_pod()
-            && <Vec<::re_types_core::ArrowString>>::is_pod()
-            && <Option<Vec<::re_types_core::ArrowString>>>::is_pod()
-            && <f32>::is_pod()
-            && <crate::testing::datatypes::FlattenedScalar>::is_pod()
-            && <Option<bool>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer1);
@@ -1097,5 +1069,33 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer1")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer1 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.single_float_optional.heap_size_bytes()
+            + self.single_string_required.heap_size_bytes()
+            + self.single_string_optional.heap_size_bytes()
+            + self.many_floats_optional.heap_size_bytes()
+            + self.many_strings_required.heap_size_bytes()
+            + self.many_strings_optional.heap_size_bytes()
+            + self.flattened_scalar.heap_size_bytes()
+            + self.almost_flattened_scalar.heap_size_bytes()
+            + self.from_parent.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<f32>>::is_pod()
+            && <::re_types_core::ArrowString>::is_pod()
+            && <Option<::re_types_core::ArrowString>>::is_pod()
+            && <Option<::re_types_core::ArrowBuffer<f32>>>::is_pod()
+            && <Vec<::re_types_core::ArrowString>>::is_pod()
+            && <Option<Vec<::re_types_core::ArrowString>>>::is_pod()
+            && <f32>::is_pod()
+            && <crate::testing::datatypes::FlattenedScalar>::is_pod()
+            && <Option<bool>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -13,39 +13,13 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer2(pub Option<f32>);
-
-impl ::re_types_core::SizeBytes for AffixFuzzer2 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<f32>>::is_pod()
-    }
-}
-
-impl From<Option<f32>> for AffixFuzzer2 {
-    #[inline]
-    fn from(single_float_optional: Option<f32>) -> Self {
-        Self(single_float_optional)
-    }
-}
-
-impl From<AffixFuzzer2> for Option<f32> {
-    #[inline]
-    fn from(value: AffixFuzzer2) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer2);
 
@@ -123,5 +97,31 @@ impl ::re_types_core::Loggable for AffixFuzzer2 {
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.testing.datatypes.AffixFuzzer2#single_float_optional")
             .with_context("rerun.testing.datatypes.AffixFuzzer2")?)
+    }
+}
+
+impl From<Option<f32>> for AffixFuzzer2 {
+    #[inline]
+    fn from(single_float_optional: Option<f32>) -> Self {
+        Self(single_float_optional)
+    }
+}
+
+impl From<AffixFuzzer2> for Option<f32> {
+    #[inline]
+    fn from(value: AffixFuzzer2) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer2 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<f32>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer2.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -13,28 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct AffixFuzzer20 {
     pub p: crate::testing::datatypes::PrimitiveComponent,
     pub s: crate::testing::datatypes::StringComponent,
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer20 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.p.heap_size_bytes() + self.s.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::PrimitiveComponent>::is_pod()
-            && <crate::testing::datatypes::StringComponent>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer20);
@@ -286,5 +273,18 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                 .with_context("rerun.testing.datatypes.AffixFuzzer20")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer20 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.p.heap_size_bytes() + self.s.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::PrimitiveComponent>::is_pod()
+            && <crate::testing::datatypes::StringComponent>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -13,27 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer21 {
     pub single_half: half::f16,
     pub many_halves: ::re_types_core::ArrowBuffer<half::f16>,
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer21 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.single_half.heap_size_bytes() + self.many_halves.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <half::f16>::is_pod() && <::re_types_core::ArrowBuffer<half::f16>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer21);
@@ -314,5 +302,17 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                 .with_context("rerun.testing.datatypes.AffixFuzzer21")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer21 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.single_half.heap_size_bytes() + self.many_halves.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <half::f16>::is_pod() && <::re_types_core::ArrowBuffer<half::f16>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AffixFuzzer22 {
     pub fixed_sized_native: [u8; 4usize],
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer22 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.fixed_sized_native.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <[u8; 4usize]>::is_pod()
-    }
-}
-
-impl From<[u8; 4usize]> for AffixFuzzer22 {
-    #[inline]
-    fn from(fixed_sized_native: [u8; 4usize]) -> Self {
-        Self { fixed_sized_native }
-    }
-}
-
-impl From<AffixFuzzer22> for [u8; 4usize] {
-    #[inline]
-    fn from(value: AffixFuzzer22) -> Self {
-        value.fixed_sized_native
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer22);
@@ -282,5 +256,31 @@ impl ::re_types_core::Loggable for AffixFuzzer22 {
                 .with_context("rerun.testing.datatypes.AffixFuzzer22")?
             }
         })
+    }
+}
+
+impl From<[u8; 4usize]> for AffixFuzzer22 {
+    #[inline]
+    fn from(fixed_sized_native: [u8; 4usize]) -> Self {
+        Self { fixed_sized_native }
+    }
+}
+
+impl From<AffixFuzzer22> for [u8; 4usize] {
+    #[inline]
+    fn from(value: AffixFuzzer22) -> Self {
+        value.fixed_sized_native
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer22 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.fixed_sized_native.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <[u8; 4usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer22.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -24,26 +24,6 @@ pub enum AffixFuzzer3 {
     Craziness(Vec<crate::testing::datatypes::AffixFuzzer1>),
     FixedSizeShenanigans([f32; 3usize]),
     EmptyVariant,
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer3 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        #![allow(clippy::match_same_arms)]
-        match self {
-            Self::Degrees(v) => v.heap_size_bytes(),
-            Self::Craziness(v) => v.heap_size_bytes(),
-            Self::FixedSizeShenanigans(v) => v.heap_size_bytes(),
-            Self::EmptyVariant => 0,
-        }
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <f32>::is_pod()
-            && <Vec<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
-            && <[f32; 3usize]>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer3);
@@ -576,5 +556,25 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer3")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer3 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        #![allow(clippy::match_same_arms)]
+        match self {
+            Self::Degrees(v) => v.heap_size_bytes(),
+            Self::Craziness(v) => v.heap_size_bytes(),
+            Self::FixedSizeShenanigans(v) => v.heap_size_bytes(),
+            Self::EmptyVariant => 0,
+        }
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <f32>::is_pod()
+            && <Vec<crate::testing::datatypes::AffixFuzzer1>>::is_pod()
+            && <[f32; 3usize]>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -13,32 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum AffixFuzzer4 {
     SingleRequired(crate::testing::datatypes::AffixFuzzer3),
     ManyRequired(Vec<crate::testing::datatypes::AffixFuzzer3>),
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer4 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        #![allow(clippy::match_same_arms)]
-        match self {
-            Self::SingleRequired(v) => v.heap_size_bytes(),
-            Self::ManyRequired(v) => v.heap_size_bytes(),
-        }
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::AffixFuzzer3>::is_pod()
-            && <Vec<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer4);
@@ -386,5 +369,22 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer4")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer4 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        #![allow(clippy::match_same_arms)]
+        match self {
+            Self::SingleRequired(v) => v.heap_size_bytes(),
+            Self::ManyRequired(v) => v.heap_size_bytes(),
+        }
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::AffixFuzzer3>::is_pod()
+            && <Vec<crate::testing::datatypes::AffixFuzzer3>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -13,57 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct AffixFuzzer5 {
     pub single_optional_union: Option<crate::testing::datatypes::AffixFuzzer4>,
-}
-
-impl ::re_types_core::SizeBytes for AffixFuzzer5 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.single_optional_union.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::testing::datatypes::AffixFuzzer4>>::is_pod()
-    }
-}
-
-impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer4>>> From<T> for AffixFuzzer5 {
-    fn from(v: T) -> Self {
-        Self {
-            single_optional_union: v.into(),
-        }
-    }
-}
-
-impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer4>> for AffixFuzzer5 {
-    #[inline]
-    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer4> {
-        &self.single_optional_union
-    }
-}
-
-impl std::ops::Deref for AffixFuzzer5 {
-    type Target = Option<crate::testing::datatypes::AffixFuzzer4>;
-
-    #[inline]
-    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer4> {
-        &self.single_optional_union
-    }
-}
-
-impl std::ops::DerefMut for AffixFuzzer5 {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer4> {
-        &mut self.single_optional_union
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(AffixFuzzer5);
@@ -200,5 +157,48 @@ impl ::re_types_core::Loggable for AffixFuzzer5 {
                 .with_context("rerun.testing.datatypes.AffixFuzzer5")?
             }
         })
+    }
+}
+
+impl<T: Into<Option<crate::testing::datatypes::AffixFuzzer4>>> From<T> for AffixFuzzer5 {
+    fn from(v: T) -> Self {
+        Self {
+            single_optional_union: v.into(),
+        }
+    }
+}
+
+impl std::borrow::Borrow<Option<crate::testing::datatypes::AffixFuzzer4>> for AffixFuzzer5 {
+    #[inline]
+    fn borrow(&self) -> &Option<crate::testing::datatypes::AffixFuzzer4> {
+        &self.single_optional_union
+    }
+}
+
+impl std::ops::Deref for AffixFuzzer5 {
+    type Target = Option<crate::testing::datatypes::AffixFuzzer4>;
+
+    #[inline]
+    fn deref(&self) -> &Option<crate::testing::datatypes::AffixFuzzer4> {
+        &self.single_optional_union
+    }
+}
+
+impl std::ops::DerefMut for AffixFuzzer5 {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Option<crate::testing::datatypes::AffixFuzzer4> {
+        &mut self.single_optional_union
+    }
+}
+
+impl ::re_types_core::SizeBytes for AffixFuzzer5 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.single_optional_union.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::testing::datatypes::AffixFuzzer4>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer5.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/enum_test.rs
+++ b/crates/store/re_types/src/testing/datatypes/enum_test.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/enum_test.rs
+++ b/crates/store/re_types/src/testing/datatypes/enum_test.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A test of the enum type.
@@ -41,57 +41,6 @@ pub enum EnumTest {
 
     /// Baby's got it.
     Back = 6,
-}
-
-impl ::re_types_core::reflection::Enum for EnumTest {
-    #[inline]
-    fn variants() -> &'static [Self] {
-        &[
-            Self::Up,
-            Self::Down,
-            Self::Right,
-            Self::Left,
-            Self::Forward,
-            Self::Back,
-        ]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Up => "Great film.",
-            Self::Down => "Feeling blue.",
-            Self::Right => "Correct.",
-            Self::Left => "It's what's remaining.",
-            Self::Forward => "It's the only way to go.",
-            Self::Back => "Baby's got it.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for EnumTest {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for EnumTest {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Up => write!(f, "Up"),
-            Self::Down => write!(f, "Down"),
-            Self::Right => write!(f, "Right"),
-            Self::Left => write!(f, "Left"),
-            Self::Forward => write!(f, "Forward"),
-            Self::Back => write!(f, "Back"),
-        }
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(EnumTest);
@@ -181,5 +130,56 @@ impl ::re_types_core::Loggable for EnumTest {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.testing.datatypes.EnumTest")?)
+    }
+}
+
+impl std::fmt::Display for EnumTest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Up => write!(f, "Up"),
+            Self::Down => write!(f, "Down"),
+            Self::Right => write!(f, "Right"),
+            Self::Left => write!(f, "Left"),
+            Self::Forward => write!(f, "Forward"),
+            Self::Back => write!(f, "Back"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for EnumTest {
+    #[inline]
+    fn variants() -> &'static [Self] {
+        &[
+            Self::Up,
+            Self::Down,
+            Self::Right,
+            Self::Left,
+            Self::Forward,
+            Self::Back,
+        ]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Up => "Great film.",
+            Self::Down => "Feeling blue.",
+            Self::Right => "Correct.",
+            Self::Left => "It's what's remaining.",
+            Self::Forward => "It's the only way to go.",
+            Self::Back => "Baby's got it.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for EnumTest {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct FlattenedScalar {
     pub value: f32,
-}
-
-impl ::re_types_core::SizeBytes for FlattenedScalar {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.value.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <f32>::is_pod()
-    }
-}
-
-impl From<f32> for FlattenedScalar {
-    #[inline]
-    fn from(value: f32) -> Self {
-        Self { value }
-    }
-}
-
-impl From<FlattenedScalar> for f32 {
-    #[inline]
-    fn from(value: FlattenedScalar) -> Self {
-        value.value
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(FlattenedScalar);
@@ -189,5 +163,31 @@ impl ::re_types_core::Loggable for FlattenedScalar {
                 .with_context("rerun.testing.datatypes.FlattenedScalar")?
             }
         })
+    }
+}
+
+impl From<f32> for FlattenedScalar {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self { value }
+    }
+}
+
+impl From<FlattenedScalar> for f32 {
+    #[inline]
+    fn from(value: FlattenedScalar) -> Self {
+        value.value
+    }
+}
+
+impl ::re_types_core::SizeBytes for FlattenedScalar {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.value.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <f32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
+++ b/crates/store/re_types/src/testing/datatypes/flattened_scalar.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/multi_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/multi_enum.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -25,19 +25,6 @@ pub struct MultiEnum {
 
     /// The second value.
     pub value2: Option<crate::testing::datatypes::ValuedEnum>,
-}
-
-impl ::re_types_core::SizeBytes for MultiEnum {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.value1.heap_size_bytes() + self.value2.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::testing::datatypes::EnumTest>::is_pod()
-            && <Option<crate::testing::datatypes::ValuedEnum>>::is_pod()
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(MultiEnum);
@@ -219,5 +206,18 @@ impl ::re_types_core::Loggable for MultiEnum {
                 .with_context("rerun.testing.datatypes.MultiEnum")?
             }
         })
+    }
+}
+
+impl ::re_types_core::SizeBytes for MultiEnum {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.value1.heap_size_bytes() + self.value2.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::testing::datatypes::EnumTest>::is_pod()
+            && <Option<crate::testing::datatypes::ValuedEnum>>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/multi_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/multi_enum.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/primitive_component.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct PrimitiveComponent(pub u32);
-
-impl ::re_types_core::SizeBytes for PrimitiveComponent {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod()
-    }
-}
-
-impl From<u32> for PrimitiveComponent {
-    #[inline]
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<PrimitiveComponent> for u32 {
-    #[inline]
-    fn from(value: PrimitiveComponent) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(PrimitiveComponent);
 
@@ -156,5 +130,31 @@ impl ::re_types_core::Loggable for PrimitiveComponent {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u32> for PrimitiveComponent {
+    #[inline]
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<PrimitiveComponent> for u32 {
+    #[inline]
+    fn from(value: PrimitiveComponent) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for PrimitiveComponent {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/primitive_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/primitive_component.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/string_component.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[repr(transparent)]
 pub struct StringComponent(pub ::re_types_core::ArrowString);
-
-impl ::re_types_core::SizeBytes for StringComponent {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <::re_types_core::ArrowString>::is_pod()
-    }
-}
-
-impl From<::re_types_core::ArrowString> for StringComponent {
-    #[inline]
-    fn from(value: ::re_types_core::ArrowString) -> Self {
-        Self(value)
-    }
-}
-
-impl From<StringComponent> for ::re_types_core::ArrowString {
-    #[inline]
-    fn from(value: StringComponent) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(StringComponent);
 
@@ -158,5 +132,31 @@ impl ::re_types_core::Loggable for StringComponent {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.testing.datatypes.StringComponent#value")
         .with_context("rerun.testing.datatypes.StringComponent")?)
+    }
+}
+
+impl From<::re_types_core::ArrowString> for StringComponent {
+    #[inline]
+    fn from(value: ::re_types_core::ArrowString) -> Self {
+        Self(value)
+    }
+}
+
+impl From<StringComponent> for ::re_types_core::ArrowString {
+    #[inline]
+    fn from(value: StringComponent) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for StringComponent {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <::re_types_core::ArrowString>::is_pod()
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/string_component.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types/src/testing/datatypes/valued_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/valued_enum.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A test of an enumate with specified values.
@@ -34,46 +34,6 @@ pub enum ValuedEnum {
 
     /// The answer to life, the universe, and everything.
     TheAnswer = 42,
-}
-
-impl ::re_types_core::reflection::Enum for ValuedEnum {
-    #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::One, Self::Two, Self::Three, Self::TheAnswer]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::One => "One.",
-            Self::Two => "Two.",
-            Self::Three => "Three.",
-            Self::TheAnswer => "The answer to life, the universe, and everything.",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for ValuedEnum {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for ValuedEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::One => write!(f, "One"),
-            Self::Two => write!(f, "Two"),
-            Self::Three => write!(f, "Three"),
-            Self::TheAnswer => write!(f, "TheAnswer"),
-        }
-    }
 }
 
 ::re_types_core::macros::impl_into_cow!(ValuedEnum);
@@ -161,5 +121,45 @@ impl ::re_types_core::Loggable for ValuedEnum {
             })
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.testing.datatypes.ValuedEnum")?)
+    }
+}
+
+impl std::fmt::Display for ValuedEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::One => write!(f, "One"),
+            Self::Two => write!(f, "Two"),
+            Self::Three => write!(f, "Three"),
+            Self::TheAnswer => write!(f, "TheAnswer"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for ValuedEnum {
+    #[inline]
+    fn variants() -> &'static [Self] {
+        &[Self::One, Self::Two, Self::Three, Self::TheAnswer]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::One => "One.",
+            Self::Two => "Two.",
+            Self::Three => "Three.",
+            Self::TheAnswer => "The answer to life, the universe, and everything.",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ValuedEnum {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types/src/testing/datatypes/valued_enum.rs
+++ b/crates/store/re_types/src/testing/datatypes/valued_enum.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The description of a container.
@@ -62,65 +62,113 @@ pub struct ContainerBlueprint {
     pub grid_columns: Option<crate::blueprint::components::GridColumns>,
 }
 
-impl ::re_types_core::SizeBytes for ContainerBlueprint {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.container_kind.heap_size_bytes()
-            + self.display_name.heap_size_bytes()
-            + self.contents.heap_size_bytes()
-            + self.col_shares.heap_size_bytes()
-            + self.row_shares.heap_size_bytes()
-            + self.active_tab.heap_size_bytes()
-            + self.visible.heap_size_bytes()
-            + self.grid_columns.heap_size_bytes()
-    }
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "rerun.blueprint.components.ContainerKind".into(),
+            archetype_field_name: Some("container_kind".into()),
+        }]
+    });
 
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::components::ContainerKind>::is_pod()
-            && <Option<crate::components::Name>>::is_pod()
-            && <Option<Vec<crate::blueprint::components::IncludedContent>>>::is_pod()
-            && <Option<Vec<crate::blueprint::components::ColumnShare>>>::is_pod()
-            && <Option<Vec<crate::blueprint::components::RowShare>>>::is_pod()
-            && <Option<crate::blueprint::components::ActiveTab>>::is_pod()
-            && <Option<crate::blueprint::components::Visible>>::is_pod()
-            && <Option<crate::blueprint::components::GridColumns>>::is_pod()
-    }
-}
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+            component_name: "ContainerBlueprintIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ContainerKind".into()]);
-
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(
-        || ["rerun.blueprint.components.ContainerBlueprintIndicator".into()],
-    );
-
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 7usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.components.Name".into(),
-            "rerun.blueprint.components.IncludedContent".into(),
-            "rerun.blueprint.components.ColumnShare".into(),
-            "rerun.blueprint.components.RowShare".into(),
-            "rerun.blueprint.components.ActiveTab".into(),
-            "rerun.blueprint.components.Visible".into(),
-            "rerun.blueprint.components.GridColumns".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("display_name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.IncludedContent".into(),
+                archetype_field_name: Some("contents".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.ColumnShare".into(),
+                archetype_field_name: Some("col_shares".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.RowShare".into(),
+                archetype_field_name: Some("row_shares".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.ActiveTab".into(),
+                archetype_field_name: Some("active_tab".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.GridColumns".into(),
+                archetype_field_name: Some("grid_columns".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 9usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.ContainerKind".into(),
-            "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
-            "rerun.components.Name".into(),
-            "rerun.blueprint.components.IncludedContent".into(),
-            "rerun.blueprint.components.ColumnShare".into(),
-            "rerun.blueprint.components.RowShare".into(),
-            "rerun.blueprint.components.ActiveTab".into(),
-            "rerun.blueprint.components.Visible".into(),
-            "rerun.blueprint.components.GridColumns".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.ContainerKind".into(),
+                archetype_field_name: Some("container_kind".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "ContainerBlueprintIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.components.Name".into(),
+                archetype_field_name: Some("display_name".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.IncludedContent".into(),
+                archetype_field_name: Some("contents".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.ColumnShare".into(),
+                archetype_field_name: Some("col_shares".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.RowShare".into(),
+                archetype_field_name: Some("row_shares".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.ActiveTab".into(),
+                archetype_field_name: Some("active_tab".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.Visible".into(),
+                archetype_field_name: Some("visible".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                component_name: "rerun.blueprint.components.GridColumns".into(),
+                archetype_field_name: Some("grid_columns".into()),
+            },
         ]
     });
 
@@ -149,26 +197,26 @@ impl ::re_types_core::Archetype for ContainerBlueprint {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ContainerBlueprintIndicator = ContainerBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -292,28 +340,102 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            Some((&self.container_kind as &dyn ComponentBatch).into()),
-            self.display_name
+            (Some(&self.container_kind as &dyn ComponentBatch)).map(|batch| {
+                ::re_types_core::MaybeOwnedComponentBatch {
+                    batch: batch.into(),
+                    descriptor_override: Some(ComponentDescriptor {
+                        archetype_name: Some(
+                            "rerun.blueprint.archetypes.ContainerBlueprint".into(),
+                        ),
+                        archetype_field_name: Some(("container_kind").into()),
+                        component_name: ("rerun.blueprint.components.ContainerKind").into(),
+                    }),
+                }
+            }),
+            (self
+                .display_name
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.contents
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("display_name").into()),
+                    component_name: ("rerun.components.Name").into(),
+                }),
+            }),
+            (self
+                .contents
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.col_shares
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("contents").into()),
+                    component_name: ("rerun.blueprint.components.IncludedContent").into(),
+                }),
+            }),
+            (self
+                .col_shares
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.row_shares
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("col_shares").into()),
+                    component_name: ("rerun.blueprint.components.ColumnShare").into(),
+                }),
+            }),
+            (self
+                .row_shares
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
-            self.active_tab
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("row_shares").into()),
+                    component_name: ("rerun.blueprint.components.RowShare").into(),
+                }),
+            }),
+            (self
+                .active_tab
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.visible
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("active_tab").into()),
+                    component_name: ("rerun.blueprint.components.ActiveTab").into(),
+                }),
+            }),
+            (self
+                .visible
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.grid_columns
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("visible").into()),
+                    component_name: ("rerun.blueprint.components.Visible").into(),
+                }),
+            }),
+            (self
+                .grid_columns
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
+                    archetype_field_name: Some(("grid_columns").into()),
+                    component_name: ("rerun.blueprint.components.GridColumns").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -420,5 +542,31 @@ impl ContainerBlueprint {
     ) -> Self {
         self.grid_columns = Some(grid_columns.into());
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for ContainerBlueprint {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.container_kind.heap_size_bytes()
+            + self.display_name.heap_size_bytes()
+            + self.contents.heap_size_bytes()
+            + self.col_shares.heap_size_bytes()
+            + self.row_shares.heap_size_bytes()
+            + self.active_tab.heap_size_bytes()
+            + self.visible.heap_size_bytes()
+            + self.grid_columns.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::components::ContainerKind>::is_pod()
+            && <Option<crate::components::Name>>::is_pod()
+            && <Option<Vec<crate::blueprint::components::IncludedContent>>>::is_pod()
+            && <Option<Vec<crate::blueprint::components::ColumnShare>>>::is_pod()
+            && <Option<Vec<crate::blueprint::components::RowShare>>>::is_pod()
+            && <Option<crate::blueprint::components::ActiveTab>>::is_pod()
+            && <Option<crate::blueprint::components::Visible>>::is_pod()
+            && <Option<crate::blueprint::components::GridColumns>>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -195,9 +195,9 @@ impl ::re_types_core::Archetype for ContainerBlueprint {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ContainerBlueprintIndicator = ContainerBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -335,13 +335,13 @@ impl ::re_types_core::Archetype for ContainerBlueprint {
 }
 
 impl ::re_types_core::AsComponents for ContainerBlueprint {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.container_kind as &dyn ComponentBatch)).map(|batch| {
-                ::re_types_core::MaybeOwnedComponentBatch {
+                ::re_types_core::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some(
@@ -356,7 +356,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .display_name
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -368,7 +368,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .contents
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -380,7 +380,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .col_shares
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -392,7 +392,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .row_shares
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -404,7 +404,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .active_tab
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -416,7 +416,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .visible
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
@@ -428,7 +428,7 @@ impl ::re_types_core::AsComponents for ContainerBlueprint {
                 .grid_columns
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -83,9 +83,9 @@ impl ::re_types_core::Archetype for PanelBlueprint {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: PanelBlueprintIndicator = PanelBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -133,7 +133,7 @@ impl ::re_types_core::Archetype for PanelBlueprint {
 }
 
 impl ::re_types_core::AsComponents for PanelBlueprint {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -142,7 +142,7 @@ impl ::re_types_core::AsComponents for PanelBlueprint {
                 .state
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Archetype**: The top-level description of the viewport.
@@ -50,52 +50,82 @@ pub struct ViewportBlueprint {
         Option<Vec<crate::blueprint::components::ViewerRecommendationHash>>,
 }
 
-impl ::re_types_core::SizeBytes for ViewportBlueprint {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.root_container.heap_size_bytes()
-            + self.maximized.heap_size_bytes()
-            + self.auto_layout.heap_size_bytes()
-            + self.auto_space_views.heap_size_bytes()
-            + self.past_viewer_recommendations.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Option<crate::blueprint::components::RootContainer>>::is_pod()
-            && <Option<crate::blueprint::components::SpaceViewMaximized>>::is_pod()
-            && <Option<crate::blueprint::components::AutoLayout>>::is_pod()
-            && <Option<crate::blueprint::components::AutoSpaceViews>>::is_pod()
-            && <Option<Vec<crate::blueprint::components::ViewerRecommendationHash>>>::is_pod()
-    }
-}
-
-static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 0usize]> =
+static REQUIRED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 0usize]> =
     once_cell::sync::Lazy::new(|| []);
 
-static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 1usize]> =
-    once_cell::sync::Lazy::new(|| ["rerun.blueprint.components.ViewportBlueprintIndicator".into()]);
+static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usize]> =
+    once_cell::sync::Lazy::new(|| {
+        [ComponentDescriptor {
+            archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+            component_name: "ViewportBlueprintIndicator".into(),
+            archetype_field_name: None,
+        }]
+    });
 
-static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 5usize]> =
+static OPTIONAL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.RootContainer".into(),
-            "rerun.blueprint.components.SpaceViewMaximized".into(),
-            "rerun.blueprint.components.AutoLayout".into(),
-            "rerun.blueprint.components.AutoSpaceViews".into(),
-            "rerun.blueprint.components.ViewerRecommendationHash".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.RootContainer".into(),
+                archetype_field_name: Some("root_container".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.SpaceViewMaximized".into(),
+                archetype_field_name: Some("maximized".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.AutoLayout".into(),
+                archetype_field_name: Some("auto_layout".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.AutoSpaceViews".into(),
+                archetype_field_name: Some("auto_space_views".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.ViewerRecommendationHash".into(),
+                archetype_field_name: Some("past_viewer_recommendations".into()),
+            },
         ]
     });
 
-static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentName; 6usize]> =
+static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
     once_cell::sync::Lazy::new(|| {
         [
-            "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
-            "rerun.blueprint.components.RootContainer".into(),
-            "rerun.blueprint.components.SpaceViewMaximized".into(),
-            "rerun.blueprint.components.AutoLayout".into(),
-            "rerun.blueprint.components.AutoSpaceViews".into(),
-            "rerun.blueprint.components.ViewerRecommendationHash".into(),
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "ViewportBlueprintIndicator".into(),
+                archetype_field_name: None,
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.RootContainer".into(),
+                archetype_field_name: Some("root_container".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.SpaceViewMaximized".into(),
+                archetype_field_name: Some("maximized".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.AutoLayout".into(),
+                archetype_field_name: Some("auto_layout".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.AutoSpaceViews".into(),
+                archetype_field_name: Some("auto_space_views".into()),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                component_name: "rerun.blueprint.components.ViewerRecommendationHash".into(),
+                archetype_field_name: Some("past_viewer_recommendations".into()),
+            },
         ]
     });
 
@@ -123,26 +153,26 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
     #[inline]
     fn indicator() -> MaybeOwnedComponentBatch<'static> {
         static INDICATOR: ViewportBlueprintIndicator = ViewportBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::Ref(&INDICATOR)
+        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         REQUIRED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn recommended_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         RECOMMENDED_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn optional_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         OPTIONAL_COMPONENTS.as_slice().into()
     }
 
     #[inline]
-    fn all_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
+    fn all_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
         ALL_COMPONENTS.as_slice().into()
     }
 
@@ -231,21 +261,66 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
         use ::re_types_core::Archetype as _;
         [
             Some(Self::indicator()),
-            self.root_container
+            (self
+                .root_container
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.maximized
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                    archetype_field_name: Some(("root_container").into()),
+                    component_name: ("rerun.blueprint.components.RootContainer").into(),
+                }),
+            }),
+            (self
+                .maximized
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.auto_layout
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                    archetype_field_name: Some(("maximized").into()),
+                    component_name: ("rerun.blueprint.components.SpaceViewMaximized").into(),
+                }),
+            }),
+            (self
+                .auto_layout
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.auto_space_views
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                    archetype_field_name: Some(("auto_layout").into()),
+                    component_name: ("rerun.blueprint.components.AutoLayout").into(),
+                }),
+            }),
+            (self
+                .auto_space_views
                 .as_ref()
-                .map(|comp| (comp as &dyn ComponentBatch).into()),
-            self.past_viewer_recommendations
+                .map(|comp| (comp as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                    archetype_field_name: Some(("auto_space_views").into()),
+                    component_name: ("rerun.blueprint.components.AutoSpaceViews").into(),
+                }),
+            }),
+            (self
+                .past_viewer_recommendations
                 .as_ref()
-                .map(|comp_batch| (comp_batch as &dyn ComponentBatch).into()),
+                .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
+            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+                batch: batch.into(),
+                descriptor_override: Some(ComponentDescriptor {
+                    archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
+                    archetype_field_name: Some(("past_viewer_recommendations").into()),
+                    component_name: ("rerun.blueprint.components.ViewerRecommendationHash").into(),
+                }),
+            }),
         ]
         .into_iter()
         .flatten()
@@ -335,5 +410,25 @@ impl ViewportBlueprint {
                 .collect(),
         );
         self
+    }
+}
+
+impl ::re_types_core::SizeBytes for ViewportBlueprint {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.root_container.heap_size_bytes()
+            + self.maximized.heap_size_bytes()
+            + self.auto_layout.heap_size_bytes()
+            + self.auto_space_views.heap_size_bytes()
+            + self.past_viewer_recommendations.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Option<crate::blueprint::components::RootContainer>>::is_pod()
+            && <Option<crate::blueprint::components::SpaceViewMaximized>>::is_pod()
+            && <Option<crate::blueprint::components::AutoLayout>>::is_pod()
+            && <Option<crate::blueprint::components::AutoSpaceViews>>::is_pod()
+            && <Option<Vec<crate::blueprint::components::ViewerRecommendationHash>>>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
@@ -151,9 +151,9 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ViewportBlueprintIndicator = ViewportBlueprintIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn ::re_types_core::ComponentBatch)
     }
 
     #[inline]
@@ -256,7 +256,7 @@ impl ::re_types_core::Archetype for ViewportBlueprint {
 }
 
 impl ::re_types_core::AsComponents for ViewportBlueprint {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use ::re_types_core::Archetype as _;
         [
@@ -265,7 +265,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .root_container
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
@@ -277,7 +277,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .maximized
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
@@ -289,7 +289,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .auto_layout
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
@@ -301,7 +301,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .auto_space_views
                 .as_ref()
                 .map(|comp| (comp as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
@@ -313,7 +313,7 @@ impl ::re_types_core::AsComponents for ViewportBlueprint {
                 .past_viewer_recommendations
                 .as_ref()
                 .map(|comp_batch| (comp_batch as &dyn ComponentBatch)))
-            .map(|batch| ::re_types_core::MaybeOwnedComponentBatch {
+            .map(|batch| ::re_types_core::ComponentBatchCowWithDescriptor {
                 batch: batch.into(),
                 descriptor_override: Some(ComponentDescriptor {
                     archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether the viewport layout is determined automatically.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct AutoLayout(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for AutoLayout {
+impl ::re_types_core::Component for AutoLayout {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for AutoLayout {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for AutoLayout {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AutoLayout {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AutoLayout {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.AutoLayout")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for AutoLayout {
     }
 }
 
-impl ::re_types_core::Component for AutoLayout {
+impl<T: Into<crate::datatypes::Bool>> From<T> for AutoLayout {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for AutoLayout {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.AutoLayout".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AutoLayout {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AutoLayout {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AutoLayout {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_layout.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether or not space views should be created automatically.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct AutoSpaceViews(pub crate::datatypes::Bool);
 
-impl ::re_types_core::SizeBytes for AutoSpaceViews {
+impl ::re_types_core::Component for AutoSpaceViews {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for AutoSpaceViews {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for AutoSpaceViews {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for AutoSpaceViews {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for AutoSpaceViews {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.AutoSpaceViews")
     }
 }
 
@@ -97,9 +63,43 @@ impl ::re_types_core::Loggable for AutoSpaceViews {
     }
 }
 
-impl ::re_types_core::Component for AutoSpaceViews {
+impl<T: Into<crate::datatypes::Bool>> From<T> for AutoSpaceViews {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for AutoSpaceViews {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.AutoSpaceViews".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AutoSpaceViews {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for AutoSpaceViews {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for AutoSpaceViews {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/auto_space_views.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
@@ -15,7 +15,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/container_kind.rs
@@ -14,9 +14,9 @@
 #![allow(non_camel_case_types)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The kind of a blueprint container (tabs, grid, …).
@@ -37,43 +37,10 @@ pub enum ContainerKind {
     Grid = 4,
 }
 
-impl ::re_types_core::reflection::Enum for ContainerKind {
+impl ::re_types_core::Component for ContainerKind {
     #[inline]
-    fn variants() -> &'static [Self] {
-        &[Self::Tabs, Self::Horizontal, Self::Vertical, Self::Grid]
-    }
-
-    #[inline]
-    fn docstring_md(self) -> &'static str {
-        match self {
-            Self::Tabs => "Put children in separate tabs",
-            Self::Horizontal => "Order the children left to right",
-            Self::Vertical => "Order the children top to bottom",
-            Self::Grid => "Organize children in a grid layout",
-        }
-    }
-}
-
-impl ::re_types_core::SizeBytes for ContainerKind {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        0
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        true
-    }
-}
-
-impl std::fmt::Display for ContainerKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Tabs => write!(f, "Tabs"),
-            Self::Horizontal => write!(f, "Horizontal"),
-            Self::Vertical => write!(f, "Vertical"),
-            Self::Grid => write!(f, "Grid"),
-        }
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.ContainerKind")
     }
 }
 
@@ -165,9 +132,42 @@ impl ::re_types_core::Loggable for ContainerKind {
     }
 }
 
-impl ::re_types_core::Component for ContainerKind {
+impl std::fmt::Display for ContainerKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tabs => write!(f, "Tabs"),
+            Self::Horizontal => write!(f, "Horizontal"),
+            Self::Vertical => write!(f, "Vertical"),
+            Self::Grid => write!(f, "Grid"),
+        }
+    }
+}
+
+impl ::re_types_core::reflection::Enum for ContainerKind {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.ContainerKind".into()
+    fn variants() -> &'static [Self] {
+        &[Self::Tabs, Self::Horizontal, Self::Vertical, Self::Grid]
+    }
+
+    #[inline]
+    fn docstring_md(self) -> &'static str {
+        match self {
+            Self::Tabs => "Put children in separate tabs",
+            Self::Horizontal => "Order the children left to right",
+            Self::Vertical => "Order the children top to bottom",
+            Self::Grid => "Organize children in a grid layout",
+        }
+    }
+}
+
+impl ::re_types_core::SizeBytes for ContainerKind {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        true
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: How many columns a grid container should have.
@@ -25,44 +25,10 @@ pub struct GridColumns(
     pub crate::datatypes::UInt32,
 );
 
-impl ::re_types_core::SizeBytes for GridColumns {
+impl ::re_types_core::Component for GridColumns {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::UInt32>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::UInt32>> From<T> for GridColumns {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::UInt32> for GridColumns {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::UInt32 {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for GridColumns {
-    type Target = crate::datatypes::UInt32;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::UInt32 {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for GridColumns {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::UInt32 {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.GridColumns")
     }
 }
 
@@ -107,9 +73,43 @@ impl ::re_types_core::Loggable for GridColumns {
     }
 }
 
-impl ::re_types_core::Component for GridColumns {
+impl<T: Into<crate::datatypes::UInt32>> From<T> for GridColumns {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::UInt32> for GridColumns {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.GridColumns".into()
+    fn borrow(&self) -> &crate::datatypes::UInt32 {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for GridColumns {
+    type Target = crate::datatypes::UInt32;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::UInt32 {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for GridColumns {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::UInt32 {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for GridColumns {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::UInt32>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/grid_columns.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: The container that sits at the root of a viewport.
@@ -26,44 +26,10 @@ pub struct RootContainer(
     pub crate::datatypes::Uuid,
 );
 
-impl ::re_types_core::SizeBytes for RootContainer {
+impl ::re_types_core::Component for RootContainer {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Uuid>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Uuid>> From<T> for RootContainer {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Uuid> for RootContainer {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Uuid {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for RootContainer {
-    type Target = crate::datatypes::Uuid;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Uuid {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for RootContainer {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Uuid {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.RootContainer")
     }
 }
 
@@ -108,9 +74,43 @@ impl ::re_types_core::Loggable for RootContainer {
     }
 }
 
-impl ::re_types_core::Component for RootContainer {
+impl<T: Into<crate::datatypes::Uuid>> From<T> for RootContainer {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Uuid> for RootContainer {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.RootContainer".into()
+    fn borrow(&self) -> &crate::datatypes::Uuid {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for RootContainer {
+    type Target = crate::datatypes::Uuid;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Uuid {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for RootContainer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Uuid {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for RootContainer {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Uuid>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/root_container.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Whether a space view is maximized.
@@ -23,44 +23,10 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 #[repr(transparent)]
 pub struct SpaceViewMaximized(pub crate::datatypes::Uuid);
 
-impl ::re_types_core::SizeBytes for SpaceViewMaximized {
+impl ::re_types_core::Component for SpaceViewMaximized {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Uuid>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Uuid>> From<T> for SpaceViewMaximized {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Uuid> for SpaceViewMaximized {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Uuid {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for SpaceViewMaximized {
-    type Target = crate::datatypes::Uuid;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Uuid {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for SpaceViewMaximized {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Uuid {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.SpaceViewMaximized")
     }
 }
 
@@ -105,9 +71,43 @@ impl ::re_types_core::Loggable for SpaceViewMaximized {
     }
 }
 
-impl ::re_types_core::Component for SpaceViewMaximized {
+impl<T: Into<crate::datatypes::Uuid>> From<T> for SpaceViewMaximized {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Uuid> for SpaceViewMaximized {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.SpaceViewMaximized".into()
+    fn borrow(&self) -> &crate::datatypes::Uuid {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for SpaceViewMaximized {
+    type Target = crate::datatypes::Uuid;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Uuid {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for SpaceViewMaximized {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Uuid {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for SpaceViewMaximized {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Uuid>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/space_view_maximized.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Component**: Override the visualizers for an entity.
@@ -58,44 +58,10 @@ pub struct VisualizerOverrides(
     pub crate::blueprint::datatypes::Utf8List,
 );
 
-impl ::re_types_core::SizeBytes for VisualizerOverrides {
+impl ::re_types_core::Component for VisualizerOverrides {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::blueprint::datatypes::Utf8List>::is_pod()
-    }
-}
-
-impl<T: Into<crate::blueprint::datatypes::Utf8List>> From<T> for VisualizerOverrides {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::blueprint::datatypes::Utf8List> for VisualizerOverrides {
-    #[inline]
-    fn borrow(&self) -> &crate::blueprint::datatypes::Utf8List {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for VisualizerOverrides {
-    type Target = crate::blueprint::datatypes::Utf8List;
-
-    #[inline]
-    fn deref(&self) -> &crate::blueprint::datatypes::Utf8List {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for VisualizerOverrides {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::Utf8List {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.blueprint.components.VisualizerOverrides")
     }
 }
 
@@ -132,9 +98,43 @@ impl ::re_types_core::Loggable for VisualizerOverrides {
     }
 }
 
-impl ::re_types_core::Component for VisualizerOverrides {
+impl<T: Into<crate::blueprint::datatypes::Utf8List>> From<T> for VisualizerOverrides {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::blueprint::datatypes::Utf8List> for VisualizerOverrides {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.blueprint.components.VisualizerOverrides".into()
+    fn borrow(&self) -> &crate::blueprint::datatypes::Utf8List {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for VisualizerOverrides {
+    type Target = crate::blueprint::datatypes::Utf8List;
+
+    #[inline]
+    fn deref(&self) -> &crate::blueprint::datatypes::Utf8List {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for VisualizerOverrides {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::blueprint::datatypes::Utf8List {
+        &mut self.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for VisualizerOverrides {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::blueprint::datatypes::Utf8List>::is_pod()
     }
 }

--- a/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/components/visualizer_overrides.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -14,7 +14,7 @@
 
 use ::re_types_core::external::arrow2;
 use ::re_types_core::SerializationResult;
-use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use ::re_types_core::external::arrow2;
-use ::re_types_core::ComponentName;
 use ::re_types_core::SerializationResult;
 use ::re_types_core::{ComponentBatch, MaybeOwnedComponentBatch};
+use ::re_types_core::{ComponentDescriptor, ComponentName};
 use ::re_types_core::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A list of strings of text, encoded as UTF-8.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 #[repr(transparent)]
 pub struct Utf8List(pub Vec<::re_types_core::ArrowString>);
-
-impl ::re_types_core::SizeBytes for Utf8List {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <Vec<::re_types_core::ArrowString>>::is_pod()
-    }
-}
-
-impl From<Vec<::re_types_core::ArrowString>> for Utf8List {
-    #[inline]
-    fn from(value: Vec<::re_types_core::ArrowString>) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Utf8List> for Vec<::re_types_core::ArrowString> {
-    #[inline]
-    fn from(value: Utf8List) -> Self {
-        value.0
-    }
-}
 
 ::re_types_core::macros::impl_into_cow!(Utf8List);
 
@@ -227,5 +201,31 @@ impl ::re_types_core::Loggable for Utf8List {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.blueprint.datatypes.Utf8List#value")
         .with_context("rerun.blueprint.datatypes.Utf8List")?)
+    }
+}
+
+impl From<Vec<::re_types_core::ArrowString>> for Utf8List {
+    #[inline]
+    fn from(value: Vec<::re_types_core::ArrowString>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Utf8List> for Vec<::re_types_core::ArrowString> {
+    #[inline]
+    fn from(value: Utf8List) -> Self {
+        value.0
+    }
+}
+
+impl ::re_types_core::SizeBytes for Utf8List {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <Vec<::re_types_core::ArrowString>>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::{
-    ComponentBatch, ComponentDescriptor, ComponentName, DeserializationResult,
-    MaybeOwnedComponentBatch, SerializationResult, _Backtrace,
+    ComponentBatch, ComponentBatchCowWithDescriptor, ComponentDescriptor, ComponentName,
+    DeserializationResult, SerializationResult, _Backtrace,
 };
 
 #[allow(unused_imports)] // used in docstrings
@@ -52,8 +52,8 @@ pub trait Archetype {
     /// This allows for associating arbitrary indicator components with arbitrary data.
     /// Check out the `manual_indicator` API example to see what's possible.
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
-        MaybeOwnedComponentBatch::new(
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
+        ComponentBatchCowWithDescriptor::new(
             Box::<<Self as Archetype>::Indicator>::default() as Box<dyn ComponentBatch>
         )
     }
@@ -290,13 +290,13 @@ pub struct NamedIndicatorComponent(pub ComponentName);
 
 impl NamedIndicatorComponent {
     #[inline]
-    pub fn as_batch(&self) -> MaybeOwnedComponentBatch<'_> {
-        MaybeOwnedComponentBatch::new(self as &dyn crate::ComponentBatch)
+    pub fn as_batch(&self) -> ComponentBatchCowWithDescriptor<'_> {
+        ComponentBatchCowWithDescriptor::new(self as &dyn crate::ComponentBatch)
     }
 
     #[inline]
-    pub fn to_batch(self) -> MaybeOwnedComponentBatch<'static> {
-        MaybeOwnedComponentBatch::new(Box::new(self) as Box<dyn crate::ComponentBatch>)
+    pub fn to_batch(self) -> ComponentBatchCowWithDescriptor<'static> {
+        ComponentBatchCowWithDescriptor::new(Box::new(self) as Box<dyn crate::ComponentBatch>)
     }
 }
 

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -247,12 +247,7 @@ impl<A: Archetype> crate::ComponentBatch for GenericIndicatorComponent<A> {
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
         let component_name =
             format!("{}Indicator", A::name().full_name()).replace("archetypes", "components");
-        ComponentDescriptor {
-            archetype_name: Some(A::name()),
-            archetype_field_name: None,
-            component_name: component_name.into(),
-        }
-        .into()
+        ComponentDescriptor::new(component_name).into()
     }
 }
 

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
@@ -137,9 +137,9 @@ impl crate::Archetype for Clear {
     }
 
     #[inline]
-    fn indicator() -> MaybeOwnedComponentBatch<'static> {
+    fn indicator() -> ComponentBatchCowWithDescriptor<'static> {
         static INDICATOR: ClearIndicator = ClearIndicator::DEFAULT;
-        MaybeOwnedComponentBatch::new(&INDICATOR as &dyn crate::ComponentBatch)
+        ComponentBatchCowWithDescriptor::new(&INDICATOR as &dyn crate::ComponentBatch)
     }
 
     #[inline]
@@ -190,13 +190,13 @@ impl crate::Archetype for Clear {
 }
 
 impl crate::AsComponents for Clear {
-    fn as_component_batches(&self) -> Vec<MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         re_tracing::profile_function!();
         use crate::Archetype as _;
         [
             Some(Self::indicator()),
             (Some(&self.is_recursive as &dyn ComponentBatch)).map(|batch| {
-                crate::MaybeOwnedComponentBatch {
+                crate::ComponentBatchCowWithDescriptor {
                     batch: batch.into(),
                     descriptor_override: Some(ComponentDescriptor {
                         archetype_name: Some("rerun.archetypes.Clear".into()),

--- a/crates/store/re_types_core/src/component_descriptor.rs
+++ b/crates/store/re_types_core/src/component_descriptor.rs
@@ -43,6 +43,8 @@ impl std::hash::Hash for ComponentDescriptor {
         let archetype_field_name = archetype_field_name.map_or(0, |v| v.hash());
         let component_name = component_name.hash();
 
+        // NOTE: This is a NoHash type, so we must respect the invariant that `write_XX` is only
+        // called one, see <https://docs.rs/nohash-hasher/0.2.0/nohash_hasher/trait.IsEnabled.html>.
         state.write_u64(archetype_name ^ archetype_field_name ^ component_name);
     }
 }

--- a/crates/store/re_types_core/src/component_descriptor.rs
+++ b/crates/store/re_types_core/src/component_descriptor.rs
@@ -1,0 +1,177 @@
+use std::borrow::Cow;
+
+use crate::{ArchetypeFieldName, ArchetypeName, ComponentName, SizeBytes};
+
+/// A [`ComponentDescriptor`] fully describes the semantics of a column of data.
+///
+/// Every component is uniquely identified by its [`ComponentDescriptor`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ComponentDescriptor {
+    /// Optional name of the `Archetype` associated with this data.
+    ///
+    /// `None` if the data wasn't logged through an archetype.
+    ///
+    /// Example: `rerun.archetypes.Points3D`.
+    pub archetype_name: Option<ArchetypeName>,
+
+    /// Optional name of the field within `Archetype` associated with this data.
+    ///
+    /// `None` if the data wasn't logged through an archetype.
+    ///
+    /// Example: `positions`.
+    pub archetype_field_name: Option<ArchetypeFieldName>,
+
+    /// Semantic name associated with this data.
+    ///
+    /// This is fully implied by `archetype_name` and `archetype_field`, but
+    /// included for semantic convenience.
+    ///
+    /// Example: `rerun.components.Position3D`.
+    pub component_name: ComponentName,
+}
+
+impl std::hash::Hash for ComponentDescriptor {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let Self {
+            archetype_name,
+            archetype_field_name,
+            component_name,
+        } = self;
+
+        let archetype_name = archetype_name.map_or(0, |v| v.hash());
+        let archetype_field_name = archetype_field_name.map_or(0, |v| v.hash());
+        let component_name = component_name.hash();
+
+        state.write_u64(archetype_name ^ archetype_field_name ^ component_name);
+    }
+}
+
+impl nohash_hasher::IsEnabled for ComponentDescriptor {}
+
+impl std::fmt::Display for ComponentDescriptor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_any_string(false))
+    }
+}
+
+impl From<ComponentDescriptor> for Cow<'static, ComponentDescriptor> {
+    #[inline]
+    fn from(descr: ComponentDescriptor) -> Self {
+        Cow::Owned(descr)
+    }
+}
+
+impl<'d> From<&'d ComponentDescriptor> for Cow<'d, ComponentDescriptor> {
+    #[inline]
+    fn from(descr: &'d ComponentDescriptor) -> Self {
+        Cow::Borrowed(descr)
+    }
+}
+
+impl ComponentDescriptor {
+    fn to_any_string(&self, use_short_names: bool) -> String {
+        let Self {
+            archetype_name,
+            archetype_field_name,
+            component_name,
+        } = self;
+
+        let (archetype_name, component_name) = if use_short_names {
+            (
+                archetype_name.map(|s| s.short_name()),
+                component_name.short_name(),
+            )
+        } else {
+            (archetype_name.map(|s| s.as_str()), component_name.as_str())
+        };
+
+        match (archetype_name, component_name, archetype_field_name) {
+            (None, component_name, None) => component_name.to_owned(),
+            (Some(archetype_name), component_name, None) => {
+                format!("{archetype_name}:{component_name}")
+            }
+            (None, component_name, Some(archetype_field_name)) => {
+                format!("{component_name}#{archetype_field_name}")
+            }
+            (Some(archetype_name), component_name, Some(archetype_field_name)) => {
+                format!("{archetype_name}:{component_name}#{archetype_field_name}")
+            }
+        }
+    }
+
+    /// Returns the fully-qualified name, e.g. `rerun.archetypes.Points3D:rerun.components.Position3D#positions`.
+    ///
+    /// This is the default `Display` implementation for [`ComponentDescriptor`].
+    #[inline]
+    pub fn full_name(&self) -> String {
+        self.to_string()
+    }
+
+    /// Returns the unqualified name, e.g. `Points3D:Position3D#positions`.
+    #[inline]
+    pub fn short_name(&self) -> String {
+        self.to_any_string(true)
+    }
+}
+
+impl SizeBytes for ComponentDescriptor {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        let Self {
+            archetype_name,
+            archetype_field_name,
+            component_name,
+        } = self;
+        archetype_name.heap_size_bytes()
+            + component_name.heap_size_bytes()
+            + archetype_field_name.heap_size_bytes()
+    }
+}
+
+impl ComponentDescriptor {
+    #[inline]
+    pub fn new(component_name: impl Into<ComponentName>) -> Self {
+        let component_name = component_name.into();
+        Self {
+            archetype_name: None,
+            archetype_field_name: None,
+            component_name,
+        }
+    }
+
+    /// Unconditionally sets [`Self::archetype_name`] to the given one.
+    #[inline]
+    pub fn with_archetype_name(mut self, archetype_name: ArchetypeName) -> Self {
+        self.archetype_name = Some(archetype_name);
+        self
+    }
+
+    /// Unconditionally sets [`Self::archetype_field_name`] to the given one.
+    #[inline]
+    pub fn with_archetype_field_name(mut self, archetype_field_name: ArchetypeFieldName) -> Self {
+        self.archetype_field_name = Some(archetype_field_name);
+        self
+    }
+
+    /// Sets [`Self::archetype_name`] to the given one iff it's not already set.
+    #[inline]
+    pub fn or_with_archetype_name(mut self, archetype_name: impl Fn() -> ArchetypeName) -> Self {
+        if self.archetype_name.is_none() {
+            self.archetype_name = Some(archetype_name());
+        }
+        self
+    }
+
+    /// Sets [`Self::archetype_field_name`] to the given one iff it's not already set.
+    #[inline]
+    pub fn or_with_archetype_field_name(
+        mut self,
+        archetype_field_name: impl FnOnce() -> ArchetypeFieldName,
+    ) -> Self {
+        if self.archetype_field_name.is_none() {
+            self.archetype_field_name = Some(archetype_field_name());
+        }
+        self
+    }
+}

--- a/crates/store/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/store/re_types_core/src/components/clear_is_recursive.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Component**: Configures how a clear operation should behave - recursive or not.
@@ -25,44 +25,10 @@ pub struct ClearIsRecursive(
     pub crate::datatypes::Bool,
 );
 
-impl crate::SizeBytes for ClearIsRecursive {
+impl crate::Component for ClearIsRecursive {
     #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Bool>::is_pod()
-    }
-}
-
-impl<T: Into<crate::datatypes::Bool>> From<T> for ClearIsRecursive {
-    fn from(v: T) -> Self {
-        Self(v.into())
-    }
-}
-
-impl std::borrow::Borrow<crate::datatypes::Bool> for ClearIsRecursive {
-    #[inline]
-    fn borrow(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::Deref for ClearIsRecursive {
-    type Target = crate::datatypes::Bool;
-
-    #[inline]
-    fn deref(&self) -> &crate::datatypes::Bool {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for ClearIsRecursive {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
-        &mut self.0
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("rerun.components.ClearIsRecursive")
     }
 }
 
@@ -99,9 +65,43 @@ impl crate::Loggable for ClearIsRecursive {
     }
 }
 
-impl crate::Component for ClearIsRecursive {
+impl<T: Into<crate::datatypes::Bool>> From<T> for ClearIsRecursive {
+    fn from(v: T) -> Self {
+        Self(v.into())
+    }
+}
+
+impl std::borrow::Borrow<crate::datatypes::Bool> for ClearIsRecursive {
     #[inline]
-    fn name() -> ComponentName {
-        "rerun.components.ClearIsRecursive".into()
+    fn borrow(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ClearIsRecursive {
+    type Target = crate::datatypes::Bool;
+
+    #[inline]
+    fn deref(&self) -> &crate::datatypes::Bool {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for ClearIsRecursive {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut crate::datatypes::Bool {
+        &mut self.0
+    }
+}
+
+impl crate::SizeBytes for ClearIsRecursive {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Bool>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/components/clear_is_recursive.rs
+++ b/crates/store/re_types_core/src/components/clear_is_recursive.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/bool.rs
+++ b/crates/store/re_types_core/src/datatypes/bool.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A single boolean.
 #[derive(Clone, Debug, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Bool(pub bool);
-
-impl crate::SizeBytes for Bool {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <bool>::is_pod()
-    }
-}
-
-impl From<bool> for Bool {
-    #[inline]
-    fn from(value: bool) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Bool> for bool {
-    #[inline]
-    fn from(value: Bool) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(Bool);
 
@@ -124,5 +98,31 @@ impl crate::Loggable for Bool {
             .collect::<DeserializationResult<Vec<Option<_>>>>()
             .with_context("rerun.datatypes.Bool#value")
             .with_context("rerun.datatypes.Bool")?)
+    }
+}
+
+impl From<bool> for Bool {
+    #[inline]
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Bool> for bool {
+    #[inline]
+    fn from(value: Bool) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for Bool {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <bool>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/bool.rs
+++ b/crates/store/re_types_core/src/datatypes/bool.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/store/re_types_core/src/datatypes/entity_path.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A path to an entity in the `ChunkStore`.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
 #[repr(transparent)]
 pub struct EntityPath(pub crate::ArrowString);
-
-impl crate::SizeBytes for EntityPath {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::ArrowString>::is_pod()
-    }
-}
-
-impl From<crate::ArrowString> for EntityPath {
-    #[inline]
-    fn from(path: crate::ArrowString) -> Self {
-        Self(path)
-    }
-}
-
-impl From<EntityPath> for crate::ArrowString {
-    #[inline]
-    fn from(value: EntityPath) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(EntityPath);
 
@@ -159,5 +133,31 @@ impl crate::Loggable for EntityPath {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.datatypes.EntityPath#path")
         .with_context("rerun.datatypes.EntityPath")?)
+    }
+}
+
+impl From<crate::ArrowString> for EntityPath {
+    #[inline]
+    fn from(path: crate::ArrowString) -> Self {
+        Self(path)
+    }
+}
+
+impl From<EntityPath> for crate::ArrowString {
+    #[inline]
+    fn from(value: EntityPath) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for EntityPath {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::ArrowString>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/store/re_types_core/src/datatypes/entity_path.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/float32.rs
+++ b/crates/store/re_types_core/src/datatypes/float32.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A single-precision 32-bit IEEE 754 floating point number.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Float32(pub f32);
-
-impl crate::SizeBytes for Float32 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <f32>::is_pod()
-    }
-}
-
-impl From<f32> for Float32 {
-    #[inline]
-    fn from(value: f32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Float32> for f32 {
-    #[inline]
-    fn from(value: Float32) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(Float32);
 
@@ -157,5 +131,31 @@ impl crate::Loggable for Float32 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<f32> for Float32 {
+    #[inline]
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Float32> for f32 {
+    #[inline]
+    fn from(value: Float32) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for Float32 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <f32>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/float32.rs
+++ b/crates/store/re_types_core/src/datatypes/float32.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/float64.rs
+++ b/crates/store/re_types_core/src/datatypes/float64.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A double-precision 64-bit IEEE 754 floating point number.
 #[derive(Clone, Debug, Default, Copy, PartialEq, PartialOrd, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(transparent)]
 pub struct Float64(pub f64);
-
-impl crate::SizeBytes for Float64 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <f64>::is_pod()
-    }
-}
-
-impl From<f64> for Float64 {
-    #[inline]
-    fn from(value: f64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Float64> for f64 {
-    #[inline]
-    fn from(value: Float64) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(Float64);
 
@@ -157,5 +131,31 @@ impl crate::Loggable for Float64 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<f64> for Float64 {
+    #[inline]
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Float64> for f64 {
+    #[inline]
+    fn from(value: Float64) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for Float64 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <f64>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/float64.rs
+++ b/crates/store/re_types_core/src/datatypes/float64.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/time_int.rs
+++ b/crates/store/re_types_core/src/datatypes/time_int.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 64-bit number describing either nanoseconds OR sequence numbers.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TimeInt(pub i64);
-
-impl crate::SizeBytes for TimeInt {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <i64>::is_pod()
-    }
-}
-
-impl From<i64> for TimeInt {
-    #[inline]
-    fn from(value: i64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<TimeInt> for i64 {
-    #[inline]
-    fn from(value: TimeInt) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(TimeInt);
 
@@ -156,5 +130,31 @@ impl crate::Loggable for TimeInt {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<i64> for TimeInt {
+    #[inline]
+    fn from(value: i64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<TimeInt> for i64 {
+    #[inline]
+    fn from(value: TimeInt) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for TimeInt {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <i64>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/time_int.rs
+++ b/crates/store/re_types_core/src/datatypes/time_int.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Visible time range bounds for a specific timeline.
@@ -26,19 +26,6 @@ pub struct TimeRange {
 
     /// High time boundary for sequence timeline.
     pub end: crate::datatypes::TimeRangeBoundary,
-}
-
-impl crate::SizeBytes for TimeRange {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.start.heap_size_bytes() + self.end.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TimeRangeBoundary>::is_pod()
-            && <crate::datatypes::TimeRangeBoundary>::is_pod()
-    }
 }
 
 crate::macros::impl_into_cow!(TimeRange);
@@ -221,5 +208,18 @@ impl crate::Loggable for TimeRange {
                 .with_context("rerun.datatypes.TimeRange")?
             }
         })
+    }
+}
+
+impl crate::SizeBytes for TimeRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.start.heap_size_bytes() + self.end.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TimeRangeBoundary>::is_pod()
+            && <crate::datatypes::TimeRangeBoundary>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Left or right boundary of a time range.
@@ -29,23 +29,6 @@ pub enum TimeRangeBoundary {
 
     /// The boundary extends to infinity.
     Infinite,
-}
-
-impl crate::SizeBytes for TimeRangeBoundary {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        #![allow(clippy::match_same_arms)]
-        match self {
-            Self::CursorRelative(v) => v.heap_size_bytes(),
-            Self::Absolute(v) => v.heap_size_bytes(),
-            Self::Infinite => 0,
-        }
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::TimeInt>::is_pod() && <crate::datatypes::TimeInt>::is_pod()
-    }
 }
 
 crate::macros::impl_into_cow!(TimeRangeBoundary);
@@ -352,5 +335,22 @@ impl crate::Loggable for TimeRangeBoundary {
                     .with_context("rerun.datatypes.TimeRangeBoundary")?
             }
         })
+    }
+}
+
+impl crate::SizeBytes for TimeRangeBoundary {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        #![allow(clippy::match_same_arms)]
+        match self {
+            Self::CursorRelative(v) => v.heap_size_bytes(),
+            Self::Absolute(v) => v.heap_size_bytes(),
+            Self::Infinite => 0,
+        }
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::TimeInt>::is_pod() && <crate::datatypes::TimeInt>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/uint16.rs
+++ b/crates/store/re_types_core/src/datatypes/uint16.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 16bit unsigned integer.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UInt16(pub u16);
-
-impl crate::SizeBytes for UInt16 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u16>::is_pod()
-    }
-}
-
-impl From<u16> for UInt16 {
-    #[inline]
-    fn from(value: u16) -> Self {
-        Self(value)
-    }
-}
-
-impl From<UInt16> for u16 {
-    #[inline]
-    fn from(value: UInt16) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(UInt16);
 
@@ -156,5 +130,31 @@ impl crate::Loggable for UInt16 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u16> for UInt16 {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value)
+    }
+}
+
+impl From<UInt16> for u16 {
+    #[inline]
+    fn from(value: UInt16) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for UInt16 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u16>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/uint16.rs
+++ b/crates/store/re_types_core/src/datatypes/uint16.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/uint32.rs
+++ b/crates/store/re_types_core/src/datatypes/uint32.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 32bit unsigned integer.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UInt32(pub u32);
-
-impl crate::SizeBytes for UInt32 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u32>::is_pod()
-    }
-}
-
-impl From<u32> for UInt32 {
-    #[inline]
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl From<UInt32> for u32 {
-    #[inline]
-    fn from(value: UInt32) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(UInt32);
 
@@ -156,5 +130,31 @@ impl crate::Loggable for UInt32 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u32> for UInt32 {
+    #[inline]
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<UInt32> for u32 {
+    #[inline]
+    fn from(value: UInt32) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for UInt32 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u32>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/uint32.rs
+++ b/crates/store/re_types_core/src/datatypes/uint32.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/uint64.rs
+++ b/crates/store/re_types_core/src/datatypes/uint64.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/uint64.rs
+++ b/crates/store/re_types_core/src/datatypes/uint64.rs
@@ -13,40 +13,14 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A 64bit unsigned integer.
 #[derive(Clone, Debug, Default, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct UInt64(pub u64);
-
-impl crate::SizeBytes for UInt64 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <u64>::is_pod()
-    }
-}
-
-impl From<u64> for UInt64 {
-    #[inline]
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<UInt64> for u64 {
-    #[inline]
-    fn from(value: UInt64) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(UInt64);
 
@@ -156,5 +130,31 @@ impl crate::Loggable for UInt64 {
                 slice.iter().copied().map(Self).collect::<Vec<_>>()
             }
         })
+    }
+}
+
+impl From<u64> for UInt64 {
+    #[inline]
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl From<UInt64> for u64 {
+    #[inline]
+    fn from(value: UInt64) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for UInt64 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <u64>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/utf8.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8.rs
@@ -13,41 +13,15 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: A string of text, encoded as UTF-8.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Utf8(pub crate::ArrowString);
-
-impl crate::SizeBytes for Utf8 {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.0.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::ArrowString>::is_pod()
-    }
-}
-
-impl From<crate::ArrowString> for Utf8 {
-    #[inline]
-    fn from(value: crate::ArrowString) -> Self {
-        Self(value)
-    }
-}
-
-impl From<Utf8> for crate::ArrowString {
-    #[inline]
-    fn from(value: Utf8) -> Self {
-        value.0
-    }
-}
 
 crate::macros::impl_into_cow!(Utf8);
 
@@ -159,5 +133,31 @@ impl crate::Loggable for Utf8 {
         .collect::<DeserializationResult<Vec<Option<_>>>>()
         .with_context("rerun.datatypes.Utf8#value")
         .with_context("rerun.datatypes.Utf8")?)
+    }
+}
+
+impl From<crate::ArrowString> for Utf8 {
+    #[inline]
+    fn from(value: crate::ArrowString) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Utf8> for crate::ArrowString {
+    #[inline]
+    fn from(value: Utf8) -> Self {
+        value.0
+    }
+}
+
+impl crate::SizeBytes for Utf8 {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.0.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::ArrowString>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/datatypes/utf8.rs
+++ b/crates/store/re_types_core/src/datatypes/utf8.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/visible_time_range.rs
@@ -14,7 +14,7 @@
 
 use crate::external::arrow2;
 use crate::SerializationResult;
-use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentBatch, ComponentBatchCowWithDescriptor};
 use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 

--- a/crates/store/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/visible_time_range.rs
@@ -13,9 +13,9 @@
 #![allow(clippy::too_many_lines)]
 
 use crate::external::arrow2;
-use crate::ComponentName;
 use crate::SerializationResult;
 use crate::{ComponentBatch, MaybeOwnedComponentBatch};
+use crate::{ComponentDescriptor, ComponentName};
 use crate::{DeserializationError, DeserializationResult};
 
 /// **Datatype**: Visible time range bounds for a specific timeline.
@@ -26,18 +26,6 @@ pub struct VisibleTimeRange {
 
     /// Time range to use for this timeline.
     pub range: crate::datatypes::TimeRange,
-}
-
-impl crate::SizeBytes for VisibleTimeRange {
-    #[inline]
-    fn heap_size_bytes(&self) -> u64 {
-        self.timeline.heap_size_bytes() + self.range.heap_size_bytes()
-    }
-
-    #[inline]
-    fn is_pod() -> bool {
-        <crate::datatypes::Utf8>::is_pod() && <crate::datatypes::TimeRange>::is_pod()
-    }
 }
 
 crate::macros::impl_into_cow!(VisibleTimeRange);
@@ -272,5 +260,17 @@ impl crate::Loggable for VisibleTimeRange {
                 .with_context("rerun.datatypes.VisibleTimeRange")?
             }
         })
+    }
+}
+
+impl crate::SizeBytes for VisibleTimeRange {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        self.timeline.heap_size_bytes() + self.range.heap_size_bytes()
+    }
+
+    #[inline]
+    fn is_pod() -> bool {
+        <crate::datatypes::Utf8>::is_pod() && <crate::datatypes::TimeRange>::is_pod()
     }
 }

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -160,7 +160,7 @@ pub trait Component: Loggable {
     // `ComponentDescriptor` might seem overkill.
     // It's not:
     // * Users might still want to register Components with specific tags.
-    // * In the future, `ComponentDescriptor`s will very likely cover than Archetype-related tags
+    // * In the future, `ComponentDescriptor`s will very likely cover more than Archetype-related tags
     //   (e.g. generics, metric units, etc).
     fn descriptor() -> ComponentDescriptor;
 

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -1,6 +1,10 @@
+use std::borrow::Cow;
+
 use nohash_hasher::IntSet;
 
-use crate::{result::_Backtrace, DeserializationResult, SerializationResult, SizeBytes};
+use crate::{
+    result::_Backtrace, ComponentDescriptor, DeserializationResult, SerializationResult, SizeBytes,
+};
 
 #[allow(unused_imports)] // used in docstrings
 use crate::{Archetype, ComponentBatch, LoggableBatch};
@@ -147,8 +151,35 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
 /// Implementing the [`Component`] trait automatically derives the [`ComponentBatch`] implementation,
 /// which makes it possible to work with lists' worth of data in a generic fashion.
 pub trait Component: Loggable {
+    /// Returns the complete [`ComponentDescriptor`] for this [`Component`].
+    ///
+    /// Every component is uniquely identified by its [`ComponentDescriptor`].
+    //
+    // NOTE: Builtin Rerun components don't (yet) have anything but a `ComponentName` attached to
+    // them (other tags are injected at the Archetype level), therefore having a full
+    // `ComponentDescriptor` might seem overkill.
+    // It's not:
+    // * Users might still want to register Components with specific tags.
+    // * In the future, `ComponentDescriptor`s will very likely cover than Archetype-related tags
+    //   (e.g. generics, metric units, etc).
+    fn descriptor() -> ComponentDescriptor;
+
     /// The fully-qualified name of this component, e.g. `rerun.components.Position2D`.
-    fn name() -> ComponentName;
+    ///
+    /// This is a trivial but useful helper for `Self::descriptor().component_name`.
+    ///
+    /// The default implementation already does the right thing: do not override unless you know
+    /// what you're doing.
+    /// `Self::name()` must exactly match the value returned by `Self::descriptor().component_name`,
+    /// or undefined behavior ensues.
+    //
+    // TODO(cmc): The only reason we keep this around is for convenience, and the only reason we need this
+    // convenience is because we're still in this weird half-way in-between state where some things
+    // are still indexed by name. Remove this entirely once we've ported everything to descriptors.
+    #[inline]
+    fn name() -> ComponentName {
+        Self::descriptor().component_name
+    }
 }
 
 // ---
@@ -161,6 +192,26 @@ re_string_interner::declare_new_type!(
     /// The fully-qualified name of a [`Component`], e.g. `rerun.components.Position2D`.
     pub struct ComponentName;
 );
+
+// TODO(cmc): The only reason this exists is for convenience, and the only reason we need this
+// convenience is because we're still in this weird half-way in-between state where some things
+// are still indexed by name. Remove this entirely once we've ported everything to descriptors.
+impl From<ComponentName> for Cow<'static, ComponentDescriptor> {
+    #[inline]
+    fn from(name: ComponentName) -> Self {
+        Cow::Owned(ComponentDescriptor::new(name))
+    }
+}
+
+// TODO(cmc): The only reason this exists is for convenience, and the only reason we need this
+// convenience is because we're still in this weird half-way in-between state where some things
+// are still indexed by name. Remove this entirely once we've ported everything to descriptors.
+impl From<&ComponentName> for Cow<'static, ComponentDescriptor> {
+    #[inline]
+    fn from(name: &ComponentName) -> Self {
+        Cow::Owned(ComponentDescriptor::new(*name))
+    }
+}
 
 impl ComponentName {
     /// Returns the fully-qualified name, e.g. `rerun.components.Position2D`.

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -1,4 +1,6 @@
-use crate::{Component, ComponentName, Loggable, SerializationResult};
+use std::borrow::Cow;
+
+use crate::{Component, ComponentDescriptor, ComponentName, Loggable, SerializationResult};
 
 use arrow2::array::ListArray as Arrow2ListArray;
 
@@ -27,9 +29,6 @@ pub trait LoggableBatch {
 
 /// A [`ComponentBatch`] represents an array's worth of [`Component`] instances.
 pub trait ComponentBatch: LoggableBatch {
-    /// The fully-qualified name of this component batch, e.g. `rerun.components.Position2D`.
-    fn name(&self) -> ComponentName;
-
     /// Serializes the batch into an Arrow list array with a single component per list.
     fn to_arrow_list_array(&self) -> SerializationResult<Arrow2ListArray<i32>> {
         let array = self.to_arrow2()?;
@@ -39,49 +38,59 @@ pub trait ComponentBatch: LoggableBatch {
         Arrow2ListArray::<i32>::try_new(data_type, offsets.into(), array.to_boxed(), None)
             .map_err(|err| err.into())
     }
+
+    /// Returns the complete [`ComponentDescriptor`] for this [`ComponentBatch`].
+    ///
+    /// Every component batch is uniquely identified by its [`ComponentDescriptor`].
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor>;
+
+    /// The fully-qualified name of this component batch, e.g. `rerun.components.Position2D`.
+    ///
+    /// This is a trivial but useful helper for `self.descriptor().component_name`.
+    ///
+    /// The default implementation already does the right thing. Do not override unless you know
+    /// what you're doing.
+    /// `Self::name()` must exactly match the value returned by `self.descriptor().component_name`,
+    /// or undefined behavior ensues.
+    #[inline]
+    fn name(&self) -> ComponentName {
+        self.descriptor().component_name
+    }
 }
 
-/// Holds either an owned [`ComponentBatch`] that lives on heap, or a reference to one.
+/// Some [`ComponentBatch`], optionally with an overridden [`ComponentDescriptor`].
 ///
-/// This doesn't use [`std::borrow::Cow`] on purpose: `Cow` requires `Clone`, which would break
-/// object-safety, which would prevent us from erasing [`ComponentBatch`]s in the first place.
-pub enum MaybeOwnedComponentBatch<'a> {
-    Owned(Box<dyn ComponentBatch>),
-    Ref(&'a dyn ComponentBatch),
+/// Used by implementers of [`crate::AsComponents`] to both efficiently expose their component data
+/// and assign the right tags given the surrounding context.
+pub struct MaybeOwnedComponentBatch<'a> {
+    /// The component data.
+    pub batch: ComponentBatchCow<'a>,
+
+    /// If set, will override the [`ComponentBatch`]'s [`ComponentDescriptor`].
+    pub descriptor_override: Option<ComponentDescriptor>,
 }
 
-impl<'a> From<&'a dyn ComponentBatch> for MaybeOwnedComponentBatch<'a> {
+impl<'a> From<ComponentBatchCow<'a>> for MaybeOwnedComponentBatch<'a> {
     #[inline]
-    fn from(comp_batch: &'a dyn ComponentBatch) -> Self {
-        Self::Ref(comp_batch)
+    fn from(batch: ComponentBatchCow<'a>) -> Self {
+        Self::new(batch)
     }
 }
 
-impl From<Box<dyn ComponentBatch>> for MaybeOwnedComponentBatch<'_> {
+impl<'a> MaybeOwnedComponentBatch<'a> {
     #[inline]
-    fn from(comp_batch: Box<dyn ComponentBatch>) -> Self {
-        Self::Owned(comp_batch)
-    }
-}
-
-impl<'a> AsRef<dyn ComponentBatch + 'a> for MaybeOwnedComponentBatch<'a> {
-    #[inline]
-    fn as_ref(&self) -> &(dyn ComponentBatch + 'a) {
-        match self {
-            MaybeOwnedComponentBatch::Owned(this) => &**this,
-            MaybeOwnedComponentBatch::Ref(this) => *this,
+    pub fn new(batch: impl Into<ComponentBatchCow<'a>>) -> Self {
+        Self {
+            batch: batch.into(),
+            descriptor_override: None,
         }
     }
-}
-
-impl<'a> std::ops::Deref for MaybeOwnedComponentBatch<'a> {
-    type Target = dyn ComponentBatch + 'a;
 
     #[inline]
-    fn deref(&self) -> &(dyn ComponentBatch + 'a) {
-        match self {
-            MaybeOwnedComponentBatch::Owned(this) => &**this,
-            MaybeOwnedComponentBatch::Ref(this) => *this,
+    pub fn with_descriptor_override(self, descriptor: ComponentDescriptor) -> Self {
+        Self {
+            descriptor_override: Some(descriptor),
+            ..self
         }
     }
 }
@@ -89,14 +98,71 @@ impl<'a> std::ops::Deref for MaybeOwnedComponentBatch<'a> {
 impl LoggableBatch for MaybeOwnedComponentBatch<'_> {
     #[inline]
     fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
-        self.as_ref().to_arrow2()
+        self.batch.to_arrow2()
     }
 }
 
-impl ComponentBatch for MaybeOwnedComponentBatch<'_> {
+impl<'a> ComponentBatch for MaybeOwnedComponentBatch<'a> {
+    #[inline]
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        self.descriptor_override
+            .as_ref()
+            .map(Into::into)
+            .unwrap_or_else(|| self.batch.descriptor())
+    }
+
     #[inline]
     fn name(&self) -> ComponentName {
-        self.as_ref().name()
+        self.batch.name()
+    }
+}
+
+/// Holds either an owned [`ComponentBatch`] that lives on heap, or a reference to one.
+///
+/// This doesn't use [`std::borrow::Cow`] on purpose: `Cow` requires `Clone`, which would break
+/// object-safety, which would prevent us from erasing [`ComponentBatch`]s in the first place.
+pub enum ComponentBatchCow<'a> {
+    Owned(Box<dyn ComponentBatch>),
+    Ref(&'a dyn ComponentBatch),
+}
+
+impl<'a> From<&'a dyn ComponentBatch> for ComponentBatchCow<'a> {
+    #[inline]
+    fn from(comp_batch: &'a dyn ComponentBatch) -> Self {
+        Self::Ref(comp_batch)
+    }
+}
+
+impl From<Box<dyn ComponentBatch>> for ComponentBatchCow<'_> {
+    #[inline]
+    fn from(comp_batch: Box<dyn ComponentBatch>) -> Self {
+        Self::Owned(comp_batch)
+    }
+}
+
+impl<'a> std::ops::Deref for ComponentBatchCow<'a> {
+    type Target = dyn ComponentBatch + 'a;
+
+    #[inline]
+    fn deref(&self) -> &(dyn ComponentBatch + 'a) {
+        match self {
+            ComponentBatchCow::Owned(this) => &**this,
+            ComponentBatchCow::Ref(this) => *this,
+        }
+    }
+}
+
+impl<'a> LoggableBatch for ComponentBatchCow<'a> {
+    #[inline]
+    fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
+        (**self).to_arrow2()
+    }
+}
+
+impl<'a> ComponentBatch for ComponentBatchCow<'a> {
+    #[inline]
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        (**self).descriptor()
     }
 }
 
@@ -110,8 +176,9 @@ impl<L: Clone + Loggable> LoggableBatch for L {
 }
 
 impl<C: Component> ComponentBatch for C {
-    fn name(&self) -> ComponentName {
-        C::name()
+    #[inline]
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -126,8 +193,8 @@ impl<L: Clone + Loggable> LoggableBatch for Option<L> {
 
 impl<C: Component> ComponentBatch for Option<C> {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -142,8 +209,8 @@ impl<L: Clone + Loggable> LoggableBatch for Vec<L> {
 
 impl<C: Component> ComponentBatch for Vec<C> {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -161,8 +228,8 @@ impl<L: Loggable> LoggableBatch for Vec<Option<L>> {
 
 impl<C: Component> ComponentBatch for Vec<Option<C>> {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -177,8 +244,8 @@ impl<L: Loggable, const N: usize> LoggableBatch for [L; N] {
 
 impl<C: Component, const N: usize> ComponentBatch for [C; N] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -196,8 +263,8 @@ impl<L: Loggable, const N: usize> LoggableBatch for [Option<L>; N] {
 
 impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -212,8 +279,8 @@ impl<L: Loggable> LoggableBatch for &[L] {
 
 impl<C: Component> ComponentBatch for &[C] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -231,8 +298,8 @@ impl<L: Loggable> LoggableBatch for &[Option<L>] {
 
 impl<C: Component> ComponentBatch for &[Option<C>] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -247,8 +314,8 @@ impl<L: Loggable, const N: usize> LoggableBatch for &[L; N] {
 
 impl<C: Component, const N: usize> ComponentBatch for &[C; N] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }
 
@@ -266,7 +333,7 @@ impl<L: Loggable, const N: usize> LoggableBatch for &[Option<L>; N] {
 
 impl<C: Component, const N: usize> ComponentBatch for &[Option<C>; N] {
     #[inline]
-    fn name(&self) -> ComponentName {
-        C::name()
+    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
+        C::descriptor().into()
     }
 }

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -62,7 +62,7 @@ pub trait ComponentBatch: LoggableBatch {
 ///
 /// Used by implementers of [`crate::AsComponents`] to both efficiently expose their component data
 /// and assign the right tags given the surrounding context.
-pub struct MaybeOwnedComponentBatch<'a> {
+pub struct ComponentBatchCowWithDescriptor<'a> {
     /// The component data.
     pub batch: ComponentBatchCow<'a>,
 
@@ -70,14 +70,14 @@ pub struct MaybeOwnedComponentBatch<'a> {
     pub descriptor_override: Option<ComponentDescriptor>,
 }
 
-impl<'a> From<ComponentBatchCow<'a>> for MaybeOwnedComponentBatch<'a> {
+impl<'a> From<ComponentBatchCow<'a>> for ComponentBatchCowWithDescriptor<'a> {
     #[inline]
     fn from(batch: ComponentBatchCow<'a>) -> Self {
         Self::new(batch)
     }
 }
 
-impl<'a> MaybeOwnedComponentBatch<'a> {
+impl<'a> ComponentBatchCowWithDescriptor<'a> {
     #[inline]
     pub fn new(batch: impl Into<ComponentBatchCow<'a>>) -> Self {
         Self {
@@ -95,14 +95,14 @@ impl<'a> MaybeOwnedComponentBatch<'a> {
     }
 }
 
-impl LoggableBatch for MaybeOwnedComponentBatch<'_> {
+impl LoggableBatch for ComponentBatchCowWithDescriptor<'_> {
     #[inline]
     fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         self.batch.to_arrow2()
     }
 }
 
-impl<'a> ComponentBatch for MaybeOwnedComponentBatch<'a> {
+impl<'a> ComponentBatch for ComponentBatchCowWithDescriptor<'a> {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
         self.descriptor_override

--- a/crates/store/re_types_core/src/tuid.rs
+++ b/crates/store/re_types_core/src/tuid.rs
@@ -189,6 +189,11 @@ macro_rules! delegate_arrow_tuid {
             fn name() -> $crate::ComponentName {
                 $fqname.into()
             }
+
+            #[inline]
+            fn descriptor() -> $crate::ComponentDescriptor {
+                $crate::ComponentDescriptor::new($fqname)
+            }
         }
     };
 }

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -77,8 +77,9 @@ pub mod sink {
 /// Things directly related to logging.
 pub mod log {
     pub use re_chunk::{
-        Chunk, ChunkBatcher, ChunkBatcherConfig, ChunkBatcherError, ChunkBatcherResult, ChunkError,
-        ChunkId, ChunkResult, PendingRow, RowId, TimeColumn, TransportChunk,
+        Chunk, ChunkBatcher, ChunkBatcherConfig, ChunkBatcherError, ChunkBatcherResult,
+        ChunkComponents, ChunkError, ChunkId, ChunkResult, PendingRow, RowId, TimeColumn,
+        TransportChunk,
     };
     pub use re_log_types::LogMsg;
 }
@@ -90,9 +91,10 @@ pub mod time {
 pub use time::{Time, TimePoint, Timeline};
 
 pub use re_types_core::{
-    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch, ComponentName, DatatypeName,
+    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch, ComponentDescriptor,
+    ComponentName, DatatypeName, DeserializationError, DeserializationResult,
     GenericIndicatorComponent, Loggable, LoggableBatch, MaybeOwnedComponentBatch,
-    NamedIndicatorComponent, SizeBytes,
+    NamedIndicatorComponent, SerializationError, SerializationResult, SizeBytes,
 };
 
 #[cfg(feature = "data_loaders")]

--- a/crates/top/re_sdk/src/lib.rs
+++ b/crates/top/re_sdk/src/lib.rs
@@ -91,10 +91,10 @@ pub mod time {
 pub use time::{Time, TimePoint, Timeline};
 
 pub use re_types_core::{
-    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch, ComponentDescriptor,
-    ComponentName, DatatypeName, DeserializationError, DeserializationResult,
-    GenericIndicatorComponent, Loggable, LoggableBatch, MaybeOwnedComponentBatch,
-    NamedIndicatorComponent, SerializationError, SerializationResult, SizeBytes,
+    Archetype, ArchetypeName, AsComponents, Component, ComponentBatch,
+    ComponentBatchCowWithDescriptor, ComponentDescriptor, ComponentName, DatatypeName,
+    DeserializationError, DeserializationResult, GenericIndicatorComponent, Loggable,
+    LoggableBatch, NamedIndicatorComponent, SerializationError, SerializationResult, SizeBytes,
 };
 
 #[cfg(feature = "data_loaders")]

--- a/crates/top/re_sdk/src/recording_stream.rs
+++ b/crates/top/re_sdk/src/recording_stream.rs
@@ -1025,28 +1025,6 @@ impl RecordingStream {
 
         let components: ChunkComponents = components?.into_iter().collect();
 
-        {
-            let mut all_lengths =
-                timelines
-                    .values()
-                    .map(|timeline| (timeline.name(), timeline.num_rows()))
-                    .chain(components.iter_flattened().map(|(descr, list_array)| {
-                        (descr.component_name.as_str(), list_array.len())
-                    }));
-
-            if let Some((_, expected)) = all_lengths.next() {
-                for (name, len) in all_lengths {
-                    if len != expected {
-                        return Err(RecordingStreamError::Chunk(ChunkError::Malformed {
-                            reason: format!(
-                                "Mismatched lengths: '{name}' has length {len} but expected {expected}",
-                            ),
-                        }));
-                    }
-                }
-            }
-        }
-
         let chunk = Chunk::from_auto_row_ids(id, ent_path.into(), timelines, components)?;
 
         self.send_chunk(chunk);

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -286,9 +286,14 @@ fn preview_if_image_ui(
         .component_mono::<components::ImageFormat>()?
         .ok()?;
 
-    let kind = if component_map.contains_key(&archetypes::DepthImage::indicator().name()) {
+    // TODO(#8129): it's ugly but indicators are going away next anyway.
+    let kind = if component_map.contains_key(&re_types_core::ComponentBatch::name(
+        &archetypes::DepthImage::indicator(),
+    )) {
         ImageKind::Depth
-    } else if component_map.contains_key(&archetypes::SegmentationImage::indicator().name()) {
+    } else if component_map.contains_key(&re_types_core::ComponentBatch::name(
+        &archetypes::SegmentationImage::indicator(),
+    )) {
         ImageKind::Segmentation
     } else {
         ImageKind::Color

--- a/crates/viewer/re_selection_panel/src/defaults_ui.rs
+++ b/crates/viewer/re_selection_panel/src/defaults_ui.rs
@@ -6,7 +6,7 @@ use re_chunk::{Chunk, RowId};
 use re_chunk_store::LatestAtQuery;
 use re_data_ui::{sorted_component_list_for_ui, DataUi as _};
 use re_log_types::EntityPath;
-use re_types_core::{ComponentName, ComponentNameSet};
+use re_types_core::{ComponentDescriptor, ComponentName, ComponentNameSet};
 use re_ui::{list_item::LabelContent, UiExt as _};
 use re_viewer_context::{
     blueprint_timeline, ComponentUiTypes, QueryContext, SystemCommand, SystemCommandSender as _,
@@ -304,7 +304,7 @@ fn add_popup_ui(
                 .with_row(
                     RowId::new(),
                     ctx.blueprint_timepoint_for_writes(),
-                    [(component_name, initial_data)],
+                    [(ComponentDescriptor::new(component_name), initial_data)],
                 )
                 .build()
             {

--- a/crates/viewer/re_space_view/src/annotation_scene_context.rs
+++ b/crates/viewer/re_space_view/src/annotation_scene_context.rs
@@ -17,7 +17,7 @@ impl ViewContextSystem for AnnotationSceneContext {
         vec![
             AnnotationContext::required_components()
                 .iter()
-                .map(ToOwned::to_owned)
+                .map(|descr| descr.component_name)
                 .collect(), //
         ]
     }

--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -51,7 +51,7 @@ pub fn diff_component_filter<T: re_types_core::Component>(
         .diff
         .chunk
         .components()
-        .get(&T::name())
+        .get_descriptor(&T::descriptor())
         .map_or(false, |list_array| {
             list_array
                 .iter()

--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -51,7 +51,7 @@ pub fn diff_component_filter<T: re_types_core::Component>(
         .diff
         .chunk
         .components()
-        .get_descriptor(&T::descriptor())
+        .get_by_descriptor(&T::descriptor())
         .map_or(false, |list_array| {
             list_array
                 .iter()

--- a/crates/viewer/re_space_view/src/query.rs
+++ b/crates/viewer/re_space_view/src/query.rs
@@ -34,17 +34,17 @@ pub fn range_with_blueprint_resolved_data(
 ) -> HybridRangeResults {
     re_tracing::profile_function!(data_result.entity_path.to_string());
 
-    let mut component_set = component_names.into_iter().collect::<IntSet<_>>();
+    let mut component_name_set = component_names.into_iter().collect::<IntSet<_>>();
 
-    let overrides = query_overrides(ctx.viewer_ctx, data_result, component_set.iter());
+    let overrides = query_overrides(ctx.viewer_ctx, data_result, component_name_set.iter());
 
     // No need to query for components that have overrides.
-    component_set.retain(|component| !overrides.components.contains_key(component));
+    component_name_set.retain(|component| !overrides.components.contains_key(component));
 
     let results = ctx.recording_engine().cache().range(
         range_query,
         &data_result.entity_path,
-        component_set.iter().copied(),
+        component_name_set.iter(),
     );
 
     // TODO(jleibs): This doesn't work when the component set contains empty results.
@@ -54,7 +54,7 @@ pub fn range_with_blueprint_resolved_data(
     let defaults = ctx.viewer_ctx.blueprint_engine().cache().latest_at(
         ctx.viewer_ctx.blueprint_query,
         ctx.defaults_path,
-        component_set.iter().copied(),
+        component_name_set.iter().copied(),
     );
 
     HybridRangeResults {
@@ -260,7 +260,7 @@ impl DataResultQuery for DataResult {
             None,
             latest_at_query,
             self,
-            A::all_components().iter().copied(),
+            A::all_components().iter().map(|descr| descr.component_name),
             query_shadowed_defaults,
         )
     }
@@ -275,7 +275,7 @@ impl DataResultQuery for DataResult {
             &view_query.timeline,
             view_query.latest_at,
             self.query_range(),
-            A::all_components().iter().copied(),
+            A::all_components().iter().map(|descr| descr.component_name),
             self,
         )
     }

--- a/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
+++ b/crates/viewer/re_space_view_spatial/src/contexts/transform_context.rs
@@ -159,8 +159,14 @@ impl Default for TransformContext {
 impl ViewContextSystem for TransformContext {
     fn compatible_component_sets(&self) -> Vec<ComponentNameSet> {
         vec![
-            Transform3D::all_components().iter().copied().collect(),
-            InstancePoses3D::all_components().iter().copied().collect(),
+            Transform3D::all_components()
+                .iter()
+                .map(|descr| descr.component_name)
+                .collect(),
+            InstancePoses3D::all_components()
+                .iter()
+                .map(|descr| descr.component_name)
+                .collect(),
             std::iter::once(PinholeProjection::name()).collect(),
             std::iter::once(DisconnectedSpace::name()).collect(),
         ]

--- a/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
+++ b/crates/viewer/re_space_view_spatial/src/max_image_dimension_subscriber.rs
@@ -78,7 +78,13 @@ impl ChunkStoreSubscriber for MaxImageDimensionSubscriber {
             }
 
             // Handle `Image`, `DepthImage`, `SegmentationImage`…
-            if let Some(all_dimensions) = event.diff.chunk.components().get(&ImageFormat::name()) {
+            if let Some(all_dimensions) = event
+                .diff
+                .chunk
+                .components()
+                .get(&ImageFormat::name())
+                .and_then(|per_desc| per_desc.values().next())
+            {
                 for new_dim in all_dimensions.iter().filter_map(|array| {
                     array.and_then(|array| {
                         ImageFormat::from_arrow2(&*array).ok()?.into_iter().next()

--- a/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
+++ b/crates/viewer/re_space_view_spatial/src/transform_component_tracker.rs
@@ -77,11 +77,11 @@ impl Default for TransformComponentTrackerStoreSubscriber {
         Self {
             transform_components: re_types::archetypes::Transform3D::all_components()
                 .iter()
-                .copied()
+                .map(|descr| descr.component_name)
                 .collect(),
             pose_components: re_types::archetypes::InstancePoses3D::all_components()
                 .iter()
-                .copied()
+                .map(|descr| descr.component_name)
                 .collect(),
             per_store: Default::default(),
         }
@@ -132,8 +132,10 @@ impl ChunkStoreSubscriber for TransformComponentTrackerStoreSubscriber {
                     .chunk
                     .components()
                     .get(&component_name)
-                    .map_or(false, |list_array| {
-                        list_array.offsets().lengths().any(|len| len > 0)
+                    .map_or(false, |per_desc| {
+                        per_desc
+                            .values()
+                            .any(|list_array| list_array.offsets().lengths().any(|len| len > 0))
                     })
             };
 

--- a/crates/viewer/re_space_view_spatial/src/view_2d.rs
+++ b/crates/viewer/re_space_view_spatial/src/view_2d.rs
@@ -369,6 +369,7 @@ fn recommended_space_views_with_image_splits(
         &mut found_image_dimensions,
     );
 
+    use re_types::ComponentBatch as _;
     let image_count = count_non_nested_images_with_component(
         image_dimensions,
         entities,

--- a/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/transform3d_arrows.rs
@@ -65,7 +65,7 @@ impl VisualizerSystem for Transform3DArrowsVisualizer {
         Some(Box::new(Transform3DApplicabilityFilter {
             applicability_trigger_components: Transform3D::all_components()
                 .iter()
-                .copied()
+                .map(|descr| descr.component_name)
                 .collect(),
         }))
     }

--- a/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
+++ b/crates/viewer/re_space_view_spatial/src/visualizers/videos.rs
@@ -409,7 +409,7 @@ fn latest_at_query_video_from_datastore(
     let results = ctx.recording_engine().cache().latest_at(
         &query,
         entity_path,
-        AssetVideo::all_components().iter().copied(),
+        AssetVideo::all_components().iter(),
     );
 
     let blob_row_id = results.component_row_id(&Blob::name())?;

--- a/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/line_visualizer_system.rs
@@ -38,10 +38,15 @@ const DEFAULT_STROKE_WIDTH: f32 = 0.75;
 impl VisualizerSystem for SeriesLineSystem {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<archetypes::Scalar>();
-        query_info
-            .queried
-            .extend(SeriesLine::all_components().iter().map(ToOwned::to_owned));
+        query_info.queried.extend(
+            SeriesLine::all_components()
+                .iter()
+                .map(|descr| descr.component_name),
+        );
+
+        use re_types::ComponentBatch as _;
         query_info.indicators = std::iter::once(SeriesLine::indicator().name()).collect();
+
         query_info
     }
 

--- a/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
+++ b/crates/viewer/re_space_view_time_series/src/point_visualizer_system.rs
@@ -38,10 +38,15 @@ const DEFAULT_MARKER_SIZE: f32 = 3.0;
 impl VisualizerSystem for SeriesPointSystem {
     fn visualizer_query_info(&self) -> VisualizerQueryInfo {
         let mut query_info = VisualizerQueryInfo::from_archetype::<archetypes::Scalar>();
-        query_info
-            .queried
-            .extend(SeriesPoint::all_components().iter().map(ToOwned::to_owned));
+        query_info.queried.extend(
+            SeriesPoint::all_components()
+                .iter()
+                .map(|descr| descr.component_name),
+        );
+
+        use re_types::ComponentBatch as _;
         query_info.indicators = std::iter::once(SeriesPoint::indicator().name()).collect();
+
         query_info
     }
 

--- a/crates/viewer/re_time_panel/tests/time_panel_tests.rs
+++ b/crates/viewer/re_time_panel/tests/time_panel_tests.rs
@@ -24,7 +24,7 @@ pub fn time_panel_two_sections_should_match_snapshot() {
             builder = builder.with_sparse_component_batches(
                 RowId::new(),
                 [build_frame_nr(frame)],
-                [(MyPoint::name(), Some(&points1 as _))],
+                [(MyPoint::descriptor(), Some(&points1 as _))],
             );
         }
         test_context
@@ -61,7 +61,7 @@ pub fn time_panel_dense_data_should_match_snapshot() {
         builder = builder.with_sparse_component_batches(
             RowId::new(),
             [build_frame_nr(frame)],
-            [(MyPoint::name(), Some(&points1 as _))],
+            [(MyPoint::descriptor(), Some(&points1 as _))],
         );
     }
     test_context

--- a/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
+++ b/crates/viewer/re_viewer_context/src/blueprint_helpers.rs
@@ -1,7 +1,7 @@
 use re_chunk::{Arrow2Array, RowId};
 use re_chunk_store::external::re_chunk::Chunk;
 use re_log_types::{EntityPath, TimeInt, TimePoint, Timeline};
-use re_types::{AsComponents, ComponentBatch, ComponentName};
+use re_types::{AsComponents, ComponentBatch, ComponentDescriptor, ComponentName};
 
 use crate::{StoreContext, SystemCommand, SystemCommandSender as _, ViewerContext};
 
@@ -91,7 +91,11 @@ impl ViewerContext<'_> {
         let timepoint = self.store_context.blueprint_timepoint_for_writes();
 
         let chunk = match Chunk::builder(entity_path.clone())
-            .with_row(RowId::new(), timepoint.clone(), [(component_name, array)])
+            .with_row(
+                RowId::new(),
+                timepoint.clone(),
+                [(ComponentDescriptor::new(component_name), array)],
+            )
             .build()
         {
             Ok(chunk) => chunk,
@@ -174,7 +178,7 @@ impl ViewerContext<'_> {
                 RowId::new(),
                 timepoint,
                 [(
-                    component_name,
+                    ComponentDescriptor::new(component_name),
                     re_chunk::external::arrow2::array::new_empty_array(datatype),
                 )],
             )

--- a/crates/viewer/re_viewer_context/src/item.rs
+++ b/crates/viewer/re_viewer_context/src/item.rs
@@ -1,5 +1,6 @@
 use re_entity_db::{EntityDb, InstancePath};
 use re_log_types::{ComponentPath, DataPath, EntityPath};
+use re_types::ComponentDescriptor;
 
 use crate::{ContainerId, Contents, SpaceViewId};
 
@@ -205,7 +206,11 @@ pub fn resolve_mono_instance_path(
         for component_name in component_names {
             if let Some(array) = engine
                 .cache()
-                .latest_at(query, &instance.entity_path, [component_name])
+                .latest_at(
+                    query,
+                    &instance.entity_path,
+                    [ComponentDescriptor::new(component_name)],
+                )
                 .component_batch_raw(&component_name)
             {
                 if array.len() > 1 {

--- a/crates/viewer/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/visualizer_entity_subscriber.rs
@@ -184,8 +184,11 @@ impl ChunkStoreSubscriber for VisualizerEntitySubscriber {
                 continue;
             }
 
-            for (component_name, list_array) in event.diff.chunk.components() {
-                if let Some(index) = self.required_components_indices.get(component_name) {
+            for (component_desc, list_array) in event.diff.chunk.components().iter_flattened() {
+                if let Some(index) = self
+                    .required_components_indices
+                    .get(&component_desc.component_name)
+                {
                     // The component might be present, but logged completely empty.
                     // That shouldn't count towards filling "having the required component present"!
                     // (Note: This happens frequently now with `Transform3D`'s component which always get logged, thus tripping of the `AxisLengthDetector`!)` )

--- a/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
+++ b/crates/viewer/re_viewer_context/src/space_view/visualizer_system.rs
@@ -55,13 +55,17 @@ pub struct VisualizerQueryInfo {
 
 impl VisualizerQueryInfo {
     pub fn from_archetype<T: Archetype>() -> Self {
+        use re_types_core::ComponentBatch as _;
         Self {
             indicators: std::iter::once(T::indicator().name()).collect(),
             required: T::required_components()
                 .iter()
-                .map(ToOwned::to_owned)
+                .map(|descr| descr.component_name)
                 .collect(),
-            queried: T::all_components().iter().map(ToOwned::to_owned).collect(),
+            queried: T::all_components()
+                .iter()
+                .map(|descr| descr.component_name)
+                .collect(),
         }
     }
 

--- a/crates/viewer/re_viewport_blueprint/src/container.rs
+++ b/crates/viewer/re_viewport_blueprint/src/container.rs
@@ -68,9 +68,7 @@ impl ContainerBlueprint {
         let results = blueprint_db.storage_engine().cache().latest_at(
             query,
             &id.as_entity_path(),
-            blueprint_archetypes::ContainerBlueprint::all_components()
-                .iter()
-                .copied(),
+            blueprint_archetypes::ContainerBlueprint::all_components().iter(),
         );
 
         // This is a required component. Note that when loading containers we crawl the subtree and so

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -58,7 +58,10 @@ impl ViewProperty {
             blueprint_query.clone(),
             view_id,
             A::name(),
-            A::all_components().as_ref(),
+            A::all_components()
+                .iter()
+                .map(|descr| descr.component_name)
+                .collect(),
         )
     }
 
@@ -67,7 +70,7 @@ impl ViewProperty {
         blueprint_query: LatestAtQuery,
         space_view_id: SpaceViewId,
         archetype_name: ArchetypeName,
-        component_names: &[ComponentName],
+        component_names: Vec<ComponentName>,
     ) -> Self {
         let blueprint_store_path =
             entity_path_for_view_property(space_view_id, blueprint_db.tree(), archetype_name);
@@ -82,7 +85,7 @@ impl ViewProperty {
             blueprint_store_path,
             archetype_name,
             query_results,
-            component_names: component_names.to_vec(),
+            component_names,
             blueprint_query,
         }
     }

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -89,9 +89,7 @@ impl ViewportBlueprint {
         let results = blueprint_engine.cache().latest_at(
             query,
             &VIEWPORT_PATH.into(),
-            blueprint_archetypes::ViewportBlueprint::all_components()
-                .iter()
-                .copied(),
+            blueprint_archetypes::ViewportBlueprint::all_components().iter(),
         );
 
         let blueprint_archetypes::ViewportBlueprint {

--- a/docs/snippets/Cargo.toml
+++ b/docs/snippets/Cargo.toml
@@ -6,19 +6,26 @@ rust-version.workspace = true
 license.workspace = true
 publish = false
 
+
 [lints]
 workspace = true
 
+
 [dependencies]
+rerun = { path = "../../crates/top/rerun" }
+
 ndarray.workspace = true
 rand = { workspace = true, features = ["std", "std_rng"] }
 rand_distr = { workspace = true, features = ["std"] }
-rerun = { path = "../../crates/top/rerun" }
+similar-asserts.workspace = true
+
 
 [build-dependencies]
-itertools.workspace = true
 re_build_tools.workspace = true
+
+itertools.workspace = true
 rust-format.workspace = true
+
 
 [package.metadata.cargo-machete]
 # false positives because they aren't used until codegen is run:

--- a/docs/snippets/Cargo.toml
+++ b/docs/snippets/Cargo.toml
@@ -29,4 +29,10 @@ rust-format.workspace = true
 
 [package.metadata.cargo-machete]
 # false positives because they aren't used until codegen is run:
-ignored = ["ndarray", "rand", "rand_distr", "rerun"]
+ignored = [
+  "ndarray",
+  "rand",
+  "rand_distr",
+  "rerun",
+  "similar-asserts",
+]

--- a/docs/snippets/all/archetypes/manual_indicator.rs
+++ b/docs/snippets/all/archetypes/manual_indicator.rs
@@ -10,8 +10,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     rec.log(
         "points_and_mesh",
         &[
-            rerun::Points3D::indicator().as_ref() as &dyn rerun::ComponentBatch,
-            rerun::Mesh3D::indicator().as_ref(),
+            &rerun::Points3D::indicator() as &dyn rerun::ComponentBatch,
+            &rerun::Mesh3D::indicator() as _,
             &[[0.0, 0.0, 0.0], [10.0, 0.0, 0.0], [0.0, 10.0, 0.0]].map(rerun::Position3D::from),
             &[[255, 0, 0], [0, 255, 0], [0, 0, 255]]
                 .map(|[r, g, b]| rerun::Color::from_rgb(r, g, b)),

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.rs
@@ -1,0 +1,65 @@
+use rerun::{ChunkStore, ChunkStoreConfig, ComponentDescriptor, VersionPolicy};
+
+#[allow(clippy::unwrap_used)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_builtin_archetype_vanilla";
+
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    rec.log_static(
+        "data",
+        &rerun::Points3D::new([(1.0, 2.0, 3.0)]).with_radii([0.3, 0.2, 0.1]),
+    )?;
+
+    // When this snippet runs through the snippet comparison machinery, this environment variable
+    // will point to the output RRD.
+    // We can thus load this RRD to check that the proper tags were indeed forwarded.
+    //
+    // Python and C++ are indirectly checked by the snippet comparison tool itself.
+    if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
+        rec.flush_blocking();
+
+        let stores = ChunkStore::from_rrd_filepath(
+            &ChunkStoreConfig::ALL_DISABLED,
+            path_to_rrd,
+            VersionPolicy::Warn,
+        )?;
+        assert_eq!(1, stores.len());
+
+        let store = stores.into_values().next().unwrap();
+        let chunks = store.iter_chunks().collect::<Vec<_>>();
+        assert_eq!(1, chunks.len());
+
+        let chunk = chunks.into_iter().next().unwrap();
+
+        let mut descriptors = chunk
+            .components()
+            .values()
+            .flat_map(|per_desc| per_desc.keys())
+            .cloned()
+            .collect::<Vec<_>>();
+        descriptors.sort();
+
+        let expected = vec![
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                archetype_field_name: None,
+                component_name: "rerun.components.Points3DIndicator".into(),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                archetype_field_name: Some("positions".into()),
+                component_name: "rerun.components.Position3D".into(),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                archetype_field_name: Some("radii".into()),
+                component_name: "rerun.components.Radius".into(),
+            },
+        ];
+
+        similar_asserts::assert_eq!(expected, descriptors);
+    }
+
+    Ok(())
+}

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.rs
@@ -2,7 +2,7 @@ use rerun::{ChunkStore, ChunkStoreConfig, ComponentDescriptor, VersionPolicy};
 
 #[allow(clippy::unwrap_used)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_builtin_archetype_vanilla";
+    const APP_ID: &str = "rerun_example_descriptors_builtin_archetype";
 
     let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
 
@@ -42,7 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         let expected = vec![
             ComponentDescriptor {
-                archetype_name: Some("rerun.archetypes.Points3D".into()),
+                archetype_name: None,
                 archetype_field_name: None,
                 component_name: "rerun.components.Points3DIndicator".into(),
             },

--- a/docs/snippets/all/descriptors/descr_builtin_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_archetype.rs
@@ -1,16 +1,31 @@
 use rerun::{ChunkStore, ChunkStoreConfig, ComponentDescriptor, VersionPolicy};
 
-#[allow(clippy::unwrap_used)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_builtin_archetype";
-
-    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
-
+fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     rec.log_static(
         "data",
         &rerun::Points3D::new([(1.0, 2.0, 3.0)]).with_radii([0.3, 0.2, 0.1]),
     )?;
 
+    Ok(())
+}
+
+// ---
+// Everything below this line is _not_ part of the example.
+// This is internal testing code to make sure the example yields the right data.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_builtin_archetype";
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    example(&rec)?;
+
+    check_tags(&rec);
+
+    Ok(())
+}
+
+#[allow(clippy::unwrap_used)]
+fn check_tags(rec: &rerun::RecordingStream) {
     // When this snippet runs through the snippet comparison machinery, this environment variable
     // will point to the output RRD.
     // We can thus load this RRD to check that the proper tags were indeed forwarded.
@@ -23,7 +38,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ChunkStoreConfig::ALL_DISABLED,
             path_to_rrd,
             VersionPolicy::Warn,
-        )?;
+        )
+        .unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();
@@ -60,6 +76,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         similar_asserts::assert_eq!(expected, descriptors);
     }
-
-    Ok(())
 }

--- a/docs/snippets/all/descriptors/descr_builtin_component.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_component.rs
@@ -1,0 +1,56 @@
+use rerun::{ChunkStore, ChunkStoreConfig, Component as _, ComponentDescriptor, VersionPolicy};
+
+#[allow(clippy::unwrap_used)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_builtin_component_vanilla";
+
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    rec.log_component_batches(
+        "data",
+        true,
+        [&rerun::components::Position3D::new(1.0, 2.0, 3.0) as &dyn rerun::ComponentBatch],
+    )?;
+
+    // When this snippet runs through the snippet comparison machinery, this environment variable
+    // will point to the output RRD.
+    // We can thus load this RRD to check that the proper tags were indeed forwarded.
+    //
+    // Python and C++ are indirectly checked by the snippet comparison tool itself.
+    if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
+        rec.flush_blocking();
+
+        let stores = ChunkStore::from_rrd_filepath(
+            &ChunkStoreConfig::ALL_DISABLED,
+            path_to_rrd,
+            VersionPolicy::Warn,
+        )?;
+        assert_eq!(1, stores.len());
+
+        let store = stores.into_values().next().unwrap();
+        let chunks = store.iter_chunks().collect::<Vec<_>>();
+        assert_eq!(1, chunks.len());
+
+        let chunk = chunks.into_iter().next().unwrap();
+
+        let mut descriptors = chunk
+            .components()
+            .values()
+            .flat_map(|per_desc| per_desc.keys())
+            .cloned()
+            .collect::<Vec<_>>();
+        descriptors.sort();
+
+        let expected = vec![
+            ComponentDescriptor {
+                archetype_name: None,
+                archetype_field_name: None,
+                component_name: rerun::components::Position3D::name(),
+            }, //
+        ];
+
+        similar_asserts::assert_eq!(expected, descriptors);
+    }
+
+    Ok(())
+}

--- a/docs/snippets/all/descriptors/descr_builtin_component.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_component.rs
@@ -2,7 +2,7 @@ use rerun::{ChunkStore, ChunkStoreConfig, Component as _, ComponentDescriptor, V
 
 #[allow(clippy::unwrap_used)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_builtin_component_vanilla";
+    const APP_ID: &str = "rerun_example_descriptors_builtin_component";
 
     let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
 

--- a/docs/snippets/all/descriptors/descr_builtin_component.rs
+++ b/docs/snippets/all/descriptors/descr_builtin_component.rs
@@ -1,17 +1,32 @@
 use rerun::{ChunkStore, ChunkStoreConfig, Component as _, ComponentDescriptor, VersionPolicy};
 
-#[allow(clippy::unwrap_used)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_builtin_component";
-
-    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
-
+fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     rec.log_component_batches(
         "data",
         true,
         [&rerun::components::Position3D::new(1.0, 2.0, 3.0) as &dyn rerun::ComponentBatch],
     )?;
 
+    Ok(())
+}
+
+// ---
+// Everything below this line is _not_ part of the example.
+// This is internal testing code to make sure the example yields the right data.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_builtin_component";
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    example(&rec)?;
+
+    check_tags(&rec);
+
+    Ok(())
+}
+
+#[allow(clippy::unwrap_used)]
+fn check_tags(rec: &rerun::RecordingStream) {
     // When this snippet runs through the snippet comparison machinery, this environment variable
     // will point to the output RRD.
     // We can thus load this RRD to check that the proper tags were indeed forwarded.
@@ -24,7 +39,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ChunkStoreConfig::ALL_DISABLED,
             path_to_rrd,
             VersionPolicy::Warn,
-        )?;
+        )
+        .unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();
@@ -51,6 +67,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         similar_asserts::assert_eq!(expected, descriptors);
     }
-
-    Ok(())
 }

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -62,15 +62,15 @@ impl CustomPoints3D {
 }
 
 impl rerun::AsComponents for CustomPoints3D {
-    fn as_component_batches(&self) -> Vec<rerun::MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<rerun::ComponentBatchCowWithDescriptor<'_>> {
         [
             Some(Self::indicator().to_batch()),
             Some(
-                rerun::MaybeOwnedComponentBatch::new(&self.positions as &dyn rerun::ComponentBatch)
+                rerun::ComponentBatchCowWithDescriptor::new(&self.positions as &dyn rerun::ComponentBatch)
                     .with_descriptor_override(Self::overridden_position_descriptor()),
             ),
             self.colors.as_ref().map(|colors| {
-                rerun::MaybeOwnedComponentBatch::new(colors as &dyn rerun::ComponentBatch)
+                rerun::ComponentBatchCowWithDescriptor::new(colors as &dyn rerun::ComponentBatch)
                     .with_descriptor_override(Self::overridden_color_descriptor())
             }),
         ]

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -82,7 +82,7 @@ impl rerun::AsComponents for CustomPoints3D {
 
 #[allow(clippy::unwrap_used)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_custom_component_vanilla";
+    const APP_ID: &str = "rerun_example_descriptors_custom_archetype";
 
     let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
 
@@ -126,9 +126,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         descriptors.sort();
 
         let expected = vec![
-            rerun::ComponentBatch::descriptor(&CustomPoints3D::indicator()).into_owned(),
-            CustomPoints3D::overridden_color_descriptor(),
-            CustomPoints3D::overridden_position_descriptor(),
+            ComponentDescriptor {
+                archetype_name: None,
+                archetype_field_name: None,
+                component_name: "user.CustomPoints3DIndicator".into(),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("user.CustomArchetype".into()),
+                archetype_field_name: Some("colors".into()),
+                component_name: rerun::components::Color::name(),
+            },
+            ComponentDescriptor {
+                archetype_name: Some("user.CustomArchetype".into()),
+                archetype_field_name: Some("positions".into()),
+                component_name: "user.CustomPosition3D".into(),
+            },
         ];
 
         similar_asserts::assert_eq!(expected, descriptors);

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -1,0 +1,138 @@
+use rerun::{
+    external::arrow2, ChunkStore, ChunkStoreConfig, Component, ComponentDescriptor, VersionPolicy,
+};
+
+#[derive(Debug, Clone, Copy)]
+struct CustomPosition3D(rerun::components::Position3D);
+
+impl rerun::SizeBytes for CustomPosition3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+}
+
+impl rerun::Loggable for CustomPosition3D {
+    #[inline]
+    fn arrow2_datatype() -> arrow2::datatypes::DataType {
+        rerun::components::Position3D::arrow2_datatype()
+    }
+
+    #[inline]
+    fn to_arrow2_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<std::borrow::Cow<'a, Self>>>>,
+    ) -> rerun::SerializationResult<Box<dyn arrow2::array::Array>>
+    where
+        Self: 'a,
+    {
+        rerun::components::Position3D::to_arrow2_opt(
+            data.into_iter().map(|opt| opt.map(Into::into).map(|c| c.0)),
+        )
+    }
+}
+
+impl rerun::Component for CustomPosition3D {
+    #[inline]
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor::new("user.CustomPosition3D")
+    }
+}
+
+struct CustomPoints3D {
+    positions: Vec<CustomPosition3D>,
+    colors: Option<Vec<rerun::components::Color>>,
+}
+
+impl CustomPoints3D {
+    fn indicator() -> rerun::NamedIndicatorComponent {
+        rerun::NamedIndicatorComponent("user.CustomPoints3DIndicator".into())
+    }
+
+    fn overridden_position_descriptor() -> ComponentDescriptor {
+        CustomPosition3D::descriptor()
+            .or_with_archetype_name(|| "user.CustomArchetype".into())
+            .or_with_archetype_field_name(|| "positions".into())
+    }
+
+    fn overridden_color_descriptor() -> ComponentDescriptor {
+        rerun::components::Color::descriptor()
+            .or_with_archetype_name(|| "user.CustomArchetype".into())
+            .or_with_archetype_field_name(|| "colors".into())
+    }
+}
+
+impl rerun::AsComponents for CustomPoints3D {
+    fn as_component_batches(&self) -> Vec<rerun::MaybeOwnedComponentBatch<'_>> {
+        [
+            Some(Self::indicator().to_batch()),
+            Some(
+                rerun::MaybeOwnedComponentBatch::new(&self.positions as &dyn rerun::ComponentBatch)
+                    .with_descriptor_override(Self::overridden_position_descriptor()),
+            ),
+            self.colors.as_ref().map(|colors| {
+                rerun::MaybeOwnedComponentBatch::new(colors as &dyn rerun::ComponentBatch)
+                    .with_descriptor_override(Self::overridden_color_descriptor())
+            }),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_custom_component_vanilla";
+
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    let position = CustomPosition3D(rerun::components::Position3D::new(1.0, 2.0, 3.0));
+    let color = rerun::components::Color::new(0xFF00FFFF);
+
+    let points = CustomPoints3D {
+        positions: vec![position],
+        colors: Some(vec![color]),
+    };
+
+    rec.log_static("data", &points as _)?;
+
+    // When this snippet runs through the snippet comparison machinery, this environment variable
+    // will point to the output RRD.
+    // We can thus load this RRD to check that the proper tags were indeed forwarded.
+    //
+    // Python and C++ are indirectly checked by the snippet comparison tool itself.
+    if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
+        rec.flush_blocking();
+
+        let stores = ChunkStore::from_rrd_filepath(
+            &ChunkStoreConfig::ALL_DISABLED,
+            path_to_rrd,
+            VersionPolicy::Warn,
+        )?;
+        assert_eq!(1, stores.len());
+
+        let store = stores.into_values().next().unwrap();
+        let chunks = store.iter_chunks().collect::<Vec<_>>();
+        assert_eq!(1, chunks.len());
+
+        let chunk = chunks.into_iter().next().unwrap();
+
+        let mut descriptors = chunk
+            .components()
+            .values()
+            .flat_map(|per_desc| per_desc.keys())
+            .cloned()
+            .collect::<Vec<_>>();
+        descriptors.sort();
+
+        let expected = vec![
+            rerun::ComponentBatch::descriptor(&CustomPoints3D::indicator()).into_owned(),
+            CustomPoints3D::overridden_color_descriptor(),
+            CustomPoints3D::overridden_position_descriptor(),
+        ];
+
+        similar_asserts::assert_eq!(expected, descriptors);
+    }
+
+    Ok(())
+}

--- a/docs/snippets/all/descriptors/descr_custom_archetype.rs
+++ b/docs/snippets/all/descriptors/descr_custom_archetype.rs
@@ -50,13 +50,13 @@ impl CustomPoints3D {
 
     fn overridden_position_descriptor() -> ComponentDescriptor {
         CustomPosition3D::descriptor()
-            .or_with_archetype_name(|| "user.CustomArchetype".into())
-            .or_with_archetype_field_name(|| "positions".into())
+            .or_with_archetype_name(|| "user.CustomPoints3D".into())
+            .or_with_archetype_field_name(|| "custom_positions".into())
     }
 
     fn overridden_color_descriptor() -> ComponentDescriptor {
         rerun::components::Color::descriptor()
-            .or_with_archetype_name(|| "user.CustomArchetype".into())
+            .or_with_archetype_name(|| "user.CustomPoints3D".into())
             .or_with_archetype_field_name(|| "colors".into())
     }
 }
@@ -132,13 +132,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 component_name: "user.CustomPoints3DIndicator".into(),
             },
             ComponentDescriptor {
-                archetype_name: Some("user.CustomArchetype".into()),
+                archetype_name: Some("user.CustomPoints3D".into()),
                 archetype_field_name: Some("colors".into()),
                 component_name: rerun::components::Color::name(),
             },
             ComponentDescriptor {
-                archetype_name: Some("user.CustomArchetype".into()),
-                archetype_field_name: Some("positions".into()),
+                archetype_name: Some("user.CustomPoints3D".into()),
+                archetype_field_name: Some("custom_positions".into()),
                 component_name: "user.CustomPosition3D".into(),
             },
         ];

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -45,7 +45,7 @@ impl Component for CustomPosition3D {
 
 #[allow(clippy::unwrap_used)]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_custom_component_vanilla";
+    const APP_ID: &str = "rerun_example_descriptors_custom_component";
 
     let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
 
@@ -81,7 +81,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .collect::<Vec<_>>();
         descriptors.sort();
 
-        let expected = vec![CustomPosition3D::descriptor()];
+        let expected = vec![
+            ComponentDescriptor {
+                archetype_name: Some("user.CustomArchetype".into()),
+                archetype_field_name: Some("user.CustomArchetypeField".into()),
+                component_name: "user.CustomPosition3D".into(),
+            }, //
+        ];
 
         similar_asserts::assert_eq!(expected, descriptors);
     }

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -43,15 +43,30 @@ impl Component for CustomPosition3D {
     }
 }
 
-#[allow(clippy::unwrap_used)]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    const APP_ID: &str = "rerun_example_descriptors_custom_component";
-
-    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
-
+fn example(rec: &rerun::RecordingStream) -> Result<(), Box<dyn std::error::Error>> {
     let position = CustomPosition3D(rerun::components::Position3D::new(1.0, 2.0, 3.0));
     rec.log_component_batches("data", true, [&position as &dyn rerun::ComponentBatch])?;
 
+    Ok(())
+}
+
+// ---
+// Everything below this line is _not_ part of the example.
+// This is internal testing code to make sure the example yields the right data.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_custom_component";
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    example(&rec)?;
+
+    check_tags(&rec);
+
+    Ok(())
+}
+
+#[allow(clippy::unwrap_used)]
+fn check_tags(rec: &rerun::RecordingStream) {
     // When this snippet runs through the snippet comparison machinery, this environment variable
     // will point to the output RRD.
     // We can thus load this RRD to check that the proper tags were indeed forwarded.
@@ -64,7 +79,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ChunkStoreConfig::ALL_DISABLED,
             path_to_rrd,
             VersionPolicy::Warn,
-        )?;
+        )
+        .unwrap();
         assert_eq!(1, stores.len());
 
         let store = stores.into_values().next().unwrap();
@@ -91,6 +107,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         similar_asserts::assert_eq!(expected, descriptors);
     }
-
-    Ok(())
 }

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -1,0 +1,90 @@
+use rerun::{
+    external::arrow2, ChunkStore, ChunkStoreConfig, Component, ComponentDescriptor, Loggable,
+    VersionPolicy,
+};
+
+#[derive(Debug, Clone, Copy)]
+struct CustomPosition3D(rerun::components::Position3D);
+
+impl rerun::SizeBytes for CustomPosition3D {
+    #[inline]
+    fn heap_size_bytes(&self) -> u64 {
+        0
+    }
+}
+
+impl Loggable for CustomPosition3D {
+    #[inline]
+    fn arrow2_datatype() -> arrow2::datatypes::DataType {
+        rerun::components::Position3D::arrow2_datatype()
+    }
+
+    #[inline]
+    fn to_arrow2_opt<'a>(
+        data: impl IntoIterator<Item = Option<impl Into<std::borrow::Cow<'a, Self>>>>,
+    ) -> rerun::SerializationResult<Box<dyn arrow2::array::Array>>
+    where
+        Self: 'a,
+    {
+        rerun::components::Position3D::to_arrow2_opt(
+            data.into_iter().map(|opt| opt.map(Into::into).map(|c| c.0)),
+        )
+    }
+}
+
+impl Component for CustomPosition3D {
+    #[inline]
+    fn descriptor() -> ComponentDescriptor {
+        ComponentDescriptor {
+            archetype_name: Some("user.CustomArchetype".into()),
+            archetype_field_name: Some("user.CustomArchetypeField".into()),
+            component_name: "user.CustomPosition3D".into(),
+        }
+    }
+}
+
+#[allow(clippy::unwrap_used)]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    const APP_ID: &str = "rerun_example_descriptors_custom_component_vanilla";
+
+    let rec = rerun::RecordingStreamBuilder::new(APP_ID).spawn()?;
+
+    let position = CustomPosition3D(rerun::components::Position3D::new(1.0, 2.0, 3.0));
+    rec.log_component_batches("data", true, [&position as &dyn rerun::ComponentBatch])?;
+
+    // When this snippet runs through the snippet comparison machinery, this environment variable
+    // will point to the output RRD.
+    // We can thus load this RRD to check that the proper tags were indeed forwarded.
+    //
+    // Python and C++ are indirectly checked by the snippet comparison tool itself.
+    if let Ok(path_to_rrd) = std::env::var("_RERUN_TEST_FORCE_SAVE") {
+        rec.flush_blocking();
+
+        let stores = ChunkStore::from_rrd_filepath(
+            &ChunkStoreConfig::ALL_DISABLED,
+            path_to_rrd,
+            VersionPolicy::Warn,
+        )?;
+        assert_eq!(1, stores.len());
+
+        let store = stores.into_values().next().unwrap();
+        let chunks = store.iter_chunks().collect::<Vec<_>>();
+        assert_eq!(1, chunks.len());
+
+        let chunk = chunks.into_iter().next().unwrap();
+
+        let mut descriptors = chunk
+            .components()
+            .values()
+            .flat_map(|per_desc| per_desc.keys())
+            .cloned()
+            .collect::<Vec<_>>();
+        descriptors.sort();
+
+        let expected = vec![CustomPosition3D::descriptor()];
+
+        similar_asserts::assert_eq!(expected, descriptors);
+    }
+
+    Ok(())
+}

--- a/docs/snippets/all/descriptors/descr_custom_component.rs
+++ b/docs/snippets/all/descriptors/descr_custom_component.rs
@@ -37,7 +37,7 @@ impl Component for CustomPosition3D {
     fn descriptor() -> ComponentDescriptor {
         ComponentDescriptor {
             archetype_name: Some("user.CustomArchetype".into()),
-            archetype_field_name: Some("user.CustomArchetypeField".into()),
+            archetype_field_name: Some("custom_positions".into()),
             component_name: "user.CustomPosition3D".into(),
         }
     }
@@ -84,7 +84,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let expected = vec![
             ComponentDescriptor {
                 archetype_name: Some("user.CustomArchetype".into()),
-                archetype_field_name: Some("user.CustomArchetypeField".into()),
+                archetype_field_name: Some("custom_positions".into()),
                 component_name: "user.CustomPosition3D".into(),
             }, //
         ];

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -3,7 +3,7 @@
 use rerun::{
     demo_util::grid,
     external::{arrow2, glam, re_types},
-    ComponentName,
+    ComponentBatch,
 };
 
 // ---
@@ -26,9 +26,17 @@ impl rerun::AsComponents for CustomPoints3D {
             .chain(
                 [
                     Some(indicator.to_batch()),
-                    self.confidences
-                        .as_ref()
-                        .map(|v| (v as &dyn rerun::ComponentBatch).into()),
+                    self.confidences.as_ref().map(|batch| {
+                        rerun::MaybeOwnedComponentBatch::new(batch as &dyn rerun::ComponentBatch)
+                            // Optionally override the descriptor with extra information.
+                            .with_descriptor_override(
+                                batch
+                                    .descriptor()
+                                    .into_owned()
+                                    .or_with_archetype_name(|| "user.CustomPoints3D".into())
+                                    .or_with_archetype_field_name(|| "confidences".into()),
+                            )
+                    }),
                 ]
                 .into_iter()
                 .flatten(),
@@ -75,8 +83,8 @@ impl rerun::Loggable for Confidence {
 
 impl rerun::Component for Confidence {
     #[inline]
-    fn name() -> ComponentName {
-        "user.Confidence".into()
+    fn descriptor() -> rerun::ComponentDescriptor {
+        rerun::ComponentDescriptor::new("user.Confidence")
     }
 }
 

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -18,7 +18,7 @@ struct CustomPoints3D {
 }
 
 impl rerun::AsComponents for CustomPoints3D {
-    fn as_component_batches(&self) -> Vec<rerun::MaybeOwnedComponentBatch<'_>> {
+    fn as_component_batches(&self) -> Vec<rerun::ComponentBatchCowWithDescriptor<'_>> {
         let indicator = rerun::NamedIndicatorComponent("user.CustomPoints3DIndicator".into());
         self.points3d
             .as_component_batches()
@@ -27,7 +27,7 @@ impl rerun::AsComponents for CustomPoints3D {
                 [
                     Some(indicator.to_batch()),
                     self.confidences.as_ref().map(|batch| {
-                        rerun::MaybeOwnedComponentBatch::new(batch as &dyn rerun::ComponentBatch)
+                        rerun::ComponentBatchCowWithDescriptor::new(batch as &dyn rerun::ComponentBatch)
                             // Optionally override the descriptor with extra information.
                             .with_descriptor_override(
                                 batch

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -27,15 +27,17 @@ impl rerun::AsComponents for CustomPoints3D {
                 [
                     Some(indicator.to_batch()),
                     self.confidences.as_ref().map(|batch| {
-                        rerun::ComponentBatchCowWithDescriptor::new(batch as &dyn rerun::ComponentBatch)
-                            // Optionally override the descriptor with extra information.
-                            .with_descriptor_override(
-                                batch
-                                    .descriptor()
-                                    .into_owned()
-                                    .or_with_archetype_name(|| "user.CustomPoints3D".into())
-                                    .or_with_archetype_field_name(|| "confidences".into()),
-                            )
+                        rerun::ComponentBatchCowWithDescriptor::new(
+                            batch as &dyn rerun::ComponentBatch,
+                        )
+                        // Optionally override the descriptor with extra information.
+                        .with_descriptor_override(
+                            batch
+                                .descriptor()
+                                .into_owned()
+                                .or_with_archetype_name(|| "user.CustomPoints3D".into())
+                                .or_with_archetype_field_name(|| "confidences".into()),
+                        )
                     }),
                 ]
                 .into_iter()

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -54,6 +54,22 @@
   "cpp",
   "rust",
 ]
+"descriptors/descr_builtin_archetype" = [ # Python and C++ not yet supported (next PRs)
+  "cpp",
+  "py",
+]
+"descriptors/descr_builtin_component" = [ # Python and C++ not yet supported (next PRs)
+  "cpp",
+  "py",
+]
+"descriptors/descr_custom_archetype" = [ # Python and C++ not yet supported (next PRs)
+  "cpp",
+  "py",
+]
+"descriptors/descr_custom_component" = [ # Python and C++ not yet supported (next PRs)
+  "cpp",
+  "py",
+]
 views = [
   "cpp",  # TODO(#5520): C++ views are not yet implemented
   "rust", # TODO(#5521): Rust views are not yet implemented

--- a/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
+++ b/examples/rust/custom_space_view/src/color_coordinates_visualizer_system.rs
@@ -2,7 +2,7 @@ use re_viewer::external::{
     egui,
     re_log_types::{EntityPath, Instance},
     re_renderer,
-    re_types::{self, components::Color, Component as _, ComponentName},
+    re_types::{self, components::Color, Component as _, ComponentDescriptor},
     re_viewer_context::{
         self, IdentifiedViewSystem, SpaceViewSystemExecutionError, ViewContext,
         ViewContextCollection, ViewQuery, ViewSystemIdentifier, VisualizerQueryInfo,
@@ -34,8 +34,8 @@ impl re_types::Archetype for ColorArchetype {
         "Instance Color"
     }
 
-    fn required_components() -> ::std::borrow::Cow<'static, [ComponentName]> {
-        vec![re_types::components::Color::name()].into()
+    fn required_components() -> ::std::borrow::Cow<'static, [ComponentDescriptor]> {
+        vec![re_types::components::Color::descriptor()].into()
     }
 }
 

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -53,6 +53,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
+        // engine.engine.read().store().iter_chunks()
+
         let query = QueryExpression {
             filtered_index: Some(timeline),
             view_contents: Some(

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -53,8 +53,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
 
-        // engine.engine.read().store().iter_chunks()
-
         let query = QueryExpression {
             filtered_index: Some(timeline),
             view_contents: Some(

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -7,6 +7,7 @@ use itertools::Itertools as _;
 use rerun::{
     demo_util::{bounce_lerp, color_spiral},
     external::glam,
+    ComponentBatch,
 };
 
 const NUM_POINTS: usize = 100;
@@ -16,6 +17,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (points1, colors1) = color_spiral(NUM_POINTS, 2.0, 0.02, 0.0, 0.1);
     let (points2, colors2) = color_spiral(NUM_POINTS, 2.0, 0.02, TAU * 0.5, 0.1);
+
+    rec.log_component_batches(
+        "data",
+        true,
+        [&rerun::components::Position3D::new(1.0, 2.0, 3.0) as &dyn ComponentBatch],
+    )?;
 
     rec.set_time_seconds("stable_time", 0f64);
 

--- a/examples/rust/dna/src/main.rs
+++ b/examples/rust/dna/src/main.rs
@@ -7,7 +7,6 @@ use itertools::Itertools as _;
 use rerun::{
     demo_util::{bounce_lerp, color_spiral},
     external::glam,
-    ComponentBatch,
 };
 
 const NUM_POINTS: usize = 100;
@@ -17,12 +16,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let (points1, colors1) = color_spiral(NUM_POINTS, 2.0, 0.02, 0.0, 0.1);
     let (points2, colors2) = color_spiral(NUM_POINTS, 2.0, 0.02, TAU * 0.5, 0.1);
-
-    rec.log_component_batches(
-        "data",
-        true,
-        [&rerun::components::Position3D::new(1.0, 2.0, 3.0) as &dyn ComponentBatch],
-    )?;
 
     rec.set_time_seconds("stable_time", 0f64);
 

--- a/rerun_py/src/arrow.rs
+++ b/rerun_py/src/arrow.rs
@@ -17,7 +17,7 @@ use pyo3::{
 
 use re_chunk::{Chunk, ChunkError, ChunkId, PendingRow, RowId, TimeColumn};
 use re_log_types::TimePoint;
-use re_sdk::{external::nohash_hasher::IntMap, ComponentName, EntityPath, Timeline};
+use re_sdk::{external::nohash_hasher::IntMap, ComponentDescriptor, EntityPath, Timeline};
 
 /// Perform conversion between a pyarrow array to arrow2 types.
 ///
@@ -59,7 +59,7 @@ pub fn build_row_from_components(
     let components = arrays
         .into_iter()
         .zip(fields)
-        .map(|(value, field)| (field.name.into(), value))
+        .map(|(value, field)| (ComponentDescriptor::new(field.name), value))
         .collect();
 
     Ok(PendingRow {
@@ -149,11 +149,11 @@ pub fn build_chunk_from_components(
                 )?
             };
 
-            Ok((field.name.into(), batch))
+            Ok((ComponentDescriptor::new(field.name), batch))
         })
         .collect();
 
-    let components: IntMap<ComponentName, ListArray<i32>> = components
+    let components = components
         .map_err(|err| PyRuntimeError::new_err(format!("Error converting component data: {err}")))?
         .into_iter()
         .collect();


### PR DESCRIPTION
I had to give up on the idea of splitting this thing into neat little PRs -- the enormous amount of extra work needed in this case is just not worth it, it's not even close (turns out changing the definition of `Component` has cascading consequences :no_mouth:).

I'll add a thorough description of what's going on to compensate, and can walk someone through this if needed.

---

### Goals and non-goals

The goal of this PR is to get component tags in, store them, and then get them out.

The goal of this PR is _not_ to port every single bit of component-name based logic to component-descriptor based logic (including but certainly not limited to datastore queries).
That will be the next step: https://github.com/rerun-io/rerun/issues/8293.


### Types and traits

First and foremost, this ofc introduces the new `ComponentDescriptor` type:
```rust
/// A [`ComponentDescriptor`] fully describes the semantics of a column of data.
///
/// Every component is uniquely identified by its [`ComponentDescriptor`].
#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
pub struct ComponentDescriptor {
    /// Optional name of the `Archetype` associated with this data.
    ///
    /// `None` if the data wasn't logged through an archetype.
    ///
    /// Example: `rerun.archetypes.Points3D`.
    pub archetype_name: Option<ArchetypeName>,

    /// Optional name of the field within `Archetype` associated with this data.
    ///
    /// `None` if the data wasn't logged through an archetype.
    ///
    /// Example: `positions`.
    pub archetype_field_name: Option<ArchetypeFieldName>,

    /// Semantic name associated with this data.
    ///
    /// This is fully implied by `archetype_name` and `archetype_field`, but
    /// included for semantic convenience.
    ///
    /// Example: `rerun.components.Position3D`.
    pub component_name: ComponentName,
}
```

Note that this is a _Rerun_ type, not a _Sorbet_ type: i.e. it uses Rerun terminology (archetypes, fields, etc), not Sorbet terminology.
As is now tradition, this terminology gets translated into its Sorbet equivalent when leaving the land of internal Chunks for the land of external RecordBatches and Dataframes.

`Component`s are now uniquely identified by a `ComponentDescriptor` rather than a `ComponentName`:
```rust
/// A [`Component`] describes semantic data that can be used by any number of [`Archetype`]s.
///
/// Implementing the [`Component`] trait automatically derives the [`ComponentBatch`] implementation,
/// which makes it possible to work with lists' worth of data in a generic fashion.
pub trait Component: Loggable {
    /// Returns the complete [`ComponentDescriptor`] for this [`Component`].
    ///
    /// Every component is uniquely identified by its [`ComponentDescriptor`].
    //
    // NOTE: Builtin Rerun components don't (yet) have anything but a `ComponentName` attached to
    // them (other tags are injected at the Archetype level), therefore having a full
    // `ComponentDescriptor` might seem overkill.
    // It's not:
    // * Users might still want to register Components with specific tags.
    // * In the future, `ComponentDescriptor`s will very likely cover than Archetype-related tags
    //   (e.g. generics, metric units, etc).
    fn descriptor() -> ComponentDescriptor;

    /// The fully-qualified name of this component, e.g. `rerun.components.Position2D`.
    ///
    /// This is a trivial but useful helper for `Self::descriptor().component_name`.
    ///
    /// The default implementation already does the right thing: do not override unless you know
    /// what you're doing.
    /// `Self::name()` must exactly match the value returned by `Self::descriptor().component_name`,
    /// or undefined behavior ensues.
    //
    // TODO(cmc): The only reason we keep this around is for convenience, and the only reason we need this
    // convenience is because we're still in this weird half-way in-between state where some things
    // are still indexed by name. Remove this entirely once we've ported everything to descriptors.
    #[inline]
    fn name() -> ComponentName {
        Self::descriptor().component_name
    }
}
```
`Component::name` still exists for now, as a convenience during the interim (that is, until we propagate `ComponentDescriptor` to every last corner of the app).


`MaybeOwnedComponentBatch` now has the possibility to augment and/or fully-override the `ComponentDescriptor` of the data within:
```rust
/// Some [`ComponentBatch`], optionally with an overridden [`ComponentDescriptor`].
///
/// Used by implementers of [`crate::AsComponents`] to both efficiently expose their component data
/// and assign the right tags given the surrounding context.
pub struct MaybeOwnedComponentBatch<'a> {
    /// The component data.
    pub batch: ComponentBatchCow<'a>,

    /// If set, will override the [`ComponentBatch`]'s [`ComponentDescriptor`].
    pub descriptor_override: Option<ComponentDescriptor>,
}
```
This is a crucial part of the story, as this is how e.g. archetypes inject their own tags when component data gets logged on their behalf.

### Override model

The override model is simple:
* Every `Component` has an associated `ComponentDescriptor`.
* Every `ComponentBatch` inherits from its underlying `Component`'s `ComponentDescriptor`.
* `AsComponents` has an opportunity to override each `ComponentBatch`'s `ComponentDescriptor` (by means of `MaybeOwnedComponentBatch`.

The goal is to try and carry those semantics over the two other SDKs (Python, C++), while somehow keeping changes to a minimum.


### Undefined behavior

Logging the same component multiple times on a single entity (e.g. by logging different archetypes that share parts of their definitions) has always been, for all intents and purposes, UB.

This PR propagates descriptors just enough to get things up and running, no more no less. By which I mean that it is possible to get component tags in and out of the system, but many things still assume that `Component`s are uniquely identified by their names.
This means that some part of the codebase are still indexing things by name, while others index by descriptor. Where these parts meet, what was UB before is even more UB now, as we generally just pick one random component among the ones available.
You'll see a lot of `get_first_component` in the code: every single one of those is UB if there are multiple components under the same name (for now!).

Debug builds assert for duplicated components, until we properly use descriptors everywhere (remember: nothing should ever be indexed by `ComponentName` in the future).


### Fully-qualified component names & column paths

`ComponentDescriptor` defines its fully-qualified name as such:
```rust
match (archetype_name, component_name, archetype_field_name) {
    (None, component_name, None) => component_name.to_owned(),
    (Some(archetype_name), component_name, None) => {
        format!("{archetype_name}:{component_name}")
    }
    (None, component_name, Some(archetype_field_name)) => {
        format!("{component_name}#{archetype_field_name}")
    }
    (Some(archetype_name), component_name, Some(archetype_field_name)) => {
        format!("{archetype_name}:{component_name}#{archetype_field_name}")
    }
}
```
which yields e.g. `rerun.archetypes.Points3D:rerun.components.Position3D#positions`, which is generally shortened to `Points3D:Position3D#positions` when there is no ambiguity.

In the dataframe API, a fully-qualified column path now becomes `{entity_path}@{archetype_name}:{component_name}#{archetype_field_name}`, e.g. `/my/points@rerun.archetypes.Points3D:rerun.components.Position3D#positions` or `/my/points@Points3D:Position3D#positions`.

This syntax needs to be debated. I have intentionally disabled the syntax in the dataframe APIs so as not to break anything external-facing.


### Transport and metadata

`ArchetypeName` and `ArchetypeFieldName` are now exposed as `rerun.archetype_name` and `rerun.archetype_field_name` in `TransportChunk`'s arrow metadata.

I really cannot wait for a better metadata system.


### Performance

`ComponentDescriptor`s add an extra layer of mappings everywhere: we used to have `IntMap<ComponentName, T>` all over the place, now we have `IntMap<ComponentName, IntMap<ComponentDescriptor, T>>`.
The extra `ComponentName` layer is needed because it is very common to want to look for anything matching a `ComponentName`, without any further tags specified.

Like before, these are NoHash maps, so performance impact should be minimal (`ComponentDescriptor` implements NoHash by xor'ing everything).


### Examples / testing / roundtrips

See:
* docs/snippets/all/descriptors/descr_builtin_archetype.rs
* docs/snippets/all/descriptors/descr_builtin_component.rs
* docs/snippets/all/descriptors/descr_custom_archetype.rs
* docs/snippets/all/descriptors/descr_custom_component.rs

These snippets play all roles at once, as usual. In particular they make sure that all languages (well, only Rust for now, Python and C++ coming soon) carry all the right tags in all the right situations.

---

* Part of #7948 