### PR TITLE
Hide outline rectangle around views

### DIFF
--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -165,6 +165,13 @@ impl ViewportUi {
                         continue;
                     };
 
+                    if matches!(contents, Contents::View(_))
+                        && !should_display_drop_destination_frame
+                    {
+                        // We already light up the view tab title; that is enough
+                        continue;
+                    }
+
                     // We want the rectangle to be on top of everything in the viewport,
                     // including stuff in "zoom-pan areas", like we use in the graph view.
                     let top_layer_id =


### PR DESCRIPTION
* Closes https://github.com/rerun-io/rerun/issues/8494

Removes the highlighted rectangle around views that are hovered or selected.
Why? Because we already have the tab title for this.

Keeps it for containers, because they have no tab title.


https://github.com/user-attachments/assets/bb407161-f3a8-4c66-bbd9-816f8dd28561

