### PR TITLE
Fix outlines for lines having more preceived aliasing since 0.20

### DIFF
--- a/crates/build/re_types_builder/src/codegen/cpp/mod.rs
+++ b/crates/build/re_types_builder/src/codegen/cpp/mod.rs
@@ -2182,7 +2182,7 @@ fn quote_archetype_field_type(hpp_includes: &mut Includes, obj_field: &ObjectFie
             quote! { Collection<#elem_type> }
         }
         // TODO(andreas): This should emit `MonoCollection` which will be a constrained version of `Collection`.
-        // (simply adapting `MonoCollection` breaks some existing code, so this not entirely trivial to do.
+        // (Simply adapting `MonoCollection` breaks some existing code, so this not entirely trivial to do.
         //  Designing constraints for `MonoCollection` is harder still)
         Type::Object(fqname) => quote_fqname_as_type_path(hpp_includes, fqname),
         _ => panic!("Only vectors and objects are allowed in archetypes."),

--- a/crates/viewer/re_renderer/shader/depth_cloud.wgsl
+++ b/crates/viewer/re_renderer/shader/depth_cloud.wgsl
@@ -202,11 +202,10 @@ fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
 
 @fragment
 fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
-    // Output is an integer target, can't use coverage therefore.
-    // But we still want to discard fragments where coverage is low.
-    // Since the outline extends a bit, a very low cut off tends to look better.
+    // Output is an integer target so we can't use coverage even though
+    // the target is anti-aliased.
     let coverage = sphere_quad_coverage(in.pos_in_world, in.point_radius, in.point_pos_in_world);
-    if coverage < 1.0 {
+    if coverage <= 0.5 {
         discard;
     }
     return depth_cloud_info.outline_mask_id;

--- a/crates/viewer/re_renderer/shader/lines.wgsl
+++ b/crates/viewer/re_renderer/shader/lines.wgsl
@@ -370,10 +370,12 @@ fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
 @fragment
 fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
     // Output is an integer target, can't use coverage therefore.
-    // But we still want to discard fragments where coverage is low.
-    // Since the outline extends a bit, a very low cut off tends to look better.
+    // But we still want to discard fragments where coverage is too low, otherwise
+    // we'd not handle rounded corners etc. correctly.
+    // Note that `compute_coverage` may already give coverage values below 1.0 along the
+    // "main body of the line", not just the caps.
     var coverage = compute_coverage(in);
-    if coverage < 1.0 {
+    if coverage <= 0.0 {
         discard;
     }
     return batch.outline_mask_ids;

--- a/crates/viewer/re_renderer/shader/point_cloud.wgsl
+++ b/crates/viewer/re_renderer/shader/point_cloud.wgsl
@@ -173,11 +173,10 @@ fn fs_main_picking_layer(in: VertexOut) -> @location(0) vec4u {
 
 @fragment
 fn fs_main_outline_mask(in: VertexOut) -> @location(0) vec2u {
-    // Output is an integer target, can't use coverage therefore.
-    // But we still want to discard fragments where coverage is low.
-    // Since the outline extends a bit, a very low cut off tends to look better.
+    // Output is an integer target so we can't use coverage even though
+    // the target is anti-aliased.
     let coverage = coverage(in.world_position, in.radius, in.point_center);
-    if coverage < 1.0 {
+    if coverage <= 0.5 {
         discard;
     }
     return batch.outline_mask;


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8314

### What

All screenshots on MacOS lowdpi (==scaling 100%) since it's easier to spot there (but also still impactful on highdpi==scaling>=200%). Listing WebGPU & WebGL separately since WebGL version doesn't do anti-aliasing on outlines (technical limitations)

0.19 WebGPU Chrome
![image](https://github.com/user-attachments/assets/1e12d179-05a3-45b9-9de9-6b87a7c8484a)

0.20/main WebGPU Chrome
![image](https://github.com/user-attachments/assets/fe7fc1a5-90d0-4ba7-b787-5c499e5ee8fc)

This PR WebGPU Chrome
![image](https://github.com/user-attachments/assets/98df0047-a9bb-4a9d-9847-5c1275aa20b0)

---

0.19 WebGL Chrome
![image](https://github.com/user-attachments/assets/127c8bee-8ede-4d8a-baa6-81c2a90135b3)


0.20/main WebGL Chrome
![image](https://github.com/user-attachments/assets/7942509e-378d-4f19-b8bc-28117f673f26)


This PR WebGL Chrome
![image](https://github.com/user-attachments/assets/f62556eb-61ca-4d28-b069-1aee0e717bed)

