### PR TITLE
Fix .gitignore ignoring `crates/build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@ __MACOSX
 *.bin
 *.o
 /arrow/
-build/
-./build/
+/build/
 **/build-msvc/
 **/CMakeFiles/
 **/CMakeCache.txt


### PR DESCRIPTION
The `build/` and `./build/` seemed to both be matching the wrong things. Changed it to `/build/`:

```
$ git check-ignore -v -- ./build/debug
.gitignore:9:/build/    ./build/debug
$ git check-ignore -v -- ./crates/build
<empty>
```