### PR TITLE
Add missing click and hover interactions for views

### DIFF
--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -206,6 +206,10 @@ Display a graph of nodes and edges.
             }
         });
 
+        if resp.hovered() {
+            ctx.selection_state().set_hovered(Item::View(query.view_id));
+        }
+
         if resp.clicked() {
             // clicked elsewhere, select the view
             ctx.selection_state()

--- a/crates/viewer/re_view_map/src/map_view.rs
+++ b/crates/viewer/re_view_map/src/map_view.rs
@@ -499,6 +499,8 @@ fn handle_ui_interactions(
         // clicked elsewhere, select the view
         ctx.selection_state()
             .set_selection(Item::View(query.view_id));
+    } else if map_response.hovered() {
+        ctx.selection_state().set_hovered(Item::View(query.view_id));
     }
 }
 

--- a/tests/python/release_checklist/check_hover_select_reset.py
+++ b/tests/python/release_checklist/check_hover_select_reset.py
@@ -94,6 +94,10 @@ def log_graph() -> None:
     rr.log("graph", rr.GraphNodes(["a", "b"], labels=["A", "B"]))
 
 
+def log_map() -> None:
+    rr.log("points", rr.GeoPoints(lat_lon=[[47.6344, 19.1397], [47.6334, 19.1399]], radii=rr.Radius.ui_points(20.0)))
+
+
 def run(args: Namespace) -> None:
     rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
 
@@ -102,6 +106,7 @@ def run(args: Namespace) -> None:
     log_points_3d()
     log_points_2d()
     log_graph()
+    log_map()
 
 
 if __name__ == "__main__":

--- a/tests/python/release_checklist/check_hover_select_reset.py
+++ b/tests/python/release_checklist/check_hover_select_reset.py
@@ -29,6 +29,13 @@ For each of the views:
     * If you think this is unexpected, create an issue.
     * Double-click the entity and verify that it becomes selected and highlighted in the blueprint tree.
 
+### Graph Select
+Should work just as 2D/3D views.
+
+### Text view
+Clicking on a text view (what you're reading right now) should select the view.
+Hovering the view should work as well.
+
 ### Reset
 For each of the views:
 * Zoom and/or pan the view
@@ -83,6 +90,10 @@ def log_points_2d() -> None:
     rr.log("2D/points", rr.Points2D(positions, colors=colors, radii=radii))
 
 
+def log_graph() -> None:
+    rr.log("graph", rr.GraphNodes(["a", "b"], labels=["A", "B"]))
+
+
 def run(args: Namespace) -> None:
     rr.script_setup(args, f"{os.path.basename(__file__)}", recording_id=uuid4())
 
@@ -90,6 +101,7 @@ def run(args: Namespace) -> None:
     log_plots()
     log_points_3d()
     log_points_2d()
+    log_graph()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* Closes #8479
* Closes #5138

### What

This adds missing view interactions the following views:

* Map view
* Graph view
* TextDocument view

@Wumpf @abey79 I feel like the pattern repeats itself and it's easy to miss when writing new views. So I wonder if this could be unified. I see several options for this:

* repurpose `handle_select_hover_drag_interactions` which only seems to be used for `DataResult` right now
* Making each view return a `Result<(Response, ViewSystemExecutionError>` (instead of `()`) and handling it outside of the view.
* Creating a function analogous to `handle_select_hover_drag_interactions`.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
