### PR TITLE
Fix the event count in the static-over-temporal error message

### DIFF
--- a/crates/store/re_chunk_store/src/stats.rs
+++ b/crates/store/re_chunk_store/src/stats.rs
@@ -320,4 +320,24 @@ impl ChunkStore {
                     .sum()
             })
     }
+
+    /// Returns the number of temporal events logged for an entity for a specific component on all timelines.
+    ///
+    /// This ignores static events.
+    pub fn num_temporal_events_for_component_on_all_timelines(
+        &self,
+        entity_path: &EntityPath,
+        component_name: ComponentName,
+    ) -> u64 {
+        self.all_timelines()
+            .iter()
+            .map(|timeline| {
+                self.num_temporal_events_for_component_on_timeline(
+                    timeline,
+                    entity_path,
+                    component_name,
+                )
+            })
+            .sum()
+    }
 }

--- a/crates/viewer/re_data_ui/src/component.rs
+++ b/crates/viewer/re_data_ui/src/component.rs
@@ -75,8 +75,7 @@ impl DataUi for ComponentPathLatestAtResults<'_> {
 
                 let temporal_message_count = engine
                     .store()
-                    .num_temporal_events_for_component_on_timeline(
-                        &query.timeline(),
+                    .num_temporal_events_for_component_on_all_timelines(
                         entity_path,
                         *component_name,
                     );


### PR DESCRIPTION
Regression introduced in #6934 and caught by `check_static_components_ui`


Before:

![image](https://github.com/user-attachments/assets/b06bea44-ae51-4989-a3a2-eb4f4a7e1bc0)


After:

![image](https://github.com/user-attachments/assets/1250995a-6ae8-42ad-90c9-aee42234ff4f)
