### PR TITLE
Fix tooltips being dragged along in graph view

### DIFF
--- a/crates/viewer/re_view_graph/src/ui/draw.rs
+++ b/crates/viewer/re_view_graph/src/ui/draw.rs
@@ -349,7 +349,7 @@ pub fn draw_graph(
                 let instance_path =
                     InstancePath::instance(entity_path.clone(), instance.instance_index);
 
-                response = response.on_hover_ui_at_pointer(|ui| {
+                response = response.on_hover_ui(|ui| {
                     list_item::list_item_scope(ui, "graph_node_hover", |ui| {
                         item_ui::instance_path_button(
                             ctx,


### PR DESCRIPTION
### Related

<!--
Include links to any related issues/PRs in a bulleted list, for example:
* Closes #1234
* Part of #1337
-->

* Closes #8568.

### What

This fixes the problem by tying to tooltip position to the node position instead of the the pointer, with the nice side-effect that tooltips can now be interacted with in the graph view.

There is some weirdness with tooltips opening for the tooltips, but we should probably tackle that separately.

<img width="607" alt="image" src="https://github.com/user-attachments/assets/43e0edba-49b6-4f49-a279-0982320c4ef6" />

<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
