### PR TITLE
Use arrow1 for formatting of arrow data in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,6 @@ dependencies = [
  "parking_lot",
  "rand",
  "re_arrow2",
- "re_byte_size",
  "re_entity_db",
  "re_format",
  "re_log",

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/HalfSize2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/HalfSize2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a56ad6b58c206e6d4d74ec51ebeccdaa6ef03357b5a070b97cd67dd5108d496a
-size 3129
+oid sha256:99072ad79063a212e7c83603fffc7a580476512ea25e3b101d71eaa232fb07c8
+size 3733

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/HalfSize3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/HalfSize3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9745c1303a456d12426c487c9bb9e6b1d699911b56adaff284d1afd422ca756c
-size 3330
+oid sha256:e40d7c37e39d0506387e5f20e600f315d7a10361356c056fda62a60bf283c19a
+size 3795

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Length_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Length_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf82be5e97ac1eb76828d8bdb19d8a66f66935ade56295890ec9836af88b9d4e
-size 2778
+oid sha256:b6cacfd925f1ceca431cfe030a7fb861bc92496bd79ba91e5e2825046988af89
+size 3087

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseRotationAxisAngle_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseRotationAxisAngle_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a54ba133a55acdf936eb7864a56dcf58921bc2abf9e394344ef6f1586f337b3
-size 4048
+oid sha256:ba28989e08db68ecbe1ae37463c8c5dd533c82d052c488b22c91110f339d31b9
+size 4008

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseRotationQuat_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseRotationQuat_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b8ec21b3ddbf24cb7fced6edb805ee356e7265ef2409c7cb2c3b90838dff0a5
-size 3843
+oid sha256:a1f278d3633ba36b302c8ddbdc7c8e19fc2662db2eb198c385ae3083e808b956
+size 4090

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseScale3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseScale3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9745c1303a456d12426c487c9bb9e6b1d699911b56adaff284d1afd422ca756c
-size 3330
+oid sha256:e40d7c37e39d0506387e5f20e600f315d7a10361356c056fda62a60bf283c19a
+size 3795

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseTransformMat3x3_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseTransformMat3x3_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d26ef2482809cb1b16d0dd6a19f77ab6b5d085bbe1a5a47e95ba7d85bae8427c
-size 3685
+oid sha256:02be2e4b69701d0749778cdcdacddc16413a81fc9ba4bd3539003acd61b4f0dd
+size 3942

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseTranslation3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/PoseTranslation3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ceb9ad32a52e1e0042eeaddf1811d2342cb867dba2331a79f26399a0649d034b
-size 3771
+oid sha256:a1f278d3633ba36b302c8ddbdc7c8e19fc2662db2eb198c385ae3083e808b956
+size 4090

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Position3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Position3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ceb9ad32a52e1e0042eeaddf1811d2342cb867dba2331a79f26399a0649d034b
-size 3771
+oid sha256:a1f278d3633ba36b302c8ddbdc7c8e19fc2662db2eb198c385ae3083e808b956
+size 4090

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/RotationAxisAngle_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/RotationAxisAngle_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a54ba133a55acdf936eb7864a56dcf58921bc2abf9e394344ef6f1586f337b3
-size 4048
+oid sha256:ba28989e08db68ecbe1ae37463c8c5dd533c82d052c488b22c91110f339d31b9
+size 4008

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/RotationQuat_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/RotationQuat_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b8ec21b3ddbf24cb7fced6edb805ee356e7265ef2409c7cb2c3b90838dff0a5
-size 3843
+oid sha256:a1f278d3633ba36b302c8ddbdc7c8e19fc2662db2eb198c385ae3083e808b956
+size 4090

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Scalar_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Scalar_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61b6ca27d4addf38ddb9ead85c25fa01dbf930ab464e4df00dade0b86197d878
-size 2938
+oid sha256:ccf36f77696b9a326a686da2d2c627b584f0515d30384f71bfb045d8d72e0bc9
+size 3247

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Texcoord2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Texcoord2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98772373ea83350e3a3e5c8f4584ec9f5122d952b5dc4a410ddf6c641183fa5a
-size 3423
+oid sha256:15a7cdf4942aba0b9faa40cd4a0b7613dc1b4ab8a48f8662ce0ebf0bb44006fa
+size 4028

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Vector2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Vector2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98772373ea83350e3a3e5c8f4584ec9f5122d952b5dc4a410ddf6c641183fa5a
-size 3423
+oid sha256:15a7cdf4942aba0b9faa40cd4a0b7613dc1b4ab8a48f8662ce0ebf0bb44006fa
+size 4028

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Vector3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_narrow/Vector3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ceb9ad32a52e1e0042eeaddf1811d2342cb867dba2331a79f26399a0649d034b
-size 3771
+oid sha256:a1f278d3633ba36b302c8ddbdc7c8e19fc2662db2eb198c385ae3083e808b956
+size 4090

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/HalfSize2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/HalfSize2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b15740484aabecc80f2e5261f7923cbde78a5e25de21a9d7aac4f1184d6e2993
-size 3441
+oid sha256:46e78858bf4940a5aecdbb36149b0b4b120907f2fc0550f4cf07c76ee81c46e7
+size 4047

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/HalfSize3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/HalfSize3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9796dc9d6b32ebef86a19855f64eb3dea9a9ddb54e6111ff1c2f4d62d4c7d9d
-size 3641
+oid sha256:caaa55b94d75a2d1d3c32adc3c444450421f1a1d6cf5f9932e8af49abb8924b7
+size 4542

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Length_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Length_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c695a351b830364136a94a2ba7fd8f1800987776c892a213fdb855b6b8163fa2
-size 3091
+oid sha256:0a1d50d3d90292e45ccf4062e6bded2eae04ecaaf127185d15bea46c25d6280f
+size 3405

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseRotationAxisAngle_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseRotationAxisAngle_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da4ae0cabdf85b8c99d487fac504b8f4ff80524714973abd91bf1ddf6e14c42c
-size 6496
+oid sha256:41a9bbeddfc2d1bf740e95c6b5a123518bdd9cc2720306d7bd1f9e398ab8940f
+size 7548

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseRotationQuat_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseRotationQuat_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:394c92143e5ea2c6487c7924f0b3e4e9f479d7709c3dcc0162e630fa64feb8f7
-size 4282
+oid sha256:ea77d32e9f169ffb1be5f24c38ef8fe14c09baf4e9040cf16121864a4195f885
+size 5453

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseScale3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseScale3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9796dc9d6b32ebef86a19855f64eb3dea9a9ddb54e6111ff1c2f4d62d4c7d9d
-size 3641
+oid sha256:caaa55b94d75a2d1d3c32adc3c444450421f1a1d6cf5f9932e8af49abb8924b7
+size 4542

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseTransformMat3x3_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseTransformMat3x3_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8457a14fc37bdb300d21c49a598a41cf1c38eeb863f05cc96574831bd2db9476
-size 5648
+oid sha256:4503c1d77cefffaa6054b6ae02d08df9a5feba3ff704b7d9eb38b9e1d02b3401
+size 8314

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseTranslation3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/PoseTranslation3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:151fb60aedceeaf62165c4b67adc039145cdd7dc6e5b2fb6a4eb932d41ba29d8
-size 4082
+oid sha256:5ea330ca7703c3cf8bcde946d2d41837780bf4d5565f089b81dddaeeab3855e1
+size 4954

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Position3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Position3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:151fb60aedceeaf62165c4b67adc039145cdd7dc6e5b2fb6a4eb932d41ba29d8
-size 4082
+oid sha256:5ea330ca7703c3cf8bcde946d2d41837780bf4d5565f089b81dddaeeab3855e1
+size 4954

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/RotationAxisAngle_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/RotationAxisAngle_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:da4ae0cabdf85b8c99d487fac504b8f4ff80524714973abd91bf1ddf6e14c42c
-size 6496
+oid sha256:41a9bbeddfc2d1bf740e95c6b5a123518bdd9cc2720306d7bd1f9e398ab8940f
+size 7548

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/RotationQuat_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/RotationQuat_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:394c92143e5ea2c6487c7924f0b3e4e9f479d7709c3dcc0162e630fa64feb8f7
-size 4282
+oid sha256:ea77d32e9f169ffb1be5f24c38ef8fe14c09baf4e9040cf16121864a4195f885
+size 5453

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Scalar_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Scalar_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56d829442c06420d942fb0da541ce2cfba460d617160541e7ab9f13bcf39a7b4
-size 3252
+oid sha256:6dfc0ba2b1e70d3dbfc85a17c75b4abe1a7fb9da80dadad33b3c7521beda132e
+size 3564

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Texcoord2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Texcoord2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6832fae63ca911d76491d93c3ae281ae3b85489ae1e4f6a1870dbe2321352909
-size 3734
+oid sha256:9ca86b716698f0cf3e42b98aba4fd5b127b758af14343484280c8bc8946d6449
+size 4342

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Vector2D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Vector2D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6832fae63ca911d76491d93c3ae281ae3b85489ae1e4f6a1870dbe2321352909
-size 3734
+oid sha256:9ca86b716698f0cf3e42b98aba4fd5b127b758af14343484280c8bc8946d6449
+size 4342

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Vector3D_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/Vector3D_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:151fb60aedceeaf62165c4b67adc039145cdd7dc6e5b2fb6a4eb932d41ba29d8
-size 4082
+oid sha256:5ea330ca7703c3cf8bcde946d2d41837780bf4d5565f089b81dddaeeab3855e1
+size 4954

--- a/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/VisibleTimeRange_placeholder.png
+++ b/crates/viewer/re_component_ui/tests/snapshots/all_components_list_item_wide/VisibleTimeRange_placeholder.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8aac02c21250aa3aeb1d23f0e68a0dd4de22cc50dfcbd6ced164ffcd1cb83e5d
-size 9417
+oid sha256:c6154a8b84ff02167cf975673ec344ce51c3325828e61aa9db6af7d8c7806619
+size 11611

--- a/crates/viewer/re_ui/Cargo.toml
+++ b/crates/viewer/re_ui/Cargo.toml
@@ -35,7 +35,6 @@ arrow = ["dep:arrow", "dep:arrow2"]
 
 [dependencies]
 re_entity_db.workspace = true # syntax-highlighting for InstancePath. TODO(emilk): move InstancePath
-re_byte_size.workspace = true
 re_format.workspace = true
 re_log.workspace = true
 re_log_types.workspace = true # syntax-highlighting for EntityPath

--- a/crates/viewer/re_ui/tests/snapshots/arrow_ui.png
+++ b/crates/viewer/re_ui/tests/snapshots/arrow_ui.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30f1fda22e9e7eb0c6e870a0b339cd960c2d8d5905a6eadce7bf3a438e035a0f
-size 21743
+oid sha256:8f43ff3f9d5398d8b4d82b809508bbcd5964efb40dc95ca21f36a5aa5eefd1f8
+size 22125


### PR DESCRIPTION
### Related
* Follow-up to https://github.com/rerun-io/rerun/pull/8590
* Part of https://github.com/rerun-io/rerun/issues/3741

### What
Uses `arrow-rs` own formatting of arrow values.

Unfortunately this adds a `.0` suffix to all integer floating point values, which makes them quite verbose. I will see if there is a way around that.