### PR TITLE
Add `grtlr` to list of `OFFICIAL_RERUN_DEVS`

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -29,6 +29,7 @@ OFFICIAL_RERUN_DEVS = [
     "abey79",
     "emilk",
     "gavrelina",
+    "grtlr",
     "jleibs",
     "jprochazk",
     "nikolausWest",


### PR DESCRIPTION
### What

Makes the `CHANGELOG.md` less verbose. Should be merged _**after**_ `v0.21.0`.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
