### PR TITLE
Add utility to `rr.components.Color` to generate colors from any string (and use it in the air traffic data example)

### DIFF
--- a/rerun_py/rerun_sdk/rerun/components/color.py
+++ b/rerun_py/rerun_sdk/rerun/components/color.py
@@ -11,11 +11,12 @@ from .._baseclasses import (
     ComponentDescriptor,
     ComponentMixin,
 )
+from .color_ext import ColorExt
 
 __all__ = ["Color", "ColorBatch"]
 
 
-class Color(datatypes.Rgba32, ComponentMixin):
+class Color(ColorExt, datatypes.Rgba32, ComponentMixin):
     """
     **Component**: An RGBA color with unmultiplied/separate alpha, in sRGB gamma space with linear alpha.
 

--- a/rerun_py/rerun_sdk/rerun/components/color_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/color_ext.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import colorsys
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from . import Color
+
+_GOLDEN_RATIO = (math.sqrt(5.0) - 1.0) / 2.0
+
+
+class ColorExt:
+    """Extension for [Color][rerun.components.Color]."""
+
+    @staticmethod
+    def from_string(s: str) -> Color:
+        """
+        Generate a random yet color based on a string.
+
+        The color is guaranteed to be identical for the same input string.
+        """
+
+        from . import Color
+
+        # adapted from egui::PlotUi
+        hue = (hash(s) & 0xFFFF) / 2**16 * _GOLDEN_RATIO
+        return Color([round(comp * 255) for comp in colorsys.hsv_to_rgb(hue, 0.85, 0.5)])

--- a/rerun_py/rerun_sdk/rerun/components/color_ext.py
+++ b/rerun_py/rerun_sdk/rerun/components/color_ext.py
@@ -16,7 +16,7 @@ class ColorExt:
     @staticmethod
     def from_string(s: str) -> Color:
         """
-        Generate a random yet color based on a string.
+        Generate a random yet deterministic color based on a string.
 
         The color is guaranteed to be identical for the same input string.
         """


### PR DESCRIPTION
### What

It's some time nice to log some color information in multiple entities to make it easier to relate them visually. This PR adds a `rr.components.Color.from_str()` utility that does exactly that: generate a nice color randomly picked up based on the provided string.

This PR also updates the air traffic data example so the barometric traces have matching colors with the map data.