### PR TITLE
Use single log call in graph examples

### DIFF
--- a/crates/store/re_types/definitions/rerun/archetypes/graph_edges.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/graph_edges.fbs
@@ -7,7 +7,7 @@ namespace rerun.archetypes;
 /// By default, edges are undirected.
 ///
 /// \example archetypes/graph_undirected !api title="Simple undirected graph" image="https://static.rerun.io/graph_undirected/15f46bec77452a8c6220558e4403b99cac188e2e/1200w.png"
-/// \example archetypes/graph_directed !api title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
+/// \example archetypes/graph_directed title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
 table GraphEdges (
   "attr.docs.category": "Graph",
   "attr.docs.unreleased",

--- a/crates/store/re_types/definitions/rerun/archetypes/graph_nodes.fbs
+++ b/crates/store/re_types/definitions/rerun/archetypes/graph_nodes.fbs
@@ -5,7 +5,7 @@ namespace rerun.archetypes;
 /// A list of nodes in a graph with optional labels, colors, etc.
 ///
 /// \example archetypes/graph_undirected !api title="Simple undirected graph" image="https://static.rerun.io/graph_undirected/15f46bec77452a8c6220558e4403b99cac188e2e/1200w.png"
-/// \example archetypes/graph_directed !api title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
+/// \example archetypes/graph_directed title="Simple directed graph" image="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png"
 table GraphNodes (
   "attr.docs.category": "Graph",
   "attr.docs.unreleased",

--- a/crates/store/re_types/src/archetypes/graph_edges.rs
+++ b/crates/store/re_types/src/archetypes/graph_edges.rs
@@ -23,6 +23,36 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// By default, edges are undirected.
 ///
 /// ⚠️ **This type is experimental and may be removed in future versions**
+///
+/// ## Example
+///
+/// ### Simple directed graph
+/// ```ignore
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_graph_directed").spawn()?;
+///
+///     rec.log(
+///         "simple",
+///         &[
+///             &rerun::GraphNodes::new(["a", "b", "c"])
+///                 .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
+///                 .with_labels(["A", "B", "C"]) as &dyn rerun::AsComponents,
+///             &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")]).with_directed_edges(),
+///         ],
+///     )?;
+///
+///     Ok(())
+/// }
+/// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png">
+///   <img src="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png" width="640">
+/// </picture>
+/// </center>
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GraphEdges {
     /// A list of node tuples.

--- a/crates/store/re_types/src/archetypes/graph_nodes.rs
+++ b/crates/store/re_types/src/archetypes/graph_nodes.rs
@@ -21,6 +21,36 @@ use ::re_types_core::{DeserializationError, DeserializationResult};
 /// **Archetype**: A list of nodes in a graph with optional labels, colors, etc.
 ///
 /// ⚠️ **This type is experimental and may be removed in future versions**
+///
+/// ## Example
+///
+/// ### Simple directed graph
+/// ```ignore
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let rec = rerun::RecordingStreamBuilder::new("rerun_example_graph_directed").spawn()?;
+///
+///     rec.log(
+///         "simple",
+///         &[
+///             &rerun::GraphNodes::new(["a", "b", "c"])
+///                 .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
+///                 .with_labels(["A", "B", "C"]) as &dyn rerun::AsComponents,
+///             &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")]).with_directed_edges(),
+///         ],
+///     )?;
+///
+///     Ok(())
+/// }
+/// ```
+/// <center>
+/// <picture>
+///   <source media="(max-width: 480px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/480w.png">
+///   <source media="(max-width: 768px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/768w.png">
+///   <source media="(max-width: 1024px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1024w.png">
+///   <source media="(max-width: 1200px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png">
+///   <img src="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png" width="640">
+/// </picture>
+/// </center>
 #[derive(Clone, Debug, PartialEq)]
 pub struct GraphNodes {
     /// A list of node IDs.

--- a/docs/snippets/all/archetypes/graph_directed.cpp
+++ b/docs/snippets/all/archetypes/graph_directed.cpp
@@ -10,12 +10,7 @@ int main() {
         "simple",
         rerun::GraphNodes({"a", "b", "c"})
             .with_positions({{0.0, 100.0}, {-100.0, 0.0}, {100.0, 0.0}})
-            .with_labels({"A", "B", "C"})
-    );
-
-    // Note: We log to the same entity here.
-    rec.log(
-        "simple",
+            .with_labels({"A", "B", "C"}),
         rerun::GraphEdges({{"a", "b"}, {"b", "c"}, {"c", "a"}})
             // Graphs are undirected by default.
             .with_graph_type(rerun::components::GraphType::Directed)

--- a/docs/snippets/all/archetypes/graph_directed.py
+++ b/docs/snippets/all/archetypes/graph_directed.py
@@ -9,8 +9,5 @@ rr.log(
     rr.GraphNodes(
         node_ids=["a", "b", "c"], positions=[(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)], labels=["A", "B", "C"]
     ),
-)
-rr.log(
-    "simple",
     rr.GraphEdges(edges=[("a", "b"), ("b", "c"), ("c", "a")], graph_type="directed"),
 )

--- a/docs/snippets/all/archetypes/graph_directed.rs
+++ b/docs/snippets/all/archetypes/graph_directed.rs
@@ -5,14 +5,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "simple",
-        &rerun::GraphNodes::new(["a", "b", "c"])
-            .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
-            .with_labels(["A", "B", "C"]),
-    )?;
-    // Note: We log to the same entity here.
-    rec.log(
-        "simple",
-        &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")]).with_directed_edges(),
+        &[
+            &rerun::GraphNodes::new(["a", "b", "c"])
+                .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
+                .with_labels(["A", "B", "C"]) as &dyn rerun::AsComponents,
+            &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")]).with_directed_edges(),
+        ],
     )?;
 
     Ok(())

--- a/docs/snippets/all/archetypes/graph_undirected.cpp
+++ b/docs/snippets/all/archetypes/graph_undirected.cpp
@@ -10,12 +10,7 @@ int main() {
         "simple",
         rerun::GraphNodes({"a", "b", "c"})
             .with_positions({{0.0, 100.0}, {-100.0, 0.0}, {100.0, 0.0}})
-            .with_labels({"A", "B", "C"})
-    );
-
-    // Note: We log to the same entity here.
-    rec.log(
-        "simple",
+            .with_labels({"A", "B", "C"}),
         rerun::GraphEdges({{"a", "b"}, {"b", "c"}, {"c", "a"}})
             // Optional: graphs are undirected by default.
             .with_graph_type(rerun::components::GraphType::Undirected)

--- a/docs/snippets/all/archetypes/graph_undirected.py
+++ b/docs/snippets/all/archetypes/graph_undirected.py
@@ -9,8 +9,9 @@ rr.log(
     rr.GraphNodes(
         node_ids=["a", "b", "c"], positions=[(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)], labels=["A", "B", "C"]
     ),
-)
-rr.log(
-    "simple",
-    rr.GraphEdges(edges=[("a", "b"), ("b", "c"), ("c", "a")], graph_type="undirected"),
+    rr.GraphEdges(
+        edges=[("a", "b"), ("b", "c"), ("c", "a")],
+        # Optional: graphs are undirected by default.
+        graph_type="undirected",
+    ),
 )

--- a/docs/snippets/all/archetypes/graph_undirected.rs
+++ b/docs/snippets/all/archetypes/graph_undirected.rs
@@ -5,14 +5,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     rec.log(
         "simple",
-        &rerun::GraphNodes::new(["a", "b", "c"])
-            .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
-            .with_labels(["A", "B", "C"]),
-    )?;
-    // Note: We log to the same entity here.
-    rec.log(
-        "simple",
-        &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")]).with_undirected_edges(), // Optional: graphs are undirected by default.
+        &[
+            &rerun::GraphNodes::new(["a", "b", "c"])
+                .with_positions([(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)])
+                .with_labels(["A", "B", "C"]) as &dyn rerun::AsComponents,
+            &rerun::GraphEdges::new([("a", "b"), ("b", "c"), ("c", "a")])
+                // Optional: graphs are undirected by default.
+                .with_undirected_edges(),
+        ],
     )?;
 
     Ok(())

--- a/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_edges.hpp
@@ -21,6 +21,30 @@ namespace rerun::archetypes {
     ///
     /// By default, edges are undirected.
     ///
+    /// ## Example
+    ///
+    /// ### Simple directed graph
+    /// ![image](https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png)
+    ///
+    /// ```cpp
+    /// #include <rerun.hpp>
+    ///
+    /// int main() {
+    ///     const auto rec = rerun::RecordingStream("rerun_example_graph_directed");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     rec.log(
+    ///         "simple",
+    ///         rerun::GraphNodes({"a", "b", "c"})
+    ///             .with_positions({{0.0, 100.0}, {-100.0, 0.0}, {100.0, 0.0}})
+    ///             .with_labels({"A", "B", "C"}),
+    ///         rerun::GraphEdges({{"a", "b"}, {"b", "c"}, {"c", "a"}})
+    ///             // Graphs are undirected by default.
+    ///             .with_graph_type(rerun::components::GraphType::Directed)
+    ///     );
+    /// }
+    /// ```
+    ///
     /// ⚠ **This is an experimental API! It is not fully supported, and is likely to change significantly in future versions.**
     struct GraphEdges {
         /// A list of node tuples.

--- a/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
+++ b/rerun_cpp/src/rerun/archetypes/graph_nodes.hpp
@@ -23,6 +23,30 @@
 namespace rerun::archetypes {
     /// **Archetype**: A list of nodes in a graph with optional labels, colors, etc.
     ///
+    /// ## Example
+    ///
+    /// ### Simple directed graph
+    /// ![image](https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png)
+    ///
+    /// ```cpp
+    /// #include <rerun.hpp>
+    ///
+    /// int main() {
+    ///     const auto rec = rerun::RecordingStream("rerun_example_graph_directed");
+    ///     rec.spawn().exit_on_failure();
+    ///
+    ///     rec.log(
+    ///         "simple",
+    ///         rerun::GraphNodes({"a", "b", "c"})
+    ///             .with_positions({{0.0, 100.0}, {-100.0, 0.0}, {100.0, 0.0}})
+    ///             .with_labels({"A", "B", "C"}),
+    ///         rerun::GraphEdges({{"a", "b"}, {"b", "c"}, {"c", "a"}})
+    ///             // Graphs are undirected by default.
+    ///             .with_graph_type(rerun::components::GraphType::Directed)
+    ///     );
+    /// }
+    /// ```
+    ///
     /// ⚠ **This is an experimental API! It is not fully supported, and is likely to change significantly in future versions.**
     struct GraphNodes {
         /// A list of node IDs.

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_edges.py
@@ -26,6 +26,33 @@ class GraphEdges(Archetype):
     By default, edges are undirected.
 
     ⚠️ **This is an experimental API! It is not fully supported, and is likely to change significantly in future versions.**
+
+    Example
+    -------
+    ### Simple directed graph:
+    ```python
+    import rerun as rr
+
+    rr.init("rerun_example_graph_directed", spawn=True)
+
+    rr.log(
+        "simple",
+        rr.GraphNodes(
+            node_ids=["a", "b", "c"], positions=[(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)], labels=["A", "B", "C"]
+        ),
+        rr.GraphEdges(edges=[("a", "b"), ("b", "c"), ("c", "a")], graph_type="directed"),
+    )
+    ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png">
+      <img src="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png" width="640">
+    </picture>
+    </center>
+
     """
 
     def __init__(self: Any, edges: datatypes.Utf8PairArrayLike, *, graph_type: components.GraphTypeLike | None = None):

--- a/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
+++ b/rerun_py/rerun_sdk/rerun/archetypes/graph_nodes.py
@@ -24,6 +24,33 @@ class GraphNodes(Archetype):
     **Archetype**: A list of nodes in a graph with optional labels, colors, etc.
 
     ⚠️ **This is an experimental API! It is not fully supported, and is likely to change significantly in future versions.**
+
+    Example
+    -------
+    ### Simple directed graph:
+    ```python
+    import rerun as rr
+
+    rr.init("rerun_example_graph_directed", spawn=True)
+
+    rr.log(
+        "simple",
+        rr.GraphNodes(
+            node_ids=["a", "b", "c"], positions=[(0.0, 100.0), (-100.0, 0.0), (100.0, 0.0)], labels=["A", "B", "C"]
+        ),
+        rr.GraphEdges(edges=[("a", "b"), ("b", "c"), ("c", "a")], graph_type="directed"),
+    )
+    ```
+    <center>
+    <picture>
+      <source media="(max-width: 480px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/480w.png">
+      <source media="(max-width: 768px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/768w.png">
+      <source media="(max-width: 1024px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1024w.png">
+      <source media="(max-width: 1200px)" srcset="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/1200w.png">
+      <img src="https://static.rerun.io/graph_directed/ca29a37b65e1e0b6482251dce401982a0bc568fa/full.png" width="640">
+    </picture>
+    </center>
+
     """
 
     def __init__(


### PR DESCRIPTION
Makes the graph examples look a lil bit nicer and more compact.

Note that this is a very recent thing that we can do this in Rust 🥳 

Also, embedds `graph_directed` in the examples (this has been done directly on the release branch already)


* [x] full check passed in order to confirm the example output is still the same (tested this locally but who knows)