### PR TITLE
Remove superfluous blanket impls in our logging traits

### DIFF
--- a/crates/store/re_types_core/src/as_components.rs
+++ b/crates/store/re_types_core/src/as_components.rs
@@ -96,6 +96,11 @@ pub trait AsComponents {
     }
 }
 
+#[allow(dead_code)]
+fn assert_object_safe() {
+    let _: &dyn AsComponents;
+}
+
 impl AsComponents for dyn ComponentBatch {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
@@ -113,24 +118,6 @@ impl<const N: usize> AsComponents for [&dyn ComponentBatch; N] {
 }
 
 impl<const N: usize> AsComponents for [Box<dyn ComponentBatch>; N] {
-    #[inline]
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        self.iter()
-            .map(|batch| ComponentBatchCowWithDescriptor::new(&**batch))
-            .collect()
-    }
-}
-
-impl AsComponents for &[&dyn ComponentBatch] {
-    #[inline]
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        self.iter()
-            .map(|batch| ComponentBatchCowWithDescriptor::new(*batch))
-            .collect()
-    }
-}
-
-impl AsComponents for &[Box<dyn ComponentBatch>] {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         self.iter()
@@ -157,6 +144,15 @@ impl AsComponents for Vec<Box<dyn ComponentBatch>> {
     }
 }
 
+impl<AS: AsComponents> AsComponents for [AS] {
+    #[inline]
+    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
+        self.iter()
+            .flat_map(|as_components| as_components.as_component_batches())
+            .collect()
+    }
+}
+
 impl<AS: AsComponents, const N: usize> AsComponents for [AS; N] {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
@@ -176,33 +172,6 @@ impl<const N: usize> AsComponents for [&dyn AsComponents; N] {
 }
 
 impl<const N: usize> AsComponents for [Box<dyn AsComponents>; N] {
-    #[inline]
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        self.iter()
-            .flat_map(|as_components| as_components.as_component_batches())
-            .collect()
-    }
-}
-
-impl<AS: AsComponents> AsComponents for &[AS] {
-    #[inline]
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        self.iter()
-            .flat_map(|as_components| as_components.as_component_batches())
-            .collect()
-    }
-}
-
-impl AsComponents for &[&dyn AsComponents] {
-    #[inline]
-    fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
-        self.iter()
-            .flat_map(|as_components| as_components.as_component_batches())
-            .collect()
-    }
-}
-
-impl AsComponents for &[Box<dyn AsComponents>] {
     #[inline]
     fn as_component_batches(&self) -> Vec<ComponentBatchCowWithDescriptor<'_>> {
         self.iter()

--- a/crates/store/re_types_core/src/loggable_batch.rs
+++ b/crates/store/re_types_core/src/loggable_batch.rs
@@ -32,6 +32,11 @@ pub trait LoggableBatch {
     fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>>;
 }
 
+#[allow(dead_code)]
+fn assert_loggablebatch_object_safe() {
+    let _: &dyn LoggableBatch;
+}
+
 /// A [`ComponentBatch`] represents an array's worth of [`Component`] instances.
 pub trait ComponentBatch: LoggableBatch {
     /// Serializes the batch into an Arrow list array with a single component per list.
@@ -73,6 +78,11 @@ pub trait ComponentBatch: LoggableBatch {
     fn name(&self) -> ComponentName {
         self.descriptor().component_name
     }
+}
+
+#[allow(dead_code)]
+fn assert_component_batch_object_safe() {
+    let _: &dyn LoggableBatch;
 }
 
 /// Some [`ComponentBatch`], optionally with an overridden [`ComponentDescriptor`].
@@ -287,14 +297,14 @@ impl<C: Component, const N: usize> ComponentBatch for [Option<C>; N] {
 
 // --- Slice ---
 
-impl<L: Loggable> LoggableBatch for &[L] {
+impl<L: Loggable> LoggableBatch for [L] {
     #[inline]
     fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow2(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
     }
 }
 
-impl<C: Component> ComponentBatch for &[C] {
+impl<C: Component> ComponentBatch for [C] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
         C::descriptor().into()
@@ -303,7 +313,7 @@ impl<C: Component> ComponentBatch for &[C] {
 
 // --- Slice<Option> ---
 
-impl<L: Loggable> LoggableBatch for &[Option<L>] {
+impl<L: Loggable> LoggableBatch for [Option<L>] {
     #[inline]
     fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
         L::to_arrow2_opt(
@@ -313,42 +323,7 @@ impl<L: Loggable> LoggableBatch for &[Option<L>] {
     }
 }
 
-impl<C: Component> ComponentBatch for &[Option<C>] {
-    #[inline]
-    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
-    }
-}
-
-// --- ArrayRef ---
-
-impl<L: Loggable, const N: usize> LoggableBatch for &[L; N] {
-    #[inline]
-    fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
-        L::to_arrow2(self.iter().map(|v| std::borrow::Cow::Borrowed(v)))
-    }
-}
-
-impl<C: Component, const N: usize> ComponentBatch for &[C; N] {
-    #[inline]
-    fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
-        C::descriptor().into()
-    }
-}
-
-// --- ArrayRef<Option> ---
-
-impl<L: Loggable, const N: usize> LoggableBatch for &[Option<L>; N] {
-    #[inline]
-    fn to_arrow2(&self) -> SerializationResult<Box<dyn ::arrow2::array::Array>> {
-        L::to_arrow2_opt(
-            self.iter()
-                .map(|opt| opt.as_ref().map(|v| std::borrow::Cow::Borrowed(v))),
-        )
-    }
-}
-
-impl<C: Component, const N: usize> ComponentBatch for &[Option<C>; N] {
+impl<C: Component> ComponentBatch for [Option<C>] {
     #[inline]
     fn descriptor(&self) -> Cow<'_, ComponentDescriptor> {
         C::descriptor().into()


### PR DESCRIPTION
Our core logging traits have to be object-safe, which means `Self` must be unsized, which means all methods must take either a shared or exclusive reference.
This in turns means that any `impl Trait for &something` is non-sensical, since this lowers to `impl Trait for &&self`, which just gives extra work to the compiler for no reason since this is semantically identical to the builtin autoderef magic.