### PR TITLE
Replace `--serve` with `--serve-web` from v0.20

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -88,11 +88,14 @@ The Rerun command-line interface:
 > Take a screenshot of the app and quit. We use this to generate screenshots of our examples. Useful together with `--window-size`.
 
 * `--serve <SERVE>`
+> `--serve` is deprecated since v0.20. Please use `--serve_web` instead.
+
+* `--serve-web <SERVE_WEB>`
 > Serve the recordings over WebSocket to one or more Rerun Viewers.
 >
 > This will also host a web-viewer over HTTP that can connect to the WebSocket address, but you can also connect with the native binary.
 >
-> `rerun --serve` will act like a proxy, listening for incoming TCP connection from logging SDKs, and forwarding it to Rerun viewers.
+> `rerun --serve-web` will act like a proxy, listening for incoming TCP connection from logging SDKs, and forwarding it to Rerun viewers.
 >
 > [Default: `false`]
 
@@ -124,7 +127,7 @@ The Rerun command-line interface:
 >
 > Requires Rerun to have been compiled with the 'web_viewer' feature.
 >
-> This implies `--serve`.
+> This implies `--serve-web`.
 >
 > [Default: `false`]
 
@@ -142,7 +145,7 @@ The Rerun command-line interface:
 > Set the screen resolution (in logical points), e.g. "1920x1080". Useful together with `--screenshot-to`.
 
 * `--ws-server-port <WS_SERVER_PORT>`
-> What port do we listen to for incoming websocket connections from the viewer A port of 0 will pick a random port.
+> What port do we listen to for incoming websocket connections from the viewer. A port of 0 will pick a random port.
 >
 > [Default: `9877`]
 


### PR DESCRIPTION
- Following the (migration guide to v0.20)[https://rerun.io/docs/reference/migration/migration-0-20] to replace `--serve` in favor of `--serve-web`.
- Added a small warning of deprecation for `--serve`
- A quick typo fix: `.` missing

### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

### What

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
