### PR TITLE
Add analytics for wgpu backend and whether the viewer runs in WSL

### DIFF
--- a/crates/top/rerun/src/commands/entrypoint.rs
+++ b/crates/top/rerun/src/commands/entrypoint.rs
@@ -845,8 +845,7 @@ fn run_impl(
                     _build_info,
                     &call_source.app_env(),
                     startup_options,
-                    cc.egui_ctx.clone(),
-                    cc.storage,
+                    cc,
                 );
                 for rx in rxs {
                     app.add_receiver(rx);

--- a/crates/viewer/re_renderer/src/config.rs
+++ b/crates/viewer/re_renderer/src/config.rs
@@ -27,6 +27,15 @@ pub enum DeviceTier {
     //HighEnd
 }
 
+impl std::fmt::Display for DeviceTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Gles => "gles",
+            Self::FullWebGpuSupport => "full_webgpu_support",
+        })
+    }
+}
+
 impl DeviceTier {
     /// Whether the current device tier supports sampling from textures with a sample count higher than 1.
     pub fn support_sampling_msaa_texture(&self) -> bool {

--- a/crates/viewer/re_renderer/src/context.rs
+++ b/crates/viewer/re_renderer/src/context.rs
@@ -8,7 +8,7 @@ use type_map::concurrent::{self, TypeMap};
 
 use crate::{
     allocator::{CpuWriteGpuReadBelt, GpuReadbackBelt},
-    config::{DeviceCaps, DeviceTier},
+    config::{DeviceCaps, WgpuBackendType},
     error_handling::{ErrorTracker, WgpuErrorScope},
     global_bindings::GlobalBindings,
     renderer::Renderer,
@@ -236,7 +236,9 @@ impl RenderContext {
         //          knowing that we're not _actually_ blocking.
         //
         //          For more details check https://github.com/gfx-rs/wgpu/issues/3601
-        if cfg!(target_arch = "wasm32") && self.device_caps.tier == DeviceTier::Gles {
+        if cfg!(target_arch = "wasm32")
+            && self.device_caps.backend_type == WgpuBackendType::WgpuCore
+        {
             self.device.poll(wgpu::Maintain::Wait);
             return;
         }

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -296,7 +296,10 @@ impl App {
             .unwrap_or(web_time::Instant::now());
 
         let (adapter_backend, device_tier) = creation_context.wgpu_render_state.as_ref().map_or(
-            (wgpu::Backend::Empty, re_renderer::config::DeviceTier::Gles),
+            (
+                wgpu::Backend::Empty,
+                re_renderer::config::DeviceTier::Limited,
+            ),
             |render_state| {
                 let egui_renderer = render_state.renderer.read();
                 let render_ctx = egui_renderer
@@ -305,7 +308,7 @@ impl App {
 
                 (
                     render_state.adapter.get_info().backend,
-                    render_ctx.map_or(re_renderer::config::DeviceTier::Gles, |ctx| {
+                    render_ctx.map_or(re_renderer::config::DeviceTier::Limited, |ctx| {
                         ctx.device_caps().tier
                     }),
                 )

--- a/crates/viewer/re_viewer/src/app.rs
+++ b/crates/viewer/re_viewer/src/app.rs
@@ -229,8 +229,7 @@ impl App {
         build_info: re_build_info::BuildInfo,
         app_env: &crate::AppEnvironment,
         startup_options: StartupOptions,
-        egui_ctx: egui::Context,
-        storage: Option<&dyn eframe::Storage>,
+        creation_context: &eframe::CreationContext<'_>,
     ) -> Self {
         re_tracing::profile_function!();
 
@@ -246,7 +245,7 @@ impl App {
         }
 
         let mut state: AppState = if startup_options.persist_state {
-            storage
+            creation_context.storage
                 .and_then(|storage| {
                     // This re-implements: `eframe::get_value` so we can customize the warning message.
                     // TODO(#2849): More thorough error-handling.
@@ -283,7 +282,7 @@ impl App {
 
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(screenshot_path) = startup_options.screenshot_to_path_then_quit.clone() {
-            screenshotter.screenshot_to_path_then_quit(&egui_ctx, screenshot_path);
+            screenshotter.screenshot_to_path_then_quit(&creation_context.egui_ctx, screenshot_path);
         }
 
         let (command_sender, command_receiver) = command_channel();
@@ -296,7 +295,23 @@ impl App {
             .checked_sub(web_time::Duration::from_secs(1_000_000_000))
             .unwrap_or(web_time::Instant::now());
 
-        analytics.on_viewer_started(build_info);
+        let (adapter_backend, device_tier) = creation_context.wgpu_render_state.as_ref().map_or(
+            (wgpu::Backend::Empty, re_renderer::config::DeviceTier::Gles),
+            |render_state| {
+                let egui_renderer = render_state.renderer.read();
+                let render_ctx = egui_renderer
+                    .callback_resources
+                    .get::<re_renderer::RenderContext>();
+
+                (
+                    render_state.adapter.get_info().backend,
+                    render_ctx.map_or(re_renderer::config::DeviceTier::Gles, |ctx| {
+                        ctx.device_caps().tier
+                    }),
+                )
+            },
+        );
+        analytics.on_viewer_started(build_info, adapter_backend, device_tier);
 
         let panel_state_overrides = startup_options.panel_state_overrides;
 
@@ -313,7 +328,7 @@ impl App {
             startup_options,
             start_time: web_time::Instant::now(),
             ram_limit_warner: re_memory::RamLimitWarner::warn_at_fraction_of_max(0.75),
-            egui_ctx,
+            egui_ctx: creation_context.egui_ctx.clone(),
             screenshotter,
 
             #[cfg(target_arch = "wasm32")]

--- a/crates/viewer/re_viewer/src/native.rs
+++ b/crates/viewer/re_viewer/src/native.rs
@@ -100,14 +100,8 @@ pub fn run_native_viewer_with_messages(
     run_native_app(
         main_thread_token,
         Box::new(move |cc| {
-            let mut app = crate::App::new(
-                main_thread_token,
-                build_info,
-                &app_env,
-                startup_options,
-                cc.egui_ctx.clone(),
-                cc.storage,
-            );
+            let mut app =
+                crate::App::new(main_thread_token, build_info, &app_env, startup_options, cc);
             app.add_receiver(rx);
             Box::new(app)
         }),

--- a/crates/viewer/re_viewer/src/viewer_analytics/event.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/event.rs
@@ -1,7 +1,7 @@
 use crate::AppEnvironment;
 
 use re_analytics::{
-    event::{Id, Identify, OpenRecording, StoreInfo, ViewerStarted},
+    event::{Id, Identify, OpenRecording, StoreInfo, ViewerRuntimeInformation, ViewerStarted},
     Config, Property,
 };
 
@@ -32,10 +32,19 @@ pub fn identify(
     }
 }
 
-pub fn viewer_started(app_env: &AppEnvironment) -> ViewerStarted {
+pub fn viewer_started(
+    app_env: &AppEnvironment,
+    adapter_backend: wgpu::Backend,
+    device_tier: re_renderer::config::DeviceTier,
+) -> ViewerStarted {
     ViewerStarted {
         url: app_env.url().cloned(),
         app_env: app_env.name(),
+        runtime_info: ViewerRuntimeInformation {
+            is_wsl: super::wsl::is_wsl(),
+            graphics_adapter_backend: adapter_backend.to_string(),
+            re_renderer_device_tier: device_tier.to_string(),
+        },
     }
 }
 

--- a/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
@@ -55,6 +55,7 @@ impl ViewerAnalytics {
     }
 
     /// When the viewer is first started
+    #[allow(unused_variables)]
     pub fn on_viewer_started(
         &self,
         build_info: re_build_info::BuildInfo,
@@ -80,9 +81,6 @@ impl ViewerAnalytics {
                 device_tier,
             ));
         }
-
-        #[cfg(not(feature = "analytics"))]
-        let _ = build_info;
     }
 
     /// When we have loaded the start of a new recording.

--- a/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/mod.rs
@@ -8,6 +8,9 @@
 #[cfg(feature = "analytics")]
 mod event;
 
+#[cfg(feature = "analytics")]
+mod wsl;
+
 use crate::AppEnvironment;
 use crate::StartupOptions;
 
@@ -52,7 +55,12 @@ impl ViewerAnalytics {
     }
 
     /// When the viewer is first started
-    pub fn on_viewer_started(&self, build_info: re_build_info::BuildInfo) {
+    pub fn on_viewer_started(
+        &self,
+        build_info: re_build_info::BuildInfo,
+        adapter_backend: wgpu::Backend,
+        device_tier: re_renderer::config::DeviceTier,
+    ) {
         re_tracing::profile_function!();
 
         #[cfg(feature = "analytics")]
@@ -66,7 +74,11 @@ impl ViewerAnalytics {
                 build_info,
                 &self.app_env,
             ));
-            analytics.record(event::viewer_started(&self.app_env));
+            analytics.record(event::viewer_started(
+                &self.app_env,
+                adapter_backend,
+                device_tier,
+            ));
         }
 
         #[cfg(not(feature = "analytics"))]

--- a/crates/viewer/re_viewer/src/viewer_analytics/wsl.rs
+++ b/crates/viewer/re_viewer/src/viewer_analytics/wsl.rs
@@ -1,0 +1,17 @@
+/// Returns true if the current process is running under WSL.
+#[cfg(target_os = "linux")]
+pub fn is_wsl() -> bool {
+    if let Ok(b) = std::fs::read("/proc/sys/kernel/osrelease") {
+        if let Ok(s) = std::str::from_utf8(&b) {
+            let a = s.to_ascii_lowercase();
+            return a.contains("microsoft") || a.contains("wsl");
+        }
+    }
+    false
+}
+
+/// Returns true if the current process is running under WSL.
+#[cfg(not(target_os = "linux"))]
+pub fn is_wsl() -> bool {
+    false
+}

--- a/crates/viewer/re_viewer/src/web.rs
+++ b/crates/viewer/re_viewer/src/web.rs
@@ -410,14 +410,7 @@ fn create_app(
     };
     crate::customize_eframe_and_setup_renderer(cc)?;
 
-    let mut app = crate::App::new(
-        main_thread_token,
-        build_info,
-        &app_env,
-        startup_options,
-        cc.egui_ctx.clone(),
-        cc.storage,
-    );
+    let mut app = crate::App::new(main_thread_token, build_info, &app_env, startup_options, cc);
 
     if enable_history {
         install_popstate_listener(&mut app).ok_or_log_js_error();

--- a/examples/rust/custom_callback/src/viewer.rs
+++ b/examples/rust/custom_callback/src/viewer.rs
@@ -63,8 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 re_viewer::build_info(),
                 &app_env,
                 startup_options,
-                cc.egui_ctx.clone(),
-                cc.storage,
+                cc,
             );
 
             rerun_app.add_receiver(rx);

--- a/examples/rust/custom_view/src/main.rs
+++ b/examples/rust/custom_view/src/main.rs
@@ -48,8 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 re_viewer::build_info(),
                 &app_env,
                 startup_options,
-                cc.egui_ctx.clone(),
-                cc.storage,
+                cc,
             );
             app.add_receiver(rx);
 

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -51,8 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 re_viewer::build_info(),
                 &app_env,
                 startup_options,
-                cc.egui_ctx.clone(),
-                cc.storage,
+                cc,
             );
             rerun_app.add_receiver(rx);
             Ok(Box::new(MyApp { rerun_app }))


### PR DESCRIPTION
Today we're driving blind on some of the key questions around Rerun Viewer usage. This PR adds three new properties to the `viewer_started` analytics event:

* `is_wsl`
    * a boolean indicating whether the viewer has been started directly from the WSL
    * we're interested in this because we want to understand the importance of WSL support 
* `graphics_adapter_backend`
    * a string identifying which of the [wgpu backends](https://docs.rs/wgpu/latest/wgpu/enum.Backend.html) is used
    * we're interested in this because we want to know which graphics backends are the most important
         * The most important distinction here is `gl` (webgl + desktop gl) vs `webgpu` vs everything else. We want to understand when the right time is to phase out support for gl.
* `re_renderer_device_tier`
     * a string identifying which of the (today two) [device tiers](https://github.com/rerun-io/rerun/blob/ddaeb06e9590dc3660c5bef97bafbc824efcc0da/crates/viewer/re_renderer/src/config.rs#L13) re_renderer settled on for a given viewer session
     * similar to the above this gives us a (very) rough idea of what abilities the graphics adapter has
     * it's likely that we'll add one or two more tiers in the future


----------

As always we're trying to be considerate with what we add to our analytics in order to be intrusive while providing valuable information to inform the development of Rerun.
If you want to learn more about analytics run `rerun analytics details`.
If you have a complaint about the intrusiveness of these analytics please reach out.

----------


Examples of what we see on Posthog with this:

Starting viewer on Windows:
![image](https://github.com/user-attachments/assets/e31b1df1-96db-4da3-8df5-7d5c3935e2c4)

Starting viewer from WSL (with  #8610 merged in):
![image](https://github.com/user-attachments/assets/280268ec-fc93-4006-90e0-f59f9e922bd8)

Starting the viewer from the Browser @ WebGL:
![image](https://github.com/user-attachments/assets/b3f07049-eaf1-46a5-8f69-876b41c80d27)

Starting the viewer from the Browser @ WebGPU:
![image](https://github.com/user-attachments/assets/3fb728d5-a935-44a5-895b-e4051c854ffd)


