### PR TITLE
Improve `VisualBounds2D` behavior in graph view

### DIFF
--- a/crates/viewer/re_view_graph/src/ui/state.rs
+++ b/crates/viewer/re_view_graph/src/ui/state.rs
@@ -1,4 +1,4 @@
-use egui::{emath::TSTransform, Rect};
+use egui::Rect;
 use re_format::format_f32;
 use re_types::blueprint::components::VisualBounds2D;
 use re_ui::UiExt;
@@ -16,7 +16,6 @@ pub struct GraphViewState {
     pub show_debug: bool,
 
     pub visual_bounds: Option<VisualBounds2D>,
-    pub ui_from_world: Option<TSTransform>,
     pub rect_in_ui: Option<Rect>,
 }
 
@@ -25,7 +24,7 @@ impl GraphViewState {
         let Some(rect) = self.layout_state.bounding_rect() else {
             return;
         };
-        ui.grid_left_hand_label("Layout")
+        ui.grid_left_hand_label("Bounding box")
             .on_hover_text("The bounding box encompassing all entities in the view right now");
         ui.vertical(|ui| {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -187,7 +187,7 @@ Display a graph of nodes and edges.
 
         let mut ui_from_world = fit_to_rect_in_scene(rect_in_ui, rect_in_scene.into());
 
-        // We store a copy o the transformation to see if it has changed.
+        // We store a copy of the transformation to see if it has changed.
         let ui_from_world_ref = ui_from_world;
 
         let resp = zoom_pan_area(ui, rect_in_ui, &mut ui_from_world, |ui| {

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -183,22 +183,14 @@ Display a graph of nodes and edges.
         let layout = state.layout_state.get(request, params);
 
         // Prepare the view and the transformations.
-        let prev_rect_in_ui = state.rect_in_ui;
         let rect_in_ui = *state.rect_in_ui.insert(ui.max_rect());
 
-        let ui_from_world = state
-            .ui_from_world
-            .get_or_insert_with(|| fit_to_rect_in_scene(rect_in_ui, rect_in_scene.into()));
+        let mut ui_from_world = fit_to_rect_in_scene(rect_in_ui, rect_in_scene.into());
 
-        // We ensure that the view's center is kept during resizing.
-        if let Some(prev) = prev_rect_in_ui {
-            if prev != rect_in_ui {
-                let delta = rect_in_ui.center() - prev.center();
-                ui_from_world.translation += delta;
-            }
-        }
+        // We store a copy o the transformation to see if it has changed.
+        let ui_from_world_ref = ui_from_world;
 
-        let resp = zoom_pan_area(ui, rect_in_ui, ui_from_world, |ui| {
+        let resp = zoom_pan_area(ui, rect_in_ui, &mut ui_from_world, |ui| {
             let mut world_bounding_rect = egui::Rect::NOTHING;
 
             for graph in &graphs {
@@ -217,8 +209,7 @@ Display a graph of nodes and edges.
             blueprint::components::VisualBounds2D::from(ui_from_world.inverse() * rect_in_ui);
         if resp.double_clicked() {
             bounds_property.reset_blueprint_component::<blueprint::components::VisualBounds2D>(ctx);
-            state.ui_from_world = None;
-        } else if rect_in_scene != updated_rect_in_scene {
+        } else if ui_from_world != ui_from_world_ref {
             bounds_property.save_blueprint_component(ctx, &updated_rect_in_scene);
         }
         // Update stored bounds on the state, so visualizers see an up-to-date value.


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* Closes #8429 

### What

This implements improved handling of `VisualBounds2D`. Specifically, it:

* Always defaults to the data bounds when user has not modified the view (@nikolausWest's suggestion).
* Zooms in and out of view when resizing the view (@abey79's suggestion).
* Fixes the `VisualBounds2D` selection panel bug (submitted by @Wumpf)

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
