### PR TITLE
Fix `custom_callback` manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1724,7 +1724,7 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "custom_callback"
-version = "0.21.0-alpha.1+dev"
+version = "0.22.0-alpha.1+dev"
 dependencies = [
  "bincode",
  "mimalloc",

--- a/crates/store/re_types_core/src/as_components.rs
+++ b/crates/store/re_types_core/src/as_components.rs
@@ -30,6 +30,7 @@ pub trait AsComponents {
     /// [`ComponentDescriptor`], see [`ComponentBatchCowWithDescriptor::descriptor_override`].
     ///
     /// [Custom Data Loader]: https://github.com/rerun-io/rerun/tree/latest/examples/rust/custom_data_loader
+    /// [`ComponentDescriptor`]: [crate::ComponentDescriptor]
     //
     // NOTE: Don't bother returning a CoW here: we need to dynamically discard optional components
     // depending on their presence (or lack thereof) at runtime anyway.
@@ -69,6 +70,8 @@ pub trait AsComponents {
     ///
     /// The default implementation will simply serialize the result of [`Self::as_component_batches`]
     /// as-is, which is what you want in 99.9% of cases.
+    ///
+    /// [`Component`]: [crate::Component]
     #[inline]
     fn to_arrow2(
         &self,

--- a/examples/rust/custom_callback/Cargo.toml
+++ b/examples/rust/custom_callback/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "custom_callback"
-version = "0.21.0-alpha.1+dev"
+version = "0.22.0-alpha.1+dev"
 edition = "2021"
-rust-version = "1.80"
+rust-version = "1.81"
 license = "MIT OR Apache-2.0"
 publish = false
 


### PR DESCRIPTION
This generates cargo warnings because of the MSRV mismatches and such.