### PR TITLE
Rust: more `impl<AsComponents>` helpers

### DIFF
--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -109,6 +109,15 @@ impl<const N: usize> AsComponents for [&dyn ComponentBatch; N] {
     }
 }
 
+impl<const N: usize> AsComponents for [Box<dyn ComponentBatch>; N] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .map(|batch| ComponentBatchCowWithDescriptor::new(&**batch))
+            .collect()
+    }
+}
+
 impl AsComponents for &[&dyn ComponentBatch] {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
@@ -118,11 +127,110 @@ impl AsComponents for &[&dyn ComponentBatch] {
     }
 }
 
+impl AsComponents for &[Box<dyn ComponentBatch>] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .map(|batch| ComponentBatchCowWithDescriptor::new(&**batch))
+            .collect()
+    }
+}
+
 impl AsComponents for Vec<&dyn ComponentBatch> {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         self.iter()
             .map(|batch| ComponentBatchCowWithDescriptor::new(*batch))
+            .collect()
+    }
+}
+
+impl AsComponents for Vec<Box<dyn ComponentBatch>> {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .map(|batch| ComponentBatchCowWithDescriptor::new(&**batch))
+            .collect()
+    }
+}
+
+impl<AS: AsComponents, const N: usize> AsComponents for [AS; N] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl<const N: usize> AsComponents for [&dyn AsComponents; N] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl<const N: usize> AsComponents for [Box<dyn AsComponents>; N] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl<AS: AsComponents> AsComponents for &[AS] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl AsComponents for &[&dyn AsComponents] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl AsComponents for &[Box<dyn AsComponents>] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl<AS: AsComponents> AsComponents for Vec<AS> {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl AsComponents for Vec<&dyn AsComponents> {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
+impl AsComponents for Vec<Box<dyn AsComponents>> {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
             .collect()
     }
 }

--- a/docs/snippets/all/archetypes/image_send_columns.rs
+++ b/docs/snippets/all/archetypes/image_send_columns.rs
@@ -23,7 +23,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Log the ImageFormat and indicator once, as static.
     let format = rerun::components::ImageFormat::rgb8([width as _, height as _]);
-    rec.log_static("images", &[&format as _, &rerun::Image::indicator() as _])?;
+    rec.log_static(
+        "images",
+        &[
+            &format as &dyn rerun::ComponentBatch,
+            &rerun::Image::indicator(),
+        ],
+    )?;
 
     // Split up the image data into several components referencing the underlying data.
     let image_size_in_bytes = width * height * 3;

--- a/docs/snippets/all/archetypes/mesh3d_partial_updates.rs
+++ b/docs/snippets/all/archetypes/mesh3d_partial_updates.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             (glam::Vec3::from(vertex_positions[1]) * factor).into(),
             (glam::Vec3::from(vertex_positions[2]) * factor).into(),
         ];
-        rec.log("triangle", &[&vertex_positions as _])?;
+        rec.log("triangle", &vertex_positions)?;
     }
 
     Ok(())


### PR DESCRIPTION
New release, new helpers, as is now customary.

These only introduced two breaking changes in all of our examples and snippets, and they look pretty innocuous.

Opinions?

* Fixes #8398