### PR TITLE
Fix indicators showing up in override ui

### DIFF
--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1097,7 +1097,7 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
         #recommended_descriptors
         ComponentDescriptor {
             archetype_name: Some(#archetype_name.into()),
-            component_name: #indicator_name.into(),
+            component_name: #quoted_indicator_name::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         },
     };

--- a/crates/build/re_types_builder/src/codegen/rust/api.rs
+++ b/crates/build/re_types_builder/src/codegen/rust/api.rs
@@ -1084,6 +1084,8 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
     let quoted_indicator_name = format_ident!("{indicator_name}");
     let quoted_indicator_doc =
         format!("Indicator component for the [`{name}`] [`::re_types_core::Archetype`]");
+    let indicator_component_name =
+        format!("{}Indicator", fqname.replace("archetypes", "components"));
 
     let (num_required_descriptors, required_descriptors) =
         compute_component_descriptors(obj, ATTR_RERUN_COMPONENT_REQUIRED);
@@ -1097,7 +1099,7 @@ fn quote_trait_impls_for_archetype(obj: &Object) -> TokenStream {
         #recommended_descriptors
         ComponentDescriptor {
             archetype_name: Some(#archetype_name.into()),
-            component_name: #quoted_indicator_name::DEFAULT.descriptor().component_name,
+            component_name: #indicator_component_name.into(),
             archetype_field_name: None,
         },
     };

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -88,7 +88,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-            component_name: "AnnotationContextIndicator".into(),
+            component_name: AnnotationContextIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -106,7 +108,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-                component_name: "AnnotationContextIndicator".into(),
+                component_name: AnnotationContextIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/annotation_context.rs
+++ b/crates/store/re_types/src/archetypes/annotation_context.rs
@@ -88,9 +88,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-            component_name: AnnotationContextIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.AnnotationContextIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -108,9 +106,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AnnotationContext".into()),
-                component_name: AnnotationContextIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.AnnotationContextIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -106,7 +106,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "Arrows2DIndicator".into(),
+                component_name: Arrows2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -163,7 +163,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: "Arrows2DIndicator".into(),
+                component_name: Arrows2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows2d.rs
+++ b/crates/store/re_types/src/archetypes/arrows2d.rs
@@ -106,7 +106,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: Arrows2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Arrows2DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -163,7 +163,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows2D".into()),
-                component_name: Arrows2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Arrows2DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -114,7 +114,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "Arrows3DIndicator".into(),
+                component_name: Arrows3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -166,7 +166,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: "Arrows3DIndicator".into(),
+                component_name: Arrows3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/arrows3d.rs
+++ b/crates/store/re_types/src/archetypes/arrows3d.rs
@@ -114,7 +114,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: Arrows3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Arrows3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -166,7 +166,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Arrows3D".into()),
-                component_name: Arrows3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Arrows3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "Asset3DIndicator".into(),
+                component_name: Asset3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -127,7 +127,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: "Asset3DIndicator".into(),
+                component_name: Asset3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset3d.rs
+++ b/crates/store/re_types/src/archetypes/asset3d.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: Asset3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Asset3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -127,7 +127,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Asset3D".into()),
-                component_name: Asset3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Asset3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -158,7 +158,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: AssetVideoIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.AssetVideoIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -182,7 +182,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: AssetVideoIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.AssetVideoIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/asset_video.rs
+++ b/crates/store/re_types/src/archetypes/asset_video.rs
@@ -158,7 +158,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "AssetVideoIndicator".into(),
+                component_name: AssetVideoIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -182,7 +182,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.AssetVideo".into()),
-                component_name: "AssetVideoIndicator".into(),
+                component_name: AssetVideoIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -68,7 +68,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.BarChart".into()),
-            component_name: "BarChartIndicator".into(),
+            component_name: BarChartIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -92,7 +92,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.BarChart".into()),
-                component_name: "BarChartIndicator".into(),
+                component_name: BarChartIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/bar_chart.rs
+++ b/crates/store/re_types/src/archetypes/bar_chart.rs
@@ -68,7 +68,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.BarChart".into()),
-            component_name: BarChartIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.BarChartIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -92,7 +92,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.BarChart".into()),
-                component_name: BarChartIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.BarChartIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -104,7 +104,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: Boxes2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Boxes2DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -161,7 +161,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: Boxes2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Boxes2DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes2d.rs
+++ b/crates/store/re_types/src/archetypes/boxes2d.rs
@@ -104,7 +104,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "Boxes2DIndicator".into(),
+                component_name: Boxes2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -161,7 +161,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes2D".into()),
-                component_name: "Boxes2DIndicator".into(),
+                component_name: Boxes2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -134,7 +134,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "Boxes3DIndicator".into(),
+                component_name: Boxes3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -201,7 +201,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: "Boxes3DIndicator".into(),
+                component_name: Boxes3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/boxes3d.rs
+++ b/crates/store/re_types/src/archetypes/boxes3d.rs
@@ -134,7 +134,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: Boxes3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Boxes3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -201,7 +201,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Boxes3D".into()),
-                component_name: Boxes3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Boxes3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -143,7 +143,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: Capsules3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Capsules3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -205,7 +205,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: Capsules3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Capsules3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/capsules3d.rs
+++ b/crates/store/re_types/src/archetypes/capsules3d.rs
@@ -143,7 +143,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "Capsules3DIndicator".into(),
+                component_name: Capsules3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -205,7 +205,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Capsules3D".into()),
-                component_name: "Capsules3DIndicator".into(),
+                component_name: Capsules3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -134,7 +134,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.DepthImage".into()),
-            component_name: "DepthImageIndicator".into(),
+            component_name: DepthImageIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -185,7 +185,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: "DepthImageIndicator".into(),
+                component_name: DepthImageIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/depth_image.rs
+++ b/crates/store/re_types/src/archetypes/depth_image.rs
@@ -134,7 +134,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.DepthImage".into()),
-            component_name: DepthImageIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.DepthImageIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -185,7 +185,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.DepthImage".into()),
-                component_name: DepthImageIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.DepthImageIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/store/re_types/src/archetypes/disconnected_space.rs
@@ -80,9 +80,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
-            component_name: DisconnectedSpaceIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.DisconnectedSpaceIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -100,9 +98,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
-                component_name: DisconnectedSpaceIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.DisconnectedSpaceIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/disconnected_space.rs
+++ b/crates/store/re_types/src/archetypes/disconnected_space.rs
@@ -80,7 +80,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
-            component_name: "DisconnectedSpaceIndicator".into(),
+            component_name: DisconnectedSpaceIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -98,7 +100,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.DisconnectedSpace".into()),
-                component_name: "DisconnectedSpaceIndicator".into(),
+                component_name: DisconnectedSpaceIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "Ellipsoids3DIndicator".into(),
+                component_name: Ellipsoids3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -164,7 +164,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: "Ellipsoids3DIndicator".into(),
+                component_name: Ellipsoids3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/ellipsoids3d.rs
+++ b/crates/store/re_types/src/archetypes/ellipsoids3d.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: Ellipsoids3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Ellipsoids3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -164,7 +164,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 11usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Ellipsoids3D".into()),
-                component_name: Ellipsoids3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Ellipsoids3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -85,7 +85,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "EncodedImageIndicator".into(),
+                component_name: EncodedImageIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -122,7 +122,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: "EncodedImageIndicator".into(),
+                component_name: EncodedImageIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/encoded_image.rs
+++ b/crates/store/re_types/src/archetypes/encoded_image.rs
@@ -85,7 +85,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: EncodedImageIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.EncodedImageIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -122,7 +122,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.EncodedImage".into()),
-                component_name: EncodedImageIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.EncodedImageIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -93,7 +93,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "GeoLineStringsIndicator".into(),
+                component_name: GeoLineStringsIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -122,7 +122,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: "GeoLineStringsIndicator".into(),
+                component_name: GeoLineStringsIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/geo_line_strings.rs
+++ b/crates/store/re_types/src/archetypes/geo_line_strings.rs
@@ -93,7 +93,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: GeoLineStringsIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GeoLineStringsIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -122,7 +122,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoLineStrings".into()),
-                component_name: GeoLineStringsIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GeoLineStringsIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -89,7 +89,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "GeoPointsIndicator".into(),
+                component_name: GeoPointsIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -124,7 +124,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: "GeoPointsIndicator".into(),
+                component_name: GeoPointsIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/geo_points.rs
+++ b/crates/store/re_types/src/archetypes/geo_points.rs
@@ -89,7 +89,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: GeoPointsIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GeoPointsIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -124,7 +124,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GeoPoints".into()),
-                component_name: GeoPointsIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GeoPointsIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -53,7 +53,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: GraphEdgesIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GraphEdgesIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -77,7 +77,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: GraphEdgesIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GraphEdgesIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -53,7 +53,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "GraphEdgesIndicator".into(),
+                component_name: GraphEdgesIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -77,7 +77,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphEdges".into()),
-                component_name: "GraphEdgesIndicator".into(),
+                component_name: GraphEdgesIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -55,7 +55,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-            component_name: "GraphNodesIndicator".into(),
+            component_name: GraphNodesIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -101,7 +101,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: "GraphNodesIndicator".into(),
+                component_name: GraphNodesIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -55,7 +55,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-            component_name: GraphNodesIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.GraphNodesIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -101,7 +101,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.GraphNodes".into()),
-                component_name: GraphNodesIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.GraphNodesIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -165,7 +165,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Image".into()),
-            component_name: ImageIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.ImageIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -201,7 +201,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: ImageIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.ImageIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/image.rs
+++ b/crates/store/re_types/src/archetypes/image.rs
@@ -165,7 +165,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Image".into()),
-            component_name: "ImageIndicator".into(),
+            component_name: ImageIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -201,7 +201,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Image".into()),
-                component_name: "ImageIndicator".into(),
+                component_name: ImageIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -115,9 +115,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-            component_name: InstancePoses3DIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.InstancePoses3DIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -158,9 +156,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: InstancePoses3DIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.InstancePoses3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/instance_poses3d.rs
+++ b/crates/store/re_types/src/archetypes/instance_poses3d.rs
@@ -115,7 +115,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-            component_name: "InstancePoses3DIndicator".into(),
+            component_name: InstancePoses3DIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -156,7 +158,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.InstancePoses3D".into()),
-                component_name: "InstancePoses3DIndicator".into(),
+                component_name: InstancePoses3DIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -138,7 +138,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: LineStrips2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.LineStrips2DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -190,7 +190,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: LineStrips2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.LineStrips2DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips2d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips2d.rs
@@ -138,7 +138,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "LineStrips2DIndicator".into(),
+                component_name: LineStrips2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -190,7 +190,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips2D".into()),
-                component_name: "LineStrips2DIndicator".into(),
+                component_name: LineStrips2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -148,7 +148,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: LineStrips3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.LineStrips3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -195,7 +195,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: LineStrips3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.LineStrips3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/line_strips3d.rs
+++ b/crates/store/re_types/src/archetypes/line_strips3d.rs
@@ -148,7 +148,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "LineStrips3DIndicator".into(),
+                component_name: LineStrips3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -195,7 +195,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 7usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.LineStrips3D".into()),
-                component_name: "LineStrips3DIndicator".into(),
+                component_name: LineStrips3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -169,7 +169,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: Mesh3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Mesh3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -231,7 +231,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: Mesh3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Mesh3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/mesh3d.rs
+++ b/crates/store/re_types/src/archetypes/mesh3d.rs
@@ -169,7 +169,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "Mesh3DIndicator".into(),
+                component_name: Mesh3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -231,7 +231,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 10usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Mesh3D".into()),
-                component_name: "Mesh3DIndicator".into(),
+                component_name: Mesh3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -155,7 +155,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "PinholeIndicator".into(),
+                component_name: PinholeIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -192,7 +192,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: "PinholeIndicator".into(),
+                component_name: PinholeIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/pinhole.rs
+++ b/crates/store/re_types/src/archetypes/pinhole.rs
@@ -155,7 +155,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: PinholeIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.PinholeIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -192,7 +192,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Pinhole".into()),
-                component_name: PinholeIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.PinholeIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -161,7 +161,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: Points2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Points2DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -218,7 +218,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: Points2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Points2DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points2d.rs
+++ b/crates/store/re_types/src/archetypes/points2d.rs
@@ -161,7 +161,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "Points2DIndicator".into(),
+                component_name: Points2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -218,7 +218,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points2D".into()),
-                component_name: "Points2DIndicator".into(),
+                component_name: Points2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -154,7 +154,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: Points3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Points3DIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -206,7 +206,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: Points3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Points3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/points3d.rs
+++ b/crates/store/re_types/src/archetypes/points3d.rs
@@ -154,7 +154,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "Points3DIndicator".into(),
+                component_name: Points3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -206,7 +206,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Points3D".into()),
-                component_name: "Points3DIndicator".into(),
+                component_name: Points3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -72,7 +72,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Scalar".into()),
-            component_name: "ScalarIndicator".into(),
+            component_name: ScalarIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -90,7 +90,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Scalar".into()),
-                component_name: "ScalarIndicator".into(),
+                component_name: ScalarIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/scalar.rs
+++ b/crates/store/re_types/src/archetypes/scalar.rs
@@ -72,7 +72,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Scalar".into()),
-            component_name: ScalarIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.ScalarIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -90,7 +90,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Scalar".into()),
-                component_name: ScalarIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.ScalarIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -103,9 +103,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-            component_name: SegmentationImageIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.SegmentationImageIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -141,9 +139,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: SegmentationImageIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.SegmentationImageIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/segmentation_image.rs
+++ b/crates/store/re_types/src/archetypes/segmentation_image.rs
@@ -103,7 +103,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-            component_name: "SegmentationImageIndicator".into(),
+            component_name: SegmentationImageIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -139,7 +141,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SegmentationImage".into()),
-                component_name: "SegmentationImageIndicator".into(),
+                component_name: SegmentationImageIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-            component_name: SeriesLineIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.SeriesLineIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -133,7 +133,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: SeriesLineIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.SeriesLineIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_line.rs
+++ b/crates/store/re_types/src/archetypes/series_line.rs
@@ -97,7 +97,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-            component_name: "SeriesLineIndicator".into(),
+            component_name: SeriesLineIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -133,7 +133,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SeriesLine".into()),
-                component_name: "SeriesLineIndicator".into(),
+                component_name: SeriesLineIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -95,7 +95,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-            component_name: "SeriesPointIndicator".into(),
+            component_name: SeriesPointIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -131,7 +131,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: "SeriesPointIndicator".into(),
+                component_name: SeriesPointIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/series_point.rs
+++ b/crates/store/re_types/src/archetypes/series_point.rs
@@ -95,7 +95,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-            component_name: SeriesPointIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.SeriesPointIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -131,7 +131,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.SeriesPoint".into()),
-                component_name: SeriesPointIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.SeriesPointIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -80,7 +80,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Tensor".into()),
-            component_name: "TensorIndicator".into(),
+            component_name: TensorIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -104,7 +104,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Tensor".into()),
-                component_name: "TensorIndicator".into(),
+                component_name: TensorIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/tensor.rs
+++ b/crates/store/re_types/src/archetypes/tensor.rs
@@ -80,7 +80,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Tensor".into()),
-            component_name: TensorIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.TensorIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -104,7 +104,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Tensor".into()),
-                component_name: TensorIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.TensorIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -115,7 +115,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.TextDocument".into()),
-            component_name: "TextDocumentIndicator".into(),
+            component_name: TextDocumentIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -139,7 +139,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                component_name: "TextDocumentIndicator".into(),
+                component_name: TextDocumentIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_document.rs
+++ b/crates/store/re_types/src/archetypes/text_document.rs
@@ -115,7 +115,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.TextDocument".into()),
-            component_name: TextDocumentIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.TextDocumentIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -139,7 +139,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextDocument".into()),
-                component_name: TextDocumentIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.TextDocumentIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -91,7 +91,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: TextLogIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.TextLogIndicator".into(),
                 archetype_field_name: None,
             },
         ]
