### PR TITLE
Show the `GraphNode` as a label by default

### DIFF
--- a/crates/viewer/re_view_graph/src/visualizers/nodes.rs
+++ b/crates/viewer/re_view_graph/src/visualizers/nodes.rs
@@ -119,6 +119,10 @@ impl VisualizerSystem for NodeVisualizer {
                             text: label.clone(),
                             color,
                         },
+                        (None, true) => Label::Text {
+                            text: node.0 .0.clone(),
+                            color,
+                        },
                         _ => Label::Circle {
                             // Radius is negative for UI radii, but we don't handle this here.
                             radius: radius.unwrap_or(FALLBACK_RADIUS).abs(),


### PR DESCRIPTION
### What

This changes the default behavior of the graph view to show the `GraphNode` ids as a label by default, if no labels are logged explicitly. Of course, this can still be overridden by `ShowLabels`

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
