### PR TITLE
improve view property ui methods

### DIFF
--- a/crates/viewer/re_space_view/src/lib.rs
+++ b/crates/viewer/re_space_view/src/lib.rs
@@ -30,7 +30,9 @@ pub use query::{
 pub use results_ext::{
     HybridLatestAtResults, HybridResults, HybridResultsChunkIter, RangeResultsExt,
 };
-pub use view_property_ui::view_property_ui;
+pub use view_property_ui::{
+    view_property_component_ui, view_property_component_ui_custom, view_property_ui,
+};
 
 pub mod external {
     pub use re_entity_db::external::*;

--- a/crates/viewer/re_viewport_blueprint/src/view_properties.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view_properties.rs
@@ -33,10 +33,17 @@ pub struct ViewProperty {
     /// stored.
     pub blueprint_store_path: EntityPath,
 
-    archetype_name: ArchetypeName,
-    component_names: Vec<ComponentName>,
-    query_results: LatestAtResults,
-    blueprint_query: LatestAtQuery,
+    /// Name of the property archetype.
+    pub archetype_name: ArchetypeName,
+
+    /// List of all components in this property.
+    pub component_names: Vec<ComponentName>,
+
+    /// Query results for all queries of this property.
+    pub query_results: LatestAtResults,
+
+    /// Blueprint query used for querying.
+    pub blueprint_query: LatestAtQuery,
 }
 
 impl ViewProperty {


### PR DESCRIPTION
### Related

* split out of #8234 

### What

* use `ViewProperty` util construct some more
* route individual property ui via `view_property_component_ui_custom` making it easier to draw custom ui for specific view properties while still having all tooltip & extra menus be the same