### PR TITLE
Add manifest links to other bot comments for consistency

### DIFF
--- a/.github/workflows/reusable_build_web.yml
+++ b/.github/workflows/reusable_build_web.yml
@@ -71,9 +71,9 @@ jobs:
           message: |
             Web viewer is being built.
 
-            | Result | Commit  | Link  |
-            | ------ | ------- | ----- |
-            | ⏳ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} |
+            | Result | Commit  | Link  | Manifest |
+            | ------ | ------- | ----- | -------- |
+            | ⏳ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>
 
@@ -125,8 +125,8 @@ jobs:
           message: |
             Web viewer failed to build.
 
-            | Result | Commit  | Link  |
-            | ------ | ------- | ----- |
-            | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} |
+            | Result | Commit  | Link  | Manifest |
+            | ------ | ------- | ----- | -------- |
+            | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>

--- a/.github/workflows/reusable_upload_web.yml
+++ b/.github/workflows/reusable_upload_web.yml
@@ -153,7 +153,7 @@ jobs:
 
             | Result | Commit  | Link | Manifest |
             | ------ | ------- | ---- | -------- |
-            | ✅ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [+nightly](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [+main](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
+            | ✅ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>
 
@@ -167,8 +167,8 @@ jobs:
           message: |
             Web viewer failed to build.
 
-            | Result | Commit  | Link  |
+            | Result | Commit  | Link | Manifest |
             | ------ | ------- | ----- |
-            | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} |
+            | ❌ | ${{ steps.get-sha.outputs.sha }} | https://rerun.io/viewer/pr/${{ github.event.pull_request.number }} | [`+nightly`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/nightly/examples_manifest.json) [`+main`](https://rerun.io/viewer/pr/${{ github.event.pull_request.number }}?manifest_url=https://app.rerun.io/version/main/examples_manifest.json) |
 
             <sup>Note: This comment is updated whenever you push a commit.</sup>


### PR DESCRIPTION
Also wraps each manifest in a `<code>` tag for :sparkles:.

### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* #8384.

### What

Title.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
