### PR TITLE
Use the correct eframe options for our custom viewer examples

### DIFF
--- a/examples/rust/custom_callback/src/viewer.rs
+++ b/examples/rust/custom_callback/src/viewer.rs
@@ -1,6 +1,6 @@
 use custom_callback::{comms::viewer::ControlViewer, panel::Control};
 
-use rerun::external::{eframe, egui, re_log, re_memory, re_sdk_comms, re_viewer};
+use rerun::external::{eframe, re_log, re_memory, re_sdk_comms, re_viewer};
 
 use std::net::Ipv4Addr;
 

--- a/examples/rust/custom_callback/src/viewer.rs
+++ b/examples/rust/custom_callback/src/viewer.rs
@@ -42,10 +42,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     // Then we start the Rerun viewer
-    let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_app_id("rerun_custom_callback_example"),
-        ..re_viewer::native::eframe_options(None)
-    };
+    let mut native_options = re_viewer::native::eframe_options(None);
+    native_options.viewport = native_options
+        .viewport
+        .with_app_id("rerun_custom_callback_example");
 
     // This is used for analytics, if the `analytics` feature is on in `Cargo.toml`
     let app_env = re_viewer::AppEnvironment::Custom("My Custom Callback".to_owned());

--- a/examples/rust/extend_viewer_ui/src/main.rs
+++ b/examples/rust/extend_viewer_ui/src/main.rs
@@ -29,10 +29,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Default::default(),
     )?;
 
-    let native_options = eframe::NativeOptions {
-        viewport: egui::ViewportBuilder::default().with_app_id("rerun_extend_viewer_ui_example"),
-        ..re_viewer::native::eframe_options(None)
-    };
+    let mut native_options = re_viewer::native::eframe_options(None);
+    native_options.viewport = native_options
+        .viewport
+        .with_app_id("rerun_extend_viewer_ui_example");
 
     let startup_options = re_viewer::StartupOptions::default();
 


### PR DESCRIPTION
The problem was that we ignored our default decoration settings, leading to an ugly top bar on mac:

![image](https://github.com/user-attachments/assets/399e1b3a-f6fd-4c9e-bd08-5775d00f5c97)

This PR fixes this.