### PR TITLE
Update remote store id field name

### DIFF
--- a/examples/python/remote/metadata.py
+++ b/examples/python/remote/metadata.py
@@ -39,14 +39,18 @@ if __name__ == "__main__":
         print(f"Registered new recording with ID: {id}")
 
     elif args.subcommand == "update":
-        id = catalog.filter(catalog["id"].str.starts_with(args.id)).select(pl.first("id")).item()
+        id = (
+            catalog.filter(catalog["rerun_recording_id"].str.starts_with(args.id))
+            .select(pl.first("rerun_recording_id"))
+            .item()
+        )
 
         if id is None:
             print("ID not found")
             exit(1)
         print(f"Updating metadata for {id}")
 
-        new_metadata = pa.Table.from_pydict({"id": [id], args.key: [args.value]})
+        new_metadata = pa.Table.from_pydict({"rerun_recording_id": [id], args.key: [args.value]})
         print(new_metadata)
 
         conn.update_catalog(new_metadata)

--- a/rerun_py/src/remote.rs
+++ b/rerun_py/src/remote.rs
@@ -294,12 +294,12 @@ impl PyStorageNodeClient {
 
             let recording_id = metadata
                 .all_columns()
-                .find(|(field, _data)| field.name == "id")
+                .find(|(field, _data)| field.name == "rerun_recording_id")
                 .map(|(_field, data)| data)
-                .ok_or(PyRuntimeError::new_err("No id"))?
+                .ok_or(PyRuntimeError::new_err("No rerun_recording_id"))?
                 .as_any()
                 .downcast_ref::<arrow2::array::Utf8Array<i32>>()
-                .ok_or(PyRuntimeError::new_err("Id is not a string"))?
+                .ok_or(PyRuntimeError::new_err("Recording Id is not a string"))?
                 .value(0)
                 .to_owned();
 
@@ -325,9 +325,13 @@ impl PyStorageNodeClient {
             let metadata = metadata.into_record_batch()?;
 
             // TODO(jleibs): This id name should probably come from `re_protos`
-            if metadata.schema().column_with_name("id").is_none() {
+            if metadata
+                .schema()
+                .column_with_name("rerun_recording_id")
+                .is_none()
+            {
                 return Err(PyRuntimeError::new_err(
-                    "Metadata must contain an 'id' column",
+                    "Metadata must contain 'rerun_recording_id' column",
                 ));
             }
 


### PR DESCRIPTION


### What

We've added prefix to all remote store catalog fields and renamed the recording id field, hence updating python SDK and relevant python example.

### Testing done

```
pixi run -e examples -- python examples/python/remote/metadata.py register file:///tmp/structure_from_motion.rrd 

Registered new recording with ID: dd3d7c47-3f04-4d12-9d9b-69b223ee9f56

pixi run -e examples -- python examples/python/remote/metadata.py print
┌────────────────┬────────────────┬────────────────┬───────────────┬───┬───────────────┬───────────────┬───────────────┬───────┐
│ row_id         ┆ rerun_registra ┆ rerun_recordin ┆ rerun_applica ┆ … ┆ rerun_descrip ┆ rerun_storage ┆ rerun_recordi ┆ extra │
│ ---            ┆ tion_time      ┆ g_id           ┆ tion_id       ┆   ┆ tion          ┆ _url          ┆ ng_type       ┆ ---   │
│ struct[2]      ┆ ---            ┆ ---            ┆ ---           ┆   ┆ ---           ┆ ---           ┆ ---           ┆ i64   │
│                ┆ datetime[ns]   ┆ str            ┆ str           ┆   ┆ str           ┆ str           ┆ cat           ┆       │
╞════════════════╪════════════════╪════════════════╪═══════════════╪═══╪═══════════════╪═══════════════╪═══════════════╪═══════╡
│ {1736421859678 ┆ 2025-01-09 11: ┆ dd3d7c47-3f04- ┆ rerun_example ┆ … ┆               ┆ file:///tmp/s ┆ rrd           ┆ 42    │
│ 872875,3498296 ┆ 24:19.678990   ┆ 4d12-9d9b-69b2 ┆ _structure_fr ┆   ┆               ┆ tructure_from ┆               ┆       │
│ 86…            ┆                ┆ 23…            ┆ om_m…         ┆   ┆               ┆ _mot…         ┆               ┆       │
└────────────────┴────────────────┴────────────────┴───────────────┴───┴───────────────┴───────────────┴───────────────┴───────┘
