### PR TITLE
Store: only run the debug assertion against recordings (not blueprints)

### DIFF
--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -31,7 +31,7 @@ impl ChunkStore {
     pub fn insert_chunk(&mut self, chunk: &Arc<Chunk>) -> ChunkStoreResult<Vec<ChunkStoreEvent>> {
         if self.chunks_per_chunk_id.contains_key(&chunk.id()) {
             // We assume that chunk IDs are unique, and that reinserting a chunk has no effect.
-            re_log::warn_once!(
+            re_log::debug_once!(
                 "Chunk #{} was inserted more than once (this has no effect)",
                 chunk.id()
             );

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -5,7 +5,6 @@ use arrow2::array::{Array as _, ListArray as Arrow2ListArray};
 use itertools::Itertools as _;
 
 use re_chunk::{Chunk, EntityPath, RowId};
-use re_log_types::StoreKind;
 use re_types_core::SizeBytes;
 
 use crate::{
@@ -44,7 +43,7 @@ impl ChunkStore {
         // I'd like to keep this debug assertion a tiny bit longer just in case, so for we just
         // ignore blueprints.
         #[cfg(debug_assertions)]
-        if self.id.kind == StoreKind::Recording {
+        if self.id.kind == re_log_types::StoreKind::Recording {
             for (component_name, per_desc) in chunk.components().iter() {
                 assert!(
                     per_desc.len() <= 1,


### PR DESCRIPTION
I'd like to keep that assertion a bit longer, just in case. So for now just ignore blueprints, as they are problematic in that case.

* Fixes #8389 