### PR TITLE
Remove wait-time when opening settings panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6512,6 +6512,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "parking_lot",
+ "poll-promise",
  "re_build_info",
  "re_build_tools",
  "re_log",

--- a/crates/utils/re_video/Cargo.toml
+++ b/crates/utils/re_video/Cargo.toml
@@ -53,6 +53,7 @@ econtext.workspace = true
 itertools.workspace = true
 once_cell.workspace = true
 parking_lot.workspace = true
+poll-promise.workspace = true
 re_mp4.workspace = true
 thiserror.workspace = true
 

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/ffmpeg.rs
@@ -811,7 +811,7 @@ impl FFmpegCliH264Decoder {
 
         // Check the version once ahead of running FFmpeg.
         // The error is still handled if it happens while running FFmpeg, but it's a bit unclear if we can get it to start in the first place then.
-        match FFmpegVersion::for_executable(ffmpeg_path.as_deref()) {
+        match FFmpegVersion::for_executable_blocking(ffmpeg_path.as_deref()) {
             Ok(version) => {
                 if !version.is_compatible() {
                     return Err(Error::UnsupportedFFmpegVersion {

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
@@ -95,7 +95,7 @@ impl FFmpegVersion {
 
     /// Like [`Self::for_executable_poll`], but blocks until the version is ready.
     ///
-    /// WARNING: this blocks for half a second on Mac, maybe more on other platforms.
+    /// WARNING: this blocks for half a second on Mac the first time this is called with a given path, maybe more on other platforms.
     pub fn for_executable_blocking(path: Option<&std::path::Path>) -> FfmpegVersionResult {
         re_tracing::profile_function!();
 

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
@@ -82,8 +82,8 @@ impl FFmpegVersion {
     ///
     /// Internally caches the result per path together with its modification time to re-run/parse the version only if the file has changed.
     pub fn for_executable(path: Option<&std::path::Path>) -> FfmpegVersionResult {
-        static CACHE: Lazy<Arc<Mutex<VersionMap>>> =
-            Lazy::new(|| Arc::new(Mutex::new(VersionMap::default())));
+        static CACHE: Lazy<Mutex<VersionMap>> =
+            Lazy::new(|| Mutex::new(VersionMap::default()));
 
         re_tracing::profile_function!();
 

--- a/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
+++ b/crates/utils/re_video/src/decode/ffmpeg_h264/version.rs
@@ -93,7 +93,7 @@ impl FFmpegVersion {
         })
     }
 
-    /// Like [`for_executable_polling`], but blocks until the version is ready.
+    /// Like [`Self::for_executable_poll`], but blocks until the version is ready.
     ///
     /// WARNING: this blocks for half a second on Mac, maybe more on other platforms.
     pub fn for_executable_blocking(path: Option<&std::path::Path>) -> FfmpegVersionResult {


### PR DESCRIPTION
### Related
* Closes https://github.com/rerun-io/rerun/issues/8263

### What
I couldn't stand the half-second delay when opening the options screen. Rerun needs to feel snappy!

Gettings the ffmpeg version is now done on a background thread, showing s spinner until it is done.

Unfortunately we still have to wait for ffmpeg when starting up an H.264 video on native. We could fix that by pre-warming the cache though 🤔 