### PR TITLE
Link to snippet index from main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ You should now be able to run `rerun --help` in any terminal.
 - 📚 [High-level docs](http://rerun.io/docs)
 - ⏃ [Loggable Types](https://www.rerun.io/docs/reference/types)
 - ⚙️ [Examples](http://rerun.io/examples)
+- 📖 [Code snippets](./docs/snippets/INDEX.md)
 - 🌊 [C++ API docs](https://ref.rerun.io/docs/cpp)
 - 🐍 [Python API docs](https://ref.rerun.io/docs/python)
 - 🦀 [Rust API docs](https://docs.rs/rerun/)


### PR DESCRIPTION
Might be a controversial one. I think it's already useful enough to quietly link to it.

* DNM: requires #8386 