### PR TITLE
Use arrow1 Fields in Archetype::from_arrow

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -1,6 +1,6 @@
 ---
 name: Project
-about: Define a
+about: A large but finite project involving many sub-tasks
 title: 'Project: <project title>'
 labels: project
 assignees: ''

--- a/crates/store/re_types/tests/types/annotation_context.rs
+++ b/crates/store/re_types/tests/types/annotation_context.rs
@@ -1,13 +1,9 @@
-use std::collections::HashMap;
-
 use re_types::{
     archetypes::AnnotationContext,
     components,
     datatypes::{ClassDescription, KeypointPair, Rgba32},
     Archetype as _, AsComponents as _,
 };
-
-use crate::util;
 
 #[test]
 fn roundtrip() {
@@ -22,9 +18,6 @@ fn roundtrip() {
 
     let arch = AnnotationContext::new(expected);
 
-    let expected_extensions: HashMap<_, _> =
-        [("context", vec!["rerun.components.AnnotationContext"])].into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -32,15 +25,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = AnnotationContext::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/annotation_context.rs
+++ b/crates/store/re_types/tests/types/annotation_context.rs
@@ -26,23 +26,23 @@ fn roundtrip() {
         [("context", vec!["rerun.components.AnnotationContext"])].into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = AnnotationContext::from_arrow2(serialized).unwrap();
+    let deserialized = AnnotationContext::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(arch, deserialized);
 }

--- a/crates/store/re_types/tests/types/arrows3d.rs
+++ b/crates/store/re_types/tests/types/arrows3d.rs
@@ -1,13 +1,9 @@
-
-
 use re_types::{
     archetypes::Arrows3D,
     components::{ClassId, Color, Position3D, Radius, Vector3D},
     datatypes::Vec3D,
     Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn roundtrip() {
@@ -55,7 +51,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
     }
 
     let deserialized = Arrows3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/arrows3d.rs
+++ b/crates/store/re_types/tests/types/arrows3d.rs
@@ -59,23 +59,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Arrows3D::from_arrow2(serialized).unwrap();
+    let deserialized = Arrows3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/arrows3d.rs
+++ b/crates/store/re_types/tests/types/arrows3d.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::Arrows3D,
@@ -7,7 +7,7 @@ use re_types::{
     Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -48,16 +48,6 @@ fn roundtrip() {
         .with_show_labels(true);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("arrows", vec!["rerun.components.Arrow3D"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("labels", vec!["rerun.components.Text"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -66,14 +56,6 @@ fn roundtrip() {
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
 
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Arrows3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/asset3d.rs
+++ b/crates/store/re_types/tests/types/asset3d.rs
@@ -24,21 +24,21 @@ fn roundtrip() {
     // .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         // util::assert_extensions(
         //     &**array,
-        //     expected_extensions[field.name.as_str()].as_slice(),
+        //     expected_extensions[field.name().as_str()].as_slice(),
         // );
     }
 
-    let deserialized = Asset3D::from_arrow2(serialized).unwrap();
+    let deserialized = Asset3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/asset3d.rs
+++ b/crates/store/re_types/tests/types/asset3d.rs
@@ -19,10 +19,6 @@ fn roundtrip() {
         .with_albedo_factor(0xEE112233);
     similar_asserts::assert_eq!(expected, arch);
 
-    // let expected_extensions: HashMap<_, _> = [
-    // ]
-    // .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -30,13 +26,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        // util::assert_extensions(
-        //     &**array,
-        //     expected_extensions[field.name().as_str()].as_slice(),
-        // );
     }
 
     let deserialized = Asset3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/box2d.rs
+++ b/crates/store/re_types/tests/types/box2d.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Boxes2D, components, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {
@@ -52,7 +48,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
     }
 
     let deserialized = Boxes2D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/box2d.rs
+++ b/crates/store/re_types/tests/types/box2d.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Boxes2D, components, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -45,18 +45,6 @@ fn roundtrip() {
         .with_show_labels(true);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("half_sizes", vec!["rerun.components.HalfSize2D"]),
-        ("centers", vec!["rerun.components.Position2D"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("labels", vec!["rerun.components.Label"]),
-        ("draw_order", vec!["rerun.components.DrawOrder"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -65,14 +53,6 @@ fn roundtrip() {
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
 
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Boxes2D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/box2d.rs
+++ b/crates/store/re_types/tests/types/box2d.rs
@@ -58,24 +58,24 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Boxes2D::from_arrow2(serialized).unwrap();
+    let deserialized = Boxes2D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }
 

--- a/crates/store/re_types/tests/types/box3d.rs
+++ b/crates/store/re_types/tests/types/box3d.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Boxes3D, components, datatypes, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/box3d.rs
+++ b/crates/store/re_types/tests/types/box3d.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Boxes3D, components, datatypes, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -58,19 +58,6 @@ fn roundtrip() {
         .with_show_labels(false);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("half_sizes", vec!["rerun.components.HalfSize2D"]),
-        ("centers", vec!["rerun.components.Position2D"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("fill_mode", vec!["rerun.components.FillMode"]),
-        ("labels", vec!["rerun.components.Label"]),
-        ("draw_order", vec!["rerun.components.DrawOrder"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -78,15 +65,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Boxes3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/box3d.rs
+++ b/crates/store/re_types/tests/types/box3d.rs
@@ -72,24 +72,24 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Boxes3D::from_arrow2(serialized).unwrap();
+    let deserialized = Boxes3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }
 

--- a/crates/store/re_types/tests/types/clear.rs
+++ b/crates/store/re_types/tests/types/clear.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Clear, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/clear.rs
+++ b/crates/store/re_types/tests/types/clear.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Clear, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -20,11 +20,6 @@ fn roundtrip() {
         Clear::flat(),      //
     ];
 
-    let expected_extensions: HashMap<_, _> = [
-        ("recursive", vec!["rerun.components.Clear"]), //
-    ]
-    .into();
-
     for (expected, arch) in all_expected.into_iter().zip(all_arch) {
         similar_asserts::assert_eq!(expected, arch);
 
@@ -35,15 +30,6 @@ fn roundtrip() {
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = Clear::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/clear.rs
+++ b/crates/store/re_types/tests/types/clear.rs
@@ -29,24 +29,24 @@ fn roundtrip() {
         similar_asserts::assert_eq!(expected, arch);
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = Clear::from_arrow2(serialized).unwrap();
+        let deserialized = Clear::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/depth_image.rs
+++ b/crates/store/re_types/tests/types/depth_image.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::DepthImage,
@@ -7,7 +7,7 @@ use re_types::{
     Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn depth_image_roundtrip() {
@@ -37,23 +37,12 @@ fn depth_image_roundtrip() {
             .unwrap(),
     ];
 
-    let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.Blob"])].into();
-
     for (expected, serialized) in all_expected.into_iter().zip(all_arch_serialized) {
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = DepthImage::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/depth_image.rs
+++ b/crates/store/re_types/tests/types/depth_image.rs
@@ -33,7 +33,7 @@ fn depth_image_roundtrip() {
         DepthImage::try_from(ndarray::array![[1u8, 2, 3], [4, 5, 6]])
             .unwrap()
             .with_meter(1000.0)
-            .to_arrow2()
+            .to_arrow()
             .unwrap(),
     ];
 
@@ -44,19 +44,19 @@ fn depth_image_roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = DepthImage::from_arrow2(serialized).unwrap();
+        let deserialized = DepthImage::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/depth_image.rs
+++ b/crates/store/re_types/tests/types/depth_image.rs
@@ -1,13 +1,9 @@
-
-
 use re_types::{
     archetypes::DepthImage,
     components::DepthMeter,
     datatypes::{ChannelDatatype, ImageFormat},
     Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn depth_image_roundtrip() {

--- a/crates/store/re_types/tests/types/fuzzy.rs
+++ b/crates/store/re_types/tests/types/fuzzy.rs
@@ -238,16 +238,7 @@ fn roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name() == "rerun.testing.components.AffixFuzzer21" {
-                // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
-                // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!(
-                    "{} = Can't be printed (float16 not supported)",
-                    field.name()
-                );
-            } else {
-                eprintln!("{} = {array:#?}", field.name());
-            }
+            eprintln!("{} = {array:#?}", field.name());
         }
 
         let deserialized = AffixFuzzer1::from_arrow(serialized).unwrap();
@@ -283,16 +274,7 @@ fn roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name() == "rerun.testing.components.AffixFuzzer21" {
-                // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
-                // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!(
-                    "{} = Can't be printed (float16 not supported)",
-                    field.name()
-                );
-            } else {
-                eprintln!("{} = {array:#?}", field.name());
-            }
+            eprintln!("{} = {array:#?}", field.name());
         }
 
         let deserialized = AffixFuzzer2::from_arrow(serialized).unwrap();
@@ -319,16 +301,7 @@ fn roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name() == "rerun.testing.components.AffixFuzzer21" {
-                // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
-                // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!(
-                    "{} = Can't be printed (float16 not supported)",
-                    field.name()
-                );
-            } else {
-                eprintln!("{} = {array:#?}", field.name());
-            }
+            eprintln!("{} = {array:#?}", field.name());
         }
 
         let deserialized = AffixFuzzer3::from_arrow(serialized).unwrap();
@@ -355,16 +328,7 @@ fn roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name() == "rerun.testing.components.AffixFuzzer21" {
-                // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
-                // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!(
-                    "{} = Can't be printed (float16 not supported)",
-                    field.name()
-                );
-            } else {
-                eprintln!("{} = {array:#?}", field.name());
-            }
+            eprintln!("{} = {array:#?}", field.name());
         }
 
         let deserialized = AffixFuzzer4::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/fuzzy.rs
+++ b/crates/store/re_types/tests/types/fuzzy.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::redundant_clone)]
 
-
-
 use re_types::{
     testing::{
         archetypes::{AffixFuzzer1, AffixFuzzer2, AffixFuzzer3, AffixFuzzer4},
@@ -11,8 +9,6 @@ use re_types::{
 };
 
 use half::f16;
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/fuzzy.rs
+++ b/crates/store/re_types/tests/types/fuzzy.rs
@@ -248,17 +248,20 @@ fn roundtrip() {
         .into();
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name == "rerun.testing.components.AffixFuzzer21" {
+            if field.name() == "rerun.testing.components.AffixFuzzer21" {
                 // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
                 // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!("{} = Can't be printed (float16 not supported)", field.name);
+                eprintln!(
+                    "{} = Can't be printed (float16 not supported)",
+                    field.name()
+                );
             } else {
-                eprintln!("{} = {array:#?}", field.name);
+                eprintln!("{} = {array:#?}", field.name());
             }
 
             // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
@@ -266,12 +269,12 @@ fn roundtrip() {
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = AffixFuzzer1::from_arrow2(serialized).unwrap();
+        let deserialized = AffixFuzzer1::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(arch, deserialized);
     }
 
@@ -310,17 +313,20 @@ fn roundtrip() {
         .into();
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name == "rerun.testing.components.AffixFuzzer21" {
+            if field.name() == "rerun.testing.components.AffixFuzzer21" {
                 // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
                 // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!("{} = Can't be printed (float16 not supported)", field.name);
+                eprintln!(
+                    "{} = Can't be printed (float16 not supported)",
+                    field.name()
+                );
             } else {
-                eprintln!("{} = {array:#?}", field.name);
+                eprintln!("{} = {array:#?}", field.name());
             }
 
             // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
@@ -328,12 +334,12 @@ fn roundtrip() {
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = AffixFuzzer2::from_arrow2(serialized).unwrap();
+        let deserialized = AffixFuzzer2::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(arch, deserialized);
     }
 
@@ -363,17 +369,20 @@ fn roundtrip() {
         .into();
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name == "rerun.testing.components.AffixFuzzer21" {
+            if field.name() == "rerun.testing.components.AffixFuzzer21" {
                 // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
                 // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!("{} = Can't be printed (float16 not supported)", field.name);
+                eprintln!(
+                    "{} = Can't be printed (float16 not supported)",
+                    field.name()
+                );
             } else {
-                eprintln!("{} = {array:#?}", field.name);
+                eprintln!("{} = {array:#?}", field.name());
             }
 
             // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
@@ -381,12 +390,12 @@ fn roundtrip() {
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = AffixFuzzer3::from_arrow2(serialized).unwrap();
+        let deserialized = AffixFuzzer3::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(arch, deserialized);
     }
 
@@ -416,17 +425,20 @@ fn roundtrip() {
         .into();
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            if field.name == "rerun.testing.components.AffixFuzzer21" {
+            if field.name() == "rerun.testing.components.AffixFuzzer21" {
                 // TODO(#3741): Fields that contain Float16 apparently don't supported fmt
                 // https://github.com/rerun-io/re_arrow2/blob/33a32000001df800e4840d92c33b03e7007311e1/src/array/primitive/fmt.rs#L39
-                eprintln!("{} = Can't be printed (float16 not supported)", field.name);
+                eprintln!(
+                    "{} = Can't be printed (float16 not supported)",
+                    field.name()
+                );
             } else {
-                eprintln!("{} = {array:#?}", field.name);
+                eprintln!("{} = {array:#?}", field.name());
             }
 
             // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
@@ -434,12 +446,12 @@ fn roundtrip() {
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = AffixFuzzer4::from_arrow2(serialized).unwrap();
+        let deserialized = AffixFuzzer4::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(arch, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/fuzzy.rs
+++ b/crates/store/re_types/tests/types/fuzzy.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::redundant_clone)]
 
-use std::collections::HashMap;
+
 
 use re_types::{
     testing::{
@@ -12,7 +12,7 @@ use re_types::{
 
 use half::f16;
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -236,17 +236,6 @@ fn roundtrip() {
             fuzzy22_1.clone(),
         );
 
-        #[rustfmt::skip]
-        let expected_extensions: HashMap<_, _> = [
-            ("fuzz1001", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1002", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1003", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1004", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1005", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1006", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
-        ]
-        .into();
-
         eprintln!("arch = {arch:#?}");
         let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
@@ -262,15 +251,6 @@ fn roundtrip() {
                 );
             } else {
                 eprintln!("{} = {array:#?}", field.name());
-            }
-
-            // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
             }
         }
 
@@ -301,17 +281,6 @@ fn roundtrip() {
             [fuzzy22_1.clone(), fuzzy22_2.clone(), fuzzy22_1.clone()],
         );
 
-        #[rustfmt::skip]
-        let expected_extensions: HashMap<_, _> = [
-            ("fuzz1101", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1102", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1103", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1104", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1105", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz1106", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
-        ]
-        .into();
-
         eprintln!("arch = {arch:#?}");
         let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
@@ -327,15 +296,6 @@ fn roundtrip() {
                 );
             } else {
                 eprintln!("{} = {array:#?}", field.name());
-            }
-
-            // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
             }
         }
 
@@ -357,17 +317,6 @@ fn roundtrip() {
             .with_fuzz2017(fuzzy17_1.clone())
             .with_fuzz2018(fuzzy18_1.clone());
 
-        #[rustfmt::skip]
-        let expected_extensions: HashMap<_, _> = [
-            ("fuzz2001", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2002", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2003", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2004", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2005", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2006", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
-        ]
-        .into();
-
         eprintln!("arch = {arch:#?}");
         let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
@@ -383,15 +332,6 @@ fn roundtrip() {
                 );
             } else {
                 eprintln!("{} = {array:#?}", field.name());
-            }
-
-            // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
             }
         }
 
@@ -413,17 +353,6 @@ fn roundtrip() {
             .with_fuzz2117([fuzzy17_1.clone(), fuzzy17_2.clone(), fuzzy17_1.clone()])
             .with_fuzz2118([fuzzy18_1.clone(), fuzzy18_2.clone(), fuzzy18_3.clone()]);
 
-        #[rustfmt::skip]
-        let expected_extensions: HashMap<_, _> = [
-            ("fuzz2101", vec!["rerun.testing.components.AffixFuzzer1", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2102", vec!["rerun.testing.components.AffixFuzzer2", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2103", vec!["rerun.testing.components.AffixFuzzer3", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2104", vec!["rerun.testing.components.AffixFuzzer4", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2105", vec!["rerun.testing.components.AffixFuzzer5", "rerun.testing.datatypes.AffixFuzzer1"]),
-            ("fuzz2106", vec!["rerun.testing.components.AffixFuzzer6", "rerun.testing.datatypes.AffixFuzzer1"]),
-        ]
-        .into();
-
         eprintln!("arch = {arch:#?}");
         let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
@@ -439,15 +368,6 @@ fn roundtrip() {
                 );
             } else {
                 eprintln!("{} = {array:#?}", field.name());
-            }
-
-            // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
             }
         }
 

--- a/crates/store/re_types/tests/types/image.rs
+++ b/crates/store/re_types/tests/types/image.rs
@@ -23,19 +23,19 @@ fn image_roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = Image::from_arrow2(serialized).unwrap();
+        let deserialized = Image::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }
@@ -70,19 +70,19 @@ fn dynamic_image_roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = Image::from_arrow2(serialized).unwrap();
+        let deserialized = Image::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/image.rs
+++ b/crates/store/re_types/tests/types/image.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Image, datatypes::ColorModel, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn image_roundtrip() {
@@ -16,23 +16,12 @@ fn image_roundtrip() {
     .to_arrow()
     .unwrap()];
 
-    let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.TensorData"])].into();
-
     for (expected, serialized) in all_expected.into_iter().zip(all_arch_serialized) {
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = Image::from_arrow(serialized).unwrap();
@@ -63,23 +52,12 @@ fn dynamic_image_roundtrip() {
 
     let all_arch_serialized = [Image::from_image(img).unwrap().to_arrow().unwrap()];
 
-    let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.TensorData"])].into();
-
     for (expected, serialized) in all_expected.into_iter().zip(all_arch_serialized) {
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = Image::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/line_strips2d.rs
+++ b/crates/store/re_types/tests/types/line_strips2d.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::LineStrips2D,
@@ -6,7 +6,7 @@ use re_types::{
     Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -50,18 +50,6 @@ fn roundtrip() {
         .with_show_labels(false);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("points", vec!["rerun.components.LineStrip2D"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("labels", vec!["rerun.components.Text"]),
-        ("draw_order", vec!["rerun.components.DrawOrder"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -69,15 +57,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = LineStrips2D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/line_strips2d.rs
+++ b/crates/store/re_types/tests/types/line_strips2d.rs
@@ -63,23 +63,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = LineStrips2D::from_arrow2(serialized).unwrap();
+    let deserialized = LineStrips2D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/line_strips2d.rs
+++ b/crates/store/re_types/tests/types/line_strips2d.rs
@@ -1,12 +1,8 @@
-
-
 use re_types::{
     archetypes::LineStrips2D,
     components::{ClassId, Color, DrawOrder, LineStrip2D, Radius},
     Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/line_strips3d.rs
+++ b/crates/store/re_types/tests/types/line_strips3d.rs
@@ -1,12 +1,8 @@
-
-
 use re_types::{
     archetypes::LineStrips3D,
     components::{ClassId, Color, LineStrip3D, Radius},
     Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn roundtrip() {
@@ -55,7 +51,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
     }
 
     let deserialized = LineStrips3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/line_strips3d.rs
+++ b/crates/store/re_types/tests/types/line_strips3d.rs
@@ -61,23 +61,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = LineStrips3D::from_arrow2(serialized).unwrap();
+    let deserialized = LineStrips3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/line_strips3d.rs
+++ b/crates/store/re_types/tests/types/line_strips3d.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::LineStrips3D,
@@ -6,7 +6,7 @@ use re_types::{
     Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -48,18 +48,6 @@ fn roundtrip() {
         .with_show_labels(true);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("points", vec!["rerun.components.LineStrip3D"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("labels", vec!["rerun.components.Text"]),
-        ("draw_order", vec!["rerun.components.DrawOrder"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -68,14 +56,6 @@ fn roundtrip() {
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
 
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = LineStrips3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/main.rs
+++ b/crates/store/re_types/tests/types/main.rs
@@ -1,9 +1,5 @@
 //! Tests mainly, but not exclusively, of [`re_types::archetypes`].
 
-// Test helpers
-
-mod util;
-
 // Tests of archetypes and their related components and datatypes
 
 mod annotation_context;

--- a/crates/store/re_types/tests/types/mesh3d.rs
+++ b/crates/store/re_types/tests/types/mesh3d.rs
@@ -1,13 +1,9 @@
-
-
 use re_types::{
     archetypes::Mesh3D,
     components::{ClassId, Position3D, Texcoord2D, TriangleIndices, Vector3D},
     datatypes::{Rgba32, UVec3D, Vec2D, Vec3D},
     Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/mesh3d.rs
+++ b/crates/store/re_types/tests/types/mesh3d.rs
@@ -60,23 +60,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Mesh3D::from_arrow2(serialized).unwrap();
+    let deserialized = Mesh3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/mesh3d.rs
+++ b/crates/store/re_types/tests/types/mesh3d.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::Mesh3D,
@@ -7,7 +7,7 @@ use re_types::{
     Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -54,11 +54,6 @@ fn roundtrip() {
         .with_albedo_texture(texture_format, texture_buffer);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("class_ids", vec!["rerun.components.ClassId"]), //
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -66,15 +61,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Mesh3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/pinhole.rs
+++ b/crates/store/re_types/tests/types/pinhole.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Pinhole, components, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -20,12 +20,6 @@ fn roundtrip() {
         .with_camera_xyz(components::ViewCoordinates::RDF);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("half_sizes", vec!["rerun.components."]),
-        ("centers", vec!["rerun.components.Position2D"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -33,15 +27,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Pinhole::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/pinhole.rs
+++ b/crates/store/re_types/tests/types/pinhole.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Pinhole, components, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/pinhole.rs
+++ b/crates/store/re_types/tests/types/pinhole.rs
@@ -27,24 +27,24 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Pinhole::from_arrow2(serialized).unwrap();
+    let deserialized = Pinhole::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }
 

--- a/crates/store/re_types/tests/types/points2d.rs
+++ b/crates/store/re_types/tests/types/points2d.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Points2D, components, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/points2d.rs
+++ b/crates/store/re_types/tests/types/points2d.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Points2D, components, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -45,18 +45,6 @@ fn roundtrip() {
         .with_show_labels(false);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("points", vec!["rerun.components.Position2D"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("labels", vec!["rerun.components.Label"]),
-        ("draw_order", vec!["rerun.components.DrawOrder"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -64,15 +52,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Points2D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/points2d.rs
+++ b/crates/store/re_types/tests/types/points2d.rs
@@ -58,23 +58,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Points2D::from_arrow2(serialized).unwrap();
+    let deserialized = Points2D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/points3d.rs
+++ b/crates/store/re_types/tests/types/points3d.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+
 
 use re_types::{archetypes::Points3D, components, Archetype as _, AsComponents as _};
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -43,17 +43,6 @@ fn roundtrip() {
         .with_show_labels(true);
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("points", vec!["rerun.components.Position3D"]),
-        ("radii", vec!["rerun.components.Radius"]),
-        ("colors", vec!["rerun.components.Color"]),
-        ("labels", vec!["rerun.components.Text"]),
-        ("class_ids", vec!["rerun.components.ClassId"]),
-        ("keypoint_ids", vec!["rerun.components.KeypointId"]),
-        ("show_labels", vec!["rerun.components.ShowLabels"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -61,15 +50,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = Points3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/points3d.rs
+++ b/crates/store/re_types/tests/types/points3d.rs
@@ -55,23 +55,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = Points3D::from_arrow2(serialized).unwrap();
+    let deserialized = Points3D::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/points3d.rs
+++ b/crates/store/re_types/tests/types/points3d.rs
@@ -1,8 +1,4 @@
-
-
 use re_types::{archetypes::Points3D, components, Archetype as _, AsComponents as _};
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/segmentation_image.rs
+++ b/crates/store/re_types/tests/types/segmentation_image.rs
@@ -30,7 +30,7 @@ fn segmentation_image_roundtrip() {
         [4, 5, 6]
     ])
     .unwrap()
-    .to_arrow2()
+    .to_arrow()
     .unwrap()];
 
     let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.Blob"])].into();
@@ -40,19 +40,19 @@ fn segmentation_image_roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = SegmentationImage::from_arrow2(serialized).unwrap();
+        let deserialized = SegmentationImage::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/segmentation_image.rs
+++ b/crates/store/re_types/tests/types/segmentation_image.rs
@@ -1,12 +1,8 @@
-use std::collections::HashMap;
-
 use re_types::{
     archetypes::SegmentationImage,
     datatypes::{ChannelDatatype, ImageFormat},
     Archetype as _, AsComponents as _,
 };
-
-use crate::util;
 
 #[test]
 fn segmentation_image_roundtrip() {
@@ -33,23 +29,12 @@ fn segmentation_image_roundtrip() {
     .to_arrow()
     .unwrap()];
 
-    let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.Blob"])].into();
-
     for (expected, serialized) in all_expected.into_iter().zip(all_arch_serialized) {
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = SegmentationImage::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/tensor.rs
+++ b/crates/store/re_types/tests/types/tensor.rs
@@ -1,13 +1,9 @@
-use std::collections::HashMap;
-
 use re_types::{
     archetypes::Tensor,
     datatypes::{TensorBuffer, TensorData},
     tensor_data::TensorCastError,
     Archetype as _, AsComponents as _, Loggable as _,
 };
-
-use crate::util;
 
 #[test]
 fn tensor_buffer_roundtrip() {
@@ -39,23 +35,12 @@ fn tensor_roundtrip() {
         .to_arrow()
         .unwrap()];
 
-    let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.TensorData"])].into();
-
     for (expected, serialized) in all_expected.into_iter().zip(all_arch_serialized) {
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = Tensor::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/tensor.rs
+++ b/crates/store/re_types/tests/types/tensor.rs
@@ -36,7 +36,7 @@ fn tensor_roundtrip() {
 
     let all_arch_serialized = [Tensor::try_from(ndarray::array![[1u8, 2, 3], [4, 5, 6]])
         .unwrap()
-        .to_arrow2()
+        .to_arrow()
         .unwrap()];
 
     let expected_extensions: HashMap<_, _> = [("data", vec!["rerun.components.TensorData"])].into();
@@ -46,19 +46,19 @@ fn tensor_roundtrip() {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = Tensor::from_arrow2(serialized).unwrap();
+        let deserialized = Tensor::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/text_document.rs
+++ b/crates/store/re_types/tests/types/text_document.rs
@@ -1,10 +1,6 @@
-
-
 use re_types::{
     archetypes::TextDocument, components::MediaType, Archetype as _, AsComponents as _,
 };
-
-
 
 #[test]
 fn roundtrip() {

--- a/crates/store/re_types/tests/types/text_document.rs
+++ b/crates/store/re_types/tests/types/text_document.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+
 
 use re_types::{
     archetypes::TextDocument, components::MediaType, Archetype as _, AsComponents as _,
 };
 
-use crate::util;
+
 
 #[test]
 fn roundtrip() {
@@ -17,12 +17,6 @@ fn roundtrip() {
         .with_media_type(MediaType::markdown());
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> = [
-        ("text", vec!["rerun.components.Text"]),
-        ("media_type", vec!["rerun.components.MediaType"]),
-    ]
-    .into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -30,15 +24,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = TextDocument::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/text_document.rs
+++ b/crates/store/re_types/tests/types/text_document.rs
@@ -24,23 +24,23 @@ fn roundtrip() {
     .into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = TextDocument::from_arrow2(serialized).unwrap();
+    let deserialized = TextDocument::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }

--- a/crates/store/re_types/tests/types/transform3d.rs
+++ b/crates/store/re_types/tests/types/transform3d.rs
@@ -84,24 +84,24 @@ fn roundtrip() {
         similar_asserts::assert_eq!(expected, arch);
 
         eprintln!("arch = {arch:#?}");
-        let serialized = arch.to_arrow2().unwrap();
+        let serialized = arch.to_arrow().unwrap();
         for (field, array) in &serialized {
             // NOTE: Keep those around please, very useful when debugging.
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
-            eprintln!("{} = {array:#?}", field.name);
+            eprintln!("{} = {array:#?}", field.name());
 
             // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
             // has been fully replaced.
             if false {
                 util::assert_extensions(
                     &**array,
-                    expected_extensions[field.name.as_str()].as_slice(),
+                    expected_extensions[field.name().as_str()].as_slice(),
                 );
             }
         }
 
-        let deserialized = Transform3D::from_arrow2(serialized).unwrap();
+        let deserialized = Transform3D::from_arrow(serialized).unwrap();
         similar_asserts::assert_eq!(expected, deserialized);
     }
 }

--- a/crates/store/re_types/tests/types/transform3d.rs
+++ b/crates/store/re_types/tests/types/transform3d.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, f32::consts::TAU};
+use std::f32::consts::TAU;
 
 use re_types::{
     archetypes::Transform3D,
@@ -6,8 +6,6 @@ use re_types::{
     datatypes::{Angle, Mat3x3, RotationAxisAngle, Vec3D},
     Archetype as _, AsComponents as _,
 };
-
-use crate::util;
 
 #[test]
 fn roundtrip() {
@@ -75,11 +73,6 @@ fn roundtrip() {
             .with_relation(TransformRelation::ParentFromChild),
     ];
 
-    let expected_extensions: HashMap<_, _> = [
-        ("transform", vec!["rerun.components.Transform3D"]), //
-    ]
-    .into();
-
     for (expected, arch) in all_expected.into_iter().zip(all_arch) {
         similar_asserts::assert_eq!(expected, arch);
 
@@ -90,15 +83,6 @@ fn roundtrip() {
             // eprintln!("field = {field:#?}");
             // eprintln!("array = {array:#?}");
             eprintln!("{} = {array:#?}", field.name());
-
-            // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-            // has been fully replaced.
-            if false {
-                util::assert_extensions(
-                    &**array,
-                    expected_extensions[field.name().as_str()].as_slice(),
-                );
-            }
         }
 
         let deserialized = Transform3D::from_arrow(serialized).unwrap();

--- a/crates/store/re_types/tests/types/util.rs
+++ b/crates/store/re_types/tests/types/util.rs
@@ -1,4 +1,0 @@
-pub(crate) fn assert_extensions(_array: &dyn ::arrow::array::Array, _expected: &[&str]) {
-    // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
-    // has been fully replaced.
-}

--- a/crates/store/re_types/tests/types/util.rs
+++ b/crates/store/re_types/tests/types/util.rs
@@ -1,25 +1,4 @@
-pub(crate) fn assert_extensions(array: &dyn ::arrow2::array::Array, expected: &[&str]) {
-    let mut extracted = vec![];
-    extract_extensions(array.data_type(), &mut extracted);
-    similar_asserts::assert_eq!(expected, extracted);
-}
-
-pub(crate) fn extract_extensions(datatype: &::arrow2::datatypes::DataType, acc: &mut Vec<String>) {
-    match datatype {
-        arrow2::datatypes::DataType::List(field)
-        | arrow2::datatypes::DataType::FixedSizeList(field, _)
-        | arrow2::datatypes::DataType::LargeList(field) => {
-            extract_extensions(field.data_type(), acc);
-        }
-        arrow2::datatypes::DataType::Struct(fields) => {
-            for field in fields.iter() {
-                extract_extensions(field.data_type(), acc);
-            }
-        }
-        arrow2::datatypes::DataType::Extension(fqname, inner, _) => {
-            acc.push(fqname.clone());
-            extract_extensions(inner, acc);
-        }
-        _ => {}
-    }
+pub(crate) fn assert_extensions(_array: &dyn ::arrow::array::Array, _expected: &[&str]) {
+    // TODO(#3741): Re-enable extensions and these assertions once `arrow2-convert`
+    // has been fully replaced.
 }

--- a/crates/store/re_types/tests/types/validity.rs
+++ b/crates/store/re_types/tests/types/validity.rs
@@ -10,8 +10,8 @@ fn validity_checks() {
         components::Position2D::new(3.0, 4.0), //
     ];
 
-    let serialized = Position2D::to_arrow2(good_non_nullable).unwrap();
-    let deserialized = Position2D::from_arrow2(serialized.as_ref());
+    let serialized = Position2D::to_arrow(good_non_nullable).unwrap();
+    let deserialized = Position2D::from_arrow(serialized.as_ref());
     assert!(deserialized.is_ok());
 
     let good_nullable = vec![
@@ -19,8 +19,8 @@ fn validity_checks() {
         Some(components::Position2D::new(3.0, 4.0)), //
     ];
 
-    let serialized = Position2D::to_arrow2_opt(good_nullable).unwrap();
-    let deserialized = Position2D::from_arrow2(serialized.as_ref());
+    let serialized = Position2D::to_arrow_opt(good_nullable).unwrap();
+    let deserialized = Position2D::from_arrow(serialized.as_ref());
     assert!(deserialized.is_ok());
 
     let bad = vec![
@@ -28,8 +28,8 @@ fn validity_checks() {
         None,
     ];
 
-    let serialized = Position2D::to_arrow2_opt(bad).unwrap();
-    let deserialized = Position2D::from_arrow2(serialized.as_ref());
+    let serialized = Position2D::to_arrow_opt(bad).unwrap();
+    let deserialized = Position2D::from_arrow(serialized.as_ref());
     assert!(deserialized.is_err());
     let actual_error = deserialized.err().unwrap().without_context();
     assert!(

--- a/crates/store/re_types/tests/types/view_coordinates.rs
+++ b/crates/store/re_types/tests/types/view_coordinates.rs
@@ -21,24 +21,24 @@ fn roundtrip() {
         [("coordinates", vec!["rerun.components.ViewCoordinates"])].into();
 
     eprintln!("arch = {arch:#?}");
-    let serialized = arch.to_arrow2().unwrap();
+    let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
         // NOTE: Keep those around please, very useful when debugging.
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
-        eprintln!("{} = {array:#?}", field.name);
+        eprintln!("{} = {array:#?}", field.name());
 
         // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
         // has been fully replaced.
         if false {
             util::assert_extensions(
                 &**array,
-                expected_extensions[field.name.as_str()].as_slice(),
+                expected_extensions[field.name().as_str()].as_slice(),
             );
         }
     }
 
-    let deserialized = ViewCoordinates::from_arrow2(serialized).unwrap();
+    let deserialized = ViewCoordinates::from_arrow(serialized).unwrap();
     similar_asserts::assert_eq!(expected, deserialized);
 }
 

--- a/crates/store/re_types/tests/types/view_coordinates.rs
+++ b/crates/store/re_types/tests/types/view_coordinates.rs
@@ -1,11 +1,7 @@
-use std::collections::HashMap;
-
 use re_types::{
     archetypes::ViewCoordinates, components, view_coordinates::ViewDir, Archetype as _,
     AsComponents as _,
 };
-
-use crate::util;
 
 #[test]
 fn roundtrip() {
@@ -17,9 +13,6 @@ fn roundtrip() {
 
     similar_asserts::assert_eq!(expected, arch);
 
-    let expected_extensions: HashMap<_, _> =
-        [("coordinates", vec!["rerun.components.ViewCoordinates"])].into();
-
     eprintln!("arch = {arch:#?}");
     let serialized = arch.to_arrow().unwrap();
     for (field, array) in &serialized {
@@ -27,15 +20,6 @@ fn roundtrip() {
         // eprintln!("field = {field:#?}");
         // eprintln!("array = {array:#?}");
         eprintln!("{} = {array:#?}", field.name());
-
-        // TODO(cmc): Re-enable extensions and these assertions once `arrow2-convert`
-        // has been fully replaced.
-        if false {
-            util::assert_extensions(
-                &**array,
-                expected_extensions[field.name().as_str()].as_slice(),
-            );
-        }
     }
 
     let deserialized = ViewCoordinates::from_arrow(serialized).unwrap();

--- a/crates/store/re_types_core/src/archetype.rs
+++ b/crates/store/re_types_core/src/archetype.rs
@@ -102,14 +102,14 @@ pub trait Archetype {
     /// logged to stderr.
     #[inline]
     fn from_arrow(
-        data: impl IntoIterator<Item = (arrow2::datatypes::Field, ::arrow::array::ArrayRef)>,
+        data: impl IntoIterator<Item = (arrow::datatypes::Field, ::arrow::array::ArrayRef)>,
     ) -> DeserializationResult<Self>
     where
         Self: Sized,
     {
         Self::from_arrow_components(
             data.into_iter()
-                .map(|(field, array)| (field.name.into(), array)),
+                .map(|(field, array)| (ComponentName::new(field.name()), array)),
         )
     }
 

--- a/crates/store/re_types_core/src/lib.rs
+++ b/crates/store/re_types_core/src/lib.rs
@@ -61,6 +61,32 @@ pub trait AsComponents {
     /// The default implementation will simply serialize the result of [`Self::as_component_batches`]
     /// as-is, which is what you want in 99.9% of cases.
     #[inline]
+    fn to_arrow(
+        &self,
+    ) -> SerializationResult<Vec<(::arrow::datatypes::Field, ::arrow::array::ArrayRef)>> {
+        self.as_component_batches()
+            .into_iter()
+            .map(|comp_batch| {
+                comp_batch
+                    .to_arrow()
+                    .map(|array| {
+                        let field = arrow::datatypes::Field::new(
+                            comp_batch.name().to_string(),
+                            array.data_type().clone(),
+                            false,
+                        );
+                        (field, array)
+                    })
+                    .with_context(comp_batch.name())
+            })
+            .collect()
+    }
+
+    /// Serializes all non-null [`Component`]s of this bundle into Arrow2 arrays.
+    ///
+    /// The default implementation will simply serialize the result of [`Self::as_component_batches`]
+    /// as-is, which is what you want in 99.9% of cases.
+    #[inline]
     fn to_arrow2(
         &self,
     ) -> SerializationResult<Vec<(::arrow2::datatypes::Field, Box<dyn ::arrow2::array::Array>)>>

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -2,7 +2,7 @@
 
 use rerun::{
     demo_util::grid,
-    external::{arrow2, glam, re_types},
+    external::{arrow, glam, re_types},
     ComponentBatch,
 };
 
@@ -68,18 +68,18 @@ impl rerun::SizeBytes for Confidence {
 
 impl rerun::Loggable for Confidence {
     #[inline]
-    fn arrow2_datatype() -> arrow2::datatypes::DataType {
-        rerun::Float32::arrow2_datatype()
+    fn arrow_datatype() -> arrow::datatypes::DataType {
+        rerun::Float32::arrow_datatype()
     }
 
     #[inline]
-    fn to_arrow2_opt<'a>(
+    fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<std::borrow::Cow<'a, Self>>>>,
-    ) -> re_types::SerializationResult<Box<dyn arrow2::array::Array>>
+    ) -> re_types::SerializationResult<Box<dyn arrow::array::Array>>
     where
         Self: 'a,
     {
-        rerun::Float32::to_arrow2_opt(data.into_iter().map(|opt| opt.map(Into::into).map(|c| c.0)))
+        rerun::Float32::to_arrow_opt(data.into_iter().map(|opt| opt.map(Into::into).map(|c| c.0)))
     }
 }
 

--- a/docs/snippets/all/tutorials/custom_data.rs
+++ b/docs/snippets/all/tutorials/custom_data.rs
@@ -75,7 +75,7 @@ impl rerun::Loggable for Confidence {
     #[inline]
     fn to_arrow_opt<'a>(
         data: impl IntoIterator<Item = Option<impl Into<std::borrow::Cow<'a, Self>>>>,
-    ) -> re_types::SerializationResult<Box<dyn arrow::array::Array>>
+    ) -> re_types::SerializationResult<arrow::array::ArrayRef>
     where
         Self: 'a,
     {


### PR DESCRIPTION
### Related
* Part of https://github.com/rerun-io/rerun/issues/3741
* Waiting for https://github.com/rerun-io/rerun/pull/8375


### What
Port our re_types roundtrip tests from arrow1 to arrow2