@@ -121,7 +121,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: TextLogIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.TextLogIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/text_log.rs
+++ b/crates/store/re_types/src/archetypes/text_log.rs
@@ -91,7 +91,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usiz
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "TextLogIndicator".into(),
+                component_name: TextLogIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]
@@ -121,7 +121,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.TextLog".into()),
-                component_name: "TextLogIndicator".into(),
+                component_name: TextLogIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -200,7 +200,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Transform3D".into()),
-            component_name: "Transform3DIndicator".into(),
+            component_name: Transform3DIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -251,7 +251,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: "Transform3DIndicator".into(),
+                component_name: Transform3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/transform3d.rs
+++ b/crates/store/re_types/src/archetypes/transform3d.rs
@@ -200,7 +200,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Transform3D".into()),
-            component_name: Transform3DIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.Transform3DIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -251,7 +251,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 8usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Transform3D".into()),
-                component_name: Transform3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.Transform3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -159,9 +159,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-            component_name: VideoFrameReferenceIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.VideoFrameReferenceIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -185,9 +183,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                component_name: VideoFrameReferenceIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.VideoFrameReferenceIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/video_frame_reference.rs
+++ b/crates/store/re_types/src/archetypes/video_frame_reference.rs
@@ -159,7 +159,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-            component_name: "VideoFrameReferenceIndicator".into(),
+            component_name: VideoFrameReferenceIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -183,7 +185,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.VideoFrameReference".into()),
-                component_name: "VideoFrameReferenceIndicator".into(),
+                component_name: VideoFrameReferenceIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -79,7 +79,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-            component_name: "ViewCoordinatesIndicator".into(),
+            component_name: ViewCoordinatesIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -97,7 +99,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-                component_name: "ViewCoordinatesIndicator".into(),
+                component_name: ViewCoordinatesIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/archetypes/view_coordinates.rs
+++ b/crates/store/re_types/src/archetypes/view_coordinates.rs
@@ -79,9 +79,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-            component_name: ViewCoordinatesIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.components.ViewCoordinatesIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -99,9 +97,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.ViewCoordinates".into()),
-                component_name: ViewCoordinatesIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.components.ViewCoordinatesIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -41,7 +41,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-            component_name: "BackgroundIndicator".into(),
+            component_name: BackgroundIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -65,7 +65,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                component_name: "BackgroundIndicator".into(),
+                component_name: BackgroundIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/background.rs
@@ -41,7 +41,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-            component_name: BackgroundIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.BackgroundIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -65,7 +65,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.Background".into()),
-                component_name: BackgroundIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.BackgroundIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -48,7 +48,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-            component_name: DataframeQueryIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -89,7 +89,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: DataframeQueryIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.DataframeQueryIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/dataframe_query.rs
@@ -48,7 +48,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-            component_name: "DataframeQueryIndicator".into(),
+            component_name: DataframeQueryIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -89,7 +89,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.DataframeQuery".into()),
-                component_name: "DataframeQueryIndicator".into(),
+                component_name: DataframeQueryIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -56,7 +56,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-            component_name: "LineGrid3DIndicator".into(),
+            component_name: LineGrid3DIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -97,7 +97,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: "LineGrid3DIndicator".into(),
+                component_name: LineGrid3DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/line_grid3d.rs
@@ -56,7 +56,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-            component_name: LineGrid3DIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -97,7 +97,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.LineGrid3D".into()),
-                component_name: LineGrid3DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.LineGrid3DIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -34,7 +34,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-            component_name: MapBackgroundIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -53,7 +53,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-                component_name: MapBackgroundIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.MapBackgroundIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_background.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_background.rs
@@ -34,7 +34,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-            component_name: "MapBackgroundIndicator".into(),
+            component_name: MapBackgroundIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -53,7 +53,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.MapBackground".into()),
-                component_name: "MapBackgroundIndicator".into(),
+                component_name: MapBackgroundIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -34,7 +34,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-            component_name: MapZoomIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -53,7 +53,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-                component_name: MapZoomIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.MapZoomIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/map_zoom.rs
@@ -34,7 +34,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-            component_name: "MapZoomIndicator".into(),
+            component_name: MapZoomIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -53,7 +53,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.MapZoom".into()),
-                component_name: "MapZoomIndicator".into(),
+                component_name: MapZoomIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -39,7 +39,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-            component_name: "PlotLegendIndicator".into(),
+            component_name: PlotLegendIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -65,7 +65,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: "PlotLegendIndicator".into(),
+                component_name: PlotLegendIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/plot_legend.rs
@@ -39,7 +39,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-            component_name: PlotLegendIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -65,7 +65,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.PlotLegend".into()),
-                component_name: PlotLegendIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.PlotLegendIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -37,7 +37,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-            component_name: "ScalarAxisIndicator".into(),
+            component_name: ScalarAxisIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -63,7 +63,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: "ScalarAxisIndicator".into(),
+                component_name: ScalarAxisIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/scalar_axis.rs
@@ -37,7 +37,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-            component_name: ScalarAxisIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -63,7 +63,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 3usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ScalarAxis".into()),
-                component_name: ScalarAxisIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.ScalarAxisIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
@@ -55,7 +55,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
-            component_name: "SpaceViewBlueprintIndicator".into(),
+            component_name: SpaceViewBlueprintIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -91,7 +93,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
-                component_name: "SpaceViewBlueprintIndicator".into(),
+                component_name: SpaceViewBlueprintIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_blueprint.rs
@@ -55,9 +55,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
-            component_name: SpaceViewBlueprintIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.SpaceViewBlueprintIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -93,9 +91,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.SpaceViewBlueprint".into()),
-                component_name: SpaceViewBlueprintIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.SpaceViewBlueprintIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -71,9 +71,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
-            component_name: SpaceViewContentsIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.SpaceViewContentsIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -92,9 +90,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
-                component_name: SpaceViewContentsIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.SpaceViewContentsIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/space_view_contents.rs
@@ -71,7 +71,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
-            component_name: "SpaceViewContentsIndicator".into(),
+            component_name: SpaceViewContentsIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -90,7 +92,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.SpaceViewContents".into()),
-                component_name: "SpaceViewContentsIndicator".into(),
+                component_name: SpaceViewContentsIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -46,9 +46,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-            component_name: TensorScalarMappingIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -79,9 +77,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: TensorScalarMappingIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.TensorScalarMappingIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_scalar_mapping.rs
@@ -46,7 +46,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-            component_name: "TensorScalarMappingIndicator".into(),
+            component_name: TensorScalarMappingIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -77,7 +79,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 4usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorScalarMapping".into()),
-                component_name: "TensorScalarMappingIndicator".into(),
+                component_name: TensorScalarMappingIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -51,7 +51,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-            component_name: "TensorSliceSelectionIndicator".into(),
+            component_name: TensorSliceSelectionIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -87,7 +89,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: "TensorSliceSelectionIndicator".into(),
+                component_name: TensorSliceSelectionIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_slice_selection.rs
@@ -51,9 +51,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-            component_name: TensorSliceSelectionIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -89,9 +87,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 5usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorSliceSelection".into()),
-                component_name: TensorSliceSelectionIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.TensorSliceSelectionIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -32,7 +32,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-            component_name: "TensorViewFitIndicator".into(),
+            component_name: TensorViewFitIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -51,7 +51,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-                component_name: "TensorViewFitIndicator".into(),
+                component_name: TensorViewFitIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/tensor_view_fit.rs
@@ -32,7 +32,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-            component_name: TensorViewFitIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -51,7 +51,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.TensorViewFit".into()),
-                component_name: TensorViewFitIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.TensorViewFitIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -48,9 +48,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-            component_name: VisibleTimeRangesIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -68,9 +66,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-                component_name: VisibleTimeRangesIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.VisibleTimeRangesIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visible_time_ranges.rs
@@ -48,7 +48,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-            component_name: "VisibleTimeRangesIndicator".into(),
+            component_name: VisibleTimeRangesIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -66,7 +68,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.VisibleTimeRanges".into()),
-                component_name: "VisibleTimeRangesIndicator".into(),
+                component_name: VisibleTimeRangesIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -46,7 +46,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-            component_name: VisualBounds2DIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.VisualBounds2DIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -64,7 +64,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-                component_name: VisualBounds2DIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.VisualBounds2DIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
+++ b/crates/store/re_types/src/blueprint/archetypes/visual_bounds2d.rs
@@ -46,7 +46,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-            component_name: "VisualBounds2DIndicator".into(),
+            component_name: VisualBounds2DIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -64,7 +64,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.VisualBounds2D".into()),
-                component_name: "VisualBounds2DIndicator".into(),
+                component_name: VisualBounds2DIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -164,7 +164,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-            component_name: AffixFuzzer1Indicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -287,7 +287,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 23usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: AffixFuzzer1Indicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.testing.components.AffixFuzzer1Indicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer1.rs
@@ -164,7 +164,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-            component_name: "AffixFuzzer1Indicator".into(),
+            component_name: AffixFuzzer1Indicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -287,7 +287,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 23usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer1".into()),
-                component_name: "AffixFuzzer1Indicator".into(),
+                component_name: AffixFuzzer1Indicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -146,7 +146,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-            component_name: AffixFuzzer2Indicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -254,7 +254,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 20usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: AffixFuzzer2Indicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.testing.components.AffixFuzzer2Indicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer2.rs
@@ -146,7 +146,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-            component_name: "AffixFuzzer2Indicator".into(),
+            component_name: AffixFuzzer2Indicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -254,7 +254,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 20usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer2".into()),
-                component_name: "AffixFuzzer2Indicator".into(),
+                component_name: AffixFuzzer2Indicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -47,7 +47,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-            component_name: "AffixFuzzer3Indicator".into(),
+            component_name: AffixFuzzer3Indicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -153,7 +153,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: "AffixFuzzer3Indicator".into(),
+                component_name: AffixFuzzer3Indicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer3.rs
@@ -47,7 +47,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-            component_name: AffixFuzzer3Indicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -153,7 +153,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer3".into()),
-                component_name: AffixFuzzer3Indicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.testing.components.AffixFuzzer3Indicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -47,7 +47,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-            component_name: "AffixFuzzer4Indicator".into(),
+            component_name: AffixFuzzer4Indicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -153,7 +153,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: "AffixFuzzer4Indicator".into(),
+                component_name: AffixFuzzer4Indicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
+++ b/crates/store/re_types/src/testing/archetypes/affix_fuzzer4.rs
@@ -47,7 +47,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-            component_name: AffixFuzzer4Indicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -153,7 +153,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 19usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.testing.archetypes.AffixFuzzer4".into()),
-                component_name: AffixFuzzer4Indicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.testing.components.AffixFuzzer4Indicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
@@ -75,7 +75,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-            component_name: "ContainerBlueprintIndicator".into(),
+            component_name: ContainerBlueprintIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -131,7 +133,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: "ContainerBlueprintIndicator".into(),
+                component_name: ContainerBlueprintIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/container_blueprint.rs
@@ -75,9 +75,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-            component_name: ContainerBlueprintIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -133,9 +131,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 9usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ContainerBlueprint".into()),
-                component_name: ContainerBlueprintIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.ContainerBlueprintIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
@@ -31,7 +31,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-            component_name: PanelBlueprintIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -50,7 +50,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-                component_name: PanelBlueprintIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.blueprint.components.PanelBlueprintIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/panel_blueprint.rs
@@ -31,7 +31,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-            component_name: "PanelBlueprintIndicator".into(),
+            component_name: PanelBlueprintIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -50,7 +50,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.PanelBlueprint".into()),
-                component_name: "PanelBlueprintIndicator".into(),
+                component_name: PanelBlueprintIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
@@ -57,7 +57,9 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-            component_name: "ViewportBlueprintIndicator".into(),
+            component_name: ViewportBlueprintIndicator::DEFAULT
+                .descriptor()
+                .component_name,
             archetype_field_name: None,
         }]
     });
