### PR TITLE
Update the remote APIs to take and send a Table

### DIFF
--- a/crates/store/re_protos/proto/rerun/v0/remote_store.proto
+++ b/crates/store/re_protos/proto/rerun/v0/remote_store.proto
@@ -44,7 +44,6 @@ message RegisterRecordingRequest {
 // ---------------- UpdateCatalog  -----------------
 
 message UpdateCatalogRequest {
-    rerun.common.v0.RecordingId recording_id = 1;
     DataframePart metadata = 2;
 }
 

--- a/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
+++ b/crates/store/re_protos/src/v0/rerun.remote_store.v0.rs
@@ -47,8 +47,6 @@ impl ::prost::Name for RegisterRecordingRequest {
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateCatalogRequest {
-    #[prost(message, optional, tag = "1")]
-    pub recording_id: ::core::option::Option<super::super::common::v0::RecordingId>,
     #[prost(message, optional, tag = "2")]
     pub metadata: ::core::option::Option<DataframePart>,
 }

--- a/examples/python/remote/metadata.py
+++ b/examples/python/remote/metadata.py
@@ -14,23 +14,31 @@ if __name__ == "__main__":
     subparsers = parser.add_subparsers(dest="subcommand")
 
     print_cmd = subparsers.add_parser("print", help="Print everything")
+    register_cmd = subparsers.add_parser("register", help="Register a new recording")
     update_cmd = subparsers.add_parser("update", help="Update metadata for a recording")
 
     update_cmd.add_argument("id", help="ID of the recording to update")
     update_cmd.add_argument("key", help="Key of the metadata to update")
     update_cmd.add_argument("value", help="Value of the metadata to update")
 
+    register_cmd.add_argument("storage_url", help="Storage URL to register")
+
     args = parser.parse_args()
 
     # Register the new rrd
     conn = rr.remote.connect("http://0.0.0.0:51234")
 
-    catalog = pl.from_arrow(conn.query_catalog())
+    catalog = pl.from_arrow(conn.query_catalog().read_all())
 
     if args.subcommand == "print":
         print(catalog)
 
-    if args.subcommand == "update":
+    elif args.subcommand == "register":
+        extra_metadata = pa.Table.from_pydict({"extra": [42]})
+        id = conn.register(args.storage_url, extra_metadata)
+        print(f"Registered new recording with ID: {id}")
+
+    elif args.subcommand == "update":
         id = catalog.filter(catalog["id"].str.starts_with(args.id)).select(pl.first("id")).item()
 
         if id is None:
@@ -38,4 +46,7 @@ if __name__ == "__main__":
             exit(1)
         print(f"Updating metadata for {id}")
 
-        conn.update_catalog(id, {args.key: pa.array([args.value])})
+        new_metadata = pa.Table.from_pydict({"id": [id], args.key: [args.value]})
+        print(new_metadata)
+
+        conn.update_catalog(new_metadata)

--- a/rerun_py/rerun_bindings/rerun_bindings.pyi
+++ b/rerun_py/rerun_bindings/rerun_bindings.pyi
@@ -3,7 +3,7 @@ from typing import Iterator, Optional, Sequence, Union
 
 import pyarrow as pa
 
-from .types import AnyColumn, AnyComponentColumn, ComponentLike, IndexValuesLike, MetadataLike, ViewContentsLike
+from .types import AnyColumn, AnyComponentColumn, ComponentLike, IndexValuesLike, TableLike, ViewContentsLike
 
 class IndexColumnDescriptor:
     """
@@ -581,7 +581,7 @@ class StorageNodeClient:
         """Get the metadata for all recordings in the storage node."""
         ...
 
-    def register(self, storage_url: str, metadata: Optional[dict[str, MetadataLike]] = None) -> str:
+    def register(self, storage_url: str, metadata: Optional[TableLike] = None) -> str:
         """
         Register a recording along with some metadata.
 
@@ -589,22 +589,24 @@ class StorageNodeClient:
         ----------
         storage_url : str
             The URL to the storage location.
-        metadata : dict[str, MetadataLike]
-            A dictionary where the keys are the metadata columns and the values are pyarrow arrays.
+        metadata : Optional[Table | RecordBatch]
+            A pyarrow Table or RecordBatch containing the metadata to update.
+            This Table must contain only a single row.
 
         """
         ...
 
-    def update_catalog(self, id: str, metadata: dict[str, MetadataLike]) -> None:
+    def update_catalog(self, metadata: TableLike) -> None:
         """
-        Update the metadata for the recording with the given id.
+        Update the catalog metadata for one or more recordings.
+
+        The updates are provided as a pyarrow Table or RecordBatch containing the metadata to update.
+        The Table must contain an 'id' column, which is used to specify the recording to update for each row.
 
         Parameters
         ----------
-        id : str
-            The id of the recording to update.
-        metadata : dict[str, MetadataLike]
-            A dictionary where the keys are the metadata columns and the values are pyarrow arrays.
+        metadata : Table | RecordBatch
+            A pyarrow Table or RecordBatch containing the metadata to update.
 
         """
         ...

--- a/rerun_py/rerun_bindings/types.py
+++ b/rerun_py/rerun_bindings/types.py
@@ -68,4 +68,7 @@ A type alias for index values.
 This can be any numpy-compatible array of integers, or a [`pa.Int64Array`][]
 """
 
-MetadataLike: TypeAlias = pa.Array
+TableLike: TypeAlias = Union[pa.Table, pa.RecordBatch, pa.RecordBatchReader]
+"""
+A type alias for TableLike pyarrow objects.
+"""


### PR DESCRIPTION
This allows the update APIs to now support multi-recording updates, and generally gives users more direct control over things like the column metadata, etc.