### PR TITLE
`EntityPathFilter` variable substitutions are now delegated to (new) `ResolvedEntityPathFilter`

### DIFF
--- a/crates/store/re_dataframe/examples/query.rs
+++ b/crates/store/re_dataframe/examples/query.rs
@@ -3,8 +3,8 @@
 use itertools::Itertools;
 
 use re_dataframe::{
-    ChunkStoreConfig, EntityPathFilter, EntityPathSubs, QueryEngine, QueryExpression,
-    ResolvedTimeRange, SparseFillStrategy, StoreKind, TimeInt, Timeline,
+    ChunkStoreConfig, EntityPathFilter, QueryEngine, QueryExpression, ResolvedTimeRange,
+    SparseFillStrategy, StoreKind, TimeInt, Timeline,
 };
 use re_log_encoding::VersionPolicy;
 
@@ -31,8 +31,7 @@ fn main() -> anyhow::Result<()> {
         TimeInt::new_temporal(s.parse::<i64>().unwrap())
     });
     let entity_path_filter =
-        EntityPathFilter::parse_strict(args.get(5).map_or("/**", |s| s.as_str()))?
-            .resolve_strict(&EntityPathSubs::empty())?;
+        EntityPathFilter::parse_strict(args.get(5).map_or("/**", |s| s.as_str()))?;
 
     // TODO(cmc): We need to take a selector, not a Timeline.
     let timeline = match timeline_name {

--- a/crates/store/re_dataframe/examples/query.rs
+++ b/crates/store/re_dataframe/examples/query.rs
@@ -3,8 +3,8 @@
 use itertools::Itertools;
 
 use re_dataframe::{
-    ChunkStoreConfig, EntityPathFilter, QueryEngine, QueryExpression, ResolvedTimeRange,
-    SparseFillStrategy, StoreKind, TimeInt, Timeline,
+    ChunkStoreConfig, EntityPathFilter, EntityPathSubs, QueryEngine, QueryExpression,
+    ResolvedTimeRange, SparseFillStrategy, StoreKind, TimeInt, Timeline,
 };
 use re_log_encoding::VersionPolicy;
 
@@ -30,7 +30,9 @@ fn main() -> anyhow::Result<()> {
     let time_to = args.get(4).map_or(TimeInt::MAX, |s| {
         TimeInt::new_temporal(s.parse::<i64>().unwrap())
     });
-    let entity_path_filter = EntityPathFilter::try_from(args.get(5).map_or("/**", |s| s.as_str()))?;
+    let entity_path_filter =
+        EntityPathFilter::parse_strict(args.get(5).map_or("/**", |s| s.as_str()))?
+            .resolve_strict(&EntityPathSubs::empty())?;
 
     // TODO(cmc): We need to take a selector, not a Timeline.
     let timeline = match timeline_name {

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -4,7 +4,7 @@ use re_chunk::{EntityPath, TransportChunk};
 use re_chunk_store::{
     ChunkStore, ChunkStoreConfig, ChunkStoreHandle, ColumnDescriptor, QueryExpression,
 };
-use re_log_types::{ResolvedEntityPathFilter, StoreId};
+use re_log_types::{EntityPathFilter, StoreId};
 use re_query::{QueryCache, QueryCacheHandle, StorageEngine, StorageEngineLike};
 
 use crate::QueryHandle;
@@ -104,13 +104,14 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     #[inline]
     pub fn iter_entity_paths_sorted<'a>(
         &self,
-        filter: &'a ResolvedEntityPathFilter,
+        filter: &'a EntityPathFilter,
     ) -> impl Iterator<Item = EntityPath> + 'a {
+        let filter = filter.clone().resolve_without_substitutions();
         self.engine.with(|store, _cache| {
             store
                 .all_entities_sorted()
                 .into_iter()
-                .filter(|entity_path| filter.matches(entity_path))
+                .filter(move |entity_path| filter.matches(entity_path))
         })
     }
 }

--- a/crates/store/re_dataframe/src/engine.rs
+++ b/crates/store/re_dataframe/src/engine.rs
@@ -4,7 +4,7 @@ use re_chunk::{EntityPath, TransportChunk};
 use re_chunk_store::{
     ChunkStore, ChunkStoreConfig, ChunkStoreHandle, ColumnDescriptor, QueryExpression,
 };
