### PR TITLE
Prepare to port codegen deserialization from arrow2

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
@@ -326,10 +326,11 @@ pub fn quote_arrow_deserializer(
                 let quoted_field_deserializers = obj
                     .fields
                     .iter()
-                    .filter(|obj_field|
-                        // For unit fields we don't have to collect any data.
-                        obj_field.typ != crate::Type::Unit)
                     .enumerate()
+                    .filter(|(_, obj_field)| {
+                        // For unit fields we don't have to collect any data.
+                        obj_field.typ != crate::Type::Unit
+                    })
                     .map(|(i, obj_field)| {
                         let data_dst = format_ident!("{}", obj_field.snake_case_name());
 

--- a/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
@@ -353,7 +353,7 @@ pub fn quote_arrow_deserializer(
                                 // input's payload's union arms, while `#type_id` is our comptime union
                                 // arm counter… there's no guarantee it's actually there at
                                 // runtime!
-                                if #type_id >= #data_src_arrays.len() {
+                                if #data_src_arrays.len() <= #type_id {
                                     // By not returning an error but rather defaulting to an empty
                                     // vector, we introduce some kind of light forwards compatibility:
                                     // old clients that don't yet know about the new arms can still

--- a/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
@@ -345,7 +345,7 @@ pub fn quote_arrow_deserializer(
                             InnerRepr::NativeIterable,
                         );
 
-                        let type_id = type_id + 1; // NOTE: +1 to account for `_null_markers` virtual arm
+                        let type_id = Literal::usize_unsuffixed(type_id + 1); // NOTE: +1 to account for `_null_markers` virtual arm
 
                         quote! {
                             let #data_dst = {

--- a/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/deserializer.rs
@@ -814,19 +814,19 @@ fn quote_arrow_field_deserializer(
 
                     let offsets = #data_src.offsets();
                     arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                        offsets.iter().zip(offsets.lengths()),
+                        offsets.windows(2),
                         #data_src.validity(),
                     )
-                    .map(|elem| elem.map(|(start, len)| {
+                    .map(|elem| elem.map(|window| {
                             // NOTE: Do _not_ use `Buffer::sliced`, it panics on malformed inputs.
 
-                            let start = *start as usize;
-                            let end = start + len;
+                            let start = window[0] as usize;
+                            let end = window[1] as usize;
 
                             // NOTE: It is absolutely crucial we explicitly handle the
                             // boundchecks manually first, otherwise rustc completely chokes
                             // when slicing the data (as in: a 100x perf drop)!
-                            if end  > #data_src_inner.len() {
+                            if #data_src_inner.len() < end {
                                 // error context is appended below during final collection
                                 return Err(DeserializationError::offset_slice_oob(
                                     (start, end), #data_src_inner.len(),

--- a/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/component_column_selector.rs
@@ -209,14 +209,15 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),
@@ -270,14 +271,15 @@ impl ::re_types_core::Loggable for ComponentColumnSelector {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -310,15 +310,15 @@ impl ::re_types_core::Loggable for SelectedColumns {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                    offsets.iter().zip(offsets.lengths()),
+                                    offsets.windows(2),
                                     arrow_data.validity(),
                                 )
                                 .map(|elem| {
                                     elem
-                                        .map(|(start, len)| {
-                                            let start = *start as usize;
-                                            let end = start + len;
-                                            if end > arrow_data_inner.len() {
+                                        .map(|window| {
+                                            let start = window[0] as usize;
+                                            let end = window[1] as usize;
+                                            if arrow_data_inner.len() < end {
                                                 return Err(
                                                     DeserializationError::offset_slice_oob(
                                                         (start, end),
@@ -390,15 +390,15 @@ impl ::re_types_core::Loggable for SelectedColumns {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                    offsets.iter().zip(offsets.lengths()),
+                                    offsets.windows(2),
                                     arrow_data.validity(),
                                 )
                                 .map(|elem| {
                                     elem
-                                        .map(|(start, len)| {
-                                            let start = *start as usize;
-                                            let end = start + len;
-                                            if end > arrow_data_inner.len() {
+                                        .map(|window| {
+                                            let start = window[0] as usize;
+                                            let end = window[1] as usize;
+                                            if arrow_data_inner.len() < end {
                                                 return Err(
                                                     DeserializationError::offset_slice_oob(
                                                         (start, end),

--- a/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
+++ b/crates/store/re_types/src/blueprint/datatypes/selected_columns.rs
@@ -265,15 +265,16 @@ impl ::re_types_core::Loggable for SelectedColumns {
                                     let arrow_data_inner_buf = arrow_data_inner.values();
                                     let offsets = arrow_data_inner.offsets();
                                     arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                            offsets.iter().zip(offsets.lengths()),
+                                            offsets.windows(2),
                                             arrow_data_inner.validity(),
                                         )
                                         .map(|elem| {
                                             elem
-                                                .map(|(start, len)| {
-                                                    let start = *start as usize;
-                                                    let end = start + len;
-                                                    if end > arrow_data_inner_buf.len() {
+                                                .map(|window| {
+                                                    let start = window[0] as usize;
+                                                    let end = window[1] as usize;
+                                                    let len = end - start;
+                                                    if arrow_data_inner_buf.len() < end {
                                                         return Err(
                                                             DeserializationError::offset_slice_oob(
                                                                 (start, end),

--- a/crates/store/re_types/src/components/annotation_context.rs
+++ b/crates/store/re_types/src/components/annotation_context.rs
@@ -134,14 +134,14 @@ impl ::re_types_core::Loggable for AnnotationContext {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/components/geo_line_string.rs
+++ b/crates/store/re_types/src/components/geo_line_string.rs
@@ -208,14 +208,14 @@ impl ::re_types_core::Loggable for GeoLineString {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/components/line_strip2d.rs
+++ b/crates/store/re_types/src/components/line_strip2d.rs
@@ -217,14 +217,14 @@ impl ::re_types_core::Loggable for LineStrip2D {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/components/line_strip3d.rs
+++ b/crates/store/re_types/src/components/line_strip3d.rs
@@ -217,14 +217,14 @@ impl ::re_types_core::Loggable for LineStrip3D {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/datatypes/annotation_info.rs
+++ b/crates/store/re_types/src/datatypes/annotation_info.rs
@@ -231,14 +231,15 @@ impl ::re_types_core::Loggable for AnnotationInfo {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types/src/datatypes/blob.rs
+++ b/crates/store/re_types/src/datatypes/blob.rs
@@ -127,14 +127,14 @@ impl ::re_types_core::Loggable for Blob {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/datatypes/class_description.rs
+++ b/crates/store/re_types/src/datatypes/class_description.rs
@@ -323,14 +323,14 @@ impl ::re_types_core::Loggable for ClassDescription {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -393,14 +393,14 @@ impl ::re_types_core::Loggable for ClassDescription {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -823,14 +823,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -891,14 +891,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -959,14 +959,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1027,14 +1027,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1095,14 +1095,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1163,14 +1163,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1231,14 +1231,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1299,14 +1299,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1367,14 +1367,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1435,14 +1435,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -1503,14 +1503,14 @@ impl ::re_types_core::Loggable for TensorBuffer {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -787,7 +787,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .with_context("rerun.datatypes.TensorBuffer");
                 }
                 let u8 = {
-                    if 1 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 1 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[1];
@@ -855,7 +855,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u16 = {
-                    if 2 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 2 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[2];
@@ -923,7 +923,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u32 = {
-                    if 3 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 3 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[3];
@@ -991,7 +991,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u64 = {
-                    if 4 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 4 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[4];
@@ -1059,7 +1059,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i8 = {
-                    if 5 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 5 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[5];
@@ -1127,7 +1127,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i16 = {
-                    if 6 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 6 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[6];
@@ -1195,7 +1195,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i32 = {
-                    if 7 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 7 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[7];
@@ -1263,7 +1263,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i64 = {
-                    if 8 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 8 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[8];
@@ -1331,7 +1331,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f16 = {
-                    if 9 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 9 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[9];
@@ -1399,7 +1399,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f32 = {
-                    if 10 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 10 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[10];
@@ -1467,7 +1467,7 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f64 = {
-                    if 11 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 11 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[11];

--- a/crates/store/re_types/src/datatypes/tensor_buffer.rs
+++ b/crates/store/re_types/src/datatypes/tensor_buffer.rs
@@ -787,10 +787,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .with_context("rerun.datatypes.TensorBuffer");
                 }
                 let u8 = {
-                    if 1usize >= arrow_data_arrays.len() {
+                    if 1 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[1usize];
+                    let arrow_data = &*arrow_data_arrays[1];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -855,10 +855,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u16 = {
-                    if 2usize >= arrow_data_arrays.len() {
+                    if 2 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[2usize];
+                    let arrow_data = &*arrow_data_arrays[2];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -923,10 +923,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u32 = {
-                    if 3usize >= arrow_data_arrays.len() {
+                    if 3 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[3usize];
+                    let arrow_data = &*arrow_data_arrays[3];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -991,10 +991,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let u64 = {
-                    if 4usize >= arrow_data_arrays.len() {
+                    if 4 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[4usize];
+                    let arrow_data = &*arrow_data_arrays[4];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1059,10 +1059,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i8 = {
-                    if 5usize >= arrow_data_arrays.len() {
+                    if 5 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[5usize];
+                    let arrow_data = &*arrow_data_arrays[5];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1127,10 +1127,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i16 = {
-                    if 6usize >= arrow_data_arrays.len() {
+                    if 6 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[6usize];
+                    let arrow_data = &*arrow_data_arrays[6];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1195,10 +1195,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i32 = {
-                    if 7usize >= arrow_data_arrays.len() {
+                    if 7 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[7usize];
+                    let arrow_data = &*arrow_data_arrays[7];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1263,10 +1263,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let i64 = {
-                    if 8usize >= arrow_data_arrays.len() {
+                    if 8 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[8usize];
+                    let arrow_data = &*arrow_data_arrays[8];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1331,10 +1331,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f16 = {
-                    if 9usize >= arrow_data_arrays.len() {
+                    if 9 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[9usize];
+                    let arrow_data = &*arrow_data_arrays[9];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1399,10 +1399,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f32 = {
-                    if 10usize >= arrow_data_arrays.len() {
+                    if 10 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[10usize];
+                    let arrow_data = &*arrow_data_arrays[10];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -1467,10 +1467,10 @@ impl ::re_types_core::Loggable for TensorBuffer {
                     .collect::<Vec<_>>()
                 };
                 let f64 = {
-                    if 11usize >= arrow_data_arrays.len() {
+                    if 11 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[11usize];
+                    let arrow_data = &*arrow_data_arrays[11];
                     {
                         let arrow_data = arrow_data
                             .as_any()

--- a/crates/store/re_types/src/datatypes/tensor_data.rs
+++ b/crates/store/re_types/src/datatypes/tensor_data.rs
@@ -227,14 +227,14 @@ impl ::re_types_core::Loggable for TensorData {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/datatypes/tensor_dimension.rs
+++ b/crates/store/re_types/src/datatypes/tensor_dimension.rs
@@ -199,14 +199,15 @@ impl ::re_types_core::Loggable for TensorDimension {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types/src/datatypes/utf8pair.rs
+++ b/crates/store/re_types/src/datatypes/utf8pair.rs
@@ -186,14 +186,15 @@ impl ::re_types_core::Loggable for Utf8Pair {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),
@@ -241,14 +242,15 @@ impl ::re_types_core::Loggable for Utf8Pair {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer10.rs
@@ -104,14 +104,15 @@ impl ::re_types_core::Loggable for AffixFuzzer10 {
             let arrow_data_buf = arrow_data.values();
             let offsets = arrow_data.offsets();
             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
+                offsets.windows(2),
                 arrow_data.validity(),
             )
             .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end > arrow_data_buf.len() {
+                elem.map(|window| {
+                    let start = window[0] as usize;
+                    let end = window[1] as usize;
+                    let len = end - start;
+                    if arrow_data_buf.len() < end {
                         return Err(DeserializationError::offset_slice_oob(
                             (start, end),
                             arrow_data_buf.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer11.rs
@@ -132,14 +132,14 @@ impl ::re_types_core::Loggable for AffixFuzzer11 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -174,14 +174,14 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer12.rs
@@ -136,14 +136,15 @@ impl ::re_types_core::Loggable for AffixFuzzer12 {
                         let arrow_data_inner_buf = arrow_data_inner.values();
                         let offsets = arrow_data_inner.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data_inner.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_inner_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_inner_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_inner_buf.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -174,14 +174,14 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer13.rs
@@ -136,14 +136,15 @@ impl ::re_types_core::Loggable for AffixFuzzer13 {
                         let arrow_data_inner_buf = arrow_data_inner.values();
                         let offsets = arrow_data_inner.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data_inner.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_inner_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_inner_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_inner_buf.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer16.rs
@@ -126,14 +126,14 @@ impl ::re_types_core::Loggable for AffixFuzzer16 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer17.rs
@@ -126,14 +126,14 @@ impl ::re_types_core::Loggable for AffixFuzzer17 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer18.rs
@@ -126,14 +126,14 @@ impl ::re_types_core::Loggable for AffixFuzzer18 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer7.rs
@@ -124,14 +124,14 @@ impl ::re_types_core::Loggable for AffixFuzzer7 {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
+++ b/crates/store/re_types/src/testing/components/affix_fuzzer9.rs
@@ -104,14 +104,15 @@ impl ::re_types_core::Loggable for AffixFuzzer9 {
             let arrow_data_buf = arrow_data.values();
             let offsets = arrow_data.offsets();
             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
+                offsets.windows(2),
                 arrow_data.validity(),
             )
             .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end > arrow_data_buf.len() {
+                elem.map(|window| {
+                    let start = window[0] as usize;
+                    let end = window[1] as usize;
+                    let len = end - start;
+                    if arrow_data_buf.len() < end {
                         return Err(DeserializationError::offset_slice_oob(
                             (start, end),
                             arrow_data_buf.len(),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -680,14 +680,14 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),
@@ -797,15 +797,15 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                    offsets.iter().zip(offsets.lengths()),
+                                    offsets.windows(2),
                                     arrow_data.validity(),
                                 )
                                 .map(|elem| {
                                     elem
-                                        .map(|(start, len)| {
-                                            let start = *start as usize;
-                                            let end = start + len;
-                                            if end > arrow_data_inner.len() {
+                                        .map(|window| {
+                                            let start = window[0] as usize;
+                                            let end = window[1] as usize;
+                                            if arrow_data_inner.len() < end {
                                                 return Err(
                                                     DeserializationError::offset_slice_oob(
                                                         (start, end),
@@ -919,15 +919,15 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                    offsets.iter().zip(offsets.lengths()),
+                                    offsets.windows(2),
                                     arrow_data.validity(),
                                 )
                                 .map(|elem| {
                                     elem
-                                        .map(|(start, len)| {
-                                            let start = *start as usize;
-                                            let end = start + len;
-                                            if end > arrow_data_inner.len() {
+                                        .map(|window| {
+                                            let start = window[0] as usize;
+                                            let end = window[1] as usize;
+                                            if arrow_data_inner.len() < end {
                                                 return Err(
                                                     DeserializationError::offset_slice_oob(
                                                         (start, end),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer1.rs
@@ -543,14 +543,15 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),
@@ -600,14 +601,15 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),
@@ -753,15 +755,16 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let arrow_data_inner_buf = arrow_data_inner.values();
                                     let offsets = arrow_data_inner.offsets();
                                     arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                            offsets.iter().zip(offsets.lengths()),
+                                            offsets.windows(2),
                                             arrow_data_inner.validity(),
                                         )
                                         .map(|elem| {
                                             elem
-                                                .map(|(start, len)| {
-                                                    let start = *start as usize;
-                                                    let end = start + len;
-                                                    if end > arrow_data_inner_buf.len() {
+                                                .map(|window| {
+                                                    let start = window[0] as usize;
+                                                    let end = window[1] as usize;
+                                                    let len = end - start;
+                                                    if arrow_data_inner_buf.len() < end {
                                                         return Err(
                                                             DeserializationError::offset_slice_oob(
                                                                 (start, end),
@@ -874,15 +877,16 @@ impl ::re_types_core::Loggable for AffixFuzzer1 {
                                     let arrow_data_inner_buf = arrow_data_inner.values();
                                     let offsets = arrow_data_inner.offsets();
                                     arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                            offsets.iter().zip(offsets.lengths()),
+                                            offsets.windows(2),
                                             arrow_data_inner.validity(),
                                         )
                                         .map(|elem| {
                                             elem
-                                                .map(|(start, len)| {
-                                                    let start = *start as usize;
-                                                    let end = start + len;
-                                                    if end > arrow_data_inner_buf.len() {
+                                                .map(|window| {
+                                                    let start = window[0] as usize;
+                                                    let end = window[1] as usize;
+                                                    let len = end - start;
+                                                    if arrow_data_inner_buf.len() < end {
                                                         return Err(
                                                             DeserializationError::offset_slice_oob(
                                                                 (start, end),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer20.rs
@@ -214,14 +214,15 @@ impl ::re_types_core::Loggable for AffixFuzzer20 {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer21.rs
@@ -242,14 +242,14 @@ impl ::re_types_core::Loggable for AffixFuzzer21 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -288,10 +288,10 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer3");
                 }
                 let degrees = {
-                    if 1usize >= arrow_data_arrays.len() {
+                    if 1 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[1usize];
+                    let arrow_data = &*arrow_data_arrays[1];
                     arrow_data
                         .as_any()
                         .downcast_ref::<Float32Array>()
@@ -306,10 +306,10 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                         .collect::<Vec<_>>()
                 };
                 let craziness = {
-                    if 2usize >= arrow_data_arrays.len() {
+                    if 2 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[2usize];
+                    let arrow_data = &*arrow_data_arrays[2];
                     {
                         let arrow_data = arrow_data
                             .as_any()
@@ -371,10 +371,10 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .collect::<Vec<_>>()
                 };
                 let fixed_size_shenanigans = {
-                    if 3usize >= arrow_data_arrays.len() {
+                    if 3 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[3usize];
+                    let arrow_data = &*arrow_data_arrays[3];
                     {
                         let arrow_data = arrow_data
                             .as_any()

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -338,14 +338,14 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer3.rs
@@ -288,7 +288,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer3");
                 }
                 let degrees = {
-                    if 1 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 1 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[1];
@@ -306,7 +306,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                         .collect::<Vec<_>>()
                 };
                 let craziness = {
-                    if 2 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 2 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[2];
@@ -371,7 +371,7 @@ impl ::re_types_core::Loggable for AffixFuzzer3 {
                     .collect::<Vec<_>>()
                 };
                 let fixed_size_shenanigans = {
-                    if 3 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 3 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[3];

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -229,20 +229,20 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer4");
                 }
                 let single_required = {
-                    if 1usize >= arrow_data_arrays.len() {
+                    if 1 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[1usize];
+                    let arrow_data = &*arrow_data_arrays[1];
                     crate::testing::datatypes::AffixFuzzer3::from_arrow2_opt(arrow_data)
                         .with_context("rerun.testing.datatypes.AffixFuzzer4#single_required")?
                         .into_iter()
                         .collect::<Vec<_>>()
                 };
                 let many_required = {
-                    if 2usize >= arrow_data_arrays.len() {
+                    if 2 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[2usize];
+                    let arrow_data = &*arrow_data_arrays[2];
                     {
                         let arrow_data = arrow_data
                             .as_any()

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -229,7 +229,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                     .with_context("rerun.testing.datatypes.AffixFuzzer4");
                 }
                 let single_required = {
-                    if 1 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 1 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[1];
@@ -239,7 +239,7 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                         .collect::<Vec<_>>()
                 };
                 let many_required = {
-                    if 2 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 2 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[2];

--- a/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/datatypes/affix_fuzzer4.rs
@@ -271,14 +271,14 @@ impl ::re_types_core::Loggable for AffixFuzzer4 {
                             };
                             let offsets = arrow_data.offsets();
                             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                                offsets.iter().zip(offsets.lengths()),
+                                offsets.windows(2),
                                 arrow_data.validity(),
                             )
                             .map(|elem| {
-                                elem.map(|(start, len)| {
-                                    let start = *start as usize;
-                                    let end = start + len;
-                                    if end > arrow_data_inner.len() {
+                                elem.map(|window| {
+                                    let start = window[0] as usize;
+                                    let end = window[1] as usize;
+                                    if arrow_data_inner.len() < end {
                                         return Err(DeserializationError::offset_slice_oob(
                                             (start, end),
                                             arrow_data_inner.len(),

--- a/crates/store/re_types/src/testing/datatypes/string_component.rs
+++ b/crates/store/re_types/src/testing/datatypes/string_component.rs
@@ -98,14 +98,15 @@ impl ::re_types_core::Loggable for StringComponent {
             let arrow_data_buf = arrow_data.values();
             let offsets = arrow_data.offsets();
             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
+                offsets.windows(2),
                 arrow_data.validity(),
             )
             .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end > arrow_data_buf.len() {
+                elem.map(|window| {
+                    let start = window[0] as usize;
+                    let end = window[1] as usize;
+                    let len = end - start;
+                    if arrow_data_buf.len() < end {
                         return Err(DeserializationError::offset_slice_oob(
                             (start, end),
                             arrow_data_buf.len(),

--- a/crates/store/re_types/tests/types/validity.rs
+++ b/crates/store/re_types/tests/types/validity.rs
@@ -31,8 +31,9 @@ fn validity_checks() {
     let serialized = Position2D::to_arrow2_opt(bad).unwrap();
     let deserialized = Position2D::from_arrow2(serialized.as_ref());
     assert!(deserialized.is_err());
-    assert!(matches!(
-        deserialized.err().unwrap(),
-        DeserializationError::MissingData { .. }
-    ));
+    let actual_error = deserialized.err().unwrap();
+    assert!(
+        matches!(actual_error, DeserializationError::MissingData { .. }),
+        "Expected error MissingData, got {actual_error:?}",
+    );
 }

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -129,14 +129,15 @@ impl ::re_types_core::Loggable for Utf8List {
                         let arrow_data_inner_buf = arrow_data_inner.values();
                         let offsets = arrow_data_inner.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data_inner.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_inner_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_inner_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_inner_buf.len(),

--- a/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/datatypes/utf8list.rs
@@ -165,14 +165,14 @@ impl ::re_types_core::Loggable for Utf8List {
                 };
                 let offsets = arrow_data.offsets();
                 arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                    offsets.iter().zip(offsets.lengths()),
+                    offsets.windows(2),
                     arrow_data.validity(),
                 )
                 .map(|elem| {
-                    elem.map(|(start, len)| {
-                        let start = *start as usize;
-                        let end = start + len;
-                        if end > arrow_data_inner.len() {
+                    elem.map(|window| {
+                        let start = window[0] as usize;
+                        let end = window[1] as usize;
+                        if arrow_data_inner.len() < end {
                             return Err(DeserializationError::offset_slice_oob(
                                 (start, end),
                                 arrow_data_inner.len(),

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -101,6 +101,24 @@ pub trait Archetype {
     /// Arrow arrays that are unknown to this [`Archetype`] will simply be ignored and a warning
     /// logged to stderr.
     #[inline]
+    fn from_arrow(
+        data: impl IntoIterator<Item = (arrow2::datatypes::Field, ::arrow::array::ArrayRef)>,
+    ) -> DeserializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::from_arrow_components(
+            data.into_iter()
+                .map(|(field, array)| (field.name.into(), array)),
+        )
+    }
+
+    /// Given an iterator of Arrow arrays and their respective field metadata, deserializes them
+    /// into this archetype.
+    ///
+    /// Arrow arrays that are unknown to this [`Archetype`] will simply be ignored and a warning
+    /// logged to stderr.
+    #[inline]
     fn from_arrow2(
         data: impl IntoIterator<Item = (arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>,
     ) -> DeserializationResult<Self>

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -119,8 +119,8 @@ pub trait Archetype {
     /// Arrow arrays that are unknown to this [`Archetype`] will simply be ignored and a warning
     /// logged to stderr.
     #[inline]
-    fn from_arrow2_components(
-        data: impl IntoIterator<Item = (ComponentName, Box<dyn ::arrow2::array::Array>)>,
+    fn from_arrow_components(
+        data: impl IntoIterator<Item = (ComponentName, ::arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self>
     where
         Self: Sized,
@@ -130,6 +130,23 @@ pub trait Archetype {
             fqname: Self::name().to_string(),
             backtrace: _Backtrace::new_unresolved(),
         })
+    }
+
+    /// Given an iterator of Arrow arrays and their respective `ComponentNames`, deserializes them
+    /// into this archetype.
+    ///
+    /// Arrow arrays that are unknown to this [`Archetype`] will simply be ignored and a warning
+    /// logged to stderr.
+    #[inline]
+    fn from_arrow2_components(
+        data: impl IntoIterator<Item = (ComponentName, Box<dyn ::arrow2::array::Array>)>,
+    ) -> DeserializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::from_arrow_components(data.into_iter().map(|(component, arrow2_array)| {
+            (component, arrow::array::ArrayRef::from(arrow2_array))
+        }))
     }
 }
 

--- a/crates/store/re_types_core/src/arrow_string.rs
+++ b/crates/store/re_types_core/src/arrow_string.rs
@@ -56,8 +56,20 @@ impl ArrowString {
     }
 
     #[inline]
+    pub fn into_arrow_buffer(self) -> arrow::buffer::Buffer {
+        self.0.into()
+    }
+
+    #[inline]
     pub fn into_arrow2_buffer(self) -> arrow2::buffer::Buffer<u8> {
         self.0
+    }
+}
+
+impl From<arrow::buffer::Buffer> for ArrowString {
+    #[inline]
+    fn from(buf: arrow::buffer::Buffer) -> Self {
+        Self(buf.into())
     }
 }
 

--- a/crates/store/re_types_core/src/datatypes/entity_path.rs
+++ b/crates/store/re_types_core/src/datatypes/entity_path.rs
@@ -99,14 +99,15 @@ impl crate::Loggable for EntityPath {
             let arrow_data_buf = arrow_data.values();
             let offsets = arrow_data.offsets();
             arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                offsets.iter().zip(offsets.lengths()),
+                offsets.windows(2),
                 arrow_data.validity(),
             )
             .map(|elem| {
-                elem.map(|(start, len)| {
-                    let start = *start as usize;
-                    let end = start + len;
-                    if end > arrow_data_buf.len() {
+                elem.map(|window| {
+                    let start = window[0] as usize;
+                    let end = window[1] as usize;
+                    let len = end - start;
+                    if arrow_data_buf.len() < end {
                         return Err(DeserializationError::offset_slice_oob(
                             (start, end),
                             arrow_data_buf.len(),

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -231,7 +231,7 @@ impl crate::Loggable for TimeRangeBoundary {
                     .with_context("rerun.datatypes.TimeRangeBoundary");
                 }
                 let cursor_relative = {
-                    if 1 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 1 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[1];
@@ -250,7 +250,7 @@ impl crate::Loggable for TimeRangeBoundary {
                         .collect::<Vec<_>>()
                 };
                 let absolute = {
-                    if 2 >= arrow_data_arrays.len() {
+                    if arrow_data_arrays.len() <= 2 {
                         return Ok(Vec::new());
                     }
                     let arrow_data = &*arrow_data_arrays[2];

--- a/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
+++ b/crates/store/re_types_core/src/datatypes/time_range_boundary.rs
@@ -231,10 +231,10 @@ impl crate::Loggable for TimeRangeBoundary {
                     .with_context("rerun.datatypes.TimeRangeBoundary");
                 }
                 let cursor_relative = {
-                    if 1usize >= arrow_data_arrays.len() {
+                    if 1 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[1usize];
+                    let arrow_data = &*arrow_data_arrays[1];
                     arrow_data
                         .as_any()
                         .downcast_ref::<Int64Array>()
@@ -250,10 +250,10 @@ impl crate::Loggable for TimeRangeBoundary {
                         .collect::<Vec<_>>()
                 };
                 let absolute = {
-                    if 2usize >= arrow_data_arrays.len() {
+                    if 2 >= arrow_data_arrays.len() {
                         return Ok(Vec::new());
                     }
-                    let arrow_data = &*arrow_data_arrays[2usize];
+                    let arrow_data = &*arrow_data_arrays[2];
                     arrow_data
                         .as_any()
                         .downcast_ref::<Int64Array>()

--- a/crates/store/re_types_core/src/datatypes/visible_time_range.rs
+++ b/crates/store/re_types_core/src/datatypes/visible_time_range.rs
@@ -190,14 +190,15 @@ impl crate::Loggable for VisibleTimeRange {
                         let arrow_data_buf = arrow_data.values();
                         let offsets = arrow_data.offsets();
                         arrow2::bitmap::utils::ZipValidity::new_with_validity(
-                            offsets.iter().zip(offsets.lengths()),
+                            offsets.windows(2),
                             arrow_data.validity(),
                         )
                         .map(|elem| {
-                            elem.map(|(start, len)| {
-                                let start = *start as usize;
-                                let end = start + len;
-                                if end > arrow_data_buf.len() {
+                            elem.map(|window| {
+                                let start = window[0] as usize;
+                                let end = window[1] as usize;
+                                let len = end - start;
+                                if arrow_data_buf.len() < end {
                                     return Err(DeserializationError::offset_slice_oob(
                                         (start, end),
                                         arrow_data_buf.len(),

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -194,6 +194,7 @@ pub mod macros {
 
 pub mod external {
     pub use anyhow;
+    pub use arrow;
     pub use arrow2;
     pub use re_tuid;
 }

--- a/crates/store/re_types_core/src/loggable.rs
+++ b/crates/store/re_types_core/src/loggable.rs
@@ -138,11 +138,8 @@ pub trait Loggable: 'static + Send + Sync + Clone + Sized + SizeBytes {
     fn from_arrow2_opt(
         data: &dyn arrow2::array::Array,
     ) -> DeserializationResult<Vec<Option<Self>>> {
-        _ = data; // NOTE: do this here to avoid breaking users' autocomplete snippets
-        Err(crate::DeserializationError::NotImplemented {
-            fqname: "<unknown>".to_owned(),
-            backtrace: _Backtrace::new_unresolved(),
-        })
+        let boxed_arrow_array = arrow::array::ArrayRef::from(data);
+        Self::from_arrow_opt(boxed_arrow_array.as_ref())
     }
 }
 

--- a/tests/python/release_checklist/main.py
+++ b/tests/python/release_checklist/main.py
@@ -32,10 +32,10 @@ def main() -> None:
     args = parser.parse_args()
 
     # Download test assets:
-    download_test_assest_path = (
+    download_test_assets_path = (
         Path(__file__).parent.parent.parent.joinpath("assets/download_test_assets.py").absolute()
     )
-    subprocess.run([sys.executable, download_test_assest_path])
+    subprocess.run([sys.executable, download_test_assets_path])
 
     log_checks(args)
 


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/3741
 
### What
Some preparatory work for migrating the codegen deserializer from `re_arrow2`
