### PR TITLE
More compact selection panel when multiple items selected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6143,6 +6143,7 @@ dependencies = [
  "re_context_menu",
  "re_data_ui",
  "re_entity_db",
+ "re_format",
  "re_log",
  "re_log_types",
  "re_space_view",

--- a/crates/viewer/re_component_ui/src/datatype_uis/singleline_string.rs
+++ b/crates/viewer/re_component_ui/src/datatype_uis/singleline_string.rs
@@ -70,7 +70,7 @@ fn edit_multiline_string_impl(
         *value = edit_name.into();
         response
     } else {
-        UiLayout::SelectionPanelFull.data_label(ui, value.as_str())
+        UiLayout::SelectionPanel.data_label(ui, value.as_str())
     }
 }
 

--- a/crates/viewer/re_component_ui/src/geo_line_string.rs
+++ b/crates/viewer/re_component_ui/src/geo_line_string.rs
@@ -24,7 +24,7 @@ fn multiline_view_geo_line_string(
     // TODO(andreas): Editing this would be nice!
     let value = value.as_ref();
 
-    UiLayout::SelectionPanelFull
+    UiLayout::SelectionPanel
         .table(ui)
         .resizable(true)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))

--- a/crates/viewer/re_component_ui/src/line_strip.rs
+++ b/crates/viewer/re_component_ui/src/line_strip.rs
@@ -27,7 +27,7 @@ fn multiline_view_line_strip_3d(
 
     // TODO(andreas): Is it really a good idea to always have the full table here?
     // Can we use the ui stack to know where we are and do the right thing instead?
-    UiLayout::SelectionPanelFull
+    UiLayout::SelectionPanel
         .table(ui)
         .resizable(true)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))
