### PR TITLE
Fix WSL support, update troubleshooting guide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,7 +2131,7 @@ dependencies = [
 [[package]]
 name = "egui_plot"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui_plot.git?rev=4a16b8842aa39e6ea6b6c9c98afe20e060e767b6#4a16b8842aa39e6ea6b6c9c98afe20e060e767b6"
+source = "git+https://github.com/emilk/egui_plot.git?rev=80e2199a2e121db288fe6b0099d91c35acc75a7c#80e2199a2e121db288fe6b0099d91c35acc75a7c"
 dependencies = [
  "ahash",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1965,7 +1965,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2004,11 +2004,12 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "accesskit",
  "ahash",
  "backtrace",
+ "bitflags 2.6.0",
  "emath",
  "epaint",
  "log",
@@ -2021,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2040,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2081,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "ahash",
  "egui",
@@ -2098,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2115,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "dify",
  "eframe",
@@ -2186,7 +2187,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2302,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2321,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
+source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1965,7 +1965,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "ahash",
  "egui",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "dify",
  "eframe",
@@ -2186,7 +2186,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2321,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
+source = "git+https://github.com/emilk/egui.git?rev=b973ffd635aadf6fae3e5a734b0701633f7c007d#b973ffd635aadf6fae3e5a734b0701633f7c007d"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1965,7 +1965,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2021,7 +2021,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2040,7 +2040,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2081,7 +2081,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "ahash",
  "egui",
@@ -2098,7 +2098,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2115,7 +2115,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "dify",
  "eframe",
@@ -2124,6 +2124,7 @@ dependencies = [
  "image",
  "kittest",
  "pollster 0.4.0",
+ "wgpu",
 ]
 
 [[package]]
@@ -2185,7 +2186,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2301,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2320,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=938d8b0d2e2a551ac354d76d6208188e5942b21e#938d8b0d2e2a551ac354d76d6208188e5942b21e"
+source = "git+https://github.com/emilk/egui.git?rev=a837994863a516a7cad6fbc207e1a0b592c2603e#a837994863a516a7cad6fbc207e1a0b592c2603e"
 
 [[package]]
 name = "equivalent"
@@ -2906,6 +2907,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.65",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -5119,6 +5132,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5461,6 +5480,12 @@ dependencies = [
  "num-traits",
  "rand",
 ]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "raw-cpuid"
@@ -9723,6 +9748,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
+ "bit-set",
  "bitflags 2.6.0",
  "block",
  "bytemuck",
@@ -9731,6 +9757,7 @@ dependencies = [
  "glow 0.14.2",
  "glutin_wgl_sys",
  "gpu-alloc",
+ "gpu-allocator",
  "gpu-descriptor",
  "js-sys",
  "khronos-egl",
@@ -9744,6 +9771,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "profiling",
+ "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
@@ -9753,6 +9781,7 @@ dependencies = [
  "web-sys",
  "wgpu-types",
  "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 [[package]]
 name = "ecolor"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "bytemuck",
  "color-hex",
@@ -1965,7 +1965,7 @@ checksum = "18aade80d5e09429040243ce1143ddc08a92d7a22820ac512610410a4dd5214f"
 [[package]]
 name = "eframe"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2004,7 +2004,7 @@ dependencies = [
 [[package]]
 name = "egui"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "accesskit",
  "ahash",
@@ -2022,7 +2022,7 @@ dependencies = [
 [[package]]
 name = "egui-wgpu"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2041,7 +2041,7 @@ dependencies = [
 [[package]]
 name = "egui-winit"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "accesskit_winit",
  "ahash",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "egui_extras"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "ahash",
  "egui",
@@ -2099,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "egui_glow"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -2116,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "egui_kittest"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "dify",
  "eframe",
@@ -2187,7 +2187,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 [[package]]
 name = "emath"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "bytemuck",
  "serde",
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "epaint"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2322,7 +2322,7 @@ dependencies = [
 [[package]]
 name = "epaint_default_fonts"
 version = "0.30.0"
-source = "git+https://github.com/emilk/egui.git?rev=443df84a22881e78f003688ce7ece802b2b050c3#443df84a22881e78f003688ce7ece802b2b050c3"
+source = "git+https://github.com/emilk/egui.git?rev=f0d7c74e838b8e8920a22e7515990fbe057ec218#f0d7c74e838b8e8920a22e7515990fbe057ec218"
 
 [[package]]
 name = "equivalent"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,13 +559,13 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }       # egui master 2025-01-TODO
-eframe = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }       # egui master 2025-01-TODO
-egui = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }         # egui master 2025-01-TODO
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }  # egui master 2025-01-TODO
-egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" } # egui master 2025-01-TODO
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }    # egui master 2025-01-TODO
-emath = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }        # egui master 2025-01-TODO
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }       # egui master 2025-01-TODO
+eframe = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }       # egui master 2025-01-TODO
+egui = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }         # egui master 2025-01-TODO
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }  # egui master 2025-01-TODO
+egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" } # egui master 2025-01-TODO
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }    # egui master 2025-01-TODO
+emath = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }        # egui master 2025-01-TODO
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -576,7 +576,7 @@ emath = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a2
 # egui-wgpu = { path = "../../egui/crates/egui-wgpu" }
 # emath = { path = "../../egui/crates/emath" }
 
