### PR TITLE
Add `MainThreadToken` to ensure file-dialogs only run on the main thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5593,6 +5593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "re_capabilities"
+version = "0.21.0-alpha.1+dev"
+dependencies = [
+ "document-features",
+ "egui",
+ "static_assertions",
+]
+
+[[package]]
 name = "re_case"
 version = "0.21.0-alpha.1+dev"
 dependencies = [
@@ -5788,6 +5797,7 @@ dependencies = [
  "image",
  "itertools 0.13.0",
  "nohash-hasher",
+ "re_capabilities",
  "re_chunk_store",
  "re_entity_db",
  "re_format",
@@ -6785,6 +6795,7 @@ dependencies = [
  "re_blueprint_tree",
  "re_build_info",
  "re_build_tools",
+ "re_capabilities",
  "re_chunk",
  "re_chunk_store",
  "re_chunk_store_ui",
@@ -6866,6 +6877,7 @@ dependencies = [
  "nohash-hasher",
  "once_cell",
  "parking_lot",
+ "re_capabilities",
  "re_chunk",
  "re_chunk_store",
  "re_data_source",
@@ -7166,6 +7178,7 @@ dependencies = [
  "re_analytics",
  "re_build_info",
  "re_build_tools",
+ "re_capabilities",
  "re_chunk",
  "re_chunk_store",
  "re_crash_handler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rerun-cli = { path = "crates/top/rerun-cli", version = "=0.21.0-alpha.1", defaul
 
 # crates/utils:
 re_analytics = { path = "crates/utils/re_analytics", version = "=0.21.0-alpha.1", default-features = false }
+re_capabilities = { path = "crates/utils/re_capabilities", version = "=0.21.0-alpha.1", default-features = false }
 re_case = { path = "crates/utils/re_case", version = "=0.21.0-alpha.1", default-features = false }
 re_crash_handler = { path = "crates/utils/re_crash_handler", version = "=0.21.0-alpha.1", default-features = false }
 re_error = { path = "crates/utils/re_error", version = "=0.21.0-alpha.1", default-features = false }

--- a/crates/top/rerun-cli/src/bin/rerun.rs
+++ b/crates/top/rerun-cli/src/bin/rerun.rs
@@ -28,11 +28,17 @@ fn main() -> std::process::ExitCode {
 }
 
 fn main_impl() -> std::process::ExitCode {
+    let main_thread_token = rerun::MainThreadToken::i_promise_i_am_on_the_main_thread();
     re_log::setup_logging();
 
     let build_info = re_build_info::build_info!();
 
-    let result = rerun::run(build_info, rerun::CallSource::Cli, std::env::args());
+    let result = rerun::run(
+        main_thread_token,
+        build_info,
+        rerun::CallSource::Cli,
+        std::env::args(),
+    );
 
     match result {
         Ok(exit_code) => std::process::ExitCode::from(exit_code),

--- a/crates/top/rerun/Cargo.toml
+++ b/crates/top/rerun/Cargo.toml
@@ -124,6 +124,7 @@ web_viewer = ["server", "dep:re_web_viewer_server", "re_sdk?/web_viewer"]
 
 [dependencies]
 re_build_info.workspace = true
+re_capabilities.workspace = true
 re_chunk.workspace = true
 re_crash_handler.workspace = true
 re_entity_db.workspace = true
@@ -131,11 +132,11 @@ re_error.workspace = true
 re_format.workspace = true
 re_log_encoding.workspace = true
 re_log_types.workspace = true
-re_video.workspace = true
 re_log.workspace = true
 re_memory.workspace = true
 re_smart_channel.workspace = true
 re_tracing.workspace = true
+re_video.workspace = true
 
 anyhow.workspace = true
 document-features.workspace = true

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -539,6 +539,7 @@ enum Command {
 // It would be nice to use [`std::process::ExitCode`] here but
 // then there's no good way to get back at the exit code from python
 pub fn run<I, T>(
+    main_thread_token: crate::MainThreadToken,
     build_info: re_build_info::BuildInfo,
     call_source: CallSource,
     args: I,
@@ -595,7 +596,7 @@ where
             }
         }
     } else {
-        run_impl(build_info, call_source, args)
+        run_impl(main_thread_token, build_info, call_source, args)
     };
 
     match res {
@@ -620,6 +621,7 @@ where
 }
 
 fn run_impl(
+    main_thread_token: crate::MainThreadToken,
     _build_info: re_build_info::BuildInfo,
     call_source: CallSource,
     args: Args,
@@ -836,8 +838,10 @@ fn run_impl(
     } else {
         #[cfg(feature = "native_viewer")]
         return re_viewer::run_native_app(
+            main_thread_token,
             Box::new(move |cc| {
                 let mut app = re_viewer::App::new(
+                    main_thread_token,
                     _build_info,
                     &call_source.app_env(),
                     startup_options,

--- a/crates/top/rerun/src/lib.rs
+++ b/crates/top/rerun/src/lib.rs
@@ -151,6 +151,8 @@ pub use re_entity_db::external::re_chunk_store::{
 };
 pub use re_log_types::StoreKind;
 
+pub use re_capabilities::MainThreadToken;
+
 /// To register a new external data loader, simply add an executable in your $PATH whose name
 /// starts with this prefix.
 // NOTE: this constant is duplicated in `re_data_source` to avoid an extra dependency here.

--- a/crates/top/rerun/src/native_viewer.rs
+++ b/crates/top/rerun/src/native_viewer.rs
@@ -5,7 +5,10 @@ use re_log_types::LogMsg;
 ///
 /// ⚠️  This function must be called from the main thread since some platforms require that
 /// their UI runs on the main thread! ⚠️
-pub fn show(msgs: Vec<LogMsg>) -> re_viewer::external::eframe::Result {
+pub fn show(
+    main_thread_token: crate::MainThreadToken,
+    msgs: Vec<LogMsg>,
+) -> re_viewer::external::eframe::Result {
     if msgs.is_empty() {
         re_log::debug!("Empty array of msgs - call to show() ignored");
         return Ok(());
@@ -18,6 +21,7 @@ pub fn show(msgs: Vec<LogMsg>) -> re_viewer::external::eframe::Result {
 
     let startup_options = re_viewer::StartupOptions::default();
     re_viewer::run_native_viewer_with_messages(
+        main_thread_token,
         re_build_info::build_info!(),
         re_viewer::AppEnvironment::from_store_source(&store_source),
         startup_options,

--- a/crates/utils/re_capabilities/Cargo.toml
+++ b/crates/utils/re_capabilities/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "re_capabilities"
+authors.workspace = true
+description = "Capability tokens for the Rerun code base."
+edition.workspace = true
+homepage.workspace = true
+include.workspace = true
+license.workspace = true
+publish = true
+readme = "README.md"
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+
+
+[features]
+default = []
+
+## Enable constructing the [`MainThreadToken`] from an [`egui::Ui`].
+egui = ["dep:egui"]
+
+
+[dependencies]
+# Internal dependencies:
+
+# External dependencies:
+document-features.workspace = true
+egui = { workspace = true, default-features = false, optional = true }
+static_assertions.workspace = true

--- a/crates/utils/re_capabilities/README.md
+++ b/crates/utils/re_capabilities/README.md
@@ -1,0 +1,11 @@
+# re_capabilities
+
+Part of the [`rerun`](https://github.com/rerun-io/rerun) family of crates.
+
+[![Latest version](https://img.shields.io/crates/v/re_capabilities.svg)](https://crates.io/crates/utils/re_capabilities)
+[![Documentation](https://docs.rs/re_capabilities/badge.svg)](https://docs.rs/re_capabilities)
+![MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+![Apache](https://img.shields.io/badge/license-Apache-blue.svg)
+
+Specifies capability tokens, required by different parts of the code base.
+These are tokens passed down the call tree, to explicitly allow different capabilities in different parts of the code base.

--- a/crates/utils/re_capabilities/src/lib.rs
+++ b/crates/utils/re_capabilities/src/lib.rs
@@ -1,0 +1,19 @@
+//! Specifies capability tokens, required by different parts of the code base.
+//! These are tokens passed down the call tree, to explicitly allow different capabilities in different parts of the code base.
+//!
+//! For instance, the [`MainThreadToken`] is taken by argument in functions that needs to run on the main thread.
+//! By requiring this token, you guarantee at compile-time that the function is only called on the main thread.
+//!
+//! All capability tokens should be created in the top-level of the call tree,
+//! (i.e. in `fn main`) and passed down to all functions that require it.
+//! That way you can be certain in what an area of code is allowed to do.
+//!
+//! See [`cap-std`](https://crates.io/crates/cap-std) for another capability-centric crate.
+//!
+//! ## Feature flags
+#![doc = document_features::document_features!()]
+//!
+
+mod main_thread_token;
+
+pub use main_thread_token::MainThreadToken;

--- a/crates/utils/re_capabilities/src/main_thread_token.rs
+++ b/crates/utils/re_capabilities/src/main_thread_token.rs
@@ -1,0 +1,53 @@
+use static_assertions::assert_not_impl_any;
+
+/// A token that proves we are on the main thread.
+///
+/// Certain operations are only allowed on the main thread.
+/// These operations should require this token.
+/// For instance, any function using file dialogs (e.g. using [`rfd`](https://docs.rs/rfd/latest/rfd/)) should require this token.
+///
+/// The token should only be constructed in `fn main`, using [`MainThreadToken::i_promise_i_am_on_the_main_thread`],
+/// and then be passed down the call tree to where it is needed.
+/// [`MainTheadToken`] is neither `Send` nor `Sync`,
+/// thus guaranteeing that it cannot be found in other threads.
+///
+/// Of course, there is nothing stopping you from calling [`MainThreadToken::i_promise_i_am_on_the_main_thread`] from a background thread,
+/// but PLEASE DON'T DO THAT.
+/// In other words, don't use this as a guarantee for unsafe code.
+///
+/// There is also [`MainThreadToken::from_egui_ui`] which uses the implicit guarantee of egui
+/// (which _usually_ is run on the main thread) to construct a [`MainThreadToken`].
+/// Use this only in a code base where you are sure that egui is running only on the main thread.
+#[derive(Clone, Copy)]
+pub struct MainThreadToken {
+    /// Prevent from being sent between threads.
+    ///
+    /// Workaround until `impl !Send for X {}` is stable.
+    _dont_send_me: std::marker::PhantomData<*const ()>,
+}
+
+impl MainThreadToken {
+    /// Only call this from `fn main`, or you may get weird runtime errors!
+    pub fn i_promise_i_am_on_the_main_thread() -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        debug_assert_eq!(std::thread::current().name(), Some("main"),
+            "DEBUG ASSERT: Trying to construct a MainThreadToken on a thread that is not the main thread!"
+        );
+
+        Self {
+            _dont_send_me: std::marker::PhantomData,
+        }
+    }
+
+    /// We should only create an `egui::Ui` on the main thread,
+    /// so having it is proof enough that we are on the main thread.
+    ///
+    /// Use this only in a code base where you are sure that egui is running only on the main thread.
+    #[cfg(feature = "egui")]
+    pub fn from_egui_ui(_ui: &egui::Ui) -> Self {
+        Self::i_promise_i_am_on_the_main_thread()
+    }
+}
+
+assert_not_impl_any!(MainThreadToken: Send, Sync);
+assert_not_impl_any!(&MainThreadToken: Send, Sync);

--- a/crates/viewer/re_data_ui/Cargo.toml
+++ b/crates/viewer/re_data_ui/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_capabilities = { workspace = true, features = ["egui"] }
 re_chunk_store.workspace = true
 re_entity_db.workspace = true
 re_format.workspace = true

--- a/crates/viewer/re_data_ui/src/blob.rs
+++ b/crates/viewer/re_data_ui/src/blob.rs
@@ -156,6 +156,7 @@ pub fn blob_preview_and_save_ui(
                 }
 
                 ctx.command_sender.save_file_dialog(
+                    re_capabilities::MainThreadToken::from_egui_ui(ui),
                     &file_name,
                     "Save blob".to_owned(),
                     blob.to_vec(),

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -389,8 +389,12 @@ fn image_download_button_ui(
                         .map_or("image", |name| name.unescaped_str())
                         .to_owned()
                 );
-                ctx.command_sender
-                    .save_file_dialog(&file_name, "Save image".to_owned(), png_bytes);
+                ctx.command_sender.save_file_dialog(
+                    re_capabilities::MainThreadToken::from_egui_ui(ui),
+                    &file_name,
+                    "Save image".to_owned(),
+                    png_bytes,
+                );
             }
             Err(err) => {
                 re_log::error!("{err}");

--- a/crates/viewer/re_viewer/Cargo.toml
+++ b/crates/viewer/re_viewer/Cargo.toml
@@ -48,6 +48,7 @@ grpc = ["re_data_source/grpc", "dep:re_grpc_client"]
 # Internal:
 re_blueprint_tree.workspace = true
 re_build_info.workspace = true
+re_capabilities.workspace = true
 re_chunk.workspace = true
 re_chunk_store.workspace = true
 re_component_ui.workspace = true

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use itertools::Itertools as _;
 
+use re_capabilities::MainThreadToken;
 use re_build_info::CrateVersion;
 use re_data_source::{DataSource, FileContents};
 use re_entity_db::entity_db::EntityDb;
@@ -158,6 +159,8 @@ struct PendingFilePromise {
 
 /// The Rerun Viewer as an [`eframe`] application.
 pub struct App {
+    #[allow(dead_code)] // Unused on wasm32
+    main_thread_token: MainThreadToken,
     build_info: re_build_info::BuildInfo,
     startup_options: StartupOptions,
     start_time: web_time::Instant,
@@ -222,6 +225,7 @@ pub struct App {
 impl App {
     /// Create a viewer that receives new log messages over time
     pub fn new(
+        main_thread_token: MainThreadToken,
         build_info: re_build_info::BuildInfo,
         app_env: &crate::AppEnvironment,
         startup_options: StartupOptions,
@@ -304,6 +308,7 @@ impl App {
         });
 
         Self {
+            main_thread_token,
             build_info,
             startup_options,
             start_time: web_time::Instant::now(),
@@ -645,7 +650,7 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Open => {
-                for file_path in open_file_dialog_native() {
+                for file_path in open_file_dialog_native(self.main_thread_token) {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
                             FileSource::FileDialog {
@@ -677,7 +682,7 @@ impl App {
 
             #[cfg(not(target_arch = "wasm32"))]
             UICommand::Import => {
-                for file_path in open_file_dialog_native() {
+                for file_path in open_file_dialog_native(self.main_thread_token) {
                     self.command_sender
                         .send_system(SystemCommand::LoadDataSource(DataSource::FilePath(
                             FileSource::FileDialog {
@@ -1648,6 +1653,7 @@ impl App {
                     } else {
                         let file_name = format!("{name}.png");
                         self.command_sender.save_file_dialog(
+                            self.main_thread_token,
                             &file_name,
                             "Save screenshot".to_owned(),
                             png_bytes,
@@ -1683,11 +1689,7 @@ fn blueprint_loader() -> BlueprintPersistence {
 
         re_log::debug!("Trying to load blueprint for {app_id} from {blueprint_path:?}");
 
-        let with_notifications = false;
-
-        if let Some(bundle) =
-            crate::loading::load_blueprint_file(&blueprint_path, with_notifications)
-        {
+        if let Some(bundle) = crate::loading::load_blueprint_file(&blueprint_path) {
             for store in bundle.entity_dbs() {
                 if store.store_kind() == StoreKind::Blueprint
                     && !crate::blueprint::is_valid_blueprint(store)
@@ -2092,8 +2094,9 @@ fn file_saver_progress_ui(egui_ctx: &egui::Context, background_tasks: &mut Backg
     }
 }
 
+/// [This may only be called on the main thread](https://docs.rs/rfd/latest/rfd/#macos-non-windowed-applications-async-and-threading).
 #[cfg(not(target_arch = "wasm32"))]
-fn open_file_dialog_native() -> Vec<std::path::PathBuf> {
+fn open_file_dialog_native(_: crate::MainThreadToken) -> Vec<std::path::PathBuf> {
     re_tracing::profile_function!();
 
     let supported: Vec<_> = if re_data_loader::iter_external_loaders().len() == 0 {

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -30,6 +30,8 @@ pub(crate) use {app_state::AppState, ui::memory_panel};
 
 pub use app::{App, StartupOptions};
 
+pub use re_capabilities::MainThreadToken;
+
 pub mod external {
     pub use {eframe, egui};
     pub use {

--- a/crates/viewer/re_viewer/src/loading.rs
+++ b/crates/viewer/re_viewer/src/loading.rs
@@ -13,10 +13,7 @@ enum BlueprintLoadError {
 ///
 /// The file must be of a matching version of rerun.
 #[must_use]
-pub fn load_blueprint_file(
-    path: &std::path::Path,
-    with_notifications: bool,
-) -> Option<StoreBundle> {
+pub fn load_blueprint_file(path: &std::path::Path) -> Option<StoreBundle> {
     fn load_file_path_impl(path: &std::path::Path) -> Result<StoreBundle, BlueprintLoadError> {
         re_tracing::profile_function!();
 
@@ -32,10 +29,6 @@ pub fn load_blueprint_file(
 
     match load_file_path_impl(path) {
         Ok(mut rrd) => {
-            if with_notifications {
-                re_log::info!("Loaded {path:?}");
-            }
-
             for entity_db in rrd.entity_dbs_mut() {
                 entity_db.data_source =
                     Some(re_smart_channel::SmartChannelSource::File(path.into()));
@@ -45,16 +38,9 @@ pub fn load_blueprint_file(
         Err(err) => {
             let msg = format!("Failed loading {path:?}: {err}");
 
-            if with_notifications {
-                re_log::error!("{msg}");
-                rfd::MessageDialog::new()
-                    .set_level(rfd::MessageLevel::Error)
-                    .set_description(&msg)
-                    .show();
-            } else {
-                // Silently ignore
-                re_log::debug!("{msg}");
-            }
+            // Silently ignore
+            re_log::debug!("{msg}");
+
             None
         }
     }

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -1,3 +1,4 @@
+use re_capabilities::MainThreadToken;
 use re_log_types::LogMsg;
 
 /// Used by `eframe` to decide where to store the app state.
@@ -7,6 +8,8 @@ type AppCreator = Box<dyn FnOnce(&eframe::CreationContext<'_>) -> Box<dyn eframe
 
 // NOTE: the name of this function is hard-coded in `crates/top/rerun/src/crash_handler.rs`!
 pub fn run_native_app(
+    // `eframe::run_native` may only be called on the main thread.
+    _: crate::MainThreadToken,
     app_creator: AppCreator,
     force_wgpu_backend: Option<String>,
 ) -> eframe::Result {
@@ -79,6 +82,7 @@ fn icon_data() -> egui::IconData {
 }
 
 pub fn run_native_viewer_with_messages(
+    main_thread_token: MainThreadToken,
     build_info: re_build_info::BuildInfo,
     app_env: crate::AppEnvironment,
     startup_options: crate::StartupOptions,
@@ -94,8 +98,10 @@ pub fn run_native_viewer_with_messages(
 
     let force_wgpu_backend = startup_options.force_wgpu_backend.clone();
     run_native_app(
+        main_thread_token,
         Box::new(move |cc| {
             let mut app = crate::App::new(
+                main_thread_token,
                 build_info,
                 &app_env,
                 startup_options,

--- a/crates/viewer/re_viewer_context/Cargo.toml
+++ b/crates/viewer/re_viewer_context/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 all-features = true
 
 [dependencies]
+re_capabilities.workspace = true
 re_chunk_store.workspace = true
 re_chunk.workspace = true
 re_data_source.workspace = true

--- a/crates/viewer/re_viewer_context/src/file_dialog.rs
+++ b/crates/viewer/re_viewer_context/src/file_dialog.rs
@@ -11,8 +11,16 @@ pub fn santitize_file_name(file_name: &str) -> String {
 
 impl CommandSender {
     /// Save some bytes to disk, after first showing a save dialog.
+    ///
+    /// [This may only be called on the main thread](https://docs.rs/rfd/latest/rfd/#macos-non-windowed-applications-async-and-threading).
     #[allow(clippy::unused_self)] // Not used on Wasm
-    pub fn save_file_dialog(&self, file_name: &str, title: String, data: Vec<u8>) {
+    pub fn save_file_dialog(
+        &self,
+        _: re_capabilities::MainThreadToken,
+        file_name: &str,
+        title: String,
+        data: Vec<u8>,
+    ) {
         re_tracing::profile_function!();
 
         let file_name = santitize_file_name(file_name);

--- a/examples/rust/custom_data_loader/src/main.rs
+++ b/examples/rust/custom_data_loader/src/main.rs
@@ -13,13 +13,19 @@ use rerun::{
 };
 
 fn main() -> anyhow::Result<std::process::ExitCode> {
+    let main_thread_token = rerun::MainThreadToken::i_promise_i_am_on_the_main_thread();
     re_log::setup_logging();
 
     re_data_loader::register_custom_data_loader(HashLoader);
 
     let build_info = re_build_info::build_info!();
-    rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
-        .map(std::process::ExitCode::from)
+    rerun::run(
+        main_thread_token,
+        build_info,
+        rerun::CallSource::Cli,
+        std::env::args(),
+    )
+    .map(std::process::ExitCode::from)
 }
 
 // ---

--- a/examples/rust/custom_store_subscriber/src/main.rs
+++ b/examples/rust/custom_store_subscriber/src/main.rs
@@ -8,7 +8,7 @@
 //!
 //! # Log any kind of data from another terminal:
 //! $ cargo r -p objectron -- --connect
-//! ```
+//! ````
 
 use std::collections::BTreeMap;
 
@@ -19,14 +19,20 @@ use rerun::{
 };
 
 fn main() -> anyhow::Result<std::process::ExitCode> {
+    let main_thread_token = rerun::MainThreadToken::i_promise_i_am_on_the_main_thread();
     re_log::setup_logging();
 
     let _handle = re_chunk_store::ChunkStore::register_subscriber(Box::<Orchestrator>::default());
     // Could use the returned handle to get a reference to the view if needed.
 
     let build_info = re_build_info::build_info!();
-    rerun::run(build_info, rerun::CallSource::Cli, std::env::args())
-        .map(std::process::ExitCode::from)
+    rerun::run(
+        main_thread_token,
+        build_info,
+        rerun::CallSource::Cli,
+        std::env::args(),
+    )
+    .map(std::process::ExitCode::from)
 }
 
 // ---

--- a/examples/rust/custom_view/src/main.rs
+++ b/examples/rust/custom_view/src/main.rs
@@ -13,6 +13,8 @@ static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
     re_memory::AccountingAllocator::new(mimalloc::MiMalloc);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let main_thread_token = re_viewer::MainThreadToken::i_promise_i_am_on_the_main_thread();
+
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
     re_log::setup_logging();
 
@@ -41,6 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     re_viewer::run_native_app(
         Box::new(move |cc| {
             let mut app = re_viewer::App::new(
+                main_thread_token,
                 re_viewer::build_info(),
                 &app_env,
                 startup_options,

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -12,6 +12,8 @@ static GLOBAL: re_memory::AccountingAllocator<mimalloc::MiMalloc> =
     re_memory::AccountingAllocator::new(mimalloc::MiMalloc);
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let main_thread_token = re_viewer::MainThreadToken::i_promise_i_am_on_the_main_thread();
+
     // Direct calls using the `log` crate to stderr. Control with `RUST_LOG=debug` etc.
     re_log::setup_logging();
 
@@ -45,6 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             re_viewer::customize_eframe_and_setup_renderer(cc)?;
 
             let mut rerun_app = re_viewer::App::new(
+                main_thread_token,
                 re_viewer::build_info(),
                 &app_env,
                 startup_options,


### PR DESCRIPTION
### What

We have a foot-gun in our code: our file dialogs (via `rfd`) [are only allowed to be run from the main thread (at least on Mac)](https://docs.rs/rfd/latest/rfd/#macos-non-windowed-applications-async-and-threading).
However, there is nothing stopping a user from accidentally calling these functions from a background thread, and if you test it on e.g. Linux, it may very well work.

So this PR introduces a new crate `re_capabilities` and a new type `MainThreadToken`. Any function that uses `rfd` should require the `MainThreadToken` as an argument. The `MainThreadToken` is only allowed to be created in `fn main`, and since it is neither `Send` nor `Sync`, this guarantees at compile-time that any functions that take a `MainThreadToken` can only be called from the main thread.

NOTE: I have no way to enforce that all uses of `rfd` also require `MainThreadToken` - we need to remember this ourselves, but I've made sure that all our _current_ uses of `rfd` require a `MainThreadToken`.