### PR TITLE
grpc codec simplification - get rid of NoData message

### DIFF
--- a/crates/store/re_grpc_client/src/lib.rs
+++ b/crates/store/re_grpc_client/src/lib.rs
@@ -191,12 +191,11 @@ async fn stream_recording_async(
         .await
         .map_err(TonicStatusError)?
         .into_inner()
-        .filter_map(|resp| {
+        .map(|resp| {
             resp.and_then(|r| {
                 decode(r.encoder_version(), &r.payload)
                     .map_err(|err| tonic::Status::internal(err.to_string()))
             })
-            .transpose()
         })
         .collect::<Result<Vec<_>, tonic::Status>>()
         .await
@@ -225,12 +224,11 @@ async fn stream_recording_async(
         .await
         .map_err(TonicStatusError)?
         .into_inner()
-        .filter_map(|resp| {
+        .map(|resp| {
             resp.and_then(|r| {
                 decode(r.encoder_version(), &r.payload)
                     .map_err(|err| tonic::Status::internal(err.to_string()))
             })
-            .transpose()
         });
 
     drop(client);
@@ -340,7 +338,6 @@ async fn stream_catalog_async(
     re_log::debug!("Fetching catalog…");
 
     let mut resp = client
-        // TODO(zehiko) add support for fetching specific columns and rows
         .query_catalog(QueryCatalogRequest {
             column_projection: None, // fetch all columns
             filter: None,            // fetch all rows
@@ -348,12 +345,11 @@ async fn stream_catalog_async(
         .await
         .map_err(TonicStatusError)?
         .into_inner()
-        .filter_map(|resp| {
+        .map(|resp| {
             resp.and_then(|r| {
                 decode(r.encoder_version(), &r.payload)
                     .map_err(|err| tonic::Status::internal(err.to_string()))
             })
-            .transpose()
         });
 
     drop(client);

--- a/crates/store/re_log_encoding/src/codec/wire/decoder.rs
+++ b/crates/store/re_log_encoding/src/codec/wire/decoder.rs
@@ -1,55 +1,23 @@
-use super::MessageHeader;
-use super::TransportMessageV0;
 use crate::codec::arrow::read_arrow_from_bytes;
 use crate::codec::CodecError;
 use re_chunk::TransportChunk;
-
-impl MessageHeader {
-    pub(crate) fn decode(read: &mut impl std::io::Read) -> Result<Self, CodecError> {
-        let mut buffer = [0_u8; Self::SIZE_BYTES];
-        read.read_exact(&mut buffer)
-            .map_err(CodecError::HeaderDecoding)?;
-
-        let header = u8::from_le(buffer[0]);
-
-        Ok(Self(header))
-    }
-}
-
-impl TransportMessageV0 {
-    pub(crate) fn from_bytes(data: &[u8]) -> Result<Self, CodecError> {
-        let mut reader = std::io::Cursor::new(data);
-        let header = MessageHeader::decode(&mut reader)?;
-
-        match header {
-            MessageHeader::NO_DATA => Ok(Self::NoData),
-            MessageHeader::RECORD_BATCH => {
-                let (schema, data) = read_arrow_from_bytes(&mut reader)?;
-
-                let tc = TransportChunk {
-                    schema: schema.clone(),
-                    data,
-                };
-
-                Ok(Self::RecordBatch(tc))
-            }
-            _ => Err(CodecError::UnknownMessageHeader),
-        }
-    }
-}
 
 /// Decode transport data from a byte stream - if there's a record batch present, return it, otherwise return `None`.
 pub fn decode(
     version: re_protos::common::v0::EncoderVersion,
     data: &[u8],
-) -> Result<Option<TransportChunk>, CodecError> {
+) -> Result<TransportChunk, CodecError> {
     match version {
         re_protos::common::v0::EncoderVersion::V0 => {
-            let msg = TransportMessageV0::from_bytes(data)?;
-            match msg {
-                TransportMessageV0::RecordBatch(chunk) => Ok(Some(chunk)),
-                TransportMessageV0::NoData => Ok(None),
-            }
+            let mut reader = std::io::Cursor::new(data);
+            let (schema, data) = read_arrow_from_bytes(&mut reader)?;
+
+            let tc = TransportChunk {
+                schema: schema.clone(),
+                data,
+            };
+
+            Ok(tc)
         }
     }
 }

--- a/crates/store/re_log_encoding/src/codec/wire/encoder.rs
+++ b/crates/store/re_log_encoding/src/codec/wire/encoder.rs
@@ -5,7 +5,7 @@ use re_chunk::TransportChunk;
 /// Encode a transport chunk into a byte stream.
 pub fn encode(
     version: re_protos::common::v0::EncoderVersion,
-    chunk: TransportChunk,
+    chunk: &TransportChunk,
 ) -> Result<Vec<u8>, CodecError> {
     match version {
         re_protos::common::v0::EncoderVersion::V0 => {

--- a/crates/store/re_log_encoding/src/codec/wire/encoder.rs
+++ b/crates/store/re_log_encoding/src/codec/wire/encoder.rs
@@ -1,50 +1,7 @@
-use super::MessageHeader;
-use super::TransportMessageV0;
 use crate::codec::arrow::write_arrow_to_bytes;
 use crate::codec::CodecError;
 use re_chunk::TransportChunk;
 
-impl MessageHeader {
-    pub(crate) fn encode(&self, write: &mut impl std::io::Write) -> Result<(), CodecError> {
-        write
-            .write_all(&[self.0])
-            .map_err(CodecError::HeaderEncoding)?;
-
-        Ok(())
-    }
-}
-
-impl TransportMessageV0 {
-    pub(crate) fn to_bytes(&self) -> Result<Vec<u8>, CodecError> {
-        match self {
-            Self::NoData => {
-                let mut data: Vec<u8> = Vec::new();
-                MessageHeader::NO_DATA.encode(&mut data)?;
-                Ok(data)
-            }
-            Self::RecordBatch(chunk) => {
-                let mut data: Vec<u8> = Vec::new();
-                MessageHeader::RECORD_BATCH.encode(&mut data)?;
-
-                write_arrow_to_bytes(&mut data, &chunk.schema, &chunk.data)?;
-
-                Ok(data)
-            }
-        }
-    }
-}
-
-/// Encode a `NoData` message into a byte stream. This can be used by the remote store
-/// (i.e. data producer) to signal back to the client that there's no data available.
-pub fn no_data(version: re_protos::common::v0::EncoderVersion) -> Result<Vec<u8>, CodecError> {
-    match version {
-        re_protos::common::v0::EncoderVersion::V0 => TransportMessageV0::NoData.to_bytes(),
-    }
-}
-
-// TODO(zehiko) add support for separately encoding schema from the record batch to get rid of overhead
-// of sending schema in each transport message for the same stream of batches. This will require codec
-// to become stateful and keep track if schema was sent / received.
 /// Encode a transport chunk into a byte stream.
 pub fn encode(
     version: re_protos::common::v0::EncoderVersion,
@@ -52,7 +9,10 @@ pub fn encode(
 ) -> Result<Vec<u8>, CodecError> {
     match version {
         re_protos::common::v0::EncoderVersion::V0 => {
-            TransportMessageV0::RecordBatch(chunk).to_bytes()
+            let mut data: Vec<u8> = Vec::new();
+            write_arrow_to_bytes(&mut data, &chunk.schema, &chunk.data)?;
+
+            Ok(data)
         }
     }
 }

--- a/crates/store/re_log_encoding/src/codec/wire/mod.rs
+++ b/crates/store/re_log_encoding/src/codec/wire/mod.rs
@@ -7,7 +7,7 @@ pub use encoder::encode;
 #[cfg(test)]
 mod tests {
     use crate::{
-        codec::wire::{decode, encode, TransportMessageV0},
+        codec::wire::{decode, encode},
         codec::CodecError,
     };
     use re_chunk::{Chunk, RowId};
@@ -38,9 +38,9 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_batch_data() {
-        let data = vec![2, 3, 4]; // '1' is NO_DATA message header
-        let decoded = TransportMessageV0::from_bytes(&data);
+    fn test_invalid_data() {
+        let data = vec![2, 3, 4];
+        let decoded = decode(EncoderVersion::V0, &data);
 
         assert!(matches!(
             decoded.err().unwrap(),
@@ -54,7 +54,7 @@ mod tests {
 
         let encoded = encode(
             EncoderVersion::V0,
-            expected_chunk.clone().to_transport().unwrap(),
+            &expected_chunk.clone().to_transport().unwrap(),
         )
         .unwrap();
         let decoded = decode(EncoderVersion::V0, &encoded).unwrap();

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -97,7 +97,7 @@ impl PyStorageNodeClient {
                 .await
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
                 .into_inner()
-                .filter_map(|resp| {
+                .map(|resp| {
                     resp.and_then(|r| {
                         decode(r.encoder_version(), &r.payload)
                             .map_err(|err| tonic::Status::internal(err.to_string()))
@@ -185,7 +185,7 @@ impl PyStorageNodeClient {
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
                 .into_inner();
             let metadata = decode(resp.encoder_version(), &resp.payload)
-                .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
+                .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
 
             let recording_id = metadata
                 .all_columns()
@@ -293,10 +293,6 @@ impl PyStorageNodeClient {
                 let response = result.map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
                 let tc = decode(EncoderVersion::V0, &response.payload)
                     .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
-
-                let Some(tc) = tc else {
-                    return Err(PyRuntimeError::new_err("Stream error"));
-                };
 
                 let chunk = Chunk::from_transport(&tc)
                     .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -269,7 +269,7 @@ impl PyStorageNodeClient {
 
                     let metadata_tc = TransportChunk::from_arrow_record_batch(&metadata);
 
-                    encode(EncoderVersion::V0, metadata_tc)
+                    encode(EncoderVersion::V0, &metadata_tc)
                         .map_err(|err| PyRuntimeError::new_err(err.to_string()))
                 })
                 .transpose()?
@@ -339,7 +339,7 @@ impl PyStorageNodeClient {
             let request = UpdateCatalogRequest {
                 metadata: Some(DataframePart {
                     encoder_version: EncoderVersion::V0 as i32,
-                    payload: encode(EncoderVersion::V0, metadata_tc)
+                    payload: encode(EncoderVersion::V0, &metadata_tc)
                         .map_err(|err| PyRuntimeError::new_err(err.to_string()))?,
                 }),
             };

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -102,7 +102,6 @@ impl PyStorageNodeClient {
                         decode(r.encoder_version(), &r.payload)
                             .map_err(|err| tonic::Status::internal(err.to_string()))
                     })
-                    .transpose()
                 })
                 .collect::<Result<Vec<_>, _>>()
                 .await
@@ -187,8 +186,6 @@ impl PyStorageNodeClient {
                 .into_inner();
             let metadata = decode(resp.encoder_version(), &resp.payload)
                 .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
-                // TODO(zehiko) this is going away soon
-                .ok_or(PyRuntimeError::new_err("No metadata"))?;
 
             let recording_id = metadata
                 .all_columns()


### PR DESCRIPTION
### What

I've been postponing this long enough - we initially thought we'd need ``NoData`` message, but our grpc protocol has been improved and redefined since and we will no longer need this, so we can slightly simplify our codec. 

Will expose helpers on ``DataframePart`` in a follow up PR.