### PR TITLE
Enforce blueprint data is always untagged during the interim

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -414,6 +414,32 @@ impl Chunk {
         self
     }
 
+    /// Clones the chunk into a new chunk where all descriptors are untagged.
+    ///
+    /// Only useful as a migration tool while the Rerun ecosystem slowly moves over
+    /// to always using tags for everything.
+    #[doc(hidden)]
+    #[inline]
+    pub fn clone_as_untagged(&self) -> Self {
+        let mut chunk = self.clone();
+
+        let per_component_name = &mut chunk.components;
+        for (component_name, per_desc) in per_component_name.iter_mut() {
+            if per_desc.len() != 1 {
+                // If there are more than one entry, then we're in the land of UB anyway (for now).
+                continue;
+            }
+
+            let untagged_descriptor = ComponentDescriptor::new(*component_name);
+            *per_desc = std::mem::take(per_desc)
+                .into_values()
+                .map(|list_array| (untagged_descriptor.clone(), list_array))
+                .collect();
+        }
+
+        chunk
+    }
+
     /// Clones the chunk into a new chunk where all [`RowId`]s are [`RowId::ZERO`].
     pub fn zeroed(self) -> Self {
         let row_ids = std::iter::repeat(RowId::ZERO)

--- a/crates/store/re_chunk_store/src/query.rs
+++ b/crates/store/re_chunk_store/src/query.rs
@@ -592,7 +592,10 @@ impl ChunkStore {
             })
             .unwrap_or_default();
 
-        debug_assert!(chunks.iter().map(|chunk| chunk.id()).all_unique());
+        debug_assert!(
+            chunks.iter().map(|chunk| chunk.id()).all_unique(),
+            "{entity_path}:{component_name} @ {query:?}",
+        );
 
         chunks
     }

--- a/crates/store/re_chunk_store/src/writes.rs
+++ b/crates/store/re_chunk_store/src/writes.rs
@@ -37,21 +37,6 @@ impl ChunkStore {
             return Ok(Vec::new());
         }
 
-        // NOTE: It is very easy to end in a situation where one pulls an old blueprint from
-        // somewhere, and then modifies it at runtime, therefore ending with both tagged and
-        // untagged components in the data.
-        // I'd like to keep this debug assertion a tiny bit longer just in case, so for we just
-        // ignore blueprints.
-        #[cfg(debug_assertions)]
-        if self.id.kind == re_log_types::StoreKind::Recording {
-            for (component_name, per_desc) in chunk.components().iter() {
-                assert!(
-                    per_desc.len() <= 1,
-                    "[DEBUG ONLY] Insert Chunk with multiple values for component named `{component_name}`: this is currently UB",
-                );
-            }
-        }
-
         if !chunk.is_sorted() {
             return Err(ChunkStoreError::UnsortedChunk);
         }
@@ -64,7 +49,31 @@ impl ChunkStore {
 
         self.insert_id += 1;
 
-        let non_compacted_chunk = Arc::clone(chunk); // we'll need it to create the store event
+        let mut chunk = Arc::clone(chunk);
+
+        // We're in a transition period during which the Rerun ecosystem is slowly moving over to tagged data.
+        //
+        // During that time, it is common to end up in situations where the blueprint intermixes both tagged
+        // and untagged components, which invariably leads to undefined behavior.
+        // To prevent that, we just always hot-patch it to untagged, for now.
+        //
+        // Examples:
+        // * An SDK logs a blueprint (tagged), which is then updated by the viewer (which uses untagged log calls).
+        // * Somebody loads an old .rbl from somewhere and starts logging new blueprint data to it.
+        // * Etc.
+        if self.id.kind == re_log_types::StoreKind::Blueprint {
+            chunk = Arc::new(chunk.clone_as_untagged());
+        }
+
+        #[cfg(debug_assertions)]
+        for (component_name, per_desc) in chunk.components().iter() {
+            assert!(
+                per_desc.len() <= 1,
+                "[DEBUG ONLY] Insert Chunk with multiple values for component named `{component_name}`: this is currently UB",
+            );
+        }
+
+        let non_compacted_chunk = Arc::clone(&chunk); // we'll need it to create the store event
 
         let (chunk, diffs) = if chunk.is_static() {
             // Static data: make sure to keep the most recent chunk available for each component column.
@@ -140,7 +149,7 @@ impl ChunkStore {
                     .or_insert_with(|| chunk.id());
             }
 
-            self.static_chunks_stats += ChunkStoreChunkStats::from_chunk(chunk);
+            self.static_chunks_stats += ChunkStoreChunkStats::from_chunk(&chunk);
 
             let mut diffs = vec![ChunkStoreDiff::addition(
                 non_compacted_chunk, /* added */
@@ -194,7 +203,7 @@ impl ChunkStore {
                 }
             }
 
-            (Arc::clone(chunk), diffs)
+            (Arc::clone(&chunk), diffs)
         } else {
             // Temporal data: just index the chunk on every dimension of interest.
             re_tracing::profile_scope!("temporal");
@@ -202,7 +211,7 @@ impl ChunkStore {
             let (elected_chunk, chunk_or_compacted) = {
                 re_tracing::profile_scope!("election");
 
-                let elected_chunk = self.find_and_elect_compaction_candidate(chunk);
+                let elected_chunk = self.find_and_elect_compaction_candidate(&chunk);
 
                 let chunk_or_compacted = if let Some(elected_chunk) = &elected_chunk {
                     let chunk_rowid_min = chunk.row_id_range().map(|(min, _)| min);
@@ -210,7 +219,7 @@ impl ChunkStore {
 
                     let mut compacted = if elected_rowid_min < chunk_rowid_min {
                         re_tracing::profile_scope!("concat");
-                        elected_chunk.concatenated(chunk)?
+                        elected_chunk.concatenated(&chunk)?
                     } else {
                         re_tracing::profile_scope!("concat");
                         chunk.concatenated(elected_chunk)?
@@ -233,7 +242,7 @@ impl ChunkStore {
 
                     Arc::new(compacted)
                 } else {
-                    Arc::clone(chunk)
+                    Arc::clone(&chunk)
                 };
 
                 (elected_chunk, chunk_or_compacted)


### PR DESCRIPTION
We're in a transition period during which the Rerun ecosystem is slowly moving over to tagged data.

During that time, it is common to end up in situations where the blueprint intermixes both tagged
and untagged components, which invariably leads to undefined behavior.
To prevent that, we just always hot-patch it to untagged, for now.

Examples:
* An SDK logs a blueprint (tagged), which is then updated by the viewer (which uses untagged log calls).
* Somebody loads an old .rbl from somewhere and starts logging new blueprint data to it.
* Etc.

This fixes all known blueprint bugs from the last couple days.

In the future, we will want to make sure that the viewer logs blueprint data with appropriate tags, which is part of the `log(MyArchetype.my_component())` story.
The sooner the better, so that the ecosystem can start to converge on always-tagged blueprint files.