### PR TITLE
Hide graph edges from individual graph node ui

### DIFF
--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -99,7 +99,7 @@ impl DataUi for InstancePath {
             // TODO(#7026): Instances today are too poorly defined:
             // For many archetypes it makes sense to slice through all their component arrays with the same index.
             // However, there are cases when there are multiple dimensions of slicing that make sense.
-            // This is most obvious for meshes & graph nodes where there are different dimentions for vertices/edges/etc.
+            // This is most obvious for meshes & graph nodes where there are different dimensions for vertices/edges/etc.
             //
             // For graph nodes this is particularly glaring since our indicices imply nodes today and
             // unlike with meshes it's very easy to hover & select individual nodes.

--- a/crates/viewer/re_data_ui/src/instance_path.rs
+++ b/crates/viewer/re_data_ui/src/instance_path.rs
@@ -67,7 +67,7 @@ impl DataUi for InstancePath {
             .filter(|c| c.is_indicator_component())
             .count();
 
-        let components = latest_at(db, query, entity_path, &components);
+        let mut components = latest_at(db, query, entity_path, &components);
 
         if components.is_empty() {
             ui_layout.label(
@@ -96,6 +96,20 @@ impl DataUi for InstancePath {
                 ),
             );
         } else {
+            // TODO(#7026): Instances today are too poorly defined:
+            // For many archetypes it makes sense to slice through all their component arrays with the same index.
+            // However, there are cases when there are multiple dimensions of slicing that make sense.
+            // This is most obvious for meshes & graph nodes where there are different dimentions for vertices/edges/etc.
+            //
+            // For graph nodes this is particularly glaring since our indicices imply nodes today and
+            // unlike with meshes it's very easy to hover & select individual nodes.
+            // In order to work around the GraphEdges showing up associated with random nodes, we just hide them here.
+            // (this is obviously a hack and these relationships should be formalized such that they are accessible to the UI, see ticket link above)
+            if !self.is_all() {
+                components
+                    .retain(|(component, _chunk)| component != &components::GraphEdge::name());
+            }
+
             component_list_ui(
                 ctx,
                 ui,


### PR DESCRIPTION
### Related

* https://github.com/rerun-io/rerun/issues/7026

### What

Lots of considerations & (soft) implications in this hack, see comment.

The important outcome here is that node hover now looks like this:
![image](https://github.com/user-attachments/assets/5f4e693b-19cf-4ac5-b359-1354dd8377e9)
node selection:
![image](https://github.com/user-attachments/assets/be75a273-bcb6-4bd4-b90a-5a19c994eb0f)
and node entity selection (note that edges are still around:
![image](https://github.com/user-attachments/assets/e76c7cf9-3a1b-4687-bc61-10c6ace02103)
also you can still browse the edges:
![image](https://github.com/user-attachments/assets/90c5d116-e9fe-4e4f-8032-ce8687e80097)
