### PR TITLE
Fix context menu release checklist formatting and casing of the `Hide/Show all` item

### DIFF
--- a/crates/viewer/re_context_menu/src/actions/show_hide.rs
+++ b/crates/viewer/re_context_menu/src/actions/show_hide.rs
@@ -26,7 +26,7 @@ impl ContextMenuAction for ShowAction {
 
     fn label(&self, ctx: &ContextMenuContext<'_>) -> String {
         if ctx.selection.len() > 1 {
-            "Show All".to_owned()
+            "Show all".to_owned()
         } else {
             "Show".to_owned()
         }
@@ -80,7 +80,7 @@ impl ContextMenuAction for HideAction {
 
     fn label(&self, ctx: &ContextMenuContext<'_>) -> String {
         if ctx.selection.len() > 1 {
-            "Hide All".to_owned()
+            "Hide all".to_owned()
         } else {
             "Hide".to_owned()
         }

--- a/tests/python/release_checklist/check_context_menu_multi_selection.py
+++ b/tests/python/release_checklist/check_context_menu_multi_selection.py
@@ -17,7 +17,7 @@ For each of the multi-selection below, check the context menu content as per the
 ==========================================================
 ITEMS                               CONTEXT MENU CONTENT
 ==========================================================
-2x Views                      Hide all
+2x Views                            Hide all
                                     Remove
 
                                     Expand all
@@ -38,7 +38,7 @@ ITEMS                               CONTEXT MENU CONTENT
                                     Expand all
                                     Collapse all
 ==========================================================
-View + 'box2d' data result    Hide all
+View + 'box2d' data result          Hide all
                                     Remove
 
                                     Expand all

--- a/tests/python/release_checklist/check_context_menu_single_selection.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection.py
@@ -42,8 +42,11 @@ Component                 <no action available>
 =================================================
 ITEM                      CONTEXT MENU CONTENT
 =================================================
-view (tab title)    Hide
+view (tab title)          Hide
                           Remove
+
+                          Copy screenshot
+                          Save screenshot…
 
                           Expand all
                           Collapse all
@@ -66,8 +69,11 @@ view (tab title)    Hide
 =================================================
 ITEM                      CONTEXT MENU CONTENT
 =================================================
-view (child list)   Hide
+view (child list)         Hide
                           Remove
+
+                          Copy screenshot
+                          Save screenshot…
 
                           Expand all
                           Collapse all

--- a/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
+++ b/tests/python/release_checklist/check_context_menu_single_selection_blueprint_tree.py
@@ -37,8 +37,11 @@ Container                  Hide (or Show, depending on visibility)
 
                            Move to new container
 ------------------------------------------------------------------
-View                 Hide (or Show, depending on visibility)
+View                       Hide (or Show, depending on visibility)
                            Remove
+
+                           Copy screenshot
+                           Save screenshot…
 
                            Expand all
                            Collapse all


### PR DESCRIPTION
### What

☝🏻 title. Formatting glitches were introduced in the "space view rename"