### PR TITLE
Fix compilation for GCC 13.3 (missing `cstdint` include)

### DIFF
--- a/rerun_cpp/src/rerun/component_descriptor.hpp
+++ b/rerun_cpp/src/rerun/component_descriptor.hpp
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string_view>
+#include <cstdint>
 
 namespace rerun {
     /// See `ComponentDescriptor::hashed`.


### PR DESCRIPTION
### Related

Closes #8608

### What

Add cstdint to define uint64_t.
<!--
Make sure the PR title and labels are set to maximize their usefulness for the CHANGELOG,
and our `git log`.

If you have noticed any breaking changes, include them in the migration guide.

We track various metrics at <https://build.rerun.io>.

For maintainers:
* To run all checks from `main`, comment on the PR with `@rerun-bot full-check`.
* To deploy documentation changes immediately after merging this PR, add the `deploy docs` label.
-->