-egui_plot = { git = "https://github.com/emilk/egui_plot.git", rev = "4a16b8842aa39e6ea6b6c9c98afe20e060e767b6" }
+egui_plot = { git = "https://github.com/emilk/egui_plot.git", rev = "80e2199a2e121db288fe6b0099d91c35acc75a7c" }
 # egui_plot = { path = "../../egui_plot/egui_plot" }
 
 # egui_tiles = { git = "https://github.com/rerun-io/egui_tiles", rev = "48e0ef566479000a23d8dabf84badced98f1b9a6" } # https://github.com/rerun-io/egui_tiles/pull/89 2024-11-19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,13 +559,13 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }       # egui master 2025-01-08
-eframe = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }       # egui master 2025-01-08
-egui = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }         # egui master 2025-01-08
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }  # egui master 2025-01-08
-egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" } # egui master 2025-01-08
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }    # egui master 2025-01-08
-emath = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }        # egui master 2025-01-08
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }       # egui master 2025-01-08
+eframe = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }       # egui master 2025-01-08
+egui = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }         # egui master 2025-01-08
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }  # egui master 2025-01-08
+egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" } # egui master 2025-01-08
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }    # egui master 2025-01-08
+emath = { git = "https://github.com/emilk/egui.git", rev = "f0d7c74e838b8e8920a22e7515990fbe057ec218" }        # egui master 2025-01-08
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,13 +559,13 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }       # egui master 2025-01-TODO
-eframe = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }       # egui master 2025-01-TODO
-egui = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }         # egui master 2025-01-TODO
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }  # egui master 2025-01-TODO
-egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" } # egui master 2025-01-TODO
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }    # egui master 2025-01-TODO
-emath = { git = "https://github.com/emilk/egui.git", rev = "b973ffd635aadf6fae3e5a734b0701633f7c007d" }        # egui master 2025-01-TODO
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }       # egui master 2025-01-08
+eframe = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }       # egui master 2025-01-08
+egui = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }         # egui master 2025-01-08
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }  # egui master 2025-01-08
+egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" } # egui master 2025-01-08
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }    # egui master 2025-01-08
+emath = { git = "https://github.com/emilk/egui.git", rev = "443df84a22881e78f003688ce7ece802b2b050c3" }        # egui master 2025-01-08
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,13 +559,13 @@ significant_drop_tightening = "allow" # An update of parking_lot made this trigg
 # As a last resport, patch with a commit to our own repository.
 # ALWAYS document what PR the commit hash is part of, or when it was merged into the upstream trunk.
 
-ecolor = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }       # egui master 2025-01-03
-eframe = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }       # egui master 2025-01-03
-egui = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }         # egui master 2025-01-03
-egui_extras = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }  # egui master 2025-01-03
-egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" } # egui master 2025-01-03
-egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }    # egui master 2025-01-03
-emath = { git = "https://github.com/emilk/egui.git", rev = "938d8b0d2e2a551ac354d76d6208188e5942b21e" }        # egui master 2025-01-03
+ecolor = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }       # egui master 2025-01-TODO
+eframe = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }       # egui master 2025-01-TODO
+egui = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }         # egui master 2025-01-TODO
+egui_extras = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }  # egui master 2025-01-TODO
+egui_kittest = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" } # egui master 2025-01-TODO
+egui-wgpu = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }    # egui master 2025-01-TODO
+emath = { git = "https://github.com/emilk/egui.git", rev = "a837994863a516a7cad6fbc207e1a0b592c2603e" }        # egui master 2025-01-TODO
 
 # Useful while developing:
 # ecolor = { path = "../../egui/crates/ecolor" }

