### PR TITLE
Remove manual truncation of tensor shape UI

### DIFF
--- a/crates/viewer/re_data_ui/src/tensor.rs
+++ b/crates/viewer/re_data_ui/src/tensor.rs
@@ -9,34 +9,20 @@ use re_viewer_context::{TensorStats, TensorStatsCache, UiLayout, ViewerContext};
 use super::EntityDataUi;
 
 pub fn format_tensor_shape_single_line(shape: &[TensorDimension]) -> String {
-    const MAX_SHOWN: usize = 4; // should be enough for width/height/depth and then some!
-    let iter = shape.iter().take(MAX_SHOWN);
+    let iter = shape.iter();
     let labelled = iter.clone().any(|dim| dim.name.is_some());
-    let shapes = iter
-        .map(|dim| {
-            format!(
-                "{}{}",
-                dim.size,
-                if let Some(name) = &dim.name {
-                    format!(" ({name})")
-                } else {
-                    String::new()
-                }
-            )
-        })
-        .join(if labelled { " × " } else { "×" });
-    format!(
-        "{shapes}{}",
-        if shape.len() > MAX_SHOWN {
-            if labelled {
-                " × …"
+    iter.map(|dim| {
+        format!(
+            "{}{}",
+            dim.size,
+            if let Some(name) = &dim.name {
+                format!(" ({name})")
             } else {
-                "×…"
+                String::new()
             }
-        } else {
-            ""
-        }
-    )
+        )
+    })
+    .join(if labelled { " × " } else { "×" })
 }
 
 impl EntityDataUi for re_types::components::TensorData {


### PR DESCRIPTION
### Related

* fixes #8525

### What

Truncation now happens at egui test level, so we no longer need that manual truncation code. (This code is soon going to disappear anyways but at least it'll disappear in a good state 🤷🏻)
