### PR TITLE
Visually differentiate implicit nodes in graph view

### DIFF
--- a/crates/viewer/re_space_view_graph/src/graph/mod.rs
+++ b/crates/viewer/re_space_view_graph/src/graph/mod.rs
@@ -114,7 +114,7 @@ impl Graph {
                     nodes.push(Node::Implicit {
                         id: edge.source_index,
                         graph_node: edge.source.clone(),
-                        label: DrawableLabel::implicit_circle(),
+                        label: DrawableLabel::implicit_circle(ui),
                     });
                     seen.insert(edge.source_index);
                 }
@@ -122,7 +122,7 @@ impl Graph {
                     nodes.push(Node::Implicit {
                         id: edge.target_index,
                         graph_node: edge.target.clone(),
-                        label: DrawableLabel::implicit_circle(),
+                        label: DrawableLabel::implicit_circle(ui),
                     });
                     seen.insert(edge.target_index);
                 }

--- a/crates/viewer/re_space_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_space_view_graph/src/ui/draw.rs
@@ -56,10 +56,10 @@ impl DrawableLabel {
         Self::Circle(CircleLabel { radius, color })
     }
 
-    pub fn implicit_circle() -> Self {
+    pub fn implicit_circle(ui: &Ui) -> Self {
         Self::Circle(CircleLabel {
             radius: 4.0,
-            color: None,
+            color: Some(ui.style().visuals.weak_text_color()),
         })
     }
 


### PR DESCRIPTION
### What

After refactoring, _implicit_ nodes were visualized using regular `text_color` and where therefore no possible to differentiate from regular nodes. This PR fixes that.

<img width="44" alt="image" src="https://github.com/user-attachments/assets/d1c32758-2154-4842-ab18-9be9b899c6d0">


The node on the bottom (darker gray) is implicit.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
