### PR TITLE
Partial revert #8390: removal of `Area` in `zoom_pan_area`

### DIFF
--- a/crates/viewer/re_ui/src/zoom_pan_area.rs
+++ b/crates/viewer/re_ui/src/zoom_pan_area.rs
@@ -5,7 +5,7 @@
 //! * `view`-space: The space where the pan-and-zoom area is drawn.
 //! * `scene`-space: The space where the actual content is drawn.
 
-use egui::{emath::TSTransform, Area, Rect, Response, Ui, UiBuilder, UiKind};
+use egui::{emath::TSTransform, Area, Rect, Response, Ui, UiKind};
 
 /// Helper function to handle pan and zoom interactions on a response.
 fn register_pan_and_zoom(ui: &Ui, resp: &Response, ui_from_scene: &mut TSTransform) {


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337 
-->

* #8390 (partial revert)

### What

We encountered some problems with this implementation.

Discussion: https://rerunio.slack.com/archives/C04MTSM2U91/p1733921898485069

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