@@ -98,7 +100,9 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: "ViewportBlueprintIndicator".into(),
+                component_name: ViewportBlueprintIndicator::DEFAULT
+                    .descriptor()
+                    .component_name,
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
+++ b/crates/store/re_types_blueprint/src/blueprint/archetypes/viewport_blueprint.rs
@@ -57,9 +57,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-            component_name: ViewportBlueprintIndicator::DEFAULT
-                .descriptor()
-                .component_name,
+            component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -100,9 +98,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 6usize]> =
         [
             ComponentDescriptor {
                 archetype_name: Some("rerun.blueprint.archetypes.ViewportBlueprint".into()),
-                component_name: ViewportBlueprintIndicator::DEFAULT
-                    .descriptor()
-                    .component_name,
+                component_name: "rerun.blueprint.components.ViewportBlueprintIndicator".into(),
                 archetype_field_name: None,
             },
             ComponentDescriptor {

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -91,7 +91,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Clear".into()),
-            component_name: ClearIndicator::DEFAULT.descriptor().component_name,
+            component_name: "rerun.components.ClearIndicator".into(),
             archetype_field_name: None,
         }]
     });
@@ -109,7 +109,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Clear".into()),
-                component_name: ClearIndicator::DEFAULT.descriptor().component_name,
+                component_name: "rerun.components.ClearIndicator".into(),
                 archetype_field_name: None,
             },
         ]

--- a/crates/store/re_types_core/src/archetypes/clear.rs
+++ b/crates/store/re_types_core/src/archetypes/clear.rs
@@ -91,7 +91,7 @@ static RECOMMENDED_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 1usiz
     once_cell::sync::Lazy::new(|| {
         [ComponentDescriptor {
             archetype_name: Some("rerun.archetypes.Clear".into()),
-            component_name: "ClearIndicator".into(),
+            component_name: ClearIndicator::DEFAULT.descriptor().component_name,
             archetype_field_name: None,
         }]
     });
@@ -109,7 +109,7 @@ static ALL_COMPONENTS: once_cell::sync::Lazy<[ComponentDescriptor; 2usize]> =
             },
             ComponentDescriptor {
                 archetype_name: Some("rerun.archetypes.Clear".into()),
-                component_name: "ClearIndicator".into(),
+                component_name: ClearIndicator::DEFAULT.descriptor().component_name,
                 archetype_field_name: None,
             },
         ]


### PR DESCRIPTION
The all components/recommended component list would previously contain a fantasy-component with an unqualified name instead of the indicator.