@@ -89,7 +89,7 @@ fn multiline_view_line_strip_2d(
 
     // TODO(andreas): Is it really a good idea to always have the full table here?
     // Can we use the ui stack to know where we are and do the right thing instead?
-    UiLayout::SelectionPanelFull
+    UiLayout::SelectionPanel
         .table(ui)
         .resizable(true)
         .cell_layout(egui::Layout::left_to_right(egui::Align::Center))

--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_space_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_space_view.rs
@@ -36,28 +36,25 @@ impl ContextMenuAction for AddEntitiesToNewSpaceViewAction {
             .collect();
 
         ui.menu_button("Add to new space view", |ui| {
-            let buttons_for_space_view_classes = |ui: &mut egui::Ui,
-                                                  space_view_classes: &IntSet<
-                SpaceViewClassIdentifier,
-            >| {
-                for (identifier, class) in space_view_classes
-                    .iter()
-                    .map(|identifier| {
-                        (
-                            identifier,
-                            space_view_class_registry.get_class_or_log_error(*identifier),
-                        )
-                    })
-                    .sorted_by_key(|(_, class)| class.display_name().to_owned())
-                {
-                    let btn =
-                        egui::Button::image_and_text(class.icon().as_image(), class.display_name());
-                    if ui.add(btn).clicked() {
-                        create_space_view_for_selected_entities(ctx, *identifier);
-                        ui.close_menu();
+            let buttons_for_space_view_classes =
+                |ui: &mut egui::Ui, space_view_classes: &IntSet<SpaceViewClassIdentifier>| {
+                    for (identifier, class) in space_view_classes
+                        .iter()
+                        .map(|identifier| {
+                            (
+                                identifier,
+                                space_view_class_registry.get_class_or_log_error(*identifier),
+                            )
+                        })
+                        .sorted_by_key(|(_, class)| class.display_name().to_owned())
+                    {
+                        let btn = egui::Button::image_and_text(class.icon(), class.display_name());
+                        if ui.add(btn).clicked() {
+                            create_space_view_for_selected_entities(ctx, *identifier);
+                            ui.close_menu();
+                        }
                     }
-                }
-            };
+                };
 
             ui.label(egui::WidgetText::from("Recommended:").italics());
             if recommended_space_view_classes.is_empty() {

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -126,7 +126,7 @@ impl DataUi for AnnotationContext {
                 };
                 ui_layout.label(ui, text);
             }
-            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => {
+            UiLayout::SelectionPanelFull => {
                 ui.vertical(|ui| {
                     ui.maybe_collapsing_header(true, "Classes", true, |ui| {
                         let annotation_infos = self
@@ -153,7 +153,7 @@ impl DataUi for AnnotationContext {
 
 fn class_description_ui(
     ui: &mut egui::Ui,
-    mut ui_layout: UiLayout,
+    ui_layout: UiLayout,
     class: &ClassDescription,
     id: re_types::datatypes::ClassId,
 ) {
@@ -163,14 +163,7 @@ fn class_description_ui(
 
     re_tracing::profile_function!();
 
-    let use_collapsible = ui_layout == UiLayout::SelectionPanelLimitHeight
-        || ui_layout == UiLayout::SelectionPanelFull;
-
-    // We use collapsible header as a means for the user to limit the height, so the annotation info
-    // tables can be fully unrolled.
-    if ui_layout == UiLayout::SelectionPanelLimitHeight {
-        ui_layout = UiLayout::SelectionPanelFull;
-    }
+    let use_collapsible = ui_layout == UiLayout::SelectionPanelFull;
 
     let row_height = DesignTokens::table_line_height();
     if !class.keypoint_annotations.is_empty() {

--- a/crates/viewer/re_data_ui/src/annotation_context.rs
+++ b/crates/viewer/re_data_ui/src/annotation_context.rs
@@ -126,7 +126,7 @@ impl DataUi for AnnotationContext {
                 };
                 ui_layout.label(ui, text);
             }
-            UiLayout::SelectionPanelFull => {
+            UiLayout::SelectionPanel => {
                 ui.vertical(|ui| {
                     ui.maybe_collapsing_header(true, "Classes", true, |ui| {
                         let annotation_infos = self
@@ -163,7 +163,7 @@ fn class_description_ui(
 
     re_tracing::profile_function!();
 
-    let use_collapsible = ui_layout == UiLayout::SelectionPanelFull;
+    let use_collapsible = ui_layout == UiLayout::SelectionPanel;
 
     let row_height = DesignTokens::table_line_height();
     if !class.keypoint_annotations.is_empty() {

--- a/crates/viewer/re_data_ui/src/app_id.rs
+++ b/crates/viewer/re_data_ui/src/app_id.rs
@@ -67,10 +67,8 @@ impl crate::DataUi for ApplicationId {
             let active_blueprint = ctx.store_context.blueprint;
             let default_blueprint = ctx.store_context.hub.default_blueprint_for_app(self);
 
-            let button = egui::Button::image_and_text(
-                re_ui::icons::RESET.as_image(),
-                "Reset to default blueprint",
-            );
+            let button =
+                egui::Button::image_and_text(&re_ui::icons::RESET, "Reset to default blueprint");
 
             let is_same_as_default = default_blueprint.map_or(false, |default_blueprint| {
                 default_blueprint.latest_row_id() == active_blueprint.latest_row_id()
@@ -95,7 +93,7 @@ impl crate::DataUi for ApplicationId {
             }
 
             if ui.add(egui::Button::image_and_text(
-                re_ui::icons::RESET.as_image(),
+                &re_ui::icons::RESET,
                 "Reset to heuristic blueprint",
             )).on_hover_text("Clear both active and default blueprint, and auto-generate a new blueprint based on heuristics").clicked() {
                 ctx.command_sender

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -44,7 +44,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
         let max_row = match ui_layout {
             UiLayout::List => 0,
             UiLayout::Tooltip => num_instances.at_most(4), // includes "…x more" if any
-            UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => num_instances,
+            UiLayout::SelectionPanelFull => num_instances,
         };
 
         let engine = db.storage_engine();

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -44,7 +44,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
         let max_row = match ui_layout {
             UiLayout::List => 0,
             UiLayout::Tooltip => num_instances.at_most(4), // includes "…x more" if any
-            UiLayout::SelectionPanelFull => num_instances,
+            UiLayout::SelectionPanel => num_instances,
         };
 
         let engine = db.storage_engine();

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -162,7 +162,7 @@ fn component_list_ui(
             // types of components).
             indicator_count == components.len()
         }
-        UiLayout::SelectionPanelFull => true,
+        UiLayout::SelectionPanel => true,
         UiLayout::List => false, // unreachable
     };
 

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -162,7 +162,7 @@ fn component_list_ui(
             // types of components).
             indicator_count == components.len()
         }
-        UiLayout::SelectionPanelLimitHeight | UiLayout::SelectionPanelFull => true,
+        UiLayout::SelectionPanelFull => true,
         UiLayout::List => false, // unreachable
     };
 

--- a/crates/viewer/re_selection_panel/Cargo.toml
+++ b/crates/viewer/re_selection_panel/Cargo.toml
@@ -19,17 +19,17 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_chunk_store.workspace = true
 re_chunk.workspace = true
 re_context_menu.workspace = true
-re_chunk_store.workspace = true
 re_data_ui.workspace = true
 re_entity_db.workspace = true
+re_format.workspace = true
 re_log_types.workspace = true
 re_log.workspace = true
 re_space_view.workspace = true
 re_tracing.workspace = true
-# TODO(jleibs): Remove this once VisualizerOverrides is gone
-re_types_blueprint.workspace = true
+re_types_blueprint.workspace = true    # TODO(jleibs): Remove this once VisualizerOverrides is gone
 re_types_core.workspace = true
 re_types.workspace = true
 re_ui.workspace = true

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -1,8 +1,9 @@
 use egui::WidgetText;
 use re_data_ui::item_ui::guess_instance_path_icon;
+use re_log_types::ComponentPath;
 use re_ui::{icons, Icon, SyntaxHighlighting};
 use re_viewer_context::{Item, ViewerContext};
-use re_viewport_blueprint::{ui, ViewportBlueprint};
+use re_viewport_blueprint::ViewportBlueprint;
 
 use crate::{
     item_heading_with_breadcrumbs::separator_icon_ui,
@@ -41,10 +42,22 @@ pub fn item_heading_no_breadcrumbs(
             );
         }
         Item::ComponentPath(component_path) => {
-            let is_static = is_component_static(ctx, component_path);
+            let is_component_static = is_component_static(ctx, component_path);
+
+            // Break up into entity path and component name:
+
+            item_heading_no_breadcrumbs(
+                ctx,
+                viewport,
+                ui,
+                &Item::from(component_path.entity_path.clone()),
+            );
+
+            separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+
             icon_and_title(
                 ui,
-                if is_static {
+                if is_component_static {
                     &icons::COMPONENT_STATIC
                 } else {
                     &icons::COMPONENT_TEMPORAL
@@ -53,7 +66,7 @@ pub fn item_heading_no_breadcrumbs(
             );
         }
         Item::DataResult(view_id, instance_path) => {
-            // Break up in two:
+            // Break up into view and instance path:
             item_heading_no_breadcrumbs(ctx, viewport, ui, &Item::SpaceView(*view_id));
             separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
             item_heading_no_breadcrumbs(

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -1,0 +1,65 @@
+use re_data_ui::item_ui::guess_instance_path_icon;
+use re_ui::{icons, SyntaxHighlighting};
+use re_viewer_context::{Item, ViewerContext};
+use re_viewport_blueprint::ViewportBlueprint;
+
+use crate::{
+    item_heading_with_breadcrumbs::separator_icon_ui,
+    item_title::{is_component_static, ItemTitle},
+};
+
+/// Fully descriptive heading for an item, without any breadcrumbs.
+pub fn item_heading_no_breadcrumbs(
+    ctx: &ViewerContext<'_>,
+    viewport: &ViewportBlueprint,
+    ui: &mut egui::Ui,
+    item: &Item,
+) {
+    match item {
+        Item::AppId(_)
+        | Item::DataSource(_)
+        | Item::StoreId(_)
+        | Item::Container(_)
+        | Item::SpaceView(_) => {
+            let ItemTitle {
+                icon,
+                label,
+                label_style: _, // no label
+                tooltip,
+            } = ItemTitle::from_item(ctx, viewport, ui.style(), item);
+
+            let response = ui.add(egui::Button::image_and_text(icon.as_image(), label));
+            if let Some(tooltip) = tooltip {
+                response.on_hover_text(tooltip);
+            }
+        }
+        Item::InstancePath(instance_path) => {
+            ui.add(egui::Button::image_and_text(
+                guess_instance_path_icon(ctx, instance_path),
+                instance_path.syntax_highlighted(ui.style()),
+            ));
+        }
+        Item::ComponentPath(component_path) => {
+            let is_static = is_component_static(ctx, component_path);
+            ui.add(egui::Button::image_and_text(
+                if is_static {
+                    &icons::COMPONENT_STATIC
+                } else {
+                    &icons::COMPONENT_TEMPORAL
+                },
+                component_path.syntax_highlighted(ui.style()),
+            ));
+        }
+        Item::DataResult(view_id, instance_path) => {
+            // Break up in two:
+            item_heading_no_breadcrumbs(ctx, viewport, ui, &Item::SpaceView(*view_id));
+            separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+            item_heading_no_breadcrumbs(
+                ctx,
+                viewport,
+                ui,
+                &Item::InstancePath(instance_path.clone()),
+            );
+        }
+    }
+}

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -11,8 +11,6 @@ use crate::{
     item_title::{is_component_static, ItemTitle},
 };
 
-const ICON_SCALE: f32 = 0.5; // Because we save all icons as 2x
-
 /// Fully descriptive heading for an item, without any breadcrumbs.
 pub fn item_heading_no_breadcrumbs(
     ctx: &ViewerContext<'_>,
@@ -81,6 +79,6 @@ pub fn item_heading_no_breadcrumbs(
 }
 
 fn icon_and_title(ui: &mut egui::Ui, icon: &Icon, title: impl Into<WidgetText>) {
-    ui.add(icon.as_image().fit_to_original_size(ICON_SCALE));
+    ui.add(icon.as_image());
     ui.label(title);
 }

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -1,8 +1,8 @@
 use egui::WidgetText;
 
-use re_data_ui::item_ui::guess_instance_path_icon;
+use re_data_ui::item_ui::{cursor_interact_with_selectable, guess_instance_path_icon};
 use re_log_types::ComponentPath;
-use re_ui::{icons, Icon, SyntaxHighlighting};
+use re_ui::{icons, list_item, Icon, SyntaxHighlighting, UiExt as _};
 use re_viewer_context::{Item, ViewerContext};
 use re_viewport_blueprint::ViewportBlueprint;
 
@@ -11,8 +11,37 @@ use crate::{
     item_title::{is_component_static, ItemTitle},
 };
 
+/// Just the title of the item; for when multiple items are selected
+pub fn item_title_list_item(
+    ctx: &ViewerContext<'_>,
+    viewport: &ViewportBlueprint,
+    ui: &mut egui::Ui,
+    item: &Item,
+) {
+    let response = ui
+        .list_item()
+        .with_height(re_ui::DesignTokens::list_item_height())
+        .interactive(true)
+        .show_flat(
+            ui,
+            list_item::CustomContent::new(|ui, context| {
+                ui.allocate_new_ui(
+                    egui::UiBuilder::new()
+                        .max_rect(context.rect)
+                        .layout(egui::Layout::left_to_right(egui::Align::Center)),
+                    |ui| {
+                        ui.spacing_mut().item_spacing.x = 4.0;
+                        ui.style_mut().interaction.selectable_labels = false;
+                        item_heading_no_breadcrumbs(ctx, viewport, ui, item);
+                    },
+                );
+            }),
+        );
+    cursor_interact_with_selectable(ctx, response, item.clone());
+}
+
 /// Fully descriptive heading for an item, without any breadcrumbs.
-pub fn item_heading_no_breadcrumbs(
+fn item_heading_no_breadcrumbs(
     ctx: &ViewerContext<'_>,
     viewport: &ViewportBlueprint,
     ui: &mut egui::Ui,

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -1,4 +1,5 @@
 use egui::WidgetText;
+
 use re_data_ui::item_ui::guess_instance_path_icon;
 use re_log_types::ComponentPath;
 use re_ui::{icons, Icon, SyntaxHighlighting};
@@ -45,30 +46,30 @@ pub fn item_heading_no_breadcrumbs(
             let is_component_static = is_component_static(ctx, component_path);
 
             // Break up into entity path and component name:
+            let ComponentPath {
+                entity_path,
+                component_name,
+            } = component_path;
 
-            item_heading_no_breadcrumbs(
-                ctx,
-                viewport,
-                ui,
-                &Item::from(component_path.entity_path.clone()),
-            );
+            item_heading_no_breadcrumbs(ctx, viewport, ui, &Item::from(entity_path.clone()));
 
-            separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+            separator_icon_ui(ui);
 
+            let component_icon = if is_component_static {
+                &icons::COMPONENT_STATIC
+            } else {
+                &icons::COMPONENT_TEMPORAL
+            };
             icon_and_title(
                 ui,
-                if is_component_static {
-                    &icons::COMPONENT_STATIC
-                } else {
-                    &icons::COMPONENT_TEMPORAL
-                },
-                component_path.syntax_highlighted(ui.style()),
+                component_icon,
+                component_name.syntax_highlighted(ui.style()),
             );
         }
         Item::DataResult(view_id, instance_path) => {
             // Break up into view and instance path:
             item_heading_no_breadcrumbs(ctx, viewport, ui, &Item::SpaceView(*view_id));
-            separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+            separator_icon_ui(ui);
             item_heading_no_breadcrumbs(
                 ctx,
                 viewport,

--- a/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_no_breadcrumbs.rs
@@ -1,12 +1,15 @@
+use egui::WidgetText;
 use re_data_ui::item_ui::guess_instance_path_icon;
-use re_ui::{icons, SyntaxHighlighting};
+use re_ui::{icons, Icon, SyntaxHighlighting};
 use re_viewer_context::{Item, ViewerContext};
-use re_viewport_blueprint::ViewportBlueprint;
+use re_viewport_blueprint::{ui, ViewportBlueprint};
 
 use crate::{
     item_heading_with_breadcrumbs::separator_icon_ui,
     item_title::{is_component_static, ItemTitle},
 };
+
+const ICON_SCALE: f32 = 0.5; // Because we save all icons as 2x
 
 /// Fully descriptive heading for an item, without any breadcrumbs.
 pub fn item_heading_no_breadcrumbs(
@@ -25,30 +28,29 @@ pub fn item_heading_no_breadcrumbs(
                 icon,
                 label,
                 label_style: _, // no label
-                tooltip,
+                tooltip: _,
             } = ItemTitle::from_item(ctx, viewport, ui.style(), item);
 
-            let response = ui.add(egui::Button::image_and_text(icon.as_image(), label));
-            if let Some(tooltip) = tooltip {
-                response.on_hover_text(tooltip);
-            }
+            icon_and_title(ui, icon, label);
         }
         Item::InstancePath(instance_path) => {
-            ui.add(egui::Button::image_and_text(
+            icon_and_title(
+                ui,
                 guess_instance_path_icon(ctx, instance_path),
                 instance_path.syntax_highlighted(ui.style()),
-            ));
+            );
         }
         Item::ComponentPath(component_path) => {
             let is_static = is_component_static(ctx, component_path);
-            ui.add(egui::Button::image_and_text(
+            icon_and_title(
+                ui,
                 if is_static {
                     &icons::COMPONENT_STATIC
                 } else {
                     &icons::COMPONENT_TEMPORAL
                 },
                 component_path.syntax_highlighted(ui.style()),
-            ));
+            );
         }
         Item::DataResult(view_id, instance_path) => {
             // Break up in two:
@@ -62,4 +64,9 @@ pub fn item_heading_no_breadcrumbs(
             );
         }
     }
+}
+
+fn icon_and_title(ui: &mut egui::Ui, icon: &Icon, title: impl Into<WidgetText>) {
+    ui.add(icon.as_image().fit_to_original_size(ICON_SCALE));
+    ui.label(title);
 }

--- a/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
@@ -22,8 +22,6 @@ use re_viewport_blueprint::ViewportBlueprint;
 
 use crate::item_title::ItemTitle;
 
-const ICON_SCALE: f32 = 0.5; // Because we save all icons as 2x
-
 /// We show this above each item section
 pub fn item_heading_with_breadcrumbs(
     ctx: &ViewerContext<'_>,
@@ -207,8 +205,7 @@ fn last_part_of_item_heading(
     };
 
     let button = if with_icon {
-        egui::Button::image_and_text(icon.as_image().fit_to_original_size(ICON_SCALE), label)
-            .image_tint_follows_text_color(true)
+        egui::Button::image_and_text(icon.as_image(), label).image_tint_follows_text_color(true)
     } else {
         egui::Button::new(label)
     };
@@ -240,10 +237,8 @@ fn viewport_breadcrumbs(
         tooltip,
     } = ItemTitle::from_contents(ctx, viewport, &contents);
 
-    let mut response = ui.add(
-        egui::Button::image(icon.as_image().fit_to_original_size(ICON_SCALE))
-            .image_tint_follows_text_color(true),
-    );
+    let mut response =
+        ui.add(egui::Button::image(icon.as_image()).image_tint_follows_text_color(true));
     if let Some(tooltip) = tooltip {
         response = response.on_hover_text(tooltip);
     }
@@ -256,7 +251,6 @@ pub fn separator_icon_ui(ui: &mut egui::Ui) {
     ui.add(
         icons::BREADCRUMBS_SEPARATOR
             .as_image()
-            .fit_to_original_size(ICON_SCALE)
             .tint(ui.visuals().text_color().gamma_multiply(0.65)),
     );
 }
@@ -298,8 +292,7 @@ fn entity_path_breadcrumbs(
             // just to make it clear that this is a different kind of hierarchy.
             &icons::RECORDING // streams hierarchy
         };
-        egui::Button::image(icon.as_image().fit_to_original_size(ICON_SCALE))
-            .image_tint_follows_text_color(true)
+        egui::Button::image(icon.as_image()).image_tint_follows_text_color(true)
     };
 
     let response = ui.add(button);

--- a/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
@@ -252,7 +252,7 @@ fn viewport_breadcrumbs(
     separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
 }
 
-fn separator_icon_ui(ui: &mut egui::Ui, icon: re_ui::Icon) {
+pub fn separator_icon_ui(ui: &mut egui::Ui, icon: re_ui::Icon) {
     ui.add(
         icon.as_image()
             .fit_to_original_size(ICON_SCALE)

--- a/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
+++ b/crates/viewer/re_selection_panel/src/item_heading_with_breadcrumbs.rs
@@ -249,12 +249,13 @@ fn viewport_breadcrumbs(
     }
     cursor_interact_with_selectable(ctx, response, item);
 
-    separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+    separator_icon_ui(ui);
 }
 
-pub fn separator_icon_ui(ui: &mut egui::Ui, icon: re_ui::Icon) {
+pub fn separator_icon_ui(ui: &mut egui::Ui) {
     ui.add(
-        icon.as_image()
+        icons::BREADCRUMBS_SEPARATOR
+            .as_image()
             .fit_to_original_size(ICON_SCALE)
             .tint(ui.visuals().text_color().gamma_multiply(0.65)),
     );
@@ -313,5 +314,5 @@ fn entity_path_breadcrumbs(
     };
     cursor_interact_with_selectable(ctx, response, item);
 
-    separator_icon_ui(ui, icons::BREADCRUMBS_SEPARATOR);
+    separator_icon_ui(ui);
 }

--- a/crates/viewer/re_selection_panel/src/lib.rs
+++ b/crates/viewer/re_selection_panel/src/lib.rs
@@ -1,6 +1,7 @@
 //! The UI for the selection panel.
 
 mod defaults_ui;
+mod item_heading_no_breadcrumbs;
 mod item_heading_with_breadcrumbs;
 mod item_title;
 mod selection_panel;

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -23,7 +23,7 @@ use re_viewport_blueprint::{ui::show_add_space_view_or_container_modal, Viewport
 
 use crate::{
     defaults_ui::view_components_defaults_section_ui,
-    item_heading_no_breadcrumbs::item_heading_no_breadcrumbs,
+    item_heading_no_breadcrumbs::item_title_list_item,
     item_heading_with_breadcrumbs::item_heading_with_breadcrumbs,
     space_view_entity_picker::SpaceViewEntityPicker,
     visible_time_range_ui::{
@@ -145,27 +145,7 @@ impl SelectionPanel {
 
                 for item in selection.iter_items() {
                     ui.add_space(4.0);
-
-                    let response = ui
-                        .list_item()
-                        .with_height(re_ui::DesignTokens::list_item_height())
-                        .interactive(true)
-                        .show_flat(
-                            ui,
-                            list_item::CustomContent::new(|ui, context| {
-                                ui.allocate_new_ui(
-                                    egui::UiBuilder::new()
-                                        .max_rect(context.rect)
-                                        .layout(egui::Layout::left_to_right(egui::Align::Center)),
-                                    |ui| {
-                                        ui.spacing_mut().item_spacing.x = 4.0;
-                                        ui.style_mut().interaction.selectable_labels = false;
-                                        item_heading_no_breadcrumbs(ctx, viewport, ui, item);
-                                    },
-                                );
-                            }),
-                        );
-                    cursor_interact_with_selectable(ctx, response, item.clone());
+                    item_title_list_item(ctx, viewport, ui, item);
                 }
             });
         }

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -112,11 +112,7 @@ impl SelectionPanel {
         ui.add_space(-ui.spacing().item_spacing.y);
 
         let selection = ctx.selection();
-        let ui_layout = if selection.len() > 1 {
-            UiLayout::SelectionPanelLimitHeight
-        } else {
-            UiLayout::SelectionPanelFull
-        };
+        let ui_layout = UiLayout::SelectionPanelFull;
         for (i, item) in selection.iter_items().enumerate() {
             list_item::list_item_scope(ui, item, |ui| {
                 item_heading_with_breadcrumbs(ctx, viewport, ui, item);

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -112,7 +112,7 @@ impl SelectionPanel {
         ui.add_space(-ui.spacing().item_spacing.y);
 
         let selection = ctx.selection();
-        let ui_layout = UiLayout::SelectionPanelFull;
+        let ui_layout = UiLayout::SelectionPanel;
         for (i, item) in selection.iter_items().enumerate() {
             list_item::list_item_scope(ui, item, |ui| {
                 item_heading_with_breadcrumbs(ctx, viewport, ui, item);

--- a/crates/viewer/re_ui/src/icons.rs
+++ b/crates/viewer/re_ui/src/icons.rs
@@ -28,6 +28,13 @@ impl Icon {
     }
 }
 
+impl From<&'static Icon> for Image<'static> {
+    #[inline]
+    fn from(icon: &'static Icon) -> Self {
+        icon.as_image()
+    }
+}
+
 /// Macro to create an [`Icon`], using the file path as the id.
 ///
 /// This avoids specifying the id manually, which is error-prone (duplicate IDs lead to silent

--- a/crates/viewer/re_ui/src/icons.rs
+++ b/crates/viewer/re_ui/src/icons.rs
@@ -24,7 +24,9 @@ impl Icon {
 
     #[inline]
     pub fn as_image(&self) -> Image<'static> {
-        Image::new(self.as_image_source())
+        // Default size is the same size as the source data specifies
+        const ICON_SCALE: f32 = 0.5; // Because we save all icons as 2x
+        Image::new(self.as_image_source()).fit_to_original_size(ICON_SCALE)
     }
 }
 

--- a/crates/viewer/re_ui/src/syntax_highlighting.rs
+++ b/crates/viewer/re_ui/src/syntax_highlighting.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use re_entity_db::InstancePath;
-use re_log_types::{EntityPath, EntityPathPart, Instance};
+use re_log_types::{
+    external::re_types_core::ComponentName, ComponentPath, EntityPath, EntityPathPart, Instance,
+};
 
 use egui::{text::LayoutJob, Color32, Style, TextFormat};
 
@@ -84,6 +86,12 @@ fn faint_text_format(style: &Style) -> TextFormat {
     }
 }
 
+impl SyntaxHighlighting for &'_ str {
+    fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
+        job.append(self.to_owned(), 0.0, text_format(style));
+    }
+}
+
 impl SyntaxHighlighting for String {
     fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
         job.append(self, 0.0, text_format(style));
@@ -125,6 +133,24 @@ impl SyntaxHighlighting for InstancePath {
         if self.instance.is_specific() {
             InstanceInBrackets(self.instance).syntax_highlight_into(style, job);
         }
+    }
+}
+
+impl SyntaxHighlighting for ComponentName {
+    fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
+        self.short_name().syntax_highlight_into(style, job);
+    }
+}
+
+impl SyntaxHighlighting for ComponentPath {
+    fn syntax_highlight_into(&self, style: &Style, job: &mut LayoutJob) {
+        let Self {
+            entity_path,
+            component_name,
+        } = self;
+        entity_path.syntax_highlight_into(style, job);
+        job.append(":", 0.0, faint_text_format(style));
+        component_name.syntax_highlight_into(style, job);
     }
 }
 

--- a/crates/viewer/re_viewer/src/ui/top_panel.rs
+++ b/crates/viewer/re_viewer/src/ui/top_panel.rs
@@ -316,7 +316,7 @@ fn panel_buttons_r2l(app: &App, app_blueprint: &AppBlueprint<'_>, ui: &mut egui:
 /// Shows clickable website link as an image (text doesn't look as nice)
 fn website_link_ui(ui: &mut egui::Ui) {
     let desired_height = ui.max_rect().height();
-    let desired_height = desired_height.at_most(28.0); // figma size 2023-02-03
+    let desired_height = desired_height.at_most(20.0);
 
     let image = re_ui::icons::RERUN_IO_TEXT
         .as_image()

--- a/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
+++ b/crates/viewer/re_viewer/src/ui/welcome_screen/example_section.rs
@@ -561,10 +561,7 @@ impl ExampleDescLayout {
                 if ui
                     .add_enabled(
                         source_url.is_some(),
-                        egui::Button::image_and_text(
-                            re_ui::icons::GITHUB.as_image(),
-                            "Source code",
-                        ),
+                        egui::Button::image_and_text(&re_ui::icons::GITHUB, "Source code"),
                     )
                     .on_hover_cursor(egui::CursorIcon::PointingHand)
                     .on_disabled_hover_text("Source code is not available for this example")

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -26,15 +26,15 @@ pub enum UiLayout {
     /// Display as much information as possible in a compact way. Used for hovering/tooltips.
     ///
     /// Keep it under a half-dozen lines. Text may wrap. Avoid interactive UI. When using a table,
-    /// use the `re_data_ui::table_for_ui_layout` function.
+    /// use the [`Self::table`] function.
     Tooltip,
 
     /// Display everything as wide as available, without height restriction. Used in the selection
     /// panel when a single item is selected.
     ///
     /// The UI will be wrapped in a [`egui::ScrollArea`], so data should be fully displayed with no
-    /// restriction. When using a table, use the `re_data_ui::table_for_ui_layout` function.
-    SelectionPanelFull,
+    /// restriction. When using a table, use the [`Self::table`] function.
+    SelectionPanel,
 }
 
 impl UiLayout {
@@ -43,7 +43,7 @@ impl UiLayout {
     pub fn is_single_line(&self) -> bool {
         match self {
             Self::List => true,
-            Self::Tooltip | Self::SelectionPanelFull => false,
+            Self::Tooltip | Self::SelectionPanel => false,
         }
     }
 
@@ -52,7 +52,7 @@ impl UiLayout {
     pub fn is_selection_panel(self) -> bool {
         match self {
             Self::List | Self::Tooltip => false,
-            Self::SelectionPanelFull => true,
+            Self::SelectionPanel => true,
         }
     }
 
@@ -68,7 +68,7 @@ impl UiLayout {
                 // the content itself must be limited (scrolling is not possible in tooltips).
                 table.auto_shrink([true, true])
             }
-            Self::SelectionPanelFull => {
+            Self::SelectionPanel => {
                 // We're alone in the selection panel. Let the outer ScrollArea do the work.
                 table.auto_shrink([false, true]).vscroll(false)
             }
@@ -93,7 +93,7 @@ impl UiLayout {
                         label = label.truncate();
                     }
                 }
-                Self::Tooltip | Self::SelectionPanelFull => {
+                Self::Tooltip | Self::SelectionPanel => {
                     label = label.wrap();
                 }
             }
@@ -133,7 +133,7 @@ impl UiLayout {
             Self::Tooltip => {
                 layout_job.wrap.max_rows = 3;
             }
-            Self::SelectionPanelFull => {
+            Self::SelectionPanel => {
                 needs_scroll_area = false;
             }
         }
@@ -465,7 +465,7 @@ impl ComponentUiRegistry {
         }
 
         // Fallback to the more specialized UI callbacks.
-        let edit_or_view_ui = if ui_layout == UiLayout::SelectionPanelFull {
+        let edit_or_view_ui = if ui_layout == UiLayout::SelectionPanel {
             self.component_multiline_edit_or_view
                 .get(&component_name)
                 .or_else(|| self.component_singleline_edit_or_view.get(&component_name))

--- a/crates/viewer/re_viewer_context/src/component_ui_registry.rs
+++ b/crates/viewer/re_viewer_context/src/component_ui_registry.rs
@@ -29,13 +29,6 @@ pub enum UiLayout {
     /// use the `re_data_ui::table_for_ui_layout` function.
     Tooltip,
 
-    /// Display everything as wide as available but limit height. Used in the selection panel when
-    /// multiple items are selected.
-    ///
-    /// When displaying lists, wrap them in a height-limited [`egui::ScrollArea`]. When using a
-    /// table, use the `re_data_ui::table_for_ui_layout` function.
-    SelectionPanelLimitHeight,
-
     /// Display everything as wide as available, without height restriction. Used in the selection
     /// panel when a single item is selected.
     ///
@@ -50,7 +43,7 @@ impl UiLayout {
     pub fn is_single_line(&self) -> bool {
         match self {
             Self::List => true,
-            Self::Tooltip | Self::SelectionPanelLimitHeight | Self::SelectionPanelFull => false,
+            Self::Tooltip | Self::SelectionPanelFull => false,
         }
     }
 
@@ -59,7 +52,7 @@ impl UiLayout {
     pub fn is_selection_panel(self) -> bool {
         match self {
             Self::List | Self::Tooltip => false,
-            Self::SelectionPanelLimitHeight | Self::SelectionPanelFull => true,
+            Self::SelectionPanelFull => true,
         }
     }
 
@@ -74,13 +67,6 @@ impl UiLayout {
                 // Be as small as possible in the hover tooltips. No scrolling related configuration, as
                 // the content itself must be limited (scrolling is not possible in tooltips).
                 table.auto_shrink([true, true])
-            }
-            Self::SelectionPanelLimitHeight => {
-                // Don't take too much vertical space to leave room for other selected items.
-                table
-                    .auto_shrink([false, true])
-                    .vscroll(true)
-                    .max_scroll_height(100.0)
             }
             Self::SelectionPanelFull => {
                 // We're alone in the selection panel. Let the outer ScrollArea do the work.
@@ -107,7 +93,7 @@ impl UiLayout {
                         label = label.truncate();
                     }
                 }
-                Self::Tooltip | Self::SelectionPanelLimitHeight | Self::SelectionPanelFull => {
+                Self::Tooltip | Self::SelectionPanelFull => {
                     label = label.wrap();
                 }
             }
@@ -146,10 +132,6 @@ impl UiLayout {
             }
             Self::Tooltip => {
                 layout_job.wrap.max_rows = 3;
-            }
-            Self::SelectionPanelLimitHeight => {
-                let num_newlines = string.chars().filter(|&c| c == '\n').count();
-                needs_scroll_area = 10 < num_newlines || 300 < string.len();
             }
             Self::SelectionPanelFull => {
                 needs_scroll_area = false;


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/8336

### What
When you have more than one item selected at once, you get a list of all items. Clicking one will select just that.

<img width="308" alt="multiple-selected-entities" src="https://github.com/user-attachments/assets/67174eed-373a-486c-a2b1-b97a08136805">

### Implementation
A bit messy, to be honest. I leveraged the existing `ItemTitle` for some items, and hand-rolled others.

It would be nice with something similar to `DataUi`, but for titles (with or without breadcrumbs).

But the amount of messy code is low and low-impact, so unless someone has a good suggestion or strongly objects, I suggestion calling this "good enough for now".