### PR TITLE
Fix single-click and double-click in the graph view

### DIFF
--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -7,7 +7,6 @@ use egui::{
 use re_chunk::EntityPath;
 use re_data_ui::{item_ui, DataUi as _};
 use re_entity_db::InstancePath;
-use re_log_types::Instance;
 use re_types::ArrowString;
 use re_ui::list_item;
 use re_viewer_context::{

--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -7,6 +7,7 @@ use egui::{
 use re_chunk::EntityPath;
 use re_data_ui::{item_ui, DataUi as _};
 use re_entity_db::InstancePath;
+use re_log_types::Instance;
 use re_types::ArrowString;
 use re_ui::list_item;
 use re_viewer_context::{
@@ -298,11 +299,6 @@ pub fn draw_graph(
 
                 let instance_path =
                     InstancePath::instance(entity_path.clone(), instance.instance_index);
-                ctx.handle_select_hover_drag_interactions(
-                    &response,
-                    Item::DataResult(query.view_id, instance_path.clone()),
-                    false,
-                );
 
                 response = response.on_hover_ui_at_pointer(|ui| {
                     list_item::list_item_scope(ui, "graph_node_hover", |ui| {
@@ -318,6 +314,21 @@ pub fn draw_graph(
                         instance_path.data_ui_recording(ctx, ui, UiLayout::Tooltip);
                     });
                 });
+
+                ctx.handle_select_hover_drag_interactions(
+                    &response,
+                    Item::DataResult(query.view_id, instance_path.clone()),
+                    false,
+                );
+
+                // double click selects the entire entity
+                if response.double_clicked() {
+                    // Select the entire entity
+                    ctx.selection_state().set_selection(Item::DataResult(
+                        query.view_id,
+                        instance_path.entity_path.clone().into(),
+                    ));
+                }
 
                 response
             }

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -19,7 +19,7 @@ use re_view::{
     view_property_ui,
 };
 use re_viewer_context::{
-    IdentifiedViewSystem as _, RecommendedView, SystemExecutionOutput, ViewClass,
+    IdentifiedViewSystem as _, Item, RecommendedView, SystemExecutionOutput, ViewClass,
     ViewClassLayoutPriority, ViewClassRegistryError, ViewId, ViewQuery, ViewSpawnHeuristics,
     ViewState, ViewStateExt as _, ViewSystemExecutionError, ViewSystemRegistrator, ViewerContext,
 };
@@ -203,6 +203,12 @@ Display a graph of nodes and edges.
                 draw_debug(ui, world_bounding_rect);
             }
         });
+
+        if resp.clicked() {
+            // clicked elsewhere, select the view
+            ctx.selection_state()
+                .set_selection(Item::View(query.view_id));
+        }
 
         // Update blueprint if changed
         let updated_rect_in_scene =


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* Closes #8437
* Closes #8442

### What

This implements:
* Single-click on empty space to select view.
* Double-click on node to select entire entity.

Merging @emilk's recent changes (#8469 and #8457) seems to have fixed the flickering on selection too.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
