### PR TITLE
Enable GH releases for RC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,7 @@ jobs:
 
   github-release:
     name: "GitHub Release"
-    if: inputs.release-type == 'final'
+    if: inputs.release-type == 'rc' || inputs.release-type == 'final'
     needs:
       [
         version,
@@ -347,9 +347,16 @@ jobs:
         run: |
           version="${{ needs.version.outputs.final }}"
           commit="${{ needs.version.outputs.release-commit }}"
+
+          if [ ${{ inputs.release-type }} = "final" ]; then
+            pre_arg=""
+          else
+            pre_arg="--prerelease"
+          fi
+
           git tag $version $commit
           git push origin $version
-          gh release create $version --verify-tag --draft --title $version
+          gh release create $version --verify-tag --draft --title $version $pre_arg
 
       - name: Create comment
         env:


### PR DESCRIPTION
This PR enables the creation of GH releases (as draft and marked as pre-release) for RCs.

Motivations for doing so:
- test that part of the workflow, in particular that all binaries are correctly produced
- test the binary using `cargo binstall`
- these releases a single-click deletable from GH (if we want to do so)
- GH releases marked as "pre-release" aren't displayed in the GH project page

Pending questions: do we want that?  what about alphas?