--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -857,7 +857,7 @@ fn run_impl(
                 }
                 Box::new(app)
             }),
-            args.renderer,
+            args.renderer.as_deref(),
         )
         .map_err(|err| err.into());
 

--- a/crates/viewer/re_component_ui/src/marker_shape.rs
+++ b/crates/viewer/re_component_ui/src/marker_shape.rs
@@ -39,7 +39,7 @@ pub(crate) fn edit_marker_shape_ui(
 
                             if response.clicked() {
                                 *edit_marker = marker;
-                                response.flags |= egui::response::Flags::CHANGED;
+                                response.mark_changed();
                             }
 
                             combined_response = Some(match combined_response {

--- a/crates/viewer/re_component_ui/src/marker_shape.rs
+++ b/crates/viewer/re_component_ui/src/marker_shape.rs
@@ -39,7 +39,7 @@ pub(crate) fn edit_marker_shape_ui(
 
                             if response.clicked() {
                                 *edit_marker = marker;
-                                response.changed = true;
+                                response.flags |= egui::response::Flags::CHANGED;
                             }
 
                             combined_response = Some(match combined_response {

--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -74,7 +74,7 @@ impl DeviceTier {
                         // I.e. we can only draw with about 16.8mio vertices per mesh.
                         // Typically we don't reach this limit.
                         //
-                        // This can happen if...
+                        // This can happen if…
                         // * OpenGL: `GL_MAX_ELEMENT_INDEX` reports a value lower than `std::u32::MAX`
                         // * Vulkan: `VkPhysicalDeviceLimits::fullDrawIndexUint32` is false.
                         // The consequence of exceeding this limit seems to be undefined.

--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -65,7 +65,7 @@ impl DeviceTier {
                     // Turn a blind eye on a few features that are missing as of writing in WSL even with latest Vulkan drivers
                     // and pretend we still have full WebGPU support anyways.
                     wgpu::DownlevelFlags::compliant()
-                        // Lack means that we can't set the format of views on suface textures (the result of `get_current_texture`) surface won't tell us which formats are supported.
+                        // Lack means that we can't set the format of views on surface textures (the result of `get_current_texture`) surface won't tell us which formats are supported.
                         // We avoid doing anything wonky with surfaces anyways, so we won't hit this.
                         .intersection(wgpu::DownlevelFlags::SURFACE_VIEW_FORMATS.complement())
                         // Lack means we only get 2^24-1 indices for drawing.

--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -70,8 +70,14 @@ impl DeviceTier {
                         // And the surface won't tell us which formats are supported.
                         // We avoid doing anything wonky with surfaces anyways, so we won't hit this.
                         .intersection(wgpu::DownlevelFlags::SURFACE_VIEW_FORMATS.complement())
-                        // Lacking `FULL_DRAW_INDEX_UINT32` means we only get 2^24-1 indices for drawing.
+                        // Lacking `FULL_DRAW_INDEX_UINT32` means that vertex indices above 2^24-1 are invalid.
+                        // I.e. we can only draw with about 16.8mio vertices per mesh.
                         // Typically we don't reach this limit.
+                        //
+                        // This can happen if...
+                        // * OpenGL: `GL_MAX_ELEMENT_INDEX` reports a value lower than `std::u32::MAX`
+                        // * Vulkan: `VkPhysicalDeviceLimits::fullDrawIndexUint32` is false.
+                        // The consequence of exceeding this limit seems to be undefined.
                         .intersection(wgpu::DownlevelFlags::FULL_DRAW_INDEX_UINT32.complement())
                 }
             },

--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -62,13 +62,15 @@ impl DeviceTier {
                 Self::Gles => wgpu::DownlevelFlags::empty(),
                 // Require fully WebGPU compliance for the native tier.
                 Self::FullWebGpuSupport => {
-                    // Turn a blind eye on a few features that are missing as of writing in WSL even with latest Vulkan drivers
-                    // and pretend we still have full WebGPU support anyways.
+                    // Turn a blind eye on a few features that are missing as of writing in WSL even with latest Vulkan drivers.
+                    // Pretend we still have full WebGPU support anyways.
                     wgpu::DownlevelFlags::compliant()
-                        // Lack means that we can't set the format of views on surface textures (the result of `get_current_texture`) surface won't tell us which formats are supported.
+                        // Lacking `SURFACE_VIEW_FORMATS` means we can't set the format of views on surface textures
+                        // (the result of `get_current_texture`).
+                        // And the surface won't tell us which formats are supported.
                         // We avoid doing anything wonky with surfaces anyways, so we won't hit this.
                         .intersection(wgpu::DownlevelFlags::SURFACE_VIEW_FORMATS.complement())
-                        // Lack means we only get 2^24-1 indices for drawing.
+                        // Lacking `FULL_DRAW_INDEX_UINT32` means we only get 2^24-1 indices for drawing.
                         // Typically we don't reach this limit.
                         .intersection(wgpu::DownlevelFlags::FULL_DRAW_INDEX_UINT32.complement())
                 }

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -23,7 +23,8 @@ const STARTUP_FRAME_IDX: u64 = u64::MAX;
 #[derive(thiserror::Error, Debug)]
 pub enum RenderContextError {
     #[error(
-        "The GPU/graphics driver is lacking some abilities: {0}.\nConsider updating the driver."
+        "The GPU/graphics driver is lacking some abilities: {0}. \
+        Check the troubleshooting guide at https://rerun.io/docs/getting-started/troubleshooting and consider updating your graphics driver."
     )]
     InsufficientDeviceCapabilities(#[from] crate::config::InsufficientDeviceCapabilities),
 }

--- a/crates/viewer/re_renderer_examples/framework.rs
+++ b/crates/viewer/re_renderer_examples/framework.rs
@@ -7,11 +7,7 @@ use std::sync::Arc;
 use anyhow::Context as _;
 use web_time::Instant;
 
-use re_renderer::{
-    config::{supported_backends, DeviceCaps},
-    view_builder::ViewBuilder,
-    RenderContext,
-};
+use re_renderer::{config::DeviceCaps, view_builder::ViewBuilder, RenderContext};
 
 use winit::{
     application::ApplicationHandler,

--- a/crates/viewer/re_renderer_examples/framework.rs
+++ b/crates/viewer/re_renderer_examples/framework.rs
@@ -112,14 +112,12 @@ fn preferred_framebuffer_format(formats: &[wgpu::TextureFormat]) -> wgpu::Textur
 impl<E: Example + 'static> Application<E> {
     async fn new(window: Window) -> anyhow::Result<Self> {
         let window = Arc::new(window);
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: supported_backends(),
-            flags: wgpu::InstanceFlags::default()
-                // Run without validation layers, they can be annoying on shader reload depending on the backend.
-                .intersection(wgpu::InstanceFlags::VALIDATION.complement()),
-            dx12_shader_compiler: wgpu::Dx12Compiler::Fxc,
-            gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
-        });
+
+        let mut instance_desc = re_renderer::config::instance_descriptor(None);
+        // Run without validation layers, they can be annoying on shader reload depending on the backend.
+        instance_desc.flags.remove(wgpu::InstanceFlags::VALIDATION);
+
+        let instance = wgpu::Instance::new(instance_desc);
         let surface = instance.create_surface(window.clone()).unwrap();
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/viewer/re_ui/examples/re_ui_example/main.rs
+++ b/crates/viewer/re_ui/examples/re_ui_example/main.rs
@@ -441,7 +441,7 @@ impl egui_tiles::Behavior<Tab> for MyTileTreeBehavior {
         _tile_id: egui_tiles::TileId,
         _pane: &mut Tab,
     ) -> egui_tiles::UiResponse {
-        egui::Frame::none().inner_margin(4.0).show(ui, |ui| {
+        egui::Frame::new().inner_margin(4.0).show(ui, |ui| {
             egui::warn_if_debug_build(ui);
             ui.label("Hover me for a tooltip")
                 .on_hover_text("This is a tooltip");

--- a/crates/viewer/re_ui/src/list_item/list_item.rs
+++ b/crates/viewer/re_ui/src/list_item/list_item.rs
@@ -332,8 +332,8 @@ impl ListItem {
         // override_hover should not affect the returned response
         let mut style_response = response.clone();
         if force_hovered {
-            style_response.contains_pointer = true;
-            style_response.hovered = true;
+            style_response.flags |= egui::response::Flags::CONTAINS_POINTER;
+            style_response.flags |= egui::response::Flags::HOVERED;
         }
 
         let mut collapse_response = None;

--- a/crates/viewer/re_ui/src/ui_ext.rs
+++ b/crates/viewer/re_ui/src/ui_ext.rs
@@ -25,7 +25,7 @@ fn notification_label(
     visible_text: &str,
     full_text: &str,
 ) -> egui::Response {
-    egui::Frame::none()
+    egui::Frame::new()
         .stroke((1.0, fg_color))
         .fill(error_label_bg_color(fg_color))
         .rounding(4.0)

--- a/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
+++ b/crates/viewer/re_view_dataframe/src/dataframe_ui.rs
@@ -85,7 +85,7 @@ pub(crate) fn dataframe_ui(
         .take_while(|cd| matches!(cd, ColumnDescriptor::Time(_)))
         .count();
 
-    egui::Frame::none().inner_margin(5.0).show(ui, |ui| {
+    egui::Frame::new().inner_margin(5.0).show(ui, |ui| {
         egui_table::Table::new()
             .id_salt(table_id_salt)
             .columns(
@@ -232,7 +232,7 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
         }
 
-        egui::Frame::none()
+        egui::Frame::new()
             .inner_margin(egui::Margin::symmetric(4, 0))
             .show(ui, |ui| {
                 if cell.row_nr == 0 {
@@ -456,7 +456,7 @@ impl egui_table::TableDelegate for DataframeTableDelegate<'_> {
                 };
 
                 // Draw the cell content with some margin.
-                egui::Frame::none()
+                egui::Frame::new()
                     .inner_margin(egui::Margin::symmetric(Self::LEFT_RIGHT_MARGIN, 0))
                     .show(ui, |ui| {
                         line_ui(

--- a/crates/viewer/re_view_map/src/map_overlays.rs
+++ b/crates/viewer/re_view_map/src/map_overlays.rs
@@ -15,7 +15,7 @@ pub fn acknowledgement_overlay(
     let mut ui = ui.new_child(egui::UiBuilder::new().max_rect(rect));
     ui.multiply_opacity(0.7);
 
-    egui::Frame::none()
+    egui::Frame::new()
         .fill(ui.visuals().window_fill)
         .inner_margin(egui::Margin::same(2))
         .show(&mut ui, |ui| {

--- a/crates/viewer/re_viewer/src/app_state.rs
+++ b/crates/viewer/re_viewer/src/app_state.rs
@@ -467,7 +467,7 @@ impl AppState {
                         let min_height_each = 90.0_f32.at_most(ui.available_height() / 2.0);
 
                         egui::TopBottomPanel::top("recording_panel")
-                            .frame(egui::Frame::none())
+                            .frame(egui::Frame::new())
                             .resizable(resizable)
                             .show_separator_line(false)
                             .min_height(min_height_each)

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -206,11 +206,16 @@ pub(crate) fn wgpu_options(force_wgpu_backend: Option<String>) -> egui_wgpu::Wgp
             // This rejection should happen with reason-message so it's tractable why a given adapter wasn't chosen.
             // Which is obviously what we want to show when we're rejecting all adapters, but it would
             // also be great to be able to show that information later on.
-            wgpu_setup: egui_wgpu::WgpuSetup::CreateNew {
+            wgpu_setup: egui_wgpu::WgpuSetup::CreateNew(egui_wgpu::WgpuSetupCreateNew {
                 device_descriptor: std::sync::Arc::new(|adapter| re_renderer::config::DeviceCaps::from_adapter_without_validation(adapter).device_descriptor()),
-                supported_backends: supported_graphics_backends(force_wgpu_backend),
-                power_preference: wgpu::util::power_preference_from_env().unwrap_or(wgpu::PowerPreference::HighPerformance),
-             },
+                instance_descriptor:
+                wgpu::InstanceDescriptor {
+                    backends: supported_graphics_backends(force_wgpu_backend),
+                    flags: wgpu::InstanceFlags::default().with_env(),
+                    ..Default::default()
+                },
+                ..Default::default()
+             }),
             ..Default::default()
         }
 }

--- a/crates/viewer/re_viewer/src/lib.rs
+++ b/crates/viewer/re_viewer/src/lib.rs
@@ -211,7 +211,7 @@ pub(crate) fn wgpu_options(force_wgpu_backend: Option<String>) -> egui_wgpu::Wgp
                 instance_descriptor:
                 wgpu::InstanceDescriptor {
                     backends: supported_graphics_backends(force_wgpu_backend),
-                    flags: wgpu::InstanceFlags::default().with_env(),
+                    flags: wgpu::InstanceFlags::default().union(wgpu::InstanceFlags::ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER).with_env(),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -11,7 +11,7 @@ pub fn run_native_app(
     // `eframe::run_native` may only be called on the main thread.
     _: crate::MainThreadToken,
     app_creator: AppCreator,
-    force_wgpu_backend: Option<String>,
+    force_wgpu_backend: Option<&str>,
 ) -> eframe::Result {
     let native_options = eframe_options(force_wgpu_backend);
 
@@ -26,7 +26,7 @@ pub fn run_native_app(
     )
 }
 
-pub fn eframe_options(force_wgpu_backend: Option<String>) -> eframe::NativeOptions {
+pub fn eframe_options(force_wgpu_backend: Option<&str>) -> eframe::NativeOptions {
     re_tracing::profile_function!();
     eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default()
@@ -111,6 +111,6 @@ pub fn run_native_viewer_with_messages(
             app.add_receiver(rx);
             Box::new(app)
         }),
-        force_wgpu_backend,
+        force_wgpu_backend.as_deref(),
     )
 }

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -72,7 +72,7 @@ impl WebHandle {
 
         let app_options = self.app_options.clone();
         let web_options = eframe::WebOptions {
-            wgpu_options: crate::wgpu_options(app_options.render_backend.clone()),
+            wgpu_options: crate::wgpu_options(app_options.render_backend.as_deref()),
             depth_buffer: 0,
             dithering: true,
             ..Default::default()

--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -53,6 +53,14 @@ sudo apt-get -y install \
     adwaita-icon-theme-full
 ```
 
+TODO:
+```
+sudo add-apt-repository ppa:kisak/kisak-mesa
+sudo apt update
+sudo apt install mesa-vulkan-drivers
+```
+
+
 [TODO(#1250)](https://github.com/rerun-io/rerun/issues/1250): Running with the wayland window manager
 sometimes causes Rerun to crash. Try unsetting the wayland display (`unset WAYLAND_DISPLAY` or `WAYLAND_DISPLAY= `) as a workaround.
 

--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -41,35 +41,33 @@ sudo dnf install \
     pkg-config
 ```
 
-### WSL2
-
-In addition to the above packages for Linux, you also need to run:
-
-```sh
-sudo apt-get -y install \
-    libvulkan1 \
-    libxcb-randr0 \
-    mesa-vulkan-drivers \
-    adwaita-icon-theme-full
-```
-
-TODO:
-```
-sudo add-apt-repository ppa:kisak/kisak-mesa
-sudo apt update
-sudo apt install mesa-vulkan-drivers
-```
-
-
 [TODO(#1250)](https://github.com/rerun-io/rerun/issues/1250): Running with the wayland window manager
 sometimes causes Rerun to crash. Try unsetting the wayland display (`unset WAYLAND_DISPLAY` or `WAYLAND_DISPLAY= `) as a workaround.
 
-If you have a multi-gpu setup, Mesa may only report the integrated GPU such that Rerun can't pick the dedicated graphics card.
-To mitigate that set `export MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA` (or `export MESA_D3D12_DEFAULT_ADAPTER_NAME=AMD` respectively for an AMD graphics card).
+## Running on WSL2 (Ubuntu)
+
+WSL's graphics drivers won't work out of the box and you'll have to update to a more recent version.
+To install the latest stable version of the mesa Vulkan drivers run:
+```sh
+sudo add-apt-repository ppa:kisak/kisak-mesa
+sudo apt update
+sudo apt-get install -y mesa-vulkan-drivers
+```
+
+<!-- The following used to be true with older drivers. Now we get all adapters listed and can pick from it ourselves. -->
+<!-- If you have a multi-gpu setup, Mesa may only report the integrated GPU such that Rerun can't pick the dedicated graphics card.
+To mitigate that set `export MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA` (or `export MESA_D3D12_DEFAULT_ADAPTER_NAME=AMD` respectively for an AMD graphics card). -->
 
 Since the Mesa driver on WSL dispatches to the Windows host graphics driver, it is important to keep the Windows drivers up-to-date as well.
 For example, [line rendering issues](https://github.com/rerun-io/rerun/issues/6749) have been observed when running from WSL with an
 outdated AMD driver on the Windows host.
+
+On Ubuntu 24 [issues with Wayland](https://github.com/rerun-io/rerun/issues/6748) have been observed.
+To mitigate this install `libxkbcommon-x11`
+```
+sudo apt install libxkbcommon-x11-0
+```
+And unset the wayland display either by `unset WAYLAND_DISPLAY` or `WAYLAND_DISPLAY= `.
 
 ## `pip install` issues
 

--- a/docs/content/getting-started/troubleshooting.md
+++ b/docs/content/getting-started/troubleshooting.md
@@ -50,13 +50,9 @@ WSL's graphics drivers won't work out of the box and you'll have to update to a 
 To install the latest stable version of the mesa Vulkan drivers run:
 ```sh
 sudo add-apt-repository ppa:kisak/kisak-mesa
-sudo apt update
+sudo apt-get update
 sudo apt-get install -y mesa-vulkan-drivers
 ```
-
-<!-- The following used to be true with older drivers. Now we get all adapters listed and can pick from it ourselves. -->
-<!-- If you have a multi-gpu setup, Mesa may only report the integrated GPU such that Rerun can't pick the dedicated graphics card.
-To mitigate that set `export MESA_D3D12_DEFAULT_ADAPTER_NAME=NVIDIA` (or `export MESA_D3D12_DEFAULT_ADAPTER_NAME=AMD` respectively for an AMD graphics card). -->
 
 Since the Mesa driver on WSL dispatches to the Windows host graphics driver, it is important to keep the Windows drivers up-to-date as well.
 For example, [line rendering issues](https://github.com/rerun-io/rerun/issues/6749) have been observed when running from WSL with an


### PR DESCRIPTION
## Related

* Fixes https://github.com/rerun-io/rerun/issues/8564
* Some steps towards https://github.com/rerun-io/rerun/issues/8475
* Dependent on https://github.com/emilk/egui/pull/5506
* Dependent on https://github.com/emilk/egui_plot/pull/67

## What

### What's broken

Since Rerun 0.19 we picking in 2D & 3D view was broken & accompanied by log spam.

The reason we failed 0.19+ is unknown but likely either that something caused us picking the "webgl-like" compatibility tier or a change in wgpu no longer allows us to texture copy depth buffers.

Rerun 0.21 then broke startup entirely. This happens due to two distinct problems
* we added a check that foresees the picking issue, aborts application start and tells the user to update their driver (which.. as far as I tried doesn't help)
* wgpu did a validation related thing that that accidentally makes us fail startup because it makes the assumption that compute shader support == glsl support for buffers with runtime size (very very reasonable, but also wrong it turns out :sob: https://github.com/gfx-rs/wgpu/issues/6841)

### This Fix

I decided to move forward more aggressively in a manner that leaves all these intertwined issues behind and sets us up better for simpler & more advanced rendering in the future:
* the troubleshooting guide now explains how to update the mesa drivers
* we configure wgpu now such that it allows picking those non-compliant Vulkan drivers

-> As a result we can draw with Vulkan rather than a (typically) outdated GL driver which is in line with us moving slowly towards WebGPU support as the minspec.
(See code comments for remaining weirdness ;-))

Turns out another benefit with this is that multi-gpu setups behave like on the host now: Previously, `MESA_D3D12_DEFAULT_ADAPTER_NAME` had to be set to pick which adapter is used. Now all adapters are passed through WSL correctly, meaning that our regular adapter selection logic (which is to be further improved) works fine, i.e. it prefers discrete over integrated GPU unless `WGPU_POWER_PREF=low` is set.

Tested on WSL with
* Ubuntu 22.04
* Ubuntu 24.04

previous tests indicate that Ubuntu 20 should behave similar to 22.


### Future work

Currently, there's a little bit of not super straight forward logging left from wgpu, warning about the wild GPU setup, but I actually feel better leaving this in for now - after all the WSL rendering stack is still rather adventurous and we should keep encouraging using the host system directly.
 ```sh
[2025-01-07T20:49:52Z INFO  re_sdk_comms::server] Hosting a SDK server over TCP at 0.0.0.0:9876. Connect with the Rerun logging SDK.
[2025-01-07T20:49:52Z WARN  wgpu_hal::vulkan::instance] InstanceFlags::VALIDATION requested, but unable to find layer: VK_LAYER_KHRONOS_validation
[2025-01-07T20:49:53Z WARN  wgpu_hal::gles::egl] Re-initializing Gles context due to Wayland window
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
WARNING: dzn is not a conformant Vulkan implementation, testing use only.
[2025-01-07T20:49:54Z WARN  wgpu_hal::vulkan::adapter] Adapter is not Vulkan compliant: Microsoft Direct3D12 (NVIDIA GeForce RTX 4070)
[2025-01-07T20:49:54Z WARN  wgpu_hal::vulkan::adapter] Adapter is not Vulkan compliant: Microsoft Direct3D12 (AMD Radeon(TM) Graphics)
[2025-01-07T20:49:54Z WARN  wgpu_hal::gles::adapter] Max vertex attribute stride unknown. Assuming it is 2048
[2025-01-07T20:49:54Z WARN  wgpu_hal::vulkan::adapter] Adapter is not Vulkan compliant: Microsoft Direct3D12 (NVIDIA GeForce RTX 4070)
[2025-01-07T20:49:54Z WARN  wgpu_hal::vulkan::adapter] Adapter is not Vulkan compliant: Microsoft Direct3D12 (AMD Radeon(TM) Graphics)
[2025-01-07T20:49:54Z WARN  wgpu_hal::gles::adapter] Max vertex attribute stride unknown. Assuming it is 2048
[2025-01-07T20:49:54Z INFO  egui_wgpu] There were 4 available wgpu adapters: {backend: Vulkan, device_type: DiscreteGpu, name: "Microsoft Direct3D12 (NVIDIA GeForce RTX 4070)", driver: "Dozen", driver_info: "Mesa 24.3.3 - kisak-mesa PPA", vendor: NVIDIA (0x10DE), device: 0x2786}, {backend: Vulkan, device_type: IntegratedGpu, name: "Microsoft Direct3D12 (AMD Radeon(TM) Graphics)", driver: "Dozen", driver_info: "Mesa 24.3.3 - kisak-mesa PPA", vendor: AMD (0x1002), device: 0x164E}, {backend: Vulkan, device_type: Cpu, name: "llvmpipe (LLVM 15.0.7, 256 bits)", driver: "llvmpipe", driver_info: "Mesa 24.3.3 - kisak-mesa PPA (LLVM 15.0.7)", vendor: Mesa (0x10005)}, {backend: Gl, device_type: Other, name: "D3D12 (AMD Radeon(TM) Graphics)", driver_info: "4.2 (Core Profile) Mesa 23.2.1-1ubuntu3.1~22.04.3"}
[2025-01-07T20:49:54Z WARN  wgpu_core::instance] Missing downlevel flags: DownlevelFlags(FULL_DRAW_INDEX_UINT32 | SURFACE_VIEW_FORMATS)
    The underlying API or device in use does not support enough features to be a fully compliant implementation of WebGPU. A subset of the features can still be used. If you are running this program on native and not in a browser and wish to limit the features you use to the supported subset, call Adapter::downlevel_properties or Device::downlevel_properties to get a listing of the features the current platform supports.
[2025-01-07T20:49:54Z WARN  wgpu_core::instance] DownlevelCapabilities {
        flags: DownlevelFlags(
            COMPUTE_SHADERS | FRAGMENT_WRITABLE_STORAGE | INDIRECT_EXECUTION | BASE_VERTEX | READ_ONLY_DEPTH_STENCIL | NON_POWER_OF_TWO_MIPMAPPED_TEXTURES | CUBE_ARRAY_TEXTURES | COMPARISON_SAMPLERS | INDEPENDENT_BLEND | VERTEX_STORAGE | ANISOTROPIC_FILTERING | FRAGMENT_STORAGE | MULTISAMPLED_SHADING | DEPTH_TEXTURE_AND_BUFFER_COPIES | WEBGPU_TEXTURE_FORMAT_SUPPORT | BUFFER_BINDINGS_NOT_16_BYTE_ALIGNED | UNRESTRICTED_INDEX_BUFFER | DEPTH_BIAS_CLAMP | VIEW_FORMATS | UNRESTRICTED_EXTERNAL_TEXTURE_COPIES | NONBLOCKING_QUERY_RESOLVE | VERTEX_AND_INSTANCE_INDEX_RESPECTS_RESPECTIVE_FIRST_VALUE_IN_INDIRECT_DRAW,
        ),
        limits: DownlevelLimits,
        shader_model: Sm5,
    }
```
(what does bug me is the duplicated messages, may hint at some issues in either wgpu or our init dance... but that's a story for another time)