### PR TITLE
Update egui to the commit before 0.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1951,7 +1951,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2007,7 +2007,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2068,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "ahash",
  "egui",
@@ -2085,7 +2085,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2102,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "dify",
  "egui",
@@ -2171,7 +2171,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2306,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.29.1"
-source = "git+https://github.com/emilk/egui.git?rev=0823a36952a6791a0e28e6e8eac4f35639ab3091#0823a36952a6791a0e28e6e8eac4f35639ab3091"
+source = "git+https://github.com/emilk/egui.git?rev=0fb340fe89e9476b2fec15c2eff1405e51e5c04e#0fb340fe89e9476b2fec15c2eff1405e51e5c04e"
 
 [[package]]
 name = "equivalent"
@@ -3731,7 +3731,8 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 [[package]]
 name = "kittest"
 version = "0.1.0"
-source = "git+https://github.com/rerun-io/kittest?branch=main#06e01f17fed36a997e1541f37b2d47e3771d7533"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f659954571a3c132356bd15c25f0dcf14d270a28ec5c58797adc2f432831bed5"
 dependencies = [
  "accesskit",
  "accesskit_consumer 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -554,13 +554,13 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }       # egui master 2024-12-16 15:08
-eframe = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }       # egui master 2024-12-16 15:08
-egui = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }         # egui master 2024-12-16 15:08
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }  # egui master 2024-12-16 15:08
-egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" } # egui master 2024-12-16 15:08
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }    # egui master 2024-12-16 15:08
-emath = { git = "https://github.com/emilk/egui.git", rev = "0823a36952a6791a0e28e6e8eac4f35639ab3091" }        # egui master 2024-12-16 15:08
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }       # egui master 2024-12-16 just pre 0.30.0 release
+eframe = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }       # egui master 2024-12-16 just pre 0.30.0 release
+egui = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }         # egui master 2024-12-16 just pre 0.30.0 release
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }  # egui master 2024-12-16 just pre 0.30.0 release
+egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" } # egui master 2024-12-16 just pre 0.30.0 release
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }    # egui master 2024-12-16 just pre 0.30.0 release
+emath = { git = "https://github.com/emilk/egui.git", rev = "0fb340fe89e9476b2fec15c2eff1405e51e5c04e" }        # egui master 2024-12-16 just pre 0.30.0 release
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }


### PR DESCRIPTION
Make sure we test everything that went into 0.30.0, while we wait for
* https://github.com/lampsitter/egui_commonmark/pull/69