### PR TITLE
Fix cargo warning

### DIFF
--- a/crates/utils/re_capabilities/Cargo.toml
+++ b/crates/utils/re_capabilities/Cargo.toml
@@ -31,5 +31,5 @@ egui = ["dep:egui"]
 
 # External dependencies:
 document-features.workspace = true
-egui = { workspace = true, default-features = false, optional = true }
+egui = { workspace = true, optional = true }
 static_assertions.workspace = true


### PR DESCRIPTION
The warning:

```
warning: /Users/hhip/src/rerun/crates/utils/re_capabilities/Cargo.toml: `default-features` is ignored for egui, since `default-features` was not specified for `workspace.dependencies.egui`, this could become a hard error in the future
```

