### PR TITLE
Add the ability to provide local data to context menu actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5782,6 +5782,7 @@ dependencies = [
  "re_viewer_context",
  "re_viewport_blueprint",
  "static_assertions",
+ "type-map",
 ]
 
 [[package]]

--- a/crates/viewer/re_context_menu/Cargo.toml
+++ b/crates/viewer/re_context_menu/Cargo.toml
@@ -35,3 +35,4 @@ itertools.workspace = true
 nohash-hasher.workspace = true
 once_cell.workspace = true
 static_assertions.workspace = true
+type-map.workspace = true


### PR DESCRIPTION
### Related
 
* Part of #8586

### What

This PR adds the possibility to provide local data to context menu action from "user" code (e.g. the place where the context menu is triggered). The local data is structured as a `TypeMap`.

This new ability is used to fix the behaviour of Collapse/Expand all in the blueprint streams tree (which never worked before). It also unblocks the possibility to have a different collapsing start for the filtered and unfiltered states of a given tree (#8586).
