### PR TITLE
Attempt to fix `StorageNodeClient.query_catalog(…)` signature mismatch

### DIFF
--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -81,7 +81,7 @@ pub struct PyStorageNodeClient {
 
 #[pymethods]
 impl PyStorageNodeClient {
-    /// Query the recordings metadata catalog.
+    /// Get the metadata for all recordings in the storage node.
     fn query_catalog(&mut self) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
         let reader = self.runtime.block_on(async {
             // TODO(jleibs): Support column projection and filtering


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

CI is failing on `nightly`: https://github.com/rerun-io/rerun/actions/runs/12335447188/job/34427482723

### What

Seems to be a mismatch between doc strings.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
