### PR TITLE
Extend (and rename) `ItemSpaceContext` to provide local context to context menu action

### DIFF
--- a/crates/viewer/re_context_menu/src/actions/collapse_expand_all.rs
+++ b/crates/viewer/re_context_menu/src/actions/collapse_expand_all.rs
@@ -1,6 +1,6 @@
 use re_entity_db::InstancePath;
 use re_log_types::StoreKind;
-use re_viewer_context::{CollapseScope, ContainerId, Contents, Item, ItemSpaceContext, ViewId};
+use re_viewer_context::{CollapseScope, ContainerId, Contents, Item, ItemContext, ViewId};
 
 use crate::{ContextMenuAction, ContextMenuContext};
 
@@ -103,16 +103,16 @@ impl ContextMenuAction for CollapseExpandAllAction {
         #[expect(clippy::match_same_arms)]
         let (db, scope) = match ctx
             .selection
-            .space_context_for_item(&Item::InstancePath(instance_path.clone()))
+            .context_for_item(&Item::InstancePath(instance_path.clone()))
         {
-            Some(&ItemSpaceContext::StreamsTree {
+            Some(&ItemContext::StreamsTree {
                 store_kind: StoreKind::Blueprint,
             }) => (
                 ctx.viewer_context.blueprint_db(),
                 CollapseScope::BlueprintStreamsTree,
             ),
 
-            Some(&ItemSpaceContext::StreamsTree {
+            Some(&ItemContext::StreamsTree {
                 store_kind: StoreKind::Recording,
             }) => (ctx.viewer_context.recording(), CollapseScope::StreamsTree),
 

--- a/crates/viewer/re_context_menu/src/actions/collapse_expand_all.rs
+++ b/crates/viewer/re_context_menu/src/actions/collapse_expand_all.rs
@@ -1,5 +1,6 @@
 use re_entity_db::InstancePath;
-use re_viewer_context::{CollapseScope, ContainerId, Contents, Item, ViewId};
+use re_log_types::StoreKind;
+use re_viewer_context::{CollapseScope, ContainerId, Contents, Item, ItemSpaceContext, ViewId};
 
 use crate::{ContextMenuAction, ContextMenuContext};
 
@@ -99,17 +100,32 @@ impl ContextMenuAction for CollapseExpandAllAction {
     }
 
     fn process_instance_path(&self, ctx: &ContextMenuContext<'_>, instance_path: &InstancePath) {
-        let Some(subtree) = ctx
-            .viewer_context
-            .recording()
-            .tree()
-            .subtree(&instance_path.entity_path)
-        else {
+        #[expect(clippy::match_same_arms)]
+        let (db, scope) = match ctx
+            .selection
+            .space_context_for_item(&Item::InstancePath(instance_path.clone()))
+        {
+            Some(&ItemSpaceContext::StreamsTree {
+                store_kind: StoreKind::Blueprint,
+            }) => (
+                ctx.viewer_context.blueprint_db(),
+                CollapseScope::BlueprintStreamsTree,
+            ),
+
+            Some(&ItemSpaceContext::StreamsTree {
+                store_kind: StoreKind::Recording,
+            }) => (ctx.viewer_context.recording(), CollapseScope::StreamsTree),
+
+            // default to recording if we don't have more specific information
+            _ => (ctx.viewer_context.recording(), CollapseScope::StreamsTree),
+        };
+
+        let Some(subtree) = db.tree().subtree(&instance_path.entity_path) else {
             return;
         };
 
         subtree.visit_children_recursively(|entity_path| {
-            CollapseScope::StreamsTree
+            scope
                 .entity(entity_path.clone())
                 .set_open(&ctx.egui_context, self.open());
         });

--- a/crates/viewer/re_context_menu/src/lib.rs
+++ b/crates/viewer/re_context_menu/src/lib.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 
 use re_entity_db::InstancePath;
 use re_viewer_context::{
-    ContainerId, Contents, Item, ItemCollection, ItemSpaceContext, ViewId, ViewerContext,
+    ContainerId, Contents, Item, ItemCollection, ItemContext, ViewId, ViewerContext,
 };
 use re_viewport_blueprint::{ContainerBlueprint, ViewportBlueprint};
 
@@ -59,7 +59,7 @@ pub fn context_menu_ui_for_item_with_context(
     ctx: &ViewerContext<'_>,
     viewport_blueprint: &ViewportBlueprint,
     item: &Item,
-    item_context: ItemSpaceContext,
+    item_context: ItemContext,
     item_response: &egui::Response,
     selection_update_behavior: SelectionUpdateBehavior,
 ) {
@@ -77,7 +77,7 @@ fn context_menu_ui_for_item_with_context_impl(
     ctx: &ViewerContext<'_>,
     viewport_blueprint: &ViewportBlueprint,
     item: &Item,
-    item_context: Option<ItemSpaceContext>,
+    item_context: Option<ItemContext>,
     item_response: &egui::Response,
     selection_update_behavior: SelectionUpdateBehavior,
 ) {

--- a/crates/viewer/re_context_menu/src/lib.rs
+++ b/crates/viewer/re_context_menu/src/lib.rs
@@ -3,7 +3,9 @@
 use once_cell::sync::OnceCell;
 
 use re_entity_db::InstancePath;
-use re_viewer_context::{ContainerId, Contents, Item, ItemCollection, ViewId, ViewerContext};
+use re_viewer_context::{
+    ContainerId, Contents, Item, ItemCollection, ItemSpaceContext, ViewId, ViewerContext,
+};
 use re_viewport_blueprint::{ContainerBlueprint, ViewportBlueprint};
 
 mod actions;
@@ -42,6 +44,43 @@ pub fn context_menu_ui_for_item(
     item_response: &egui::Response,
     selection_update_behavior: SelectionUpdateBehavior,
 ) {
+    context_menu_ui_for_item_with_context_impl(
+        ctx,
+        viewport_blueprint,
+        item,
+        None,
+        item_response,
+        selection_update_behavior,
+    );
+}
+
+/// Display a context menu for the provided [`Item`]
+pub fn context_menu_ui_for_item_with_context(
+    ctx: &ViewerContext<'_>,
+    viewport_blueprint: &ViewportBlueprint,
+    item: &Item,
+    item_context: ItemSpaceContext,
+    item_response: &egui::Response,
+    selection_update_behavior: SelectionUpdateBehavior,
+) {
+    context_menu_ui_for_item_with_context_impl(
+        ctx,
+        viewport_blueprint,
+        item,
+        Some(item_context),
+        item_response,
+        selection_update_behavior,
+    );
+}
+
+fn context_menu_ui_for_item_with_context_impl(
+    ctx: &ViewerContext<'_>,
+    viewport_blueprint: &ViewportBlueprint,
+    item: &Item,
+    item_context: Option<ItemSpaceContext>,
+    item_response: &egui::Response,
+    selection_update_behavior: SelectionUpdateBehavior,
+) {
     item_response.context_menu(|ui| {
         if ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape)) {
             ui.close_menu();
@@ -59,6 +98,8 @@ pub fn context_menu_ui_for_item(
             show_context_menu_for_selection(&context_menu_ctx, ui);
         };
 
+        let item_collection = ItemCollection::from(std::iter::once((item.clone(), item_context)));
+
         // handle selection
         match selection_update_behavior {
             SelectionUpdateBehavior::UseSelection => {
@@ -66,9 +107,8 @@ pub fn context_menu_ui_for_item(
                     // When the context menu is triggered open, we check if we're part of the selection,
                     // and, if not, we update the selection to include only the item that was clicked.
                     if item_response.hovered() && item_response.secondary_clicked() {
-                        ctx.selection_state().set_selection(item.clone());
-
-                        show_context_menu(&ItemCollection::from(item.clone()));
+                        show_context_menu(&item_collection);
+                        ctx.selection_state().set_selection(item_collection);
                     } else {
                         show_context_menu(ctx.selection());
                     }
@@ -78,15 +118,15 @@ pub fn context_menu_ui_for_item(
             }
 
             SelectionUpdateBehavior::OverrideSelection => {
-                if item_response.secondary_clicked() {
-                    ctx.selection_state().set_selection(item.clone());
-                }
+                show_context_menu(&item_collection);
 
-                show_context_menu(&ItemCollection::from(item.clone()));
+                if item_response.secondary_clicked() {
+                    ctx.selection_state().set_selection(item_collection);
+                }
             }
 
             SelectionUpdateBehavior::Ignore => {
-                show_context_menu(&ItemCollection::from(item.clone()));
+                show_context_menu(&item_collection);
             }
         };
     });

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 use egui::emath::Rangef;
 use egui::{pos2, Color32, CursorIcon, NumExt, Painter, PointerButton, Rect, Shape, Ui, Vec2};
 
-use re_context_menu::{context_menu_ui_for_item, SelectionUpdateBehavior};
+use re_context_menu::{
+    context_menu_ui_for_item, context_menu_ui_for_item_with_context, SelectionUpdateBehavior,
+};
 use re_data_ui::DataUi as _;
 use re_data_ui::{item_ui::guess_instance_path_icon, sorted_component_list_for_ui};
 use re_entity_db::{EntityDb, EntityTree, InstancePath};
@@ -30,8 +32,8 @@ use re_log_types::{
 use re_types::blueprint::components::PanelState;
 use re_ui::{list_item, ContextExt as _, DesignTokens, UiExt as _};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, RecordingConfig, TimeControl, TimeView, UiLayout,
-    ViewerContext,
+    CollapseScope, HoverHighlight, Item, ItemSpaceContext, RecordingConfig, TimeControl, TimeView,
+    UiLayout, ViewerContext,
 };
 use re_viewport_blueprint::ViewportBlueprint;
 
@@ -98,6 +100,15 @@ impl From<TimePanelSource> for egui::Id {
         match source {
             TimePanelSource::Recording => "recording".into(),
             TimePanelSource::Blueprint => "blueprint".into(),
+        }
+    }
+}
+
+impl From<TimePanelSource> for re_log_types::StoreKind {
+    fn from(source: TimePanelSource) -> Self {
+        match source {
+            TimePanelSource::Recording => Self::Recording,
+            TimePanelSource::Blueprint => Self::Blueprint,
         }
     }
 }
@@ -722,10 +733,14 @@ impl TimePanel {
             }
         }
 
-        context_menu_ui_for_item(
+        context_menu_ui_for_item_with_context(
             ctx,
             viewport_blueprint,
             &item.to_item(),
+            // expand/collapse context menu actions need this information
+            ItemSpaceContext::StreamsTree {
+                store_kind: self.source.into(),
+            },
             &response,
             SelectionUpdateBehavior::UseSelection,
         );

--- a/crates/viewer/re_time_panel/src/lib.rs
+++ b/crates/viewer/re_time_panel/src/lib.rs
@@ -32,7 +32,7 @@ use re_log_types::{
 use re_types::blueprint::components::PanelState;
 use re_ui::{list_item, ContextExt as _, DesignTokens, UiExt as _};
 use re_viewer_context::{
-    CollapseScope, HoverHighlight, Item, ItemSpaceContext, RecordingConfig, TimeControl, TimeView,
+    CollapseScope, HoverHighlight, Item, ItemContext, RecordingConfig, TimeControl, TimeView,
     UiLayout, ViewerContext,
 };
 use re_viewport_blueprint::ViewportBlueprint;
@@ -738,7 +738,7 @@ impl TimePanel {
             viewport_blueprint,
             &item.to_item(),
             // expand/collapse context menu actions need this information
-            ItemSpaceContext::StreamsTree {
+            ItemContext::StreamsTree {
                 store_kind: self.source.into(),
             },
             &response,

--- a/crates/viewer/re_view_spatial/src/picking_ui.rs
+++ b/crates/viewer/re_view_spatial/src/picking_ui.rs
@@ -8,7 +8,7 @@ use re_ui::{
 };
 use re_view::AnnotationSceneContext;
 use re_viewer_context::{
-    Item, ItemSpaceContext, UiLayout, ViewQuery, ViewSystemExecutionError, ViewerContext,
+    Item, ItemContext, UiLayout, ViewQuery, ViewSystemExecutionError, ViewerContext,
     VisualizerCollection,
 };
 
@@ -203,7 +203,7 @@ pub fn picking(
 
     if let Some((_, context)) = hovered_items.first_mut() {
         *context = Some(match spatial_kind {
-            SpatialViewKind::TwoD => ItemSpaceContext::TwoD {
+            SpatialViewKind::TwoD => ItemContext::TwoD {
                 space_2d: query.space_origin.clone(),
                 pos: picking_context
                     .pointer_in_camera_plane
@@ -214,7 +214,7 @@ pub fn picking(
                 let cameras_visualizer_output =
                     system_output.view_systems.get::<CamerasVisualizer>()?;
 
-                ItemSpaceContext::ThreeD {
+                ItemContext::ThreeD {
                     space_3d: query.space_origin.clone(),
                     pos: hovered_point,
                     tracked_entity: state.state_3d.tracked_entity.clone(),

--- a/crates/viewer/re_view_spatial/src/ui_2d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_2d.rs
@@ -15,7 +15,7 @@ use re_types::{
 use re_ui::{ContextExt as _, ModifiersMarkdown, MouseButtonMarkdown};
 use re_view::controls::{DRAG_PAN2D_BUTTON, ZOOM_SCROLL_MODIFIER};
 use re_viewer_context::{
-    gpu_bridge, ItemSpaceContext, ViewQuery, ViewSystemExecutionError, ViewerContext,
+    gpu_bridge, ItemContext, ViewQuery, ViewSystemExecutionError, ViewerContext,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -269,7 +269,7 @@ impl SpatialView2D {
         ));
 
         // Make sure to _first_ draw the selected, and *then* the hovered context on top!
-        for selected_context in ctx.selection_state().selection_space_contexts() {
+        for selected_context in ctx.selection_state().selection_item_contexts() {
             painter.extend(show_projections_from_3d_space(
                 ui,
                 query.space_origin,
@@ -278,7 +278,7 @@ impl SpatialView2D {
                 ui.ctx().selection_stroke().color,
             ));
         }
-        if let Some(hovered_context) = ctx.selection_state().hovered_space_context() {
+        if let Some(hovered_context) = ctx.selection_state().hovered_item_context() {
             painter.extend(show_projections_from_3d_space(
                 ui,
                 query.space_origin,
@@ -429,14 +429,14 @@ fn show_projections_from_3d_space(
     ui: &egui::Ui,
     space: &EntityPath,
     ui_from_scene: &RectTransform,
-    space_context: &ItemSpaceContext,
+    item_context: &ItemContext,
     circle_fill_color: egui::Color32,
 ) -> Vec<Shape> {
     let mut shapes = Vec::new();
-    if let ItemSpaceContext::ThreeD {
+    if let ItemContext::ThreeD {
         point_in_space_cameras: target_spaces,
         ..
-    } = space_context
+    } = item_context
     {
         for (space_2d, pos_2d) in target_spaces {
             if space_2d == space {

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -22,7 +22,7 @@ use re_view::controls::{
     ROTATE3D_BUTTON, SPEED_UP_3D_MODIFIER, TRACKED_OBJECT_RESTORE_KEY,
 };
 use re_viewer_context::{
-    gpu_bridge, Item, ItemSpaceContext, ViewQuery, ViewSystemExecutionError, ViewerContext,
+    gpu_bridge, Item, ItemContext, ViewQuery, ViewSystemExecutionError, ViewerContext,
 };
 use re_viewport_blueprint::ViewProperty;
 
@@ -614,7 +614,7 @@ impl SpatialView3D {
             }
         }
 
-        for selected_context in ctx.selection_state().selection_space_contexts() {
+        for selected_context in ctx.selection_state().selection_item_contexts() {
             show_projections_from_2d_space(
                 &mut line_builder,
                 space_cameras,
@@ -623,7 +623,7 @@ impl SpatialView3D {
                 ui.ctx().selection_stroke().color,
             );
         }
-        if let Some(hovered_context) = ctx.selection_state().hovered_space_context() {
+        if let Some(hovered_context) = ctx.selection_state().hovered_item_context() {
             show_projections_from_2d_space(
                 &mut line_builder,
                 space_cameras,
@@ -848,11 +848,11 @@ fn show_projections_from_2d_space(
     line_builder: &mut re_renderer::LineDrawableBuilder<'_>,
     space_cameras: &[SpaceCamera3D],
     state: &SpatialViewState,
-    space_context: &ItemSpaceContext,
+    item_context: &ItemContext,
     ray_color: egui::Color32,
 ) {
-    match space_context {
-        ItemSpaceContext::TwoD { space_2d, pos } => {
+    match item_context {
+        ItemContext::TwoD { space_2d, pos } => {
             if let Some(cam) = space_cameras.iter().find(|cam| &cam.ent_path == space_2d) {
                 if let Some(pinhole) = cam.pinhole.as_ref() {
                     // Render a thick line to the actual z value if any and a weaker one as an extension
@@ -888,7 +888,7 @@ fn show_projections_from_2d_space(
                 }
             }
         }
-        ItemSpaceContext::ThreeD {
+        ItemContext::ThreeD {
             pos: Some(pos),
             tracked_entity: Some(tracked_entity),
             ..
@@ -915,7 +915,7 @@ fn show_projections_from_2d_space(
                 }
             }
         }
-        ItemSpaceContext::ThreeD { .. } | ItemSpaceContext::StreamsTree { .. } => {}
+        ItemContext::ThreeD { .. } | ItemContext::StreamsTree { .. } => {}
     }
 }
 

--- a/crates/viewer/re_view_spatial/src/ui_3d.rs
+++ b/crates/viewer/re_view_spatial/src/ui_3d.rs
@@ -915,7 +915,7 @@ fn show_projections_from_2d_space(
                 }
             }
         }
-        ItemSpaceContext::ThreeD { .. } => {}
+        ItemSpaceContext::ThreeD { .. } | ItemSpaceContext::StreamsTree { .. } => {}
     }
 }
 

--- a/crates/viewer/re_viewer_context/src/lib.rs
+++ b/crates/viewer/re_viewer_context/src/lib.rs
@@ -66,7 +66,7 @@ pub use self::{
     query_range::QueryRange,
     selection_state::{
         ApplicationSelectionState, HoverHighlight, InteractionHighlight, ItemCollection,
-        ItemSpaceContext, SelectionHighlight,
+        ItemContext, SelectionHighlight,
     },
     store_context::StoreContext,
     store_hub::StoreHub,

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -2,9 +2,9 @@ use ahash::HashMap;
 use indexmap::IndexMap;
 use parking_lot::Mutex;
 
-use re_entity_db::EntityPath;
-
 use crate::{item::resolve_mono_instance_path_item, ViewerContext};
+use re_entity_db::EntityPath;
+use re_log_types::StoreKind;
 
 use super::Item;
 
@@ -34,6 +34,12 @@ pub enum ItemSpaceContext {
 
         /// Corresponding 2D spaces and pixel coordinates (with Z=depth)
         point_in_space_cameras: Vec<(EntityPath, Option<glam::Vec3>)>,
+    },
+
+    /// Hovering/selecting in one of the streams trees.
+    StreamsTree {
+        /// Which store does this streams tree correspond to?
+        store_kind: StoreKind,
     },
 }
 
@@ -156,6 +162,10 @@ impl ItemCollection {
         self.0
             .iter()
             .filter_map(|(_, space_context)| space_context.as_ref())
+    }
+
+    pub fn space_context_for_item(&self, item: &Item) -> Option<&ItemSpaceContext> {
+        self.0.get(item).and_then(Option::as_ref)
     }
 
     /// Returns true if the exact selection is part of the current selection.

--- a/crates/viewer/re_viewer_context/src/selection_state.rs
+++ b/crates/viewer/re_viewer_context/src/selection_state.rs
@@ -11,7 +11,7 @@ use super::Item;
 /// Context information that a view might attach to an item from [`ItemCollection`] and useful
 /// for how a selection might be displayed and interacted with.
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
-pub enum ItemSpaceContext {
+pub enum ItemContext {
     /// Hovering/Selecting in a 2D space.
     TwoD {
         space_2d: EntityPath,
@@ -87,11 +87,11 @@ impl InteractionHighlight {
     }
 }
 
-/// An ordered collection of [`Item`] and optional associated space context objects.
+/// An ordered collection of [`Item`] and optional associated context objects.
 ///
 /// Used to store what is currently selected and/or hovered.
 #[derive(Debug, Default, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ItemCollection(IndexMap<Item, Option<ItemSpaceContext>>);
+pub struct ItemCollection(IndexMap<Item, Option<ItemContext>>);
 
 impl From<Item> for ItemCollection {
     #[inline]
@@ -102,7 +102,7 @@ impl From<Item> for ItemCollection {
 
 impl<T> From<T> for ItemCollection
 where
-    T: Iterator<Item = (Item, Option<ItemSpaceContext>)>,
+    T: Iterator<Item = (Item, Option<ItemContext>)>,
 {
     #[inline]
     fn from(value: T) -> Self {
@@ -111,8 +111,8 @@ where
 }
 
 impl IntoIterator for ItemCollection {
-    type Item = (Item, Option<ItemSpaceContext>);
-    type IntoIter = indexmap::map::IntoIter<Item, Option<ItemSpaceContext>>;
+    type Item = (Item, Option<ItemContext>);
+    type IntoIter = indexmap::map::IntoIter<Item, Option<ItemContext>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -126,14 +126,14 @@ impl ItemCollection {
         Self(
             self.0
                 .into_iter()
-                .map(|(item, space_ctx)| {
+                .map(|(item, item_context)| {
                     (
                         resolve_mono_instance_path_item(
                             ctx.recording(),
                             &ctx.current_query(),
                             &item,
                         ),
-                        space_ctx,
+                        item_context,
                     )
                 })
                 .collect(),
@@ -158,13 +158,13 @@ impl ItemCollection {
         self.0.keys()
     }
 
-    pub fn iter_space_context(&self) -> impl Iterator<Item = &ItemSpaceContext> {
+    pub fn iter_item_context(&self) -> impl Iterator<Item = &ItemContext> {
         self.0
             .iter()
-            .filter_map(|(_, space_context)| space_context.as_ref())
+            .filter_map(|(_, item_context)| item_context.as_ref())
     }
 
-    pub fn space_context_for_item(&self, item: &Item) -> Option<&ItemSpaceContext> {
+    pub fn context_for_item(&self, item: &Item) -> Option<&ItemContext> {
         self.0.get(item).and_then(Option::as_ref)
     }
 
@@ -187,7 +187,7 @@ impl ItemCollection {
     }
 
     /// Retains elements that fulfill a certain condition.
-    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<ItemSpaceContext>) -> bool) {
+    pub fn retain(&mut self, f: impl FnMut(&Item, &mut Option<ItemContext>) -> bool) {
         self.0.retain(f);
     }
 
@@ -201,18 +201,18 @@ impl ItemCollection {
         self.0.is_empty()
     }
 
-    /// Returns an iterator over the items and their selected space context.
-    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<ItemSpaceContext>)> {
+    /// Returns an iterator over the items and their selected context.
+    pub fn iter(&self) -> impl Iterator<Item = (&Item, &Option<ItemContext>)> {
         self.0.iter()
     }
 
-    /// Returns a mutable iterator over the items and their selected space context.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<ItemSpaceContext>)> {
+    /// Returns a mutable iterator over the items and their selected context.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&Item, &mut Option<ItemContext>)> {
         self.0.iter_mut()
     }
 
     /// Extend the selection with more items.
-    pub fn extend(&mut self, other: impl IntoIterator<Item = (Item, Option<ItemSpaceContext>)>) {
+    pub fn extend(&mut self, other: impl IntoIterator<Item = (Item, Option<ItemContext>)>) {
         self.0.extend(other);
     }
 }
@@ -275,7 +275,7 @@ impl ApplicationSelectionState {
 
     /// Sets several objects to be selected, updating history as needed.
     ///
-    /// Clears the selected space context if none was specified.
+    /// Clears the selected item context if none was specified.
     pub fn set_selection(&self, items: impl Into<ItemCollection>) {
         *self.selection_this_frame.lock() = items.into();
     }
@@ -301,12 +301,12 @@ impl ApplicationSelectionState {
     }
 
     /// Select passed objects unless already selected in which case they get unselected.
-    /// If however an object is already selected but now gets passed a *different* selected space context, it stays selected after all
-    /// but with an updated selected space context!
+    /// If however an object is already selected but now gets passed a *different* item context, it stays selected after all
+    /// but with an updated context!
     pub fn toggle_selection(&self, toggle_items: ItemCollection) {
         re_tracing::profile_function!();
 
-        let mut toggle_items_set: HashMap<Item, Option<ItemSpaceContext>> = toggle_items
+        let mut toggle_items_set: HashMap<Item, Option<ItemContext>> = toggle_items
             .iter()
             .map(|(item, ctx)| (item.clone(), ctx.clone()))
             .collect();
@@ -348,12 +348,12 @@ impl ApplicationSelectionState {
         *self.selection_this_frame.lock() = new_selection;
     }
 
-    pub fn selection_space_contexts(&self) -> impl Iterator<Item = &ItemSpaceContext> {
-        self.selection_previous_frame.iter_space_context()
+    pub fn selection_item_contexts(&self) -> impl Iterator<Item = &ItemContext> {
+        self.selection_previous_frame.iter_item_context()
     }
 
-    pub fn hovered_space_context(&self) -> Option<&ItemSpaceContext> {
-        self.hovered_previous_frame.iter_space_context().next()
+    pub fn hovered_item_context(&self) -> Option<&ItemContext> {
+        self.hovered_previous_frame.iter_item_context().next()
     }
 
     pub fn highlight_for_ui_element(&self, test: &Item) -> HoverHighlight {


### PR DESCRIPTION
### Related

* Part of 8586
* Supersedes #8625

### ~Context~ Background

The lingua franca that allows `re_context_menu` to be both useful and low in the crate hierarchy (so it may be used by various UI areas) is the `re_viewer_context::Item`. This generally makes sense. `Item` are the things that can be hovered, selected, interacted with, so, in most case, there exists a meaningful mapping between an `Item` and actions that applie to it.

This breaks down when the action is not about the `Item` _per se_, but about how that `Item` is represented _in this specific UI area_. The `Expand/Collapse all…` actions fall in this category (e.g. they are about collapsing the item representation _in this specific UI area_, not all of them).

In order to be correctly implemented, the context menu action needs to have additional context for the item (namely, where it was clicked/selected). This is why expand/collapse all is currently broken in the blueprint streams tree.

Because we support right-clicking on a multi-selections that includes items that might have been selected in various places across the UI, the only place where that local context is next to the `Item`, in the `ItemCollection` representing the selection. As  it turns out, we already have such a thing. It's called `ItemSpaceContext` and is used to handle the specific interaction between the 2D and 3D views (rays, etc.) when interacting with some of the entities.

### What

This PR extends the `ItemSpaceContext` to include the case where the entity is picked from the streams tree, with information whether this is the blueprint or regular streams tree. This fixes the aforementioned bug. It also rename `ItemSpaceContext` to `ItemContext`.

**Review commit-by-commit**: first commit is the meat, second is pure renames.

### Future work

- The implementation of #8586 will build on this PR and add some more data to handle the interaction of filtering and collapsing state.
- In the long run, we will probably give some love to `ItemContext` to make it more flexible. Maybe it should be turned into a `TypeMap` (which, ironically, was at the core of my 1st failed attempt at this #8625).



