### PR TITLE
Reallow `#[cfg(TODO)]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -383,8 +383,10 @@ rust_2018_idioms = { level = "warn", priority = -1 }
 rust_2021_prelude_collisions = "warn"
 semicolon_in_expressions_from_macros = "warn"
 trivial_numeric_casts = "warn"
-unsafe_op_in_unsafe_fn = "warn"                         # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(TODO)'] } # allow `#[cfg(TODO)]` to compile (it will still fail CI) -- NOLINT
+unsafe_op_in_unsafe_fn = "warn" # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
+unexpected_cfgs = { level = "deny", check-cfg = [
+  'cfg(TODO)',
+] } # allow `#[cfg(TODO)]` to compile (it will still fail CI) -- NOLINT
 unused_extern_crates = "warn"
 unused_import_braces = "warn"
 unused_lifetimes = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,8 +385,8 @@ semicolon_in_expressions_from_macros = "warn"
 trivial_numeric_casts = "warn"
 unsafe_op_in_unsafe_fn = "warn" # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
 unexpected_cfgs = { level = "deny", check-cfg = [
-  'cfg(TODO)',
-] } # allow `#[cfg(TODO)]` to compile (it will still fail CI) -- NOLINT
+  'cfg(TODO)', # NOLINT
+] } # allow `#[cfg(TODO)]` to compile (it will still fail CI)
 unused_extern_crates = "warn"
 unused_import_braces = "warn"
 unused_lifetimes = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ rust_2021_prelude_collisions = "warn"
 semicolon_in_expressions_from_macros = "warn"
 trivial_numeric_casts = "warn"
 unsafe_op_in_unsafe_fn = "warn"                         # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
-unexpected_cfgs = "deny"
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(TODO)'] } # allow `#[cfg(TODO)]` to compile (it will still fail CI)
 unused_extern_crates = "warn"
 unused_import_braces = "warn"
 unused_lifetimes = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -384,7 +384,7 @@ rust_2021_prelude_collisions = "warn"
 semicolon_in_expressions_from_macros = "warn"
 trivial_numeric_casts = "warn"
 unsafe_op_in_unsafe_fn = "warn"                         # `unsafe_op_in_unsafe_fn` may become the default in future Rust versions: https://github.com/rust-lang/rust/issues/71668
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(TODO)'] } # allow `#[cfg(TODO)]` to compile (it will still fail CI)
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(TODO)'] } # allow `#[cfg(TODO)]` to compile (it will still fail CI) -- NOLINT
 unused_extern_crates = "warn"
 unused_import_braces = "warn"
 unused_lifetimes = "warn"


### PR DESCRIPTION
I very often use `#[cfg(TODO)]` as a way to semantically comment entire scopes of code at once, safely (i.e. the CI will fail if the code is committed as is).

Rust 1.81 broke that because `cfg(TODO)` is not referenced in the lint database, thus failing to compile this kind of code.
This PR tells `cargo` to relax. 