-use re_log_types::{EntityPathFilter, StoreId};
+use re_log_types::{ResolvedEntityPathFilter, StoreId};
 use re_query::{QueryCache, QueryCacheHandle, StorageEngine, StorageEngineLike};
 
 use crate::QueryHandle;
@@ -104,7 +104,7 @@ impl<E: StorageEngineLike + Clone> QueryEngine<E> {
     #[inline]
     pub fn iter_entity_paths_sorted<'a>(
         &self,
-        filter: &'a EntityPathFilter,
+        filter: &'a ResolvedEntityPathFilter,
     ) -> impl Iterator<Item = EntityPath> + 'a {
         self.engine.with(|store, _cache| {
             store

--- a/crates/store/re_dataframe/src/lib.rs
+++ b/crates/store/re_dataframe/src/lib.rs
@@ -17,7 +17,8 @@ pub use self::external::re_chunk_store::{
 };
 #[doc(no_inline)]
 pub use self::external::re_log_types::{
-    EntityPath, EntityPathFilter, ResolvedTimeRange, StoreKind, TimeInt, Timeline,
+    EntityPath, EntityPathFilter, EntityPathSubs, ResolvedEntityPathFilter, ResolvedTimeRange,
+    StoreKind, TimeInt, Timeline,
 };
 #[doc(no_inline)]
 pub use self::external::re_query::{QueryCache, QueryCacheHandle, StorageEngine};

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -577,7 +577,7 @@ fn activate_catalog_blueprint(
         .with_archetype(RowId::new(), timepoint, &vb)
         .build()?;
 
-    let epf = EntityPathFilter::parse_forgiving("/**", &Default::default());
+    let epf = EntityPathFilter::parse_forgiving("/**");
     let vc = ViewContents::new(epf.iter_expressions());
     let view_contents_chunk = ChunkBuilder::new(
         ChunkId::new(),

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -72,7 +72,8 @@ impl TryFrom<&str> for EntityPathFilter {
 
 /// An [`EntityPathFilter`] with all variables Resolved.
 ///
-/// [`ResolvedEntityPathFilter`] sorts the rule by entity path, with recursive coming before non-recursive.
+/// [`ResolvedEntityPathFilter`] sorts the rule by specificity of the entity path,
+/// with recursive coming before non-recursive.
 /// This means the last matching rule is also the most specific one.
 /// For instance:
 ///
@@ -298,9 +299,8 @@ impl EntityPathFilter {
     /// The rest of the line is trimmed and treated as an entity path after variable substitution through [`Self::resolve_forgiving`]/[`Self::resolve_strict`].
     ///
     /// Conflicting rules are resolved by the last rule.
-    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::unnecessary_wraps)] // TODO(andreas): Do some error checking here?
     pub fn parse_strict(rules: &str) -> Result<Self, EntityPathFilterError> {
-        // TODO(andreas): Do some error checking here.
         Ok(Self::parse_forgiving(rules))
     }
 

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -118,6 +118,7 @@ impl From<EntityPath> for EntityPathRule {
 impl std::ops::Deref for EntityPathRule {
     type Target = str;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -410,14 +411,14 @@ impl EntityPathFilter {
     }
 
     /// Resolve variables & parse paths, ignoring any errors.
-    pub fn resolve_forgiving(self, subst_env: &EntityPathSubs) -> ResolvedEntityPathFilter {
+    pub fn resolve_forgiving(&self, subst_env: &EntityPathSubs) -> ResolvedEntityPathFilter {
         let rules = self
             .rules
-            .into_iter()
+            .iter()
             .map(|(rule, effect)| {
                 (
-                    ResolvedEntityPathRule::parse_forgiving(&rule, subst_env),
-                    effect,
+                    ResolvedEntityPathRule::parse_forgiving(rule, subst_env),
+                    *effect,
                 )
             })
             .collect();

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -441,6 +441,11 @@ impl EntityPathFilter {
             rules: BTreeMap::from_iter(rules),
         })
     }
+
+    /// Resolve variables & parse paths, without any substitutions.
+    pub fn resolve_without_substitutions(self) -> ResolvedEntityPathFilter {
+        self.resolve_forgiving(&EntityPathSubs::empty())
+    }
 }
 
 impl ResolvedEntityPathFilter {

--- a/crates/store/re_log_types/src/path/entity_path_filter.rs
+++ b/crates/store/re_log_types/src/path/entity_path_filter.rs
@@ -274,7 +274,7 @@ impl EntityPathFilter {
     /// Each line is a rule.
     ///
     /// The first character should be `+` or `-`. If missing, `+` is assumed.
-    /// The rest of the line is trimmed and treated as an entity path after variable substitution through [`Self::resolve`].
+    /// The rest of the line is trimmed and treated as an entity path after variable substitution through [`Self::resolve_forgiving`]/[`Self::resolve_strict`].
     ///
     /// Conflicting rules are resolved by the last rule.
     pub fn parse_forgiving(rules: &str) -> Self {
@@ -295,7 +295,7 @@ impl EntityPathFilter {
     /// Each line is a rule.
     ///
     /// The first character should be `+` or `-`. If missing, `+` is assumed.
-    /// The rest of the line is trimmed and treated as an entity path after variable substitution through [`Self::resolve`].
+    /// The rest of the line is trimmed and treated as an entity path after variable substitution through [`Self::resolve_forgiving`]/[`Self::resolve_strict`].
     ///
     /// Conflicting rules are resolved by the last rule.
     #[allow(clippy::unnecessary_wraps)]

--- a/crates/store/re_log_types/src/path/mod.rs
+++ b/crates/store/re_log_types/src/path/mod.rs
@@ -14,7 +14,10 @@ mod parse_path;
 pub use component_path::ComponentPath;
 pub use data_path::DataPath;
 pub use entity_path::{EntityPath, EntityPathHash};
-pub use entity_path_filter::{EntityPathFilter, EntityPathRule, EntityPathSubs, RuleEffect};
+pub use entity_path_filter::{
+    EntityPathFilter, EntityPathFilterError, EntityPathRule, EntityPathSubs,
+    ResolvedEntityPathFilter, ResolvedEntityPathRule, RuleEffect,
+};
 pub use entity_path_part::EntityPathPart;
 pub use parse_path::PathParseError;
 

--- a/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
+++ b/crates/viewer/re_context_menu/src/actions/add_entities_to_new_view.rs
@@ -144,7 +144,7 @@ fn create_view_for_selected_entities(
         .recommended_root_for_entities(&entities_of_interest, ctx.viewer_context.recording())
         .unwrap_or_else(EntityPath::root);
 
-    let mut filter = EntityPathFilter::default();
+    let mut query_filter = EntityPathFilter::default();
 
     let target_container_id = ctx
         .clicked_item_enclosing_container_id_and_position()
@@ -154,11 +154,14 @@ fn create_view_for_selected_entities(
     // relative to the origin. This makes sense since if you create a view and
     // then change the origin you likely wanted those entities to still be there.
     for path in entities_of_interest {
-        filter.add_rule(RuleEffect::Include, EntityPathRule::including_subtree(path));
+        query_filter.add_rule(
+            RuleEffect::Include,
+            EntityPathRule::including_entity_subtree(&path),
+        );
     }
     let recommended = RecommendedView {
         origin,
-        query_filter: filter,
+        query_filter,
     };
 
     let view = ViewBlueprint::new(identifier, recommended);

--- a/crates/viewer/re_selection_panel/src/selection_panel.rs
+++ b/crates/viewer/re_selection_panel/src/selection_panel.rs
@@ -7,7 +7,7 @@ use re_data_ui::{
     DataUi,
 };
 use re_entity_db::{EntityPath, InstancePath};
-use re_log_types::{ComponentPath, EntityPathFilter, EntityPathSubs};
+use re_log_types::{ComponentPath, EntityPathFilter, ResolvedEntityPathFilter};
 use re_types::blueprint::components::Interactive;
 use re_ui::{
     icons,
@@ -478,7 +478,7 @@ fn entity_path_filter_ui(
     ctx: &ViewerContext<'_>,
     ui: &mut egui::Ui,
     view_id: ViewId,
-    filter: &EntityPathFilter,
+    filter: &ResolvedEntityPathFilter,
     origin: &EntityPath,
 ) -> Option<EntityPathFilter> {
     fn syntax_highlight_entity_path_filter(
@@ -559,13 +559,8 @@ fn entity_path_filter_ui(
     }
 
     // Apply the edit.
-    //
-    // NOTE: The comparison of `EntityPathFilter` is done on the _expanded_ data (i.e. with variables substituted),
-    // so we must make sure to expand the new filter too before we compare it to the existing one.
-    // See <https://github.com/rerun-io/rerun/pull/8526>
-    let new_filter =
-        EntityPathFilter::parse_forgiving(&filter_string, &EntityPathSubs::new_with_origin(origin));
-    if &new_filter == filter {
+    let new_filter = EntityPathFilter::parse_forgiving(&filter_string);
+    if new_filter == filter.unresolved() {
         None // no change
     } else {
         Some(new_filter)

--- a/crates/viewer/re_selection_panel/src/view_entity_picker.rs
+++ b/crates/viewer/re_selection_panel/src/view_entity_picker.rs
@@ -3,7 +3,7 @@ use nohash_hasher::IntMap;
 
 use re_data_ui::item_ui;
 use re_entity_db::{EntityPath, EntityTree, InstancePath};
-use re_log_types::{EntityPathFilter, EntityPathRule};
+use re_log_types::{ResolvedEntityPathFilter, ResolvedEntityPathRule};
 use re_ui::{list_item, UiExt as _};
 use re_viewer_context::{DataQueryResult, ViewId, ViewerContext};
 use re_viewport_blueprint::{
@@ -87,7 +87,7 @@ fn add_entities_tree_ui(
     tree: &EntityTree,
     view: &ViewBlueprint,
     query_result: &DataQueryResult,
-    entity_path_filter: &EntityPathFilter,
+    entity_path_filter: &ResolvedEntityPathFilter,
     entities_add_info: &IntMap<EntityPath, EntityAddInfo>,
 ) {
     let item_content = list_item::CustomContent::new(|ui, content_ctx| {
@@ -153,7 +153,7 @@ fn add_entities_line_ui(
     entity_tree: &EntityTree,
     view: &ViewBlueprint,
     query_result: &DataQueryResult,
-    entity_path_filter: &EntityPathFilter,
+    entity_path_filter: &ResolvedEntityPathFilter,
     entities_add_info: &IntMap<EntityPath, EntityAddInfo>,
 ) {
     re_tracing::profile_function!();
@@ -214,7 +214,7 @@ fn add_entities_line_ui(
             if response.clicked() {
                 view.contents.raw_add_entity_exclusion(
                     ctx,
-                    EntityPathRule::including_subtree(entity_tree.path.clone()),
+                    ResolvedEntityPathRule::including_subtree(&entity_tree.path),
                 );
             }
 
@@ -231,7 +231,7 @@ fn add_entities_line_ui(
                 if response.clicked() {
                     view.contents.raw_add_entity_inclusion(
                         ctx,
-                        EntityPathRule::including_subtree(entity_tree.path.clone()),
+                        ResolvedEntityPathRule::including_subtree(&entity_tree.path),
                     );
                 }
 

--- a/crates/viewer/re_viewer_context/src/view/spawn_heuristics.rs
+++ b/crates/viewer/re_viewer_context/src/view/spawn_heuristics.rs
@@ -1,4 +1,4 @@
-use re_log_types::{hash::Hash64, EntityPath, EntityPathFilter, EntityPathSubs};
+use re_log_types::{hash::Hash64, EntityPath, EntityPathFilter};
 use re_types::ViewClassIdentifier;
 
 /// Properties of a view that as recommended to be spawned by default via view spawn heuristics.
@@ -48,25 +48,19 @@ impl ViewSpawnHeuristics {
 
 impl RecommendedView {
     #[inline]
-    pub fn new<'a>(origin: EntityPath, expressions: impl IntoIterator<Item = &'a str>) -> Self {
-        let space_env = EntityPathSubs::new_with_origin(&origin);
+    pub fn new_subtree(origin: EntityPath) -> Self {
         Self {
             origin,
-            query_filter: EntityPathFilter::from_query_expressions_forgiving(
-                expressions,
-                &space_env,
-            ),
+            query_filter: EntityPathFilter::subtree_filter("$origin"),
         }
     }
 
     #[inline]
-    pub fn new_subtree(origin: EntityPath) -> Self {
-        Self::new(origin, std::iter::once("$origin/**"))
-    }
-
-    #[inline]
     pub fn new_single_entity(origin: EntityPath) -> Self {
-        Self::new(origin, std::iter::once("$origin"))
+        Self {
+            origin,
+            query_filter: EntityPathFilter::single_filter("$origin"),
+        }
     }
 
     #[inline]

--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -284,7 +284,7 @@ impl ViewportUi {
                         if can_entity_be_added(entity) {
                             filter.add_rule(
                                 RuleEffect::Include,
-                                ResolvedEntityPathRule::including_subtree(&entity),
+                                ResolvedEntityPathRule::including_subtree(entity),
                             );
                         }
                     }

--- a/crates/viewer/re_viewport/src/viewport_ui.rs
+++ b/crates/viewer/re_viewport/src/viewport_ui.rs
@@ -6,7 +6,7 @@ use ahash::HashMap;
 use egui_tiles::{Behavior as _, EditAction};
 
 use re_context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
-use re_log_types::{EntityPath, EntityPathRule, RuleEffect};
+use re_log_types::{EntityPath, ResolvedEntityPathRule, RuleEffect};
 use re_ui::{design_tokens, ContextExt as _, DesignTokens, Icon, UiExt as _};
 use re_viewer_context::{
     blueprint_id_to_tile_id, icon_for_container_kind, Contents, DragAndDropFeedback,
@@ -284,7 +284,7 @@ impl ViewportUi {
                         if can_entity_be_added(entity) {
                             filter.add_rule(
                                 RuleEffect::Include,
-                                EntityPathRule::including_subtree(entity.clone()),
+                                ResolvedEntityPathRule::including_subtree(&entity),
                             );
                         }
                     }

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -71,7 +71,6 @@ impl ViewBlueprint {
     pub fn new(view_class: ViewClassIdentifier, recommended: RecommendedView) -> Self {
         let id = ViewId::random();
 
-        // TODO(andreas): do we need more context here?
         let path_subs = EntityPathSubs::new_with_origin(&recommended.origin);
         let query_filter = recommended.query_filter.resolve_forgiving(&path_subs);
 

--- a/crates/viewer/re_viewport_blueprint/src/view.rs
+++ b/crates/viewer/re_viewport_blueprint/src/view.rs
@@ -71,12 +71,16 @@ impl ViewBlueprint {
     pub fn new(view_class: ViewClassIdentifier, recommended: RecommendedView) -> Self {
         let id = ViewId::random();
 
+        // TODO(andreas): do we need more context here?
+        let path_subs = EntityPathSubs::new_with_origin(&recommended.origin);
+        let query_filter = recommended.query_filter.resolve_forgiving(&path_subs);
+
         Self {
             display_name: None,
             class_identifier: view_class,
             id,
             space_origin: recommended.origin,
-            contents: ViewContents::new(id, view_class, recommended.query_filter),
+            contents: ViewContents::new(id, view_class, query_filter),
             visible: true,
             defaults_path: Self::defaults_path(id),
             pending_writes: Default::default(),

--- a/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
+++ b/crates/viewer/re_viewport_blueprint/src/viewport_blueprint.rs
@@ -357,7 +357,7 @@ impl ViewportBlueprint {
                 .map(|view| {
                     // Today this looks trivial and something like we could do during recommendation-creation. But in the future variable substitutions might become more complex!
                     let path_subs = EntityPathSubs::new_with_origin(&view.origin);
-                    let query_filter = view.query_filter.clone().resolve_forgiving(&path_subs);
+                    let query_filter = view.query_filter.resolve_forgiving(&path_subs);
                     (query_filter, view)
                 })
                 .collect::<Vec<_>>();
@@ -372,7 +372,7 @@ impl ViewportBlueprint {
             recommended_views.retain(|(query_filter, _)| {
                 existing_path_filters
                     .iter()
-                    .all(|existing_filter| !existing_filter.is_superset_of(&query_filter))
+                    .all(|existing_filter| !existing_filter.is_superset_of(query_filter))
             });
 
             // Remove all views that are redundant within the remaining recommendation.
@@ -385,7 +385,7 @@ impl ViewportBlueprint {
                         .iter()
                         .enumerate()
                         .all(|(i, (other_query_filter, _))| {
-                            i == *j || !other_query_filter.is_superset_of(&candidate_query_filter)
+                            i == *j || !other_query_filter.is_superset_of(candidate_query_filter)
                         })
                 })
                 .map(|(_, recommendation)| recommendation);

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use rerun::{
     dataframe::{
-        concatenate_record_batches, EntityPathFilter, QueryEngine, QueryExpression,
+        concatenate_record_batches, EntityPathFilter, EntityPathSubs, QueryEngine, QueryExpression,
         SparseFillStrategy, Timeline,
     },
     ChunkStoreConfig, StoreKind, VersionPolicy,
@@ -57,7 +57,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             filtered_index: Some(timeline),
             view_contents: Some(
                 engine
-                    .iter_entity_paths_sorted(&entity_path_filter)
+                    .iter_entity_paths_sorted(
+                        &entity_path_filter.resolve_forgiving(&EntityPathSubs::empty()),
+                    )
                     .map(|entity_path| (entity_path, None))
                     .collect(),
             ),

--- a/examples/rust/dataframe_query/src/main.rs
+++ b/examples/rust/dataframe_query/src/main.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 
 use rerun::{
     dataframe::{
-        concatenate_record_batches, EntityPathFilter, EntityPathSubs, QueryEngine, QueryExpression,
+        concatenate_record_batches, EntityPathFilter, QueryEngine, QueryExpression,
         SparseFillStrategy, Timeline,
     },
     ChunkStoreConfig, StoreKind, VersionPolicy,
@@ -57,9 +57,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             filtered_index: Some(timeline),
             view_contents: Some(
                 engine
-                    .iter_entity_paths_sorted(
-                        &entity_path_filter.resolve_forgiving(&EntityPathSubs::empty()),
-                    )
+                    .iter_entity_paths_sorted(&entity_path_filter)
                     .map(|entity_path| (entity_path, None))
                     .collect(),
             ),

--- a/rerun_py/src/dataframe.rs
+++ b/rerun_py/src/dataframe.rs
@@ -25,7 +25,7 @@ use re_chunk_store::{
 };
 use re_dataframe::{QueryEngine, StorageEngine};
 use re_log_encoding::VersionPolicy;
-use re_log_types::{EntityPathFilter, EntityPathSubs, ResolvedTimeRange, TimeType};
+use re_log_types::{EntityPathFilter, ResolvedTimeRange, TimeType};
 use re_sdk::{ComponentName, EntityPath, StoreId, StoreKind};
 
 /// Register the `rerun.dataframe` module.
@@ -1162,7 +1162,6 @@ impl PyRecording {
 
             let path_filter =
                 EntityPathFilter::parse_strict(&expr)
-                    .and_then(|epf| epf.resolve_strict(&EntityPathSubs::empty()))
                     .map_err(|err| {
                         PyValueError::new_err(format!(
                             "Could not interpret `contents` as a ViewContentsLike. Failed to parse {expr}: {err}.",
@@ -1187,7 +1186,7 @@ impl PyRecording {
                     )
                 })?;
 
-                let path_filter = EntityPathFilter::parse_strict(&key).and_then(|epf| epf.resolve_strict(&EntityPathSubs::empty())).map_err(|err| {
+                let path_filter = EntityPathFilter::parse_strict(&key).map_err(|err| {
                     PyValueError::new_err(format!(
                         "Could not interpret `contents` as a ViewContentsLike. Failed to parse {key}: {err}.",
                     ))


### PR DESCRIPTION
### Related

* Fixes https://github.com/rerun-io/rerun/issues/8530

### What

(Motivation see ticket)
Originally I wanted `EntityPathFilter` to be a hashmap of rules. However, I realized that we still want a defined order when storing path filters into the blueprint (in order to avoid changes to it when only order changes!). Therefore, it is still a btreemap but now _sorts alphabetically_!
Generally, I struggled a bit of where to put resolved vs unresolved entity path filter/rules, but I think the end-result here makes sense for the most part and keeps the semantics clean enough: in the viewer resolved entity paths should be used whenever working with known paths whereas unresolved are used when dealing with user inputs and when storing back to the blueprint.