### PR TITLE
Bump `hashbrown@0.15.0` to `0.15.1` to fix vuln

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
 dependencies = [
  "accesskit",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "immutable-chunkmap",
 ]
 
@@ -71,7 +71,7 @@ checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
  "accesskit",
  "accesskit_consumer 0.26.0",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -103,7 +103,7 @@ checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
  "accesskit",
  "accesskit_consumer 0.26.0",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "paste",
  "static_assertions",
  "windows 0.58.0",
@@ -2998,9 +2998,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3409,7 +3409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -3826,7 +3826,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
 ]
 
 [[package]]


### PR DESCRIPTION
### What

Fixes CI problems (https://github.com/rerun-io/rerun/actions/runs/12160549310/job/33913118372?pr=8313):

```
error[vulnerability]: Borsh serialization of HashMap is non-canonical
    ┌─ /home/runner/work/rerun/rerun/Cargo.lock:225:1
    │
225 │ hashbrown 0.15.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
    │
    ├ ID: RUSTSEC-2024-0402
    ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0402
    ├ The borsh serialization of the HashMap did not follow the borsh specification.
      It potentially produced non-canonical encodings dependent on insertion order.
      It also did not perform canonicty checks on decoding.
      
      This can result in consensus splits and cause equivalent objects to be
      considered distinct.
      
      This was patched in 0.15.1.
```



<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
