### PR TITLE
Enable remote feature in all pypi builds

### DIFF
--- a/rerun_py/Cargo.toml
+++ b/rerun_py/Cargo.toml
@@ -18,11 +18,11 @@ name = "rerun_bindings" # name of the .so library that the Python module will im
 default = ["extension-module"]
 
 ## Extra features that aren't ready to be included in release builds yet.
-extra = ["pypi", "remote"]
+extra = []
 
 ## The features we turn on when building the `rerun-sdk` PyPi package
 ## for <https://pypi.org/project/rerun-sdk/>.
-pypi = ["extension-module", "nasm", "web_viewer"]
+pypi = ["extension-module", "nasm", "web_viewer", "remote"]
 
 ## We need to enable the `pyo3/extension-module` when building the SDK,
 ## but we cannot enable it when building tests and benchmarks, so we

--- a/scripts/ci/build_and_upload_wheels.py
+++ b/scripts/ci/build_and_upload_wheels.py
@@ -72,7 +72,7 @@ def build_and_upload(bucket: Bucket | None, mode: BuildMode, gcs_dir: str, targe
     elif mode is BuildMode.PR:
         maturin_feature_flags = "--no-default-features --features extension-module"
     elif mode is BuildMode.EXTRA:
-        maturin_feature_flags = "--no-default-features --features extra"
+        maturin_feature_flags = "--no-default-features --features pypi,extra"
 
     dist = f"dist/{target}"
 


### PR DESCRIPTION
### What
- Make it so `remote` is enabled in wheels for release/nightly
- Still stays off for PRs, etc, to keep build times down
- Also `pypi,extra` seemed more clear to me than `extra` implying `pypi`

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
