### PR TITLE
Fix downcast typo in line visualizers

### DIFF
--- a/crates/viewer/re_view_spatial/src/visualizers/lines2d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/lines2d.rs
@@ -199,7 +199,7 @@ impl VisualizerSystem for Lines2DVisualizer {
 
                 let num_strips = all_strip_chunks
                     .iter()
-                    .flat_map(|chunk| chunk.iter_slices::<[f32; 2]>(LineStrip2D::name()))
+                    .flat_map(|chunk| chunk.iter_slices::<&[[f32; 2]]>(LineStrip2D::name()))
                     .map(|strips| strips.len())
                     .sum();
                 if num_strips == 0 {
@@ -209,7 +209,7 @@ impl VisualizerSystem for Lines2DVisualizer {
 
                 let num_vertices = all_strip_chunks
                     .iter()
-                    .flat_map(|chunk| chunk.iter_slices::<[f32; 2]>(LineStrip2D::name()))
+                    .flat_map(|chunk| chunk.iter_slices::<&[[f32; 2]]>(LineStrip2D::name()))
                     .map(|strips| strips.iter().map(|strip| strip.len()).sum::<usize>())
                     .sum::<usize>();
                 line_builder.reserve_vertices(num_vertices)?;

--- a/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
+++ b/crates/viewer/re_view_spatial/src/visualizers/lines3d.rs
@@ -202,7 +202,7 @@ impl VisualizerSystem for Lines3DVisualizer {
 
                 let num_strips = all_strip_chunks
                     .iter()
-                    .flat_map(|chunk| chunk.iter_slices::<[f32; 3]>(LineStrip3D::name()))
+                    .flat_map(|chunk| chunk.iter_slices::<&[[f32; 3]]>(LineStrip3D::name()))
                     .map(|strips| strips.len())
                     .sum();
                 if num_strips == 0 {
@@ -212,7 +212,7 @@ impl VisualizerSystem for Lines3DVisualizer {
 
                 let num_vertices = all_strip_chunks
                     .iter()
-                    .flat_map(|chunk| chunk.iter_slices::<[f32; 3]>(LineStrip3D::name()))
+                    .flat_map(|chunk| chunk.iter_slices::<&[[f32; 3]]>(LineStrip3D::name()))
                     .map(|strips| strips.iter().map(|strip| strip.len()).sum::<usize>())
                     .sum::<usize>();
                 line_builder.reserve_vertices(num_vertices)?;


### PR DESCRIPTION
Introduced in the chunk iteration refactoring from a couple hours ago.

![image](https://github.com/user-attachments/assets/2607a92b-3ef4-4fa1-bf0a-32c5c1b4ec1a)
![image](https://github.com/user-attachments/assets/b9a6ff2f-369d-4ee9-85b3-728e4116f40b)
