### PR TITLE
Support cmd-Y for redo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6597,6 +6597,7 @@ dependencies = [
  "re_tracing",
  "serde",
  "serde_json",
+ "smallvec",
  "strum",
  "strum_macros",
  "sublime_fuzzy",

--- a/crates/viewer/re_time_panel/src/time_control_ui.rs
+++ b/crates/viewer/re_time_panel/src/time_control_ui.rs
@@ -237,8 +237,10 @@ You can also define your own timelines, e.g. for sensor time or camera frame num
 }
 
 fn toggle_playback_text(egui_ctx: &egui::Context) -> String {
-    if let Some(shortcut) = re_ui::UICommand::PlaybackTogglePlayPause.kb_shortcut() {
-        format!(" Toggle with {}", egui_ctx.format_shortcut(&shortcut))
+    if let Some(shortcut_text) =
+        re_ui::UICommand::PlaybackTogglePlayPause.formatted_kb_shortcut(egui_ctx)
+    {
+        format!(" Toggle with {shortcut_text}")
     } else {
         Default::default()
     }

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -51,6 +51,7 @@ sublime_fuzzy.workspace = true
 eframe = { workspace = true, default-features = false, features = ["wgpu"] }
 egui_tiles.workspace = true
 rand.workspace = true
+smallvec.workspace = true
 
 
 [dev-dependencies]

--- a/crates/viewer/re_ui/src/command.rs
+++ b/crates/viewer/re_ui/src/command.rs
@@ -1,4 +1,5 @@
 use egui::{os::OperatingSystem, Key, KeyboardShortcut, Modifiers};
+use smallvec::{smallvec, SmallVec};
 
 /// Interface for sending [`UICommand`] messages.
 pub trait UICommandSender {
@@ -260,7 +261,7 @@ impl UICommand {
     }
 
     /// All keyboard shortcuts, with the primary first.
-    pub fn kb_shortcuts(self, os: OperatingSystem) -> Vec<KeyboardShortcut> {
+    pub fn kb_shortcuts(self, os: OperatingSystem) -> SmallVec<[KeyboardShortcut; 2]> {
         fn key(key: Key) -> KeyboardShortcut {
             KeyboardShortcut::new(Modifiers::NONE, key)
         }
@@ -286,91 +287,91 @@ impl UICommand {
         }
 
         match self {
-            Self::SaveRecording => vec![cmd(Key::S)],
-            Self::SaveRecordingSelection => vec![cmd_alt(Key::S)],
-            Self::SaveBlueprint => vec![],
-            Self::Open => vec![cmd(Key::O)],
-            Self::Import => vec![cmd_shift(Key::O)],
-            Self::CloseCurrentRecording => vec![],
-            Self::CloseAllRecordings => vec![],
+            Self::SaveRecording => smallvec![cmd(Key::S)],
+            Self::SaveRecordingSelection => smallvec![cmd_alt(Key::S)],
+            Self::SaveBlueprint => smallvec![],
+            Self::Open => smallvec![cmd(Key::O)],
+            Self::Import => smallvec![cmd_shift(Key::O)],
+            Self::CloseCurrentRecording => smallvec![],
+            Self::CloseAllRecordings => smallvec![],
 
-            Self::Undo => vec![cmd(Key::Z)],
+            Self::Undo => smallvec![cmd(Key::Z)],
             Self::Redo => {
                 if os == OperatingSystem::Mac {
-                    vec![cmd_shift(Key::Z), cmd(Key::Y)]
+                    smallvec![cmd_shift(Key::Z), cmd(Key::Y)]
                 } else {
-                    vec![ctrl(Key::Y), ctrl_shift(Key::Z)]
+                    smallvec![ctrl(Key::Y), ctrl_shift(Key::Z)]
                 }
             }
 
             #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
-            Self::Quit => vec![KeyboardShortcut::new(Modifiers::ALT, Key::F4)],
+            Self::Quit => smallvec![KeyboardShortcut::new(Modifiers::ALT, Key::F4)],
 
-            Self::OpenWebHelp => vec![],
-            Self::OpenRerunDiscord => vec![],
+            Self::OpenWebHelp => smallvec![],
+            Self::OpenRerunDiscord => smallvec![],
 
             #[cfg(all(not(target_arch = "wasm32"), not(target_os = "windows")))]
-            Self::Quit => vec![cmd(Key::Q)],
+            Self::Quit => smallvec![cmd(Key::Q)],
 
-            Self::ResetViewer => vec![ctrl_shift(Key::R)],
-            Self::ClearAndGenerateBlueprint => vec![],
+            Self::ResetViewer => smallvec![ctrl_shift(Key::R)],
+            Self::ClearAndGenerateBlueprint => smallvec![],
 
             #[cfg(not(target_arch = "wasm32"))]
-            Self::OpenProfiler => vec![ctrl_shift(Key::P)],
-            Self::ToggleMemoryPanel => vec![ctrl_shift(Key::M)],
-            Self::TogglePanelStateOverrides => vec![],
-            Self::ToggleTopPanel => vec![],
-            Self::ToggleBlueprintPanel => vec![ctrl_shift(Key::B)],
-            Self::ToggleSelectionPanel => vec![ctrl_shift(Key::S)],
-            Self::ToggleTimePanel => vec![ctrl_shift(Key::T)],
-            Self::ToggleChunkStoreBrowser => vec![ctrl_shift(Key::D)],
-            Self::Settings => vec![cmd(Key::Comma)],
+            Self::OpenProfiler => smallvec![ctrl_shift(Key::P)],
+            Self::ToggleMemoryPanel => smallvec![ctrl_shift(Key::M)],
+            Self::TogglePanelStateOverrides => smallvec![],
+            Self::ToggleTopPanel => smallvec![],
+            Self::ToggleBlueprintPanel => smallvec![ctrl_shift(Key::B)],
+            Self::ToggleSelectionPanel => smallvec![ctrl_shift(Key::S)],
+            Self::ToggleTimePanel => smallvec![ctrl_shift(Key::T)],
+            Self::ToggleChunkStoreBrowser => smallvec![ctrl_shift(Key::D)],
+            Self::Settings => smallvec![cmd(Key::Comma)],
 
             #[cfg(debug_assertions)]
-            Self::ToggleBlueprintInspectionPanel => vec![ctrl_shift(Key::I)],
+            Self::ToggleBlueprintInspectionPanel => smallvec![ctrl_shift(Key::I)],
 
             #[cfg(debug_assertions)]
-            Self::ToggleEguiDebugPanel => vec![ctrl_shift(Key::U)],
+            Self::ToggleEguiDebugPanel => smallvec![ctrl_shift(Key::U)],
 
             #[cfg(not(target_arch = "wasm32"))]
-            Self::ToggleFullscreen => vec![key(Key::F11)],
+            Self::ToggleFullscreen => smallvec![key(Key::F11)],
             #[cfg(target_arch = "wasm32")]
-            Self::ToggleFullscreen => vec![],
+            Self::ToggleFullscreen => smallvec![],
 
             #[cfg(not(target_arch = "wasm32"))]
-            Self::ZoomIn => vec![egui::gui_zoom::kb_shortcuts::ZOOM_IN],
+            Self::ZoomIn => smallvec![egui::gui_zoom::kb_shortcuts::ZOOM_IN],
             #[cfg(not(target_arch = "wasm32"))]
-            Self::ZoomOut => vec![egui::gui_zoom::kb_shortcuts::ZOOM_OUT],
+            Self::ZoomOut => smallvec![egui::gui_zoom::kb_shortcuts::ZOOM_OUT],
             #[cfg(not(target_arch = "wasm32"))]
-            Self::ZoomReset => vec![egui::gui_zoom::kb_shortcuts::ZOOM_RESET],
+            Self::ZoomReset => smallvec![egui::gui_zoom::kb_shortcuts::ZOOM_RESET],
 
-            Self::ToggleCommandPalette => vec![cmd(Key::P)],
+            Self::ToggleCommandPalette => smallvec![cmd(Key::P)],
 
-            Self::PlaybackTogglePlayPause => vec![key(Key::Space)],
-            Self::PlaybackFollow => vec![cmd(Key::ArrowRight)],
-            Self::PlaybackStepBack => vec![key(Key::ArrowLeft)],
-            Self::PlaybackStepForward => vec![key(Key::ArrowRight)],
-            Self::PlaybackRestart => vec![cmd(Key::ArrowLeft)],
+            Self::PlaybackTogglePlayPause => smallvec![key(Key::Space)],
+            Self::PlaybackFollow => smallvec![cmd(Key::ArrowRight)],
+            Self::PlaybackStepBack => smallvec![key(Key::ArrowLeft)],
+            Self::PlaybackStepForward => smallvec![key(Key::ArrowRight)],
+            Self::PlaybackRestart => smallvec![cmd(Key::ArrowLeft)],
 
             #[cfg(not(target_arch = "wasm32"))]
-            Self::ScreenshotWholeApp => vec![],
+            Self::ScreenshotWholeApp => smallvec![],
             #[cfg(not(target_arch = "wasm32"))]
-            Self::PrintChunkStore => vec![],
+            Self::PrintChunkStore => smallvec![],
             #[cfg(not(target_arch = "wasm32"))]
-            Self::PrintBlueprintStore => vec![],
+            Self::PrintBlueprintStore => smallvec![],
             #[cfg(not(target_arch = "wasm32"))]
-            Self::PrintPrimaryCache => vec![],
+            Self::PrintPrimaryCache => smallvec![],
 
             #[cfg(debug_assertions)]
-            Self::ResetEguiMemory => vec![],
+            Self::ResetEguiMemory => smallvec![],
 
             #[cfg(target_arch = "wasm32")]
-            Self::CopyDirectLink => vec![],
+            Self::CopyDirectLink => smallvec![],
 
             #[cfg(target_arch = "wasm32")]
-            Self::RestartWithWebGl => vec![],
+            Self::RestartWithWebGl => smallvec![],
             #[cfg(target_arch = "wasm32")]
-            Self::RestartWithWebGpu => vec![],
+            Self::RestartWithWebGpu => smallvec![],
         }
     }
 

--- a/crates/viewer/re_ui/src/command_palette.rs
+++ b/crates/viewer/re_ui/src/command_palette.rs
@@ -99,10 +99,7 @@ impl CommandPalette {
 
         for (i, fuzzy_match) in commands_that_match(&query).iter().enumerate() {
             let command = fuzzy_match.command;
-            let kb_shortcut = command
-                .kb_shortcut()
-                .map(|shortcut| ui.ctx().format_shortcut(&shortcut))
-                .unwrap_or_default();
+            let kb_shortcut_text = command.formatted_kb_shortcut(ui.ctx()).unwrap_or_default();
 
             let (rect, response) = ui.allocate_at_least(
                 egui::vec2(ui.available_width(), item_height),
@@ -148,7 +145,7 @@ impl CommandPalette {
             ui.painter().text(
                 rect.right_center(),
                 Align2::RIGHT_CENTER,
-                kb_shortcut,
+                kb_shortcut_text,
                 font_id.clone(),
                 if selected {
                     style.text_color()


### PR DESCRIPTION
### Related
* #3135 

### What
You can now use cmd-Y to redo.

To implement that, I added the ability to have multiple keyboard shortcuts per command, with the first one being the primary one.

Also adds `ctrl + ,` to open options on all platforms.