### PR TITLE
Bump `fjadra` to `v0.2.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2455,9 +2455,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fjadra"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d17b174735bd1464bc491c49570fc824466e9140617c371de9a6d86ebd33ec"
+checksum = "c1671b620ba6e60c11c62b0ea5fec4f8621991e7b1229fa13c010a2cd04e4342"
 
 [[package]]
 name = "flatbuffers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ enumset = "1.0.12"
 env_logger = { version = "0.10", default-features = false }
 ffmpeg-sidecar = { version = "2.0.2", default-features = false }
 fixed = { version = "1.28", default-features = false }
-fjadra = "0.2"
+fjadra = "0.2.1"
 flatbuffers = "23.0"
 futures-channel = "0.3"
 futures-util = { version = "0.3", default-features = false }


### PR DESCRIPTION
### What

This provides a temporary "fix" to the integer overflows that can happen in very rare cases in `fjadra`.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
