### PR TITLE
Fix applicability filters for bar chart & images

### DIFF
--- a/crates/store/re_chunk/src/chunk.rs
+++ b/crates/store/re_chunk/src/chunk.rs
@@ -73,6 +73,18 @@ impl ChunkComponents {
             .insert(component_desc, list_array);
     }
 
+    /// Returns the first list array for the given component name.
+    ///
+    /// It's undefined which one is returned if there are more than one component with this name.
+    #[inline]
+    pub fn get_by_component_name(
+        &self,
+        component_name: &ComponentName,
+    ) -> Option<&Arrow2ListArray<i32>> {
+        self.get(component_name)
+            .and_then(|per_desc| per_desc.values().next())
+    }
+
     #[inline]
     pub fn get_by_descriptor(
         &self,

--- a/crates/viewer/re_view/src/lib.rs
+++ b/crates/viewer/re_view/src/lib.rs
@@ -51,7 +51,7 @@ pub fn diff_component_filter<T: re_types_core::Component>(
         .diff
         .chunk
         .components()
-        .get_by_descriptor(&T::descriptor())
+        .get_by_component_name(&T::descriptor().component_name)
         .map_or(false, |list_array| {
             list_array
                 .iter()


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8423

### What

bar chart & image applicability filters were the only callers of `diff_component_filter` which broke. Couldn't find any related breakages on a quick search