### PR TITLE
Fix graph view node highlight on hover

### DIFF
--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -330,6 +330,7 @@ pub fn draw_graph(
     layout: &Layout,
     query: &ViewQuery<'_>,
     lod: LevelOfDetail,
+    hovered: &mut Option<Item>,
 ) -> Rect {
     let entity_path = graph.entity();
     let entity_highlights = query.highlights.entity_highlight(entity_path.hash());
@@ -363,11 +364,9 @@ pub fn draw_graph(
                     });
                 });
 
-                ctx.handle_select_hover_drag_interactions(
-                    &response,
-                    Item::DataResult(query.view_id, instance_path.clone()),
-                    false,
-                );
+                if response.hovered() {
+                    *hovered = Some(Item::DataResult(query.view_id, instance_path.clone()));
+                }
 
                 // double click selects the entire entity
                 if response.double_clicked() {

--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -330,7 +330,7 @@ pub fn draw_graph(
     layout: &Layout,
     query: &ViewQuery<'_>,
     lod: LevelOfDetail,
-    hovered: &mut Option<Item>,
+    hover_click_item: &mut Option<(Item, Response)>,
 ) -> Rect {
     let entity_path = graph.entity();
     let entity_highlights = query.highlights.entity_highlight(entity_path.hash());
@@ -364,16 +364,17 @@ pub fn draw_graph(
                     });
                 });
 
-                if response.hovered() {
-                    *hovered = Some(Item::DataResult(query.view_id, instance_path.clone()));
-                }
-
-                // double click selects the entire entity
+                // Warning! The order is very important here.
                 if response.double_clicked() {
                     // Select the entire entity
                     ctx.selection_state().set_selection(Item::DataResult(
                         query.view_id,
                         instance_path.entity_path.clone().into(),
+                    ));
+                } else if response.hovered() || response.clicked() {
+                    *hover_click_item = Some((
+                        Item::DataResult(query.view_id, instance_path.clone()),
+                        response.clone(),
                     ));
                 }
 

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -191,18 +191,21 @@ Display a graph of nodes and edges.
 
         let level_of_detail = LevelOfDetail::from_scaling(ui_from_world.scaling);
 
+        let mut hovered: Option<Item> = None;
+
         let resp = zoom_pan_area(ui, &mut ui_from_world, |ui| {
             let mut world_bounding_rect = egui::Rect::NOTHING;
 
             for graph in &graphs {
-                let graph_rect = draw_graph(ui, ctx, graph, layout, query, level_of_detail);
+                let graph_rect =
+                    draw_graph(ui, ctx, graph, layout, query, level_of_detail, &mut hovered);
                 world_bounding_rect = world_bounding_rect.union(graph_rect);
             }
         });
 
-        // Don't set the view to hovered if something else was already hovered.
-        // (this can only mean that a graph node/edge was hovered)
-        if resp.hovered() && ctx.selection_state().hovered_items().is_empty() {
+        if let Some(hovered_item) = hovered {
+            ctx.selection_state().set_hovered(hovered_item);
+        } else if resp.hovered() {
             ctx.selection_state().set_hovered(Item::View(query.view_id));
         }
 

--- a/crates/viewer/re_view_graph/src/view.rs
+++ b/crates/viewer/re_view_graph/src/view.rs
@@ -1,3 +1,4 @@
+use egui::Response;
 use re_log_types::EntityPath;
 use re_types::{
     blueprint::{
@@ -191,20 +192,27 @@ Display a graph of nodes and edges.
 
         let level_of_detail = LevelOfDetail::from_scaling(ui_from_world.scaling);
 
-        let mut hovered: Option<Item> = None;
+        let mut hover_click_item: Option<(Item, Response)> = None;
 
         let resp = zoom_pan_area(ui, &mut ui_from_world, |ui| {
             let mut world_bounding_rect = egui::Rect::NOTHING;
 
             for graph in &graphs {
-                let graph_rect =
-                    draw_graph(ui, ctx, graph, layout, query, level_of_detail, &mut hovered);
+                let graph_rect = draw_graph(
+                    ui,
+                    ctx,
+                    graph,
+                    layout,
+                    query,
+                    level_of_detail,
+                    &mut hover_click_item,
+                );
                 world_bounding_rect = world_bounding_rect.union(graph_rect);
             }
         });
 
-        if let Some(hovered_item) = hovered {
-            ctx.selection_state().set_hovered(hovered_item);
+        if let Some((item, response)) = hover_click_item {
+            ctx.handle_select_hover_drag_interactions(&response, item, false);
         } else if resp.hovered() {
             ctx.selection_state().set_hovered(Item::View(query.view_id));
         }


### PR DESCRIPTION
### What

This fixes a problem introduced by #8495 that was only partially fixed by #8508, with graph view highlights flickering (ping-ponging) in the blueprint view.

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
