### PR TITLE
Enrich ReDap Catalog with RecordingUri on the fly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5932,6 +5932,7 @@ dependencies = [
  "re_log_types",
  "re_protos",
  "re_smart_channel",
+ "re_types",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/store/re_grpc_client/Cargo.toml
+++ b/crates/store/re_grpc_client/Cargo.toml
@@ -27,6 +27,7 @@ re_log_encoding.workspace = true
 re_log_types.workspace = true
 re_protos.workspace = true
 re_smart_channel.workspace = true
+re_types.workspace = true
 
 thiserror.workspace = true
 tokio-stream.workspace = true


### PR DESCRIPTION
### What

As of right now, only the viewer is fully aware of Data Platform's endpoint, so we leverage that to enrich Catalog view with ``RecordingUri`` for each recording. 

### Testing done

```
pixi run rerun rerun://0.0.0.0:51234/catalog
```

<img width="1713" alt="Screenshot 2024-12-11 at 16 25 34" src="https://github.com/user-attachments/assets/00e21e22-cb39-4d71-93ac-ae280293e33e" />
