### PR TITLE
Snippet index: support for enumerating custom features

### DIFF
--- a/docs/snippets/INDEX.md
+++ b/docs/snippets/INDEX.md
@@ -9,12 +9,25 @@ Use it to quickly find copy-pastable snippets of code for any Rerun feature you'
 ---
 
 *Table of contents:*
+* [Features](#features)
 * [Types](#types)
     * [Archetypes](#archetypes)
     * [Components](#components)
     * [Views](#views-blueprint)
     * [Archetypes (blueprint)](#archetypes-blueprint)
     * [Components (blueprint)](#components-blueprint)
+
+
+## Features
+
+| Feature | Example | Description | Python | Rust | C++ |
+| ------- | ------- | ----------- | ------ | ---- | --- |
+| **Dataframes** | `dataframe_query` | Query and display the first 10 rows of a recording | [🐍](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/reference/dataframe_query.py) | [🦀](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/reference/dataframe_query.rs) |  |
+| **Dataframes** | `dataframe_view_query` | Query and display the first 10 rows of a recording in a dataframe view | [🐍](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/reference/dataframe_view_query.py) |  |  |
+| **`AnyValue`** | `any_values` | Log arbitrary data | [🐍](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/tutorials/any_values.py) |  |  |
+| **`AnyValue`** | `any_values_send_columns` | Use `AnyValues` and `send_column` to send entire columns of custom data to Rerun | [🐍](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/howto/any_values_send_columns.py?speculative-link) |  |  |
+| **`AnyValue`** | `extra_values` | Log extra values with a Points2D | [🐍](https://github.com/rerun-io/rerun/blob/latest/docs/snippets/all/tutorials/extra_values.py) |  |  |
+
 
 
 ## Types

--- a/docs/snippets/snippets.toml
+++ b/docs/snippets/snippets.toml
@@ -16,6 +16,19 @@
   "tutorials/data_out",
 ]
 
+# These arbitrary feature names will be indexed exactly as written down.
+# Add anything you can think about!
+[snippets_ref.features]
+"Dataframes" = [
+  "reference/dataframe_query",
+  "reference/dataframe_view_query",
+]
+"`AnyValue`" = [
+  "tutorials/any_values",
+  "tutorials/extra_values",
+  "howto/any_values_send_columns",
+]
+
 # These entries won't run at all.
 #
 # You should only ever use this if the test isn't implemented and cannot yet be implemented


### PR DESCRIPTION
Adds the ability to manually opt-out of the index for specific snippets/archetypes/components.

E.g.:
```toml
# These arbitrary feature names will be indexed exactly as written down.
# Add anything you can think about!
[snippets_ref.features]
"Dataframes" = [
  "reference/dataframe_query",
  "reference/dataframe_view_query",
]
"`AnyValue`" = [
  "tutorials/any_values",
  "tutorials/extra_values",
  "howto/any_values_send_columns",
]
```

Config will have to be filled over time!

[Rendered](https://github.com/rerun-io/rerun/blob/cmc/snippets_index_3_features/docs/snippets/INDEX.md)

* Part of https://github.com/rerun-io/rerun/issues/1123
* Part of https://github.com/rerun-io/rerun/issues/5662
* DNM: requires https://github.com/rerun-io/rerun/pull/8385