### PR TITLE
Remove `Chunk::iter_component_arrays`

### DIFF
--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -212,7 +212,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array_list`]
     /// * [`Self::iter_string`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     #[inline]
     pub fn iter_primitive<T: arrow2::types::NativeType>(
@@ -255,7 +254,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array_list`]
     /// * [`Self::iter_string`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     #[inline]
     pub fn iter_bool(
@@ -298,7 +296,6 @@ impl Chunk {
     /// * [`Self::iter_primitive`]
     /// * [`Self::iter_string`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_primitive_array<const N: usize, T: arrow2::types::NativeType>(
         &self,
@@ -360,7 +357,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array`]
     /// * [`Self::iter_string`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_primitive_array_list<const N: usize, T: arrow2::types::NativeType>(
         &self,
@@ -445,7 +441,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array`]
     /// * [`Self::iter_primitive_array_list`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_string(
         &self,
@@ -496,7 +491,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array`]
     /// * [`Self::iter_primitive_array_list`]
     /// * [`Self::iter_string`].
-    /// * [`Self::iter_component_arrays`].
     /// * [`Self::iter_component`].
     pub fn iter_buffer<T: arrow::datatypes::ArrowNativeType + arrow2::types::NativeType>(
         &self,
@@ -719,7 +713,6 @@ impl Chunk {
     /// * [`Self::iter_primitive_array_list`]
     /// * [`Self::iter_string`]
     /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component_arrays`].
     #[inline]
     pub fn iter_component<C: Component>(
         &self,

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use arrow2::{
     array::{
-        Array as Arrow2Array, BooleanArray as Arrow2BooleanArray,
-        FixedSizeListArray as Arrow2FixedSizeListArray, ListArray as Arrow2ListArray,
-        PrimitiveArray as Arrow2PrimitiveArray, Utf8Array as Arrow2Utf8Array,
+        BooleanArray as Arrow2BooleanArray, FixedSizeListArray as Arrow2FixedSizeListArray,
+        ListArray as Arrow2ListArray, PrimitiveArray as Arrow2PrimitiveArray,
+        Utf8Array as Arrow2Utf8Array,
     },
     bitmap::Bitmap as Arrow2Bitmap,
     Either,

--- a/crates/store/re_chunk/src/iter.rs
+++ b/crates/store/re_chunk/src/iter.rs
@@ -200,27 +200,6 @@ impl Chunk {
         }
     }
 
-    /// Returns an iterator over the raw arrays of a [`Chunk`], for a given component.
-    ///
-    /// See also:
-    /// * [`Self::iter_primitive`]
-    /// * [`Self::iter_primitive_array`]
-    /// * [`Self::iter_primitive_array_list`]
-    /// * [`Self::iter_string`]
-    /// * [`Self::iter_buffer`].
-    /// * [`Self::iter_component`].
-    #[inline]
-    pub fn iter_component_arrays(
-        &self,
-        component_name: &ComponentName,
-    ) -> impl Iterator<Item = Box<dyn Arrow2Array>> + '_ {
-        let Some(list_array) = self.get_first_component(component_name) else {
-            return Either::Left(std::iter::empty());
-        };
-
-        Either::Right(list_array.iter().flatten())
-    }
-
     /// Returns an iterator over the raw primitive values of a [`Chunk`], for a given component.
     ///
     /// This is a very fast path: the entire column will be downcasted at once, and then every

--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -484,15 +484,9 @@ async fn stream_catalog_async(
             )))?;
 
         let recording_uri_arrays: Vec<Box<dyn Arrow2Array>> = chunk
-            .iter_component_arrays(&"id".into())
+            .iter_string(&"id".into())
             .map(|id| {
-                let rec_id = id
-                    .as_any()
-                    .downcast_ref::<Arrow2Utf8Array<i32>>()
-                    .ok_or(StreamError::ChunkError(re_chunk::ChunkError::Malformed {
-                        reason: format!("id must be a utf8 array: {:?}", tc.schema),
-                    }))?
-                    .value(0); // each component batch is of length 1 i.e. single 'id' value
+                let rec_id = &id[0]; // each component batch is of length 1 i.e. single 'id' value
 
                 let recording_uri = format!("rerun://{host}:{port}/recording/{rec_id}");
 


### PR DESCRIPTION
This method makes no sense. It's a complete anti-pattern. The whole point of the Chunk level methods is to pay the cost of reflection/downcasting/deserialization once for the whole Chunk, this can never happen with the way this method is defined.

I'm not sure what I was thinking back then. I likely wasn't. There is never a good reason